### PR TITLE
feat: jeepney route menu (mock stops for Kaliwa/Kanan and Forestry)

### DIFF
--- a/src/components/svelte/JeepneyMenu.svelte
+++ b/src/components/svelte/JeepneyMenu.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import { Bus, X } from "@lucide/svelte";
+  import { JEEPNEY_ROUTES } from "../../constants/jeepney-routes";
+  import { jeepneyStore } from "../../lib/store.svelte";
+</script>
+
+<div class="jeepney-menu">
+  {#if jeepneyStore.menuOpen}
+    <div class="route-list" role="menu">
+      <div class="route-list-header">
+        <span>Jeepney Routes</span>
+        <button
+          type="button"
+          class="close-btn"
+          onclick={() => jeepneyStore.closeMenu()}
+          aria-label="Close jeepney menu"
+        >
+          <X size="16" />
+        </button>
+      </div>
+      {#each JEEPNEY_ROUTES as route (route.id)}
+        {@const isActive = jeepneyStore.selectedRouteId === route.id}
+        <button
+          type="button"
+          class="route-option"
+          class:active={isActive}
+          onclick={() => jeepneyStore.selectRoute(route.id)}
+        >
+          <span class="route-color" style:background-color={route.color}></span>
+          <span class="route-text">
+            <span class="route-name">{route.name}</span>
+            <span class="route-description">{route.description}</span>
+          </span>
+        </button>
+      {/each}
+      {#if jeepneyStore.selectedRouteId !== null}
+        <button
+          type="button"
+          class="clear-btn"
+          onclick={() => jeepneyStore.clearRoute()}
+        >
+          Clear active route
+        </button>
+      {/if}
+    </div>
+  {/if}
+
+  <button
+    class="jeepney-btn"
+    class:active={jeepneyStore.selectedRouteId !== null}
+    onclick={() => jeepneyStore.toggleMenu()}
+    title="Jeepney Routes"
+    aria-label="Jeepney Routes"
+    aria-expanded={jeepneyStore.menuOpen}
+  >
+    <Bus />
+  </button>
+</div>
+
+<style>
+  .jeepney-menu {
+    pointer-events: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+  }
+  .jeepney-btn {
+    background-color: white;
+    border: 1px solid #ececec;
+    border-radius: 50%;
+    width: 3rem;
+    height: 3rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    color: hsl(5, 53%, 32%);
+    transition:
+      background-color 0.2s,
+      transform 0.2s;
+  }
+  .jeepney-btn:hover {
+    background-color: hsl(5, 53%, 98%);
+    transform: scale(1.05);
+  }
+  .jeepney-btn.active {
+    background-color: hsl(5, 53%, 32%);
+    color: white;
+  }
+
+  .route-list {
+    background-color: white;
+    border-radius: 0.875rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    width: 17rem;
+    max-width: calc(100vw - 1rem);
+  }
+  .route-list-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 600;
+    font-size: 0.875rem;
+    color: hsl(0, 0%, 20%);
+    padding: 0.125rem 0.25rem;
+  }
+  .close-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: hsl(0, 0%, 40%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.125rem;
+    border-radius: 0.375rem;
+  }
+  .close-btn:hover {
+    background-color: hsl(0, 0%, 95%);
+  }
+
+  .route-option {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: 0.625rem;
+    border: 1px solid transparent;
+    background-color: hsl(0, 0%, 98%);
+    cursor: pointer;
+    text-align: left;
+    transition:
+      background-color 0.15s,
+      border-color 0.15s;
+  }
+  .route-option:hover {
+    background-color: hsl(0, 0%, 94%);
+  }
+  .route-option.active {
+    background-color: hsl(5, 53%, 96%);
+    border-color: hsl(5, 53%, 75%);
+  }
+  .route-color {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 50%;
+    flex: 0 0 auto;
+    box-shadow: 0 0 0 2px white;
+  }
+  .route-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    line-height: 1.2;
+  }
+  .route-name {
+    font-weight: 600;
+    font-size: 0.875rem;
+    color: hsl(0, 0%, 15%);
+  }
+  .route-description {
+    font-size: 0.75rem;
+    color: hsl(0, 0%, 45%);
+  }
+
+  .clear-btn {
+    margin-top: 0.25rem;
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid hsl(0, 0%, 88%);
+    background-color: white;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: hsl(5, 53%, 32%);
+    font-weight: 500;
+  }
+  .clear-btn:hover {
+    background-color: hsl(5, 53%, 98%);
+  }
+</style>

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -1,15 +1,144 @@
 <script lang="ts">
   import { FillExtrusionLayer, MapLibre, Marker } from "svelte-maplibre";
   import { getAppData } from "../../lib/context";
-  import { queryStore, locationStore, mapStore } from "../../lib/store.svelte";
+  import {
+    queryStore,
+    locationStore,
+    mapStore,
+    jeepneyStore,
+  } from "../../lib/store.svelte";
   import { untrack } from "svelte";
   import { fade } from "svelte/transition";
   import MapLibreGlDirections from "@maplibre/maplibre-gl-directions";
   import { University } from "@lucide/svelte";
   import { MediaQuery } from "svelte/reactivity";
   import * as mapGl from "maplibre-gl";
+  import {
+    JEEPNEY_ROUTES,
+    type JeepneyRoute,
+    type JeepneyStop,
+  } from "../../constants/jeepney-routes";
   const { buildings, rooms } = getAppData();
   let directions: MapLibreGlDirections | undefined = $state.raw();
+
+  const JEEPNEY_ROUTE_SOURCE_ID = "jeepney-route-line";
+  const JEEPNEY_ROUTE_LAYER_ID = "jeepney-route-line";
+  const JEEPNEY_ROUTE_LAYER_CASING_ID = "jeepney-route-line-casing";
+
+  let activeRouteId = $state<string | null>(null);
+  let activeRouteStops = $state<JeepneyStop[]>([]);
+  let activeRouteColor = $state<string>("#dc2626");
+
+  async function fetchRouteGeometry(
+    route: JeepneyRoute,
+  ): Promise<GeoJSON.LineString | null> {
+    if (route.stops.length < 2) return null;
+    const coordsParam = route.stops
+      .map((stop) => `${stop.lon},${stop.lat}`)
+      .join(";");
+    const url = `https://routing.openstreetmap.de/routed-car/route/v1/driving/${coordsParam}?overview=full&geometries=geojson`;
+
+    try {
+      const res = await fetch(url);
+      if (!res.ok) return null;
+      const data = (await res.json()) as {
+        routes?: { geometry?: GeoJSON.LineString }[];
+      };
+      const geometry = data.routes?.[0]?.geometry;
+      if (!geometry || geometry.type !== "LineString") return null;
+      return geometry;
+    } catch {
+      return null;
+    }
+  }
+
+  function buildStraightLineGeometry(
+    route: JeepneyRoute,
+  ): GeoJSON.LineString {
+    return {
+      type: "LineString",
+      coordinates: route.stops.map((stop) => [stop.lon, stop.lat]),
+    };
+  }
+
+  function ensureJeepneyRouteLayers(map: mapGl.MapLibreMap, color: string) {
+    if (!map.getSource(JEEPNEY_ROUTE_SOURCE_ID)) {
+      map.addSource(JEEPNEY_ROUTE_SOURCE_ID, {
+        type: "geojson",
+        data: {
+          type: "FeatureCollection",
+          features: [],
+        },
+      });
+    }
+
+    if (!map.getLayer(JEEPNEY_ROUTE_LAYER_CASING_ID)) {
+      map.addLayer({
+        id: JEEPNEY_ROUTE_LAYER_CASING_ID,
+        type: "line",
+        source: JEEPNEY_ROUTE_SOURCE_ID,
+        layout: { "line-cap": "round", "line-join": "round" },
+        paint: {
+          "line-color": "#ffffff",
+          "line-width": 8,
+          "line-opacity": 0.95,
+        },
+      });
+    }
+
+    if (!map.getLayer(JEEPNEY_ROUTE_LAYER_ID)) {
+      map.addLayer({
+        id: JEEPNEY_ROUTE_LAYER_ID,
+        type: "line",
+        source: JEEPNEY_ROUTE_SOURCE_ID,
+        layout: { "line-cap": "round", "line-join": "round" },
+        paint: {
+          "line-color": color,
+          "line-width": 5,
+          "line-opacity": 0.95,
+        },
+      });
+    } else {
+      map.setPaintProperty(JEEPNEY_ROUTE_LAYER_ID, "line-color", color);
+    }
+  }
+
+  function clearJeepneyRouteLayers(map: mapGl.MapLibreMap) {
+    if (map.getLayer(JEEPNEY_ROUTE_LAYER_ID)) {
+      map.removeLayer(JEEPNEY_ROUTE_LAYER_ID);
+    }
+    if (map.getLayer(JEEPNEY_ROUTE_LAYER_CASING_ID)) {
+      map.removeLayer(JEEPNEY_ROUTE_LAYER_CASING_ID);
+    }
+    if (map.getSource(JEEPNEY_ROUTE_SOURCE_ID)) {
+      map.removeSource(JEEPNEY_ROUTE_SOURCE_ID);
+    }
+  }
+
+  function fitMapToRoute(map: mapGl.MapLibreMap, route: JeepneyRoute) {
+    if (route.stops.length === 0) return;
+    let minLng = Infinity;
+    let minLat = Infinity;
+    let maxLng = -Infinity;
+    let maxLat = -Infinity;
+    for (const stop of route.stops) {
+      if (stop.lon < minLng) minLng = stop.lon;
+      if (stop.lon > maxLng) maxLng = stop.lon;
+      if (stop.lat < minLat) minLat = stop.lat;
+      if (stop.lat > maxLat) maxLat = stop.lat;
+    }
+    map.fitBounds(
+      [
+        [minLng, minLat],
+        [maxLng, maxLat],
+      ],
+      {
+        padding: { top: 80, bottom: 80, left: 80, right: 80 },
+        duration: 1200,
+        pitch: 30,
+      },
+    );
+  }
 
   let animationFrameId: number | null = $state(null);
 
@@ -118,6 +247,73 @@
     } else {
       directions.clear();
     }
+  });
+
+  $effect(() => {
+    const selectedId = jeepneyStore.selectedRouteId;
+    const map = mapStore.mapInstance;
+    if (!map) return;
+
+    let cancelled = false;
+
+    const apply = async () => {
+      const route = selectedId
+        ? (JEEPNEY_ROUTES.find((r) => r.id === selectedId) ?? null)
+        : null;
+
+      if (!route) {
+        clearJeepneyRouteLayers(map);
+        activeRouteId = null;
+        activeRouteStops = [];
+        return;
+      }
+
+      activeRouteId = route.id;
+      activeRouteStops = route.stops;
+      activeRouteColor = route.color;
+
+      const ensureLayersAndPaint = (geometry: GeoJSON.LineString) => {
+        if (cancelled) return;
+        ensureJeepneyRouteLayers(map, route.color);
+        const source = map.getSource(JEEPNEY_ROUTE_SOURCE_ID) as
+          | mapGl.GeoJSONSource
+          | undefined;
+        const featureCollection: GeoJSON.FeatureCollection<GeoJSON.LineString> =
+          {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                geometry,
+                properties: { routeId: route.id },
+              },
+            ],
+          };
+        source?.setData(featureCollection);
+      };
+
+      const drawWhenReady = (action: () => void) => {
+        if (map.isStyleLoaded()) action();
+        else map.once("load", action);
+      };
+
+      drawWhenReady(() => {
+        ensureJeepneyRouteLayers(map, route.color);
+        ensureLayersAndPaint(buildStraightLineGeometry(route));
+        fitMapToRoute(map, route);
+      });
+
+      const snapped = await fetchRouteGeometry(route);
+      if (!cancelled && snapped) {
+        drawWhenReady(() => ensureLayersAndPaint(snapped));
+      }
+    };
+
+    apply();
+
+    return () => {
+      cancelled = true;
+    };
   });
 
   $effect(() => {
@@ -273,6 +469,20 @@
         </Marker>
       {/if}
     {/each}
+    {#if activeRouteId}
+      {#each activeRouteStops as stop, i (`${activeRouteId}-${i}-${stop.name}`)}
+        <Marker lngLat={[stop.lon, stop.lat]}>
+          <div
+            class="jeepney-stop-pin"
+            style:--stop-color={activeRouteColor}
+            title={stop.name}
+          >
+            <span class="stop-index">{i + 1}</span>
+            <span class="stop-label" transition:fade>{stop.name}</span>
+          </div>
+        </Marker>
+      {/each}
+    {/if}
   </MapLibre>
 </div>
 
@@ -379,5 +589,48 @@
     .pin-label {
       opacity: 1;
     }
+  }
+
+  .jeepney-stop-pin {
+    --stop-color: #dc2626;
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: 50%;
+    background-color: var(--stop-color);
+    border: 2px solid white;
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.35);
+    cursor: default;
+    position: relative;
+    z-index: 50;
+  }
+  .jeepney-stop-pin .stop-index {
+    pointer-events: none;
+  }
+  .jeepney-stop-pin .stop-label {
+    position: absolute;
+    bottom: calc(100% + 0.4rem);
+    left: 50%;
+    translate: -50% 0;
+    background-color: white;
+    color: hsl(0, 0%, 15%);
+    border-radius: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    white-space: nowrap;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    opacity: 0;
+    transition: opacity 0.15s;
+    pointer-events: none;
+  }
+  .jeepney-stop-pin:hover .stop-label {
+    opacity: 1;
   }
 </style>

--- a/src/components/svelte/sidepanel/SidePanel.svelte
+++ b/src/components/svelte/sidepanel/SidePanel.svelte
@@ -7,12 +7,16 @@
   import RoomResult from "../room/RoomResult.svelte";
   import ClassQuery from "./ClassQuery.svelte";
   import LocationButton from "../LocationButton.svelte";
+  import JeepneyMenu from "../JeepneyMenu.svelte";
 </script>
 
 <div class="side-panel-wrapper">
   <Search />
   <div class="side-panel-controls">
-    <LocationButton />
+    <div class="floating-actions">
+      <JeepneyMenu />
+      <LocationButton />
+    </div>
     {#if queryStore.category !== null}
       <div class="side-panel-content">
         {#if queryStore.category === "building"}
@@ -64,6 +68,13 @@
     flex-direction: row-reverse;
     justify-content: space-between;
     gap: 1rem;
+  }
+  .floating-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+    pointer-events: none;
   }
 
   /* Mobile responsiveness for side panel */

--- a/src/constants/jeepney-routes.ts
+++ b/src/constants/jeepney-routes.ts
@@ -1,0 +1,43 @@
+export type JeepneyStop = {
+  name: string;
+  lat: number;
+  lon: number;
+};
+
+export type JeepneyRoute = {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  stops: JeepneyStop[];
+};
+
+export const JEEPNEY_ROUTES: JeepneyRoute[] = [
+  {
+    id: "kaliwa-kanan",
+    name: "Kaliwa / Kanan",
+    description: "Mock loop around the main UPLB campus.",
+    color: "#dc2626",
+    stops: [
+      { name: "Carabao Park", lat: 14.16384, lon: 121.24134 },
+      { name: "Maquiling / SU", lat: 14.1668, lon: 121.2438 },
+      { name: "IPB Junction", lat: 14.16458, lon: 121.24555 },
+      { name: "College of Engineering", lat: 14.1627, lon: 121.24378 },
+      { name: "Senior's Social Garden", lat: 14.16195, lon: 121.24281 },
+      { name: "Carabao Park", lat: 14.16384, lon: 121.24134 },
+    ],
+  },
+  {
+    id: "forestry",
+    name: "Forestry",
+    description: "Mock route from main campus down to the Forestry area.",
+    color: "#15803d",
+    stops: [
+      { name: "Carabao Park", lat: 14.16384, lon: 121.24134 },
+      { name: "DA-PhilRice", lat: 14.16035, lon: 121.23972 },
+      { name: "CFNR Gate", lat: 14.157, lon: 121.2372 },
+      { name: "CFNR Building", lat: 14.1543, lon: 121.2353 },
+      { name: "Forestry Biological Sciences", lat: 14.1548, lon: 121.2358 },
+    ],
+  },
+];

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -244,8 +244,31 @@ class MapStore {
   mapInstance: maplibre.MapLibreMap | undefined = $state.raw()
 }
 
+class JeepneyStore {
+  selectedRouteId: string | null = $state(null);
+  menuOpen: boolean = $state(false);
+
+  toggleMenu = () => {
+    this.menuOpen = !this.menuOpen;
+  };
+
+  closeMenu = () => {
+    this.menuOpen = false;
+  };
+
+  selectRoute = (id: string) => {
+    this.selectedRouteId = this.selectedRouteId === id ? null : id;
+    this.menuOpen = false;
+  };
+
+  clearRoute = () => {
+    this.selectedRouteId = null;
+  };
+}
+
 export const queryStore = new QueryStore();
 export const modalStore = new ModalStore();
 export const toastStore = new ToastStore();
 export const locationStore = new LocationStore();
 export const mapStore = new MapStore();
+export const jeepneyStore = new JeepneyStore();


### PR DESCRIPTION
## Summary

Adds a Jeepney Route picker so users can overlay a route on the 3D map.

> [!IMPORTANT]
> **All stop coordinates and route memberships in this PR are mock data**, not the real UPLB jeepney routes. They're plausible placeholders so the UI/rendering pipeline can ship now; the real stops can be filled in later by editing `src/constants/jeepney-routes.ts` (no other code changes needed).

### What's in scope (real)
- `JeepneyMenu` floating button (next to the location button) that opens a popover listing available routes. Selecting toggles on, selecting again or *Clear active route* turns off.
- `jeepneyStore` tracks active route id and menu open state.
- `Map.svelte` renders the active route as a casing + colored line layer, plus numbered stop markers. The polyline is fetched from public OSRM (`routed-car`) so it actually follows OSM roads. Falls back to straight lines while the request is in flight or if OSRM fails.
- On selection, map fits its bounds to the route stops.

### What's mock (will be replaced later)
- The two routes in `src/constants/jeepney-routes.ts`:
  - **Kaliwa / Kanan** (red) — placeholder campus loop, ~6 stops.
  - **Forestry** (green) — placeholder route from main campus down to the CFNR area, ~5 stops.
- Each stop's `name`, `lat`, `lon`. Coordinates were eyeballed from known UPLB landmarks within the map's bounds; they are *not* surveyed jeepney stops.

To replace with real data later, edit `JEEPNEY_ROUTES` in `src/constants/jeepney-routes.ts`. Adding new routes is the same shape (id, name, description, color, stops[]).

## Test plan

- [ ] Click the bus button in the bottom-right; the popover shows both routes (each labeled with its mock description).
- [ ] Selecting **Kaliwa / Kanan** draws a red road-following loop with numbered stops; map fits to the loop.
- [ ] Selecting **Forestry** swaps to a green route running south to the CFNR area.
- [ ] Selecting the same route again, or hitting *Clear active route*, removes the line and stops.
- [ ] If OSRM is unreachable, straight lines still appear (no broken state).