### PR TITLE
feat: add map orientation controls (2D toggle + rotate/tilt/reset)

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -10,6 +10,7 @@
   import Modal from "./modal/Modal.svelte";
   import SidePanel from "./sidepanel/SidePanel.svelte";
   import Map from "./Map.svelte";
+  import MapControls from "./MapControls.svelte";
   import StatusBar from "./StatusBar.svelte";
   import Toast from "./Toast.svelte";
   import type { RecentSearch } from "../../lib/types";
@@ -73,6 +74,7 @@
 <div class="app-layout">
   <Map />
   <div class="ui-layer">
+    <MapControls />
     <!-- <header class="top-header">
       <h2>Room TBA</h2>
     </header> -->

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -480,6 +480,18 @@
   });
 
   $effect(() => {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    mapStore.stopAutoRotate = () => {
+      stopRotation();
+      map.off("moveend", startRotation);
+    };
+    return () => {
+      mapStore.stopAutoRotate = null;
+    };
+  });
+
+  $effect(() => {
     if (mapStore.mapInstance && !directions) {
       const initDirections = () => {
         if (!directions && mapStore.mapInstance) {

--- a/src/components/svelte/MapControls.svelte
+++ b/src/components/svelte/MapControls.svelte
@@ -98,7 +98,9 @@
     class="control view-toggle"
     onclick={toggleView}
     title={is2D ? "Switch to 3D tilted view" : "Switch to 2D top-down view"}
-    aria-label={is2D ? "Switch to 3D tilted view" : "Switch to 2D top-down view"}
+    aria-label={is2D
+      ? "Switch to 3D tilted view"
+      : "Switch to 2D top-down view"}
     aria-pressed={is2D}
   >
     {#if is2D}

--- a/src/components/svelte/MapControls.svelte
+++ b/src/components/svelte/MapControls.svelte
@@ -243,15 +243,18 @@
   }
 
   @media (max-width: 800px) {
-    /* Drop below the full-width search box so the two never overlap. */
+    /* Drop below the full-width search box so the two never overlap, and
+       grow the tap targets to the 44px touch-friendly minimum. Native
+       touch gestures (two-finger twist/drag) exist but aren't discoverable,
+       so these explicit affordances stay visible on mobile too. */
     .map-controls {
       right: 0.5rem;
       top: 4rem;
     }
 
     .control {
-      width: 2.5rem;
-      height: 2.5rem;
+      width: 2.75rem;
+      height: 2.75rem;
     }
   }
 </style>

--- a/src/components/svelte/MapControls.svelte
+++ b/src/components/svelte/MapControls.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+  import {
+    Compass,
+    RotateCcw,
+    RotateCw,
+    ChevronUp,
+    ChevronDown,
+    Box,
+    Map as MapIcon,
+  } from "@lucide/svelte";
+  import { mapStore } from "../../lib/store.svelte";
+  import type { MapLibreMap } from "maplibre-gl";
+
+  const ROTATE_STEP = 30;
+  const PITCH_STEP = 15;
+  const MAX_PITCH = 60;
+  const THREE_D_PITCH = 60;
+  // Pitch at or below this (in degrees) is treated as a flat 2D top-down view.
+  const TWO_D_THRESHOLD = 1;
+
+  let bearing = $state(0);
+  let pitch = $state(0);
+
+  const is2D = $derived(pitch <= TWO_D_THRESHOLD);
+
+  function syncCamera() {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    bearing = map.getBearing();
+    pitch = map.getPitch();
+  }
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    syncCamera();
+    const onChange = () => syncCamera();
+    map.on("rotate", onChange);
+    map.on("pitch", onChange);
+    map.on("move", onChange);
+    return () => {
+      map.off("rotate", onChange);
+      map.off("pitch", onChange);
+      map.off("move", onChange);
+    };
+  });
+
+  function withMap(fn: (map: MapLibreMap) => void) {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    // Manual camera moves should win over the idle auto-rotation animation.
+    mapStore.stopAutoRotate?.();
+    fn(map);
+  }
+
+  const rotateLeft = () =>
+    withMap((map) =>
+      map.easeTo({ bearing: map.getBearing() - ROTATE_STEP, duration: 300 }),
+    );
+
+  const rotateRight = () =>
+    withMap((map) =>
+      map.easeTo({ bearing: map.getBearing() + ROTATE_STEP, duration: 300 }),
+    );
+
+  const tiltUp = () =>
+    withMap((map) =>
+      map.easeTo({
+        pitch: Math.min(map.getPitch() + PITCH_STEP, MAX_PITCH),
+        duration: 300,
+      }),
+    );
+
+  const tiltDown = () =>
+    withMap((map) =>
+      map.easeTo({
+        pitch: Math.max(map.getPitch() - PITCH_STEP, 0),
+        duration: 300,
+      }),
+    );
+
+  const resetNorth = () =>
+    withMap((map) => map.easeTo({ bearing: 0, duration: 400 }));
+
+  const toggleView = () =>
+    withMap((map) => {
+      if (map.getPitch() > TWO_D_THRESHOLD) {
+        // Switch to a flat, north-up top-down view.
+        map.easeTo({ pitch: 0, bearing: 0, duration: 600 });
+      } else {
+        map.easeTo({ pitch: THREE_D_PITCH, duration: 600 });
+      }
+    });
+</script>
+
+<div class="map-controls" aria-label="Map orientation controls">
+  <button
+    class="control view-toggle"
+    onclick={toggleView}
+    title={is2D ? "Switch to 3D tilted view" : "Switch to 2D top-down view"}
+    aria-label={is2D ? "Switch to 3D tilted view" : "Switch to 2D top-down view"}
+    aria-pressed={is2D}
+  >
+    {#if is2D}
+      <Box size={18} />
+      <span>3D</span>
+    {:else}
+      <MapIcon size={18} />
+      <span>2D</span>
+    {/if}
+  </button>
+
+  <div class="divider"></div>
+
+  <div class="rotate-row">
+    <button
+      class="control"
+      onclick={rotateLeft}
+      title="Rotate left"
+      aria-label="Rotate map left"
+    >
+      <RotateCcw size={18} />
+    </button>
+    <button
+      class="control compass"
+      onclick={resetNorth}
+      title="Reset to north"
+      aria-label="Reset map orientation to north"
+    >
+      <span class="compass-icon" style:rotate={`${-bearing}deg`}>
+        <Compass size={20} />
+      </span>
+    </button>
+    <button
+      class="control"
+      onclick={rotateRight}
+      title="Rotate right"
+      aria-label="Rotate map right"
+    >
+      <RotateCw size={18} />
+    </button>
+  </div>
+
+  <div class="divider"></div>
+
+  <div class="tilt-row">
+    <button
+      class="control"
+      onclick={tiltDown}
+      title="Tilt down (less 3D)"
+      aria-label="Decrease map tilt"
+      disabled={pitch <= 0}
+    >
+      <ChevronDown size={18} />
+    </button>
+    <button
+      class="control"
+      onclick={tiltUp}
+      title="Tilt up (more 3D)"
+      aria-label="Increase map tilt"
+      disabled={pitch >= MAX_PITCH}
+    >
+      <ChevronUp size={18} />
+    </button>
+  </div>
+</div>
+
+<style>
+  .map-controls {
+    position: absolute;
+    right: 0.5rem;
+    top: 0.5rem;
+    z-index: 15;
+    pointer-events: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.375rem;
+    padding: 0.375rem;
+    background-color: white;
+    border-radius: 0.875rem;
+    box-shadow: 0 2px 0.5rem 0 hsla(0, 0%, 0%, 0.2);
+  }
+
+  .divider {
+    height: 1px;
+    background-color: hsl(0, 0%, 90%);
+    margin: 0 0.125rem;
+  }
+
+  .rotate-row,
+  .tilt-row {
+    display: flex;
+    gap: 0.25rem;
+    justify-content: center;
+  }
+
+  .control {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: none;
+    border-radius: 0.625rem;
+    background-color: transparent;
+    color: hsl(0, 0%, 20%);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+  }
+
+  .control:hover {
+    background-color: hsla(0, 0%, 0%, 0.08);
+  }
+
+  .control:active {
+    background-color: hsla(0, 0%, 0%, 0.14);
+  }
+
+  .control:disabled {
+    color: hsl(0, 0%, 75%);
+    cursor: default;
+    background-color: transparent;
+  }
+
+  .view-toggle {
+    width: 100%;
+    height: 2.25rem;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: hsl(5, 53%, 32%);
+  }
+
+  .compass {
+    color: hsl(5, 53%, 32%);
+  }
+
+  .compass-icon {
+    display: inline-flex;
+    transition: rotate 0.2s ease;
+  }
+
+  @media (max-width: 800px) {
+    /* Drop below the full-width search box so the two never overlap. */
+    .map-controls {
+      right: 0.5rem;
+      top: 4rem;
+    }
+
+    .control {
+      width: 2.5rem;
+      height: 2.5rem;
+    }
+  }
+</style>

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -259,6 +259,9 @@ class LocationStore {
 
 class MapStore {
   mapInstance: maplibre.MapLibreMap | undefined = $state.raw();
+  // Set by Map.svelte so UI controls can halt the idle auto-rotation
+  // before performing a manual camera change.
+  stopAutoRotate: (() => void) | null = null;
 }
 
 class JeepneyStore {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a compact map orientation control panel in the **top-right** corner, addressing two issues:

- **Closes #173** — a **2D/3D toggle** that animates the camera to a flat, north-up top-down view (and back to a 3D tilted view).
- **Closes #174** — discoverable web affordances for **rotate left/right**, a **compass** button that resets bearing to north, and **tilt up/down** (pitch) controls — for users who don't know the map gestures.

The panel mirrors the top-left search box, uses the app's existing white/rounded/maroon design language, and has labelled `title`/`aria-label`s. Tilt buttons disable at the pitch limits (0° / 60°). All controls halt the idle auto-rotation before moving the camera, via a new decoupled `mapStore.stopAutoRotate` hook set by `Map.svelte`.

### Mobile
Native touch gestures (two-finger twist to rotate, two-finger drag to pitch) exist on mobile but aren't discoverable — the same gap #174 calls out. So the explicit controls stay visible on mobile, drop below the full-width search box, and use 44px touch targets. Verified at iPhone SE width: fully on-screen, no overlap with the search box/dropdown, all controls responsive.

### Changes
- `src/components/svelte/MapControls.svelte` (new) — the control panel.
- `src/components/svelte/Entry.svelte` — render `MapControls` in the UI layer.
- `src/components/svelte/Map.svelte` — register `stopAutoRotate` hook.
- `src/lib/store.svelte.ts` — add `stopAutoRotate` to `MapStore`.

## Testing

- ✅ `bun run build` — 651 pages built, no errors.
- ✅ Manual desktop testing of every control (rotate, compass reset, tilt down/up, 2D/3D toggle).
- ✅ Manual mobile testing at iPhone SE (375px) — layout + all controls verified.

### Walkthrough

Desktop demo:
[map_orientation_controls_demo.mp4](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmap_orientation_controls_demo.mp4)

Top-right panel (desktop):
[Map controls in top-right corner](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontrols_top_right.webp)

Mobile layout (iPhone SE) — controls top-right, below search:
[Mobile layout with map controls in top-right](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_controls_layout.webp)

2D top-down view (mobile):
[Flat 2D top-down view on mobile](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_2d_view.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f22fa558-058c-4cf2-b7f5-c9271e26171f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

