### PR TITLE
Changing how the width of the directions' progress bar was styled

### DIFF
--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -24,7 +24,7 @@
       <div class="progress-bar">
         <div
           class="progress-bar__value"
-          data-value={Math.floor((directionCount / totalRooms) * 100)}
+          style:width={`${Math.floor((directionCount / totalRooms) * 100)}%`}
         ></div>
       </div>
       <div>
@@ -162,7 +162,6 @@
           height: 100%;
           background-color: #7b1113;
           border-radius: 0.5rem;
-          width: calc(attr(data-value number) * 1%);
         }
       }
     }

--- a/src/components/svelte/search/Suggestion.svelte
+++ b/src/components/svelte/search/Suggestion.svelte
@@ -3,12 +3,11 @@
   import {
     ArrowUpRight,
     BookText,
-    Building,
     DoorClosed,
     GraduationCap,
     School,
     University,
-  } from "@lucide/svelte/icons";
+  } from "@lucide/svelte";
   let {
     value,
     category,

--- a/src/components/svelte/search/Suggestion.svelte
+++ b/src/components/svelte/search/Suggestion.svelte
@@ -54,7 +54,7 @@
 <button class="suggestion" onclick={handleSuggestionClick}>
   {@render icon(category)}
   <div class="text">{@html highlightSearch(value, pattern)}</div>
-  <ArrowUpRight size={20} style={"margin-left:auto"} />
+  <ArrowUpRight size={20} style={"margin-left:auto"} class="icon" />
 </button>
 
 <style>
@@ -72,7 +72,7 @@
     }
   }
 
-  .icon {
+  :global(.icon) {
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
To improve compatibility, the progress bar of the directions' located in the utmost left side of the status bar was modified based on how the width was styled. Instead of using css `attr()` function, the fix now uses inline styling that sets the progress bar value in compile time.