### PR TITLE
Add Makiling terrain mode

### DIFF
--- a/docs/editor-foundation-test-plan.md
+++ b/docs/editor-foundation-test-plan.md
@@ -20,6 +20,20 @@ Use this checklist before merging the in-app editor foundation PR.
 - A successful save updates the inline editor toolbar status.
 - A failed save restores the pin to its previous location and shows the entity name in the error.
 
+## Terrain Mode
+
+- The Makiling terrain control is visible with the other compact map controls.
+- Terrain mode is off by default and does not request hosted elevation tiles before it is enabled.
+- Enabling terrain loads the hosted DEM layer, expands the map bounds toward Mt. Makiling, and moves to the Makiling terrain view.
+- Turning terrain off restores the flat campus map bounds and leaves building, dorm, jeepney, and location markers usable.
+- Exaggeration controls update the terrain without clearing the current search or route state.
+- Reset view returns to the Makiling terrain camera without clearing the current search.
+- Offline mode shows terrain as unavailable and keeps the flat map usable.
+- Failed or blocked terrain tile requests do not leave the control implying terrain is active.
+- MapTiler attribution/logo remains visible when terrain is active.
+- On a low-bandwidth or data-saver connection, terrain copy warns that hosted elevation tiles are online-only.
+- Mobile terrain controls are reachable and do not cover the side panel, editor toolbar, or attribution.
+
 ## Room Side-Panel Editing
 
 - Non-admin users only see read-only room details in the existing main app side panel.

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -33,6 +33,8 @@
     MAKILING_TERRAIN_CAMERA,
     MAKILING_TERRAIN_MAX_BOUNDS,
     MAKILING_TERRAIN_SOURCE_BOUNDS,
+    TERRAIN_HILLSHADE_BEFORE_LAYER_ID,
+    TERRAIN_HILLSHADE_LAYER_ID,
     TERRAIN_SOURCE_ID,
     TERRAIN_TILE_FAILURE_MESSAGE,
     TERRAIN_TILEJSON_URL,
@@ -209,16 +211,50 @@
     );
   }
 
-  function ensureTerrainSource(map: mapGl.MapLibreMap) {
-    if (map.getSource(TERRAIN_SOURCE_ID)) return;
+  function ensureTerrainRendering(map: mapGl.MapLibreMap) {
+    if (!map.getSource(TERRAIN_SOURCE_ID)) {
+      map.addSource(TERRAIN_SOURCE_ID, {
+        type: "raster-dem",
+        url: TERRAIN_TILEJSON_URL,
+        bounds: MAKILING_TERRAIN_SOURCE_BOUNDS,
+        maxzoom: 14,
+        tileSize: 512,
+      });
+    }
 
-    map.addSource(TERRAIN_SOURCE_ID, {
-      type: "raster-dem",
-      url: TERRAIN_TILEJSON_URL,
-      bounds: MAKILING_TERRAIN_SOURCE_BOUNDS,
-      maxzoom: 14,
-      tileSize: 512,
-    });
+    if (!map.getLayer(TERRAIN_HILLSHADE_LAYER_ID)) {
+      map.addLayer(
+        {
+          id: TERRAIN_HILLSHADE_LAYER_ID,
+          type: "hillshade",
+          source: TERRAIN_SOURCE_ID,
+          layout: { visibility: "none" },
+          paint: {
+            "hillshade-accent-color": "rgba(112, 79, 40, 0.28)",
+            "hillshade-exaggeration": 0.85,
+            "hillshade-highlight-color": "rgba(255, 244, 214, 0.35)",
+            "hillshade-illumination-anchor": "viewport",
+            "hillshade-illumination-direction": 315,
+            "hillshade-shadow-color": "rgba(34, 25, 14, 0.55)",
+          },
+        },
+        map.getLayer(TERRAIN_HILLSHADE_BEFORE_LAYER_ID)
+          ? TERRAIN_HILLSHADE_BEFORE_LAYER_ID
+          : undefined,
+      );
+    }
+  }
+
+  function setTerrainHillshadeVisible(
+    map: mapGl.MapLibreMap,
+    visible: boolean,
+  ) {
+    if (!map.getLayer(TERRAIN_HILLSHADE_LAYER_ID)) return;
+    map.setLayoutProperty(
+      TERRAIN_HILLSHADE_LAYER_ID,
+      "visibility",
+      visible ? "visible" : "none",
+    );
   }
 
   function setBuildingExtrusionsVisible(
@@ -249,6 +285,7 @@
 
   function disableTerrain(map: mapGl.MapLibreMap) {
     map.setTerrain(null);
+    setTerrainHillshadeVisible(map, false);
     setBuildingExtrusionsVisible(map, true);
     map.setMaxBounds(CAMPUS_MAX_BOUNDS);
   }
@@ -731,8 +768,9 @@
 
       try {
         terrainStore.markLoading();
-        ensureTerrainSource(map);
+        ensureTerrainRendering(map);
         map.setTerrain({ source: TERRAIN_SOURCE_ID, exaggeration });
+        setTerrainHillshadeVisible(map, true);
         setBuildingExtrusionsVisible(map, false);
         map.setMaxBounds(MAKILING_TERRAIN_MAX_BOUNDS);
         if (!terrainModeWasEnabled) {

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -290,6 +290,74 @@
     map.setMaxBounds(CAMPUS_MAX_BOUNDS);
   }
 
+  function restoreFlatMapCamera(map: mapGl.MapLibreMap) {
+    untrack(() => {
+      const category = queryStore.category;
+      const type = queryStore.type;
+      const value = queryStore.inputValue;
+
+      stopRotation();
+      map.off("moveend", startRotation);
+
+      if (category === "building" && type === "result") {
+        if (!loaded) return;
+        const currentBuilding = buildings.find(
+          (building) => building.buildingName === value,
+        );
+
+        if (currentBuilding && currentBuilding.lon && currentBuilding.lat) {
+          map.flyTo({
+            center: [currentBuilding.lon, currentBuilding.lat],
+            zoom: 18,
+            pitch: 60,
+            padding: calculatePadding(md.current),
+            duration: 1500,
+          });
+          map.once("moveend", startRotation);
+        }
+      } else if (category === null) {
+        flyToCamera(map, CAMPUS_DEFAULT_CAMERA);
+        if (directions) directions.clear();
+      } else if (category === "room") {
+        currentRoom.getRoomByCode(value).then(() => {
+          if (
+            currentRoom.value &&
+            currentRoom.value.building &&
+            currentRoom.value.building.lat &&
+            currentRoom.value.building.lon &&
+            !terrainStore.enabled
+          ) {
+            map.flyTo({
+              center: [
+                currentRoom.value.building.lon,
+                currentRoom.value.building.lat,
+              ],
+              zoom: 18,
+              pitch: 60,
+              padding: calculatePadding(md.current),
+              duration: 1500,
+            });
+            map.once("moveend", startRotation);
+          }
+        });
+      } else if (category === "dorm") {
+        if (!loaded) return;
+
+        const currentDorm = dorms.find((dorm) => dorm.dormName === value);
+        if (currentDorm && currentDorm.lon && currentDorm.lat) {
+          map.flyTo({
+            center: [currentDorm.lon, currentDorm.lat],
+            zoom: 18,
+            pitch: 60,
+            padding: calculatePadding(md.current),
+            duration: 1500,
+          });
+          map.once("moveend", startRotation);
+        }
+      }
+    });
+  }
+
   function failTerrain(map: mapGl.MapLibreMap, message: string) {
     disableTerrain(map);
     terrainStore.markUnavailable(message);
@@ -344,7 +412,7 @@
 
   function startRotation() {
     stopRotation();
-    if (!mapStore.mapInstance) return;
+    if (!mapStore.mapInstance || terrainStore.enabled) return;
     isRotating = true;
     lastTimestamp = 0;
     currentRotation = mapStore.mapInstance.getBearing();
@@ -756,8 +824,11 @@
       if (cancelled) return;
 
       if (!enabled) {
+        const shouldRestoreFlatCamera = terrainModeWasEnabled;
         disableTerrain(map);
+        map.off("moveend", startRotation);
         terrainModeWasEnabled = false;
+        if (shouldRestoreFlatCamera) restoreFlatMapCamera(map);
         return;
       }
 
@@ -774,6 +845,7 @@
         setBuildingExtrusionsVisible(map, false);
         map.setMaxBounds(MAKILING_TERRAIN_MAX_BOUNDS);
         if (!terrainModeWasEnabled) {
+          map.off("moveend", startRotation);
           stopRotation();
           flyToCamera(map, MAKILING_TERRAIN_CAMERA);
         }

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -11,6 +11,7 @@
     currentRoom,
     adminAuthStore,
     toastStore,
+    terrainStore,
   } from "../../lib/store.svelte";
   import { untrack } from "svelte";
   import { fade } from "svelte/transition";
@@ -26,6 +27,17 @@
     type JeepneyRoute,
     type JeepneyStop,
   } from "../../constants/jeepney-routes";
+  import {
+    CAMPUS_DEFAULT_CAMERA,
+    CAMPUS_MAX_BOUNDS,
+    MAKILING_TERRAIN_CAMERA,
+    MAKILING_TERRAIN_MAX_BOUNDS,
+    MAKILING_TERRAIN_SOURCE_BOUNDS,
+    TERRAIN_SOURCE_ID,
+    TERRAIN_TILE_FAILURE_MESSAGE,
+    TERRAIN_TILEJSON_URL,
+    TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE,
+  } from "../../constants/map-terrain";
   const data = getAppData();
   const { buildings, dorms, loaded } = $derived(data());
   const filteredDorms = $derived.by(() => {
@@ -39,10 +51,12 @@
   const JEEPNEY_ROUTE_SOURCE_ID = "jeepney-route-line";
   const JEEPNEY_ROUTE_LAYER_ID = "jeepney-route-line";
   const JEEPNEY_ROUTE_LAYER_CASING_ID = "jeepney-route-line-casing";
+  const BUILDING_3D_LAYER_ID = "building-3d";
 
   let activeRouteId = $state<string | null>(null);
   let activeRouteStops = $state<JeepneyStop[]>([]);
   let activeRouteColor = $state<string>("#dc2626");
+  let terrainModeWasEnabled = false;
   let selectedEditKey = $state<string | null>(null);
   let savingEditKey = $state<string | null>(null);
   let savedEditKey = $state<string | null>(null);
@@ -192,6 +206,64 @@
         duration: 1200,
         pitch: 30,
       },
+    );
+  }
+
+  function ensureTerrainSource(map: mapGl.MapLibreMap) {
+    if (map.getSource(TERRAIN_SOURCE_ID)) return;
+
+    map.addSource(TERRAIN_SOURCE_ID, {
+      type: "raster-dem",
+      url: TERRAIN_TILEJSON_URL,
+      bounds: MAKILING_TERRAIN_SOURCE_BOUNDS,
+      maxzoom: 14,
+      tileSize: 512,
+    });
+  }
+
+  function setBuildingExtrusionsVisible(
+    map: mapGl.MapLibreMap,
+    visible: boolean,
+  ) {
+    if (!map.getLayer(BUILDING_3D_LAYER_ID)) return;
+    map.setLayoutProperty(
+      BUILDING_3D_LAYER_ID,
+      "visibility",
+      visible ? "visible" : "none",
+    );
+  }
+
+  function flyToCamera(
+    map: mapGl.MapLibreMap,
+    camera: typeof CAMPUS_DEFAULT_CAMERA,
+  ) {
+    map.easeTo({
+      center: camera.center,
+      zoom: camera.zoom,
+      pitch: camera.pitch,
+      bearing: camera.bearing,
+      duration: 1500,
+      padding: calculatePadding(untrack(() => md.current)),
+    });
+  }
+
+  function disableTerrain(map: mapGl.MapLibreMap) {
+    map.setTerrain(null);
+    setBuildingExtrusionsVisible(map, true);
+    map.setMaxBounds(CAMPUS_MAX_BOUNDS);
+  }
+
+  function failTerrain(map: mapGl.MapLibreMap, message: string) {
+    disableTerrain(map);
+    terrainStore.markUnavailable(message);
+  }
+
+  function sourceErrorMatchesTerrain(event: mapGl.ErrorEvent) {
+    const sourceId = (event as mapGl.ErrorEvent & { sourceId?: string })
+      .sourceId;
+    const message = event.error?.message ?? "";
+    return (
+      sourceId === TERRAIN_SOURCE_ID || message.includes(TERRAIN_SOURCE_ID)
     );
   }
 
@@ -617,17 +689,82 @@
   $effect(() => {
     if (mapStore.mapInstance) {
       const map = mapStore.mapInstance;
+      const handleMapError = (event: mapGl.ErrorEvent) => {
+        if (!terrainStore.enabled || !sourceErrorMatchesTerrain(event)) return;
+        failTerrain(map, TERRAIN_TILE_FAILURE_MESSAGE);
+      };
       map.on("mousedown", stopRotation);
       map.on("touchstart", stopRotation);
       map.on("wheel", stopRotation);
       map.on("zoom", handleZoom);
+      map.on("error", handleMapError);
       return () => {
         map.off("mousedown", stopRotation);
         map.off("touchstart", stopRotation);
         map.off("wheel", stopRotation);
         map.off("zoom", handleZoom);
+        map.off("error", handleMapError);
       };
     }
+  });
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    const enabled = terrainStore.enabled;
+    const exaggeration = terrainStore.exaggeration;
+    if (!map) return;
+
+    let cancelled = false;
+    const apply = () => {
+      if (cancelled) return;
+
+      if (!enabled) {
+        disableTerrain(map);
+        terrainModeWasEnabled = false;
+        return;
+      }
+
+      if (typeof navigator !== "undefined" && !navigator.onLine) {
+        failTerrain(map, TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE);
+        return;
+      }
+
+      try {
+        terrainStore.markLoading();
+        ensureTerrainSource(map);
+        map.setTerrain({ source: TERRAIN_SOURCE_ID, exaggeration });
+        setBuildingExtrusionsVisible(map, false);
+        map.setMaxBounds(MAKILING_TERRAIN_MAX_BOUNDS);
+        if (!terrainModeWasEnabled) {
+          stopRotation();
+          flyToCamera(map, MAKILING_TERRAIN_CAMERA);
+        }
+        terrainModeWasEnabled = true;
+        terrainStore.markActive();
+      } catch (error) {
+        console.warn("Terrain setup failed", error);
+        failTerrain(map, TERRAIN_TILE_FAILURE_MESSAGE);
+      }
+    };
+
+    if (map.isStyleLoaded()) {
+      apply();
+    } else {
+      map.once("load", apply);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    const resetNonce = terrainStore.resetNonce;
+    if (!map || !terrainStore.enabled || resetNonce === 0) return;
+
+    stopRotation();
+    flyToCamera(map, MAKILING_TERRAIN_CAMERA);
   });
 
   $effect(() => {
@@ -747,6 +884,7 @@
     if (!map) return;
 
     untrack(() => {
+      const isTerrainEnabled = terrainStore.enabled;
       stopRotation();
       map.off("moveend", startRotation);
       if (category === "building" && type === "result") {
@@ -763,16 +901,13 @@
             padding: calculatePadding(md.current),
             duration: 1500,
           });
-          map.once("moveend", startRotation);
+          if (!isTerrainEnabled) map.once("moveend", startRotation);
         }
       } else if (category === null) {
-        map.flyTo({
-          center: [121.24125948460573, 14.16323736946326],
-          zoom: 15.81,
-          pitch: 60,
-          bearing: -154.48,
-          duration: 1500,
-        });
+        flyToCamera(
+          map,
+          isTerrainEnabled ? MAKILING_TERRAIN_CAMERA : CAMPUS_DEFAULT_CAMERA,
+        );
         if (directions) directions.clear();
       } else if (category === "room") {
         currentRoom.getRoomByCode(value).then(() => {
@@ -792,7 +927,7 @@
               padding: calculatePadding(md.current),
               duration: 1500,
             });
-            map.once("moveend", startRotation);
+            if (!isTerrainEnabled) map.once("moveend", startRotation);
           }
         });
       } else if (category === "dorm") {
@@ -807,7 +942,7 @@
             padding: calculatePadding(md.current),
             duration: 1500,
           });
-          map.once("moveend", startRotation);
+          if (!isTerrainEnabled) map.once("moveend", startRotation);
         }
       }
     });
@@ -911,14 +1046,11 @@
   <MapLibre
     bind:map={mapStore.mapInstance}
     style="/liberty-customized.json"
-    maxBounds={[
-      [121.22951431520816, 14.143739048514412],
-      [121.28117994803134, 14.18059150108623],
-    ]}
-    center={[121.24224620509085, 14.16283754850545]}
+    maxBounds={CAMPUS_MAX_BOUNDS}
+    center={CAMPUS_DEFAULT_CAMERA.center}
     zoom={17}
-    pitch={60}
-    bearing={-154.48}
+    pitch={CAMPUS_DEFAULT_CAMERA.pitch}
+    bearing={CAMPUS_DEFAULT_CAMERA.bearing}
     minZoom={13}
     class="map"
   >
@@ -1056,6 +1188,20 @@
       {/if}
     {/each}
   </MapLibre>
+  {#if terrainStore.enabled}
+    <a
+      class="maptiler-logo"
+      href="https://www.maptiler.com/"
+      target="_blank"
+      rel="noreferrer"
+      aria-label="MapTiler"
+    >
+      <img
+        src="https://api.maptiler.com/resources/logo.svg"
+        alt="MapTiler logo"
+      />
+    </a>
+  {/if}
 </div>
 
 <style>
@@ -1066,6 +1212,26 @@
     width: 100%;
     height: 100%;
     z-index: 0;
+  }
+
+  .maptiler-logo {
+    position: absolute;
+    bottom: 0.75rem;
+    left: calc(25.75rem + 1rem);
+    z-index: 5;
+    display: inline-flex;
+    align-items: center;
+    border-radius: 0.375rem;
+    background-color: rgba(255, 255, 255, 0.92);
+    padding: 0.25rem 0.375rem;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+    pointer-events: auto;
+  }
+
+  .maptiler-logo img {
+    display: block;
+    width: auto;
+    height: 1.25rem;
   }
 
   .map-edit-toolbar {
@@ -1154,6 +1320,11 @@
   }
 
   @media (max-width: 48rem) {
+    .maptiler-logo {
+      bottom: calc(50vh + 0.75rem);
+      left: 0.75rem;
+    }
+
     .map-edit-toolbar {
       right: 0.5rem;
       bottom: 4.25rem;

--- a/src/components/svelte/TerrainControl.svelte
+++ b/src/components/svelte/TerrainControl.svelte
@@ -1,0 +1,327 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Mountain from "@lucide/svelte/icons/mountain";
+  import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
+  import X from "@lucide/svelte/icons/x";
+  import {
+    TERRAIN_EXAGGERATION_OPTIONS,
+    TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE,
+  } from "../../constants/map-terrain";
+  import { terrainStore } from "../../lib/store.svelte";
+
+  type NetworkInformation = EventTarget & {
+    effectiveType?: string;
+    saveData?: boolean;
+  };
+
+  let isOnline = $state(true);
+  let lowDataConnection = $state(false);
+
+  const statusText = $derived.by(() => {
+    if (!isOnline) return TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE;
+    if (terrainStore.status === "loading") {
+      return "Loading hosted elevation tiles...";
+    }
+    if (terrainStore.status === "active") {
+      return "Terrain is contextual, not survey-grade elevation data.";
+    }
+    if (terrainStore.status === "unavailable") {
+      return terrainStore.message ?? "Terrain is unavailable right now.";
+    }
+    if (lowDataConnection) {
+      return "Terrain uses online elevation tiles. Keep it off on low-data connections.";
+    }
+    return "Terrain loads hosted elevation tiles only when enabled.";
+  });
+
+  function getConnection(): NetworkInformation | undefined {
+    return (navigator as Navigator & { connection?: NetworkInformation })
+      .connection;
+  }
+
+  function updateNetworkState() {
+    isOnline = navigator.onLine;
+    const connection = getConnection();
+    lowDataConnection = Boolean(
+      connection?.saveData || connection?.effectiveType?.includes("2g"),
+    );
+  }
+
+  function handleToggle() {
+    if (terrainStore.enabled) {
+      terrainStore.disable();
+      return;
+    }
+
+    if (!isOnline) {
+      terrainStore.markUnavailable(TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE);
+      return;
+    }
+
+    terrainStore.enable();
+  }
+
+  onMount(() => {
+    updateNetworkState();
+
+    const connection = getConnection();
+    window.addEventListener("online", updateNetworkState);
+    window.addEventListener("offline", updateNetworkState);
+    connection?.addEventListener?.("change", updateNetworkState);
+
+    return () => {
+      window.removeEventListener("online", updateNetworkState);
+      window.removeEventListener("offline", updateNetworkState);
+      connection?.removeEventListener?.("change", updateNetworkState);
+    };
+  });
+</script>
+
+<div class="terrain-control">
+  {#if terrainStore.menuOpen}
+    <div class="terrain-panel" role="menu">
+      <div class="terrain-panel-header">
+        <span>Makiling Terrain</span>
+        <button
+          type="button"
+          class="close-btn"
+          onclick={() => terrainStore.closeMenu()}
+          aria-label="Close terrain menu"
+        >
+          <X size="16" />
+        </button>
+      </div>
+
+      <p class="terrain-copy">
+        Explore Mt. Makiling in 3D context. This layer is online-only for now
+        and stays off until you enable it.
+      </p>
+
+      <button
+        type="button"
+        class="terrain-toggle"
+        class:active={terrainStore.enabled}
+        onclick={handleToggle}
+        aria-pressed={terrainStore.enabled}
+      >
+        {terrainStore.enabled ? "Turn terrain off" : "Turn terrain on"}
+      </button>
+
+      <div class="terrain-options" aria-label="Terrain exaggeration">
+        <span>Exaggeration</span>
+        <div class="terrain-option-buttons">
+          {#each TERRAIN_EXAGGERATION_OPTIONS as option (option)}
+            <button
+              type="button"
+              class="terrain-option"
+              class:active={terrainStore.exaggeration === option}
+              onclick={() => terrainStore.setExaggeration(option)}
+            >
+              {option}x
+            </button>
+          {/each}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        class="reset-btn"
+        disabled={!terrainStore.enabled}
+        onclick={() => terrainStore.requestReset()}
+      >
+        <RotateCcw size="14" />
+        Reset Makiling view
+      </button>
+
+      <p
+        class="terrain-status"
+        class:warning={!isOnline ||
+          lowDataConnection ||
+          terrainStore.status === "unavailable"}
+        aria-live="polite"
+      >
+        {statusText}
+      </p>
+
+      <p class="terrain-attribution">
+        Elevation tiles by
+        <a href="https://www.maptiler.com/" target="_blank" rel="noreferrer">
+          MapTiler
+        </a>
+        .
+      </p>
+    </div>
+  {/if}
+
+  <button
+    class="terrain-btn"
+    class:active={terrainStore.enabled}
+    onclick={() => terrainStore.toggleMenu()}
+    title="Makiling Terrain"
+    aria-label="Makiling Terrain"
+    aria-expanded={terrainStore.menuOpen}
+  >
+    <Mountain />
+  </button>
+</div>
+
+<style>
+  .terrain-control {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+    pointer-events: auto;
+  }
+
+  .terrain-btn {
+    display: flex;
+    width: 3rem;
+    height: 3rem;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #ececec;
+    border-radius: 50%;
+    background-color: white;
+    color: hsl(5, 53%, 32%);
+    cursor: pointer;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    transition:
+      background-color 0.2s,
+      transform 0.2s;
+  }
+
+  .terrain-btn:hover {
+    background-color: hsl(5, 53%, 98%);
+    transform: scale(1.05);
+  }
+
+  .terrain-btn.active {
+    border-color: hsl(160, 84%, 26%);
+    background-color: hsl(160, 84%, 26%);
+    color: white;
+  }
+
+  .terrain-panel {
+    display: flex;
+    width: 18rem;
+    max-width: calc(100vw - 1rem);
+    flex-direction: column;
+    gap: 0.625rem;
+    border-radius: 0.875rem;
+    background-color: white;
+    padding: 0.75rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  .terrain-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.125rem 0.25rem;
+    color: hsl(0, 0%, 20%);
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+
+  .close-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 0.375rem;
+    background: transparent;
+    color: hsl(0, 0%, 40%);
+    cursor: pointer;
+    padding: 0.125rem;
+  }
+
+  .close-btn:hover {
+    background-color: hsl(0, 0%, 95%);
+  }
+
+  .terrain-copy,
+  .terrain-status,
+  .terrain-attribution {
+    margin: 0;
+    color: hsl(0, 0%, 38%);
+    font-size: 0.75rem;
+    line-height: 1.35;
+  }
+
+  .terrain-toggle,
+  .reset-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 0.625rem;
+    background-color: white;
+    color: hsl(5, 53%, 32%);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    padding: 0.55rem 0.625rem;
+  }
+
+  .terrain-toggle:hover,
+  .reset-btn:hover:not(:disabled) {
+    background-color: hsl(5, 53%, 98%);
+  }
+
+  .terrain-toggle.active {
+    border-color: hsl(160, 84%, 26%);
+    background-color: hsl(160, 84%, 26%);
+    color: white;
+  }
+
+  .terrain-options {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    color: hsl(0, 0%, 30%);
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  .terrain-option-buttons {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .terrain-option {
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 999px;
+    background-color: white;
+    color: hsl(0, 0%, 30%);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .terrain-option.active {
+    border-color: hsl(5, 53%, 32%);
+    background-color: hsl(5, 53%, 96%);
+    color: hsl(5, 53%, 32%);
+  }
+
+  .reset-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .terrain-status.warning {
+    color: hsl(25, 80%, 35%);
+    font-weight: 600;
+  }
+
+  .terrain-attribution a {
+    color: hsl(5, 53%, 32%);
+    font-weight: 700;
+  }
+</style>

--- a/src/components/svelte/TerrainControl.svelte
+++ b/src/components/svelte/TerrainControl.svelte
@@ -45,6 +45,9 @@
     lowDataConnection = Boolean(
       connection?.saveData || connection?.effectiveType?.includes("2g"),
     );
+    if (!isOnline && terrainStore.enabled) {
+      terrainStore.markUnavailable(TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE);
+    }
   }
 
   function handleToggle() {

--- a/src/components/svelte/sidepanel/SidePanel.svelte
+++ b/src/components/svelte/sidepanel/SidePanel.svelte
@@ -10,6 +10,7 @@
   import ClassQuery from "./ClassQuery.svelte";
   import LocationButton from "../LocationButton.svelte";
   import JeepneyMenu from "../JeepneyMenu.svelte";
+  import TerrainControl from "../TerrainControl.svelte";
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
@@ -66,6 +67,7 @@
     class:is-collapsed={sidePanelStore.collapsed}
   >
     <div class="floating-actions">
+      <TerrainControl />
       <JeepneyMenu />
       <LocationButton />
     </div>

--- a/src/constants/map-terrain.ts
+++ b/src/constants/map-terrain.ts
@@ -1,6 +1,8 @@
 const MAPTILER_KEY = "B6m4DQknxd9wZ70DnDV4";
 
 export const TERRAIN_SOURCE_ID = "makiling-terrain-dem";
+export const TERRAIN_HILLSHADE_LAYER_ID = "makiling-terrain-hillshade";
+export const TERRAIN_HILLSHADE_BEFORE_LAYER_ID = "road_area_pattern";
 export const TERRAIN_TILEJSON_URL = `https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=${MAPTILER_KEY}`;
 
 export const TERRAIN_EXAGGERATION_OPTIONS = [1, 1.5, 2] as const;

--- a/src/constants/map-terrain.ts
+++ b/src/constants/map-terrain.ts
@@ -1,0 +1,45 @@
+const MAPTILER_KEY = "B6m4DQknxd9wZ70DnDV4";
+
+export const TERRAIN_SOURCE_ID = "makiling-terrain-dem";
+export const TERRAIN_TILEJSON_URL = `https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=${MAPTILER_KEY}`;
+
+export const TERRAIN_EXAGGERATION_OPTIONS = [1, 1.5, 2] as const;
+export const DEFAULT_TERRAIN_EXAGGERATION = 1.5;
+
+export const CAMPUS_MAX_BOUNDS: [[number, number], [number, number]] = [
+  [121.22951431520816, 14.143739048514412],
+  [121.28117994803134, 14.18059150108623],
+];
+
+export const CAMPUS_DEFAULT_CAMERA = {
+  center: [121.24125948460573, 14.16323736946326] as [number, number],
+  zoom: 15.81,
+  pitch: 60,
+  bearing: -154.48,
+};
+
+export const MAKILING_TERRAIN_MAX_BOUNDS: [[number, number], [number, number]] =
+  [
+    [121.168, 14.095],
+    [121.29, 14.19],
+  ];
+
+export const MAKILING_TERRAIN_SOURCE_BOUNDS = [
+  MAKILING_TERRAIN_MAX_BOUNDS[0][0],
+  MAKILING_TERRAIN_MAX_BOUNDS[0][1],
+  MAKILING_TERRAIN_MAX_BOUNDS[1][0],
+  MAKILING_TERRAIN_MAX_BOUNDS[1][1],
+] as [number, number, number, number];
+
+export const MAKILING_TERRAIN_CAMERA = {
+  center: [121.218, 14.142] as [number, number],
+  zoom: 13.25,
+  pitch: 68,
+  bearing: 190,
+};
+
+export const TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE =
+  "Terrain needs an internet connection for hosted elevation tiles.";
+
+export const TERRAIN_TILE_FAILURE_MESSAGE =
+  "Terrain tiles could not load. The flat map is still available.";

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -1,6 +1,7 @@
 // src/lib/store.svelte.ts
 
 import type { modalOptions } from "../constants/modal-states";
+import { DEFAULT_TERRAIN_EXAGGERATION } from "../constants/map-terrain";
 import { SvelteMap } from "svelte/reactivity";
 import * as maplibre from "maplibre-gl";
 import { RoomData, type RecentSearch } from "./types";
@@ -338,6 +339,68 @@ class MapEditStore {
   };
 }
 
+type TerrainStatus = "idle" | "loading" | "active" | "unavailable";
+
+class TerrainStore {
+  enabled: boolean = $state(false);
+  menuOpen: boolean = $state(false);
+  exaggeration: number = $state(DEFAULT_TERRAIN_EXAGGERATION);
+  status: TerrainStatus = $state("idle");
+  message: string | null = $state(null);
+  resetNonce: number = $state(0);
+
+  toggleMenu = () => {
+    this.menuOpen = !this.menuOpen;
+  };
+
+  closeMenu = () => {
+    this.menuOpen = false;
+  };
+
+  enable = () => {
+    this.enabled = true;
+    this.status = "loading";
+    this.message = null;
+  };
+
+  disable = () => {
+    this.enabled = false;
+    this.status = "idle";
+    this.message = null;
+  };
+
+  toggle = () => {
+    if (this.enabled) this.disable();
+    else this.enable();
+  };
+
+  setExaggeration = (value: number) => {
+    this.exaggeration = value;
+  };
+
+  markLoading = () => {
+    if (!this.enabled) return;
+    this.status = "loading";
+    this.message = null;
+  };
+
+  markActive = () => {
+    if (!this.enabled) return;
+    this.status = "active";
+    this.message = null;
+  };
+
+  markUnavailable = (message: string) => {
+    this.enabled = false;
+    this.status = "unavailable";
+    this.message = message;
+  };
+
+  requestReset = () => {
+    this.resetNonce += 1;
+  };
+}
+
 class Building3DStore {
   buildingName: string | null = $state(null);
 
@@ -537,6 +600,7 @@ export const locationStore = new LocationStore();
 export const mapStore = new MapStore();
 export const sidePanelStore = new SidePanelStore();
 export const mapEditStore = new MapEditStore();
+export const terrainStore = new TerrainStore();
 export const jeepneyStore = new JeepneyStore();
 export const syncToastStore = new SyncToastStore();
 export const building3DStore = new Building3DStore();


### PR DESCRIPTION
## Summary
- Add an opt-in Mt. Makiling terrain mode using hosted MapTiler raster-dem tiles and MapLibre terrain.
- Add hillshade shadows over the terrain DEM so Makiling reads as a 3D landform instead of a flat blob.
- Add compact terrain controls for toggling, exaggeration, reset view, online-only copy, low-data warnings, and attribution.
- Keep terrain separate from the building 3D viewer and document manual QA coverage.

## Test plan
- `bunx prettier --write \"src/constants/map-terrain.ts\" \"src/lib/store.svelte.ts\" \"src/components/svelte/Map.svelte\" \"src/components/svelte/TerrainControl.svelte\" \"src/components/svelte/sidepanel/SidePanel.svelte\" \"docs/editor-foundation-test-plan.md\"`
- `bunx eslint \"src/constants/map-terrain.ts\" \"src/components/svelte/Map.svelte\" \"src/components/svelte/TerrainControl.svelte\" \"src/components/svelte/sidepanel/SidePanel.svelte\"`
- `bun run build`

Notes: `bun run lint` is currently blocked by pre-existing repo-wide Prettier drift in untouched files, so targeted lint was run for the changed parseable files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial changes to core map behavior and reliance on hosted elevation tiles; a MapTiler API key is committed in client-side constants, though terrain is off by default with rollback on errors.
> 
> **Overview**
> Adds an **opt-in Mt. Makiling terrain mode** driven by a new `terrainStore`, `map-terrain` constants, and a **Makiling Terrain** control in the side panel floating actions.
> 
> When enabled, `Map.svelte` loads MapTiler **raster-dem** tiles and hillshade, applies terrain exaggeration, widens max bounds, flies to the Makiling camera, hides style **building-3d** extrusions, and shows MapTiler logo attribution. Tiles are not requested until the user turns terrain on. Disabling terrain restores campus bounds and re-runs the existing search-driven camera logic; map auto-rotation is skipped while terrain is active.
> 
> `TerrainControl` covers toggle, exaggeration presets, reset view, offline/low-data messaging, and tile failure handling (map `error` listener rolls back UI state). Manual QA steps for terrain are added to `docs/editor-foundation-test-plan.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b8bfbbafe02b817ddf331abad7edfcccc6d82bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->