### PR TITLE
Add retractable result sidebars

### DIFF
--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -20,6 +20,7 @@
   import University from "@lucide/svelte/icons/university";
   import { MediaQuery } from "svelte/reactivity";
   import * as mapGl from "maplibre-gl";
+  import type { FeatureCollection, LineString } from "geojson";
   import {
     JEEPNEY_ROUTES,
     type JeepneyRoute,
@@ -87,7 +88,7 @@
 
   async function fetchRouteGeometry(
     route: JeepneyRoute,
-  ): Promise<GeoJSON.LineString | null> {
+  ): Promise<LineString | null> {
     if (route.stops.length < 2) return null;
     const coordsParam = route.stops
       .map((stop) => `${stop.lon},${stop.lat}`)
@@ -98,7 +99,7 @@
       const res = await fetch(url);
       if (!res.ok) return null;
       const data = (await res.json()) as {
-        routes?: { geometry?: GeoJSON.LineString }[];
+        routes?: { geometry?: LineString }[];
       };
       const geometry = data.routes?.[0]?.geometry;
       if (!geometry || geometry.type !== "LineString") return null;
@@ -108,7 +109,7 @@
     }
   }
 
-  function buildStraightLineGeometry(route: JeepneyRoute): GeoJSON.LineString {
+  function buildStraightLineGeometry(route: JeepneyRoute): LineString {
     return {
       type: "LineString",
       coordinates: route.stops.map((stop) => [stop.lon, stop.lat]),
@@ -694,23 +695,22 @@
       activeRouteStops = route.stops;
       activeRouteColor = route.color;
 
-      const ensureLayersAndPaint = (geometry: GeoJSON.LineString) => {
+      const ensureLayersAndPaint = (geometry: LineString) => {
         if (cancelled) return;
         ensureJeepneyRouteLayers(map, route.color);
         const source = map.getSource(JEEPNEY_ROUTE_SOURCE_ID) as
           | mapGl.GeoJSONSource
           | undefined;
-        const featureCollection: GeoJSON.FeatureCollection<GeoJSON.LineString> =
-          {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                geometry,
-                properties: { routeId: route.id },
-              },
-            ],
-          };
+        const featureCollection: FeatureCollection<LineString> = {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              geometry,
+              properties: { routeId: route.id },
+            },
+          ],
+        };
         source?.setData(featureCollection);
       };
 

--- a/src/components/svelte/sidepanel/SidePanel.svelte
+++ b/src/components/svelte/sidepanel/SidePanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Search from "../search/Search.svelte";
-  import { queryStore } from "../../../lib/store.svelte";
+  import { queryStore, sidePanelStore } from "../../../lib/store.svelte";
+  import type { QueryStoreState } from "../../../lib/store.svelte";
   import BuildingResult from "./BuildingResult.svelte";
   import CollegeResult from "./CollegeResult.svelte";
   import DivisionResult from "./DivisionResult.svelte";
@@ -9,30 +10,117 @@
   import ClassQuery from "./ClassQuery.svelte";
   import LocationButton from "../LocationButton.svelte";
   import JeepneyMenu from "../JeepneyMenu.svelte";
+  import ChevronDown from "@lucide/svelte/icons/chevron-down";
+  import ChevronLeft from "@lucide/svelte/icons/chevron-left";
+  import ChevronRight from "@lucide/svelte/icons/chevron-right";
+  import { cubicOut } from "svelte/easing";
+  import { MediaQuery } from "svelte/reactivity";
+  import { fly } from "svelte/transition";
+
+  type ResultCategory = Exclude<QueryStoreState["category"], null>;
+
+  const categoryLabels: Record<ResultCategory, string> = {
+    building: "Building",
+    college: "College",
+    division: "Division",
+    room: "Room",
+    class: "Class search",
+    dorm: "Dorm",
+  };
+
+  const mobile = new MediaQuery("max-width:48rem");
+  let lastPanelIdentity = $state<string | null>(null);
+  const panelIdentity = $derived(
+    queryStore.category === null
+      ? null
+      : `${queryStore.category}:${queryStore.queryValue}`,
+  );
+  const summaryLabel = $derived.by(() => {
+    const category = queryStore.category;
+    return category === null ? "" : categoryLabels[category];
+  });
+  const summaryValue = $derived(queryStore.queryValue || queryStore.inputValue);
+  const toggleLabel = $derived(
+    sidePanelStore.collapsed
+      ? "Expand details panel"
+      : "Collapse details panel",
+  );
+
+  $effect(() => {
+    const identity = panelIdentity;
+    if (identity === lastPanelIdentity) return;
+
+    sidePanelStore.expand();
+    lastPanelIdentity = identity;
+  });
+
+  function togglePanel() {
+    sidePanelStore.collapsed = !sidePanelStore.collapsed;
+  }
 </script>
 
 <div class="side-panel-wrapper">
   <Search />
-  <div class="side-panel-controls">
+  <div
+    class="side-panel-controls"
+    class:is-collapsed={sidePanelStore.collapsed}
+  >
     <div class="floating-actions">
       <JeepneyMenu />
       <LocationButton />
     </div>
     {#if queryStore.category !== null}
-      <div class="side-panel-content">
-        {#if queryStore.category === "building"}
-          <BuildingResult />
-        {:else if queryStore.category === "college"}
-          <CollegeResult />
-        {:else if queryStore.category === "division"}
-          <DivisionResult />
-        {:else if queryStore.category === "room"}
-          <RoomResult />
-        {:else if queryStore.category === "class"}
-          <ClassQuery />
-        {:else if queryStore.category === "dorm"}
-          <DormResult />
-        {/if}
+      <div
+        class="side-panel-content"
+        class:is-collapsed={sidePanelStore.collapsed}
+        in:fly={{ x: -12, duration: 160, easing: cubicOut }}
+        out:fly={{ x: -12, duration: 120 }}
+      >
+        <div class="side-panel-summary">
+          <div class="summary-copy">
+            <span class="summary-label">{summaryLabel}</span>
+            <span class="summary-title">{summaryValue}</span>
+          </div>
+          <button
+            class="panel-toggle"
+            type="button"
+            aria-expanded={!sidePanelStore.collapsed}
+            aria-controls="side-panel-details"
+            aria-label={toggleLabel}
+            on:click={togglePanel}
+          >
+            {#if sidePanelStore.collapsed}
+              <ChevronRight size={18} />
+              <span>Expand</span>
+            {:else}
+              {#if mobile.current}
+                <ChevronDown size={18} />
+              {:else}
+                <ChevronLeft size={18} />
+              {/if}
+              <span>Collapse</span>
+            {/if}
+          </button>
+        </div>
+        <div
+          id="side-panel-details"
+          class="side-panel-details"
+          hidden={sidePanelStore.collapsed}
+        >
+          {#if queryStore.category === "building"}
+            <BuildingResult />
+          {:else if queryStore.category === "college"}
+            <CollegeResult />
+          {:else if queryStore.category === "division"}
+            <DivisionResult />
+          {:else if queryStore.category === "room"}
+            <RoomResult />
+          {:else if queryStore.category === "class"}
+            <ClassQuery />
+          {:else if queryStore.category === "dorm"}
+            <DormResult />
+          {/if}
+        </div>
       </div>
     {/if}
   </div>
@@ -55,13 +143,102 @@
     pointer-events: auto;
     display: flex;
     flex-direction: column;
+    gap: 0.75rem;
     height: 100%;
     flex: 0 0 min(25.75rem, calc(50% - 4rem));
     box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.25);
-    & > :global(*) {
+    overflow: hidden;
+    animation: panel-settle-in 160ms cubic-bezier(0.22, 1, 0.36, 1);
+    &.is-collapsed {
+      position: absolute;
+      top: 50%;
+      left: -0.5rem;
+      z-index: 2;
+      translate: 0 -50%;
+      width: min(9.75rem, calc(100vw - 1rem));
+      height: auto;
+      flex: none;
+      padding: 0.5rem 0.75rem 0.5rem 0.625rem;
+      border-radius: 0 999px 999px 0;
+      animation: tab-peek-left 180ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+    .side-panel-details > :global(*) {
       scrollbar-width: thin;
       scrollbar-color: hsl(6, 63%, 48%) hsl(0, 0%, 98%);
     }
+  }
+  .side-panel-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    min-width: 0;
+    flex-shrink: 0;
+  }
+  .side-panel-content:not(.is-collapsed) .side-panel-summary {
+    justify-content: flex-end;
+    margin-bottom: -0.25rem;
+  }
+  .side-panel-content:not(.is-collapsed) .summary-copy {
+    display: none;
+  }
+  .summary-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+  .summary-label {
+    color: #7b1113;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+  .summary-title {
+    color: black;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    line-height: 1.2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .panel-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex: 0 0 auto;
+    border: 1px solid #d8b9ba;
+    border-radius: 999px;
+    background-color: white;
+    color: #7b1113;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.375rem 0.625rem;
+    transition:
+      background-color 0.2s,
+      border-color 0.2s;
+  }
+  .panel-toggle:hover,
+  .panel-toggle:focus-visible {
+    background-color: #fdf3f3;
+    border-color: #c58f91;
+  }
+  .panel-toggle:focus-visible {
+    outline: 2px solid #7b1113;
+    outline-offset: 2px;
+  }
+  .side-panel-details {
+    display: flex;
+    flex: 1 1 0;
+    min-height: 0;
+  }
+  .side-panel-details[hidden] {
+    display: none;
   }
   .side-panel-controls {
     display: flex;
@@ -72,6 +249,9 @@
     justify-content: space-between;
     gap: 1rem;
   }
+  .side-panel-controls.is-collapsed {
+    align-items: flex-end;
+  }
   .floating-actions {
     display: flex;
     flex-direction: column;
@@ -79,7 +259,44 @@
     gap: 0.5rem;
     pointer-events: none;
   }
-
+  .side-panel-content.is-collapsed .side-panel-summary {
+    gap: 0.5rem;
+  }
+  .side-panel-content.is-collapsed .summary-label {
+    font-size: 0.625rem;
+  }
+  .side-panel-content.is-collapsed .summary-title {
+    font-size: 0.8125rem;
+  }
+  .side-panel-content.is-collapsed .panel-toggle {
+    width: 1.875rem;
+    height: 1.875rem;
+    justify-content: center;
+    padding: 0;
+  }
+  .side-panel-content.is-collapsed .panel-toggle span {
+    display: none;
+  }
+  @keyframes panel-settle-in {
+    from {
+      opacity: 0.92;
+      transform: translateX(-0.5rem) scale(0.99);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0) scale(1);
+    }
+  }
+  @keyframes tab-peek-left {
+    from {
+      opacity: 0.9;
+      transform: translateX(-1rem) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0) scale(1);
+    }
+  }
   /* Mobile responsiveness for side panel */
   @media screen and (max-width: 48rem) {
     .side-panel-wrapper {
@@ -103,11 +320,34 @@
       width: 100%;
       flex: 0 0 50%;
     }
+    .side-panel-content.is-collapsed {
+      top: 50%;
+      bottom: auto;
+      left: -0.5rem;
+      translate: 0 -50%;
+      width: min(9.75rem, calc(100vw - 1rem));
+      max-height: 5.5rem;
+      flex: none;
+      padding: 0.5rem 0.75rem 0.5rem 0.625rem;
+      border-radius: 0 999px 999px 0;
+      animation: tab-peek-left 180ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
     /* .side-panel-content {
       flex: none;
       margin-top: auto;
       max-height: 45vh;
       box-shadow: 0px -4px 12px rgba(0, 0, 0, 0.1);
     } */
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .side-panel-content,
+    .side-panel-content.is-collapsed {
+      animation: none;
+    }
+
+    .panel-toggle {
+      transition: none;
+    }
   }
 </style>

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -310,6 +310,22 @@ class MapStore {
   mapInstance: maplibre.MapLibreMap | undefined = $state.raw();
 }
 
+class SidePanelStore {
+  collapsed: boolean = $state(false);
+
+  toggle = () => {
+    this.collapsed = !this.collapsed;
+  };
+
+  expand = () => {
+    this.collapsed = false;
+  };
+
+  collapse = () => {
+    this.collapsed = true;
+  };
+}
+
 class MapEditStore {
   enabled: boolean = $state(false);
 
@@ -519,6 +535,7 @@ export const modalStore = new ModalStore();
 export const toastStore = new ToastStore();
 export const locationStore = new LocationStore();
 export const mapStore = new MapStore();
+export const sidePanelStore = new SidePanelStore();
 export const mapEditStore = new MapEditStore();
 export const jeepneyStore = new JeepneyStore();
 export const syncToastStore = new SyncToastStore();


### PR DESCRIPTION
## Summary
- Adds a shared retractable side-panel shell for building, room, dorm, college, division, and class results.
- Preserves selected result context while collapsed and exposes a compact accessible pull tab.
- Keeps map camera stable during drawer toggles and cleans up GeoJSON typing in `Map.svelte`.

## Test plan
- `bunx prettier --check src/lib/store.svelte.ts src/components/svelte/sidepanel/SidePanel.svelte src/components/svelte/Map.svelte`
- `bunx eslint src/components/svelte/sidepanel/SidePanel.svelte src/components/svelte/Map.svelte`
- `bunx eslint src/lib/store.svelte.ts --parser @typescript-eslint/parser`
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only panel state and styling; map logic unchanged aside from type imports.
> 
> **Overview**
> Adds a **collapsible details drawer** around existing building, room, dorm, college, division, and class result views so users can tuck the panel away and see more of the map.
> 
> A new `sidePanelStore` holds `collapsed` plus `toggle`, `expand`, and `collapse`. **SidePanel** wraps result content in a summary row (category label + query title when collapsed) and an accessible expand/collapse control (`aria-expanded`, `aria-controls`). Choosing a **new** result (`category` + `queryValue`) auto-expands the panel; toggling only hides `#side-panel-details` via `hidden`, so the selection stays active. Collapsed mode uses a left-edge pill tab with motion (`fly`, keyframes) and **prefers-reduced-motion** overrides; mobile uses a down chevron when expanded.
> 
> **Map.svelte** only swaps global `GeoJSON.*` types for explicit `geojson` imports (`LineString`, `FeatureCollection`) in jeepney route drawing—no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbda15ecb58f94f73461c5cfb7cd2c5189329b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->