### PR TITLE
chore: remove AMIS and data-sourcing disclosures from public copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A web app to help UPLB students find rooms on campus. "Saan sa UPLB ang \_\_\_?"
 - Mobile-responsive design with accessibility features
 - Offline support in cases where data is not accessible
 
-## Data Source
+## Data
 
-Data is sourced from UPLB AMIS for 2nd Semester AY 2025-2026.
+Course and room listings are maintained for UPLB students and updated each term; they currently reflect 2nd Semester AY 2025–2026.
 
 ## Development/Contribution
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,7 +26,7 @@ import Contributor from "./Contributor.astro";
       <a href="/changelog">{APP_VERSION_LABEL}</a>
     </div>
     <p class="data-updated">
-      Data sourced from <strong>UPLB AMIS</strong>. Last updated: <strong
+      Course and room information is updated regularly. Last updated: <strong
         >January 2026.</strong
       >
     </p>

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -42,7 +42,7 @@
     </div>
     <div class="metadata">
       <div class="data-updated">
-        Data sourced from <strong>UPLB AMIS</strong>. Last updated:
+        Course and room information is updated regularly. Last updated:
         <strong>January 2026.</strong>
       </div>
       <div>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -7,7 +7,7 @@ const changelogEntries = [
     date: "April 2026",
     summary: "Initial public release of Room TBA.",
     changes: [
-      "Initial course and room dataset reflects schedule information as represented in UPLB AMIS for 2nd Semester AY 2025-2026.",
+      "Initial course and room dataset for 2nd Semester AY 2025-2026.",
       "Simply search for a course, room, or building to view its details, including schedule, room status, and other relevant information.",
       "Implemented a responsive design to ensure a seamless experience across different devices.",
       "Add directions to all buildings listed on the website, making it easier for users to navigate the campus.",


### PR DESCRIPTION
## Summary
Removes public-facing references to **AMIS**, **scraping**, and **data sourcing** so the site does not imply a relationship with or method of obtaining data from third-party systems.

## Changes
- **README**: Replaces the “Data Source” section with a neutral “Data” blurb (term scope, no named system).
- **Footer & status bar**: Drops “Data sourced from …”; keeps a simple “updated regularly” + last-updated date.
- **Changelog (v1.0.0)**: Shortens the first bullet to the term scope only.

## Note
Contributor names (e.g. Ramiscal) are unchanged; they are unrelated to this wording policy.