### PR TITLE
Pin Vercel build runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "astro-room",
   "type": "module",
   "version": "1.7.3",
+  "packageManager": "bun@1.3.14",
   "license": "MIT",
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "dev": "astro dev",
     "dev:debug": "astro dev --verbose",


### PR DESCRIPTION
## Summary
- Pins the project package manager to Bun and the runtime to Node 20 so Vercel resolves build tooling consistently with the locked install.
- Documents the PR #167 Vercel failure investigation in the PR context: local builds pass, while the failed deployment path points at PWA/tooling dependency resolution around `lru-cache`.

## Test plan
- `bun install --frozen-lockfile`
- `bunx prettier --check package.json`
- `bun run build`

## Manual QA
- No user-facing editor behavior changed; the existing room side-panel QA checklist remains applicable.