### PR TITLE
Add building and dorm type filter

### DIFF
--- a/docs/editor-foundation-test-plan.md
+++ b/docs/editor-foundation-test-plan.md
@@ -37,10 +37,10 @@ Use this checklist before merging the in-app editor foundation PR.
 ## Building Type Filter
 
 - The building type filter defaults to All and shows the same building pins and suggestions as before.
-- Selecting Administrative shows only administrative building pins and building suggestions.
-- Selecting Non-administrative shows only non-administrative building pins and building suggestions.
-- A search with no matching buildings under the active building type filter keeps the existing empty/query fallback understandable.
-- Building type filtering does not change dorm filter behavior or dorm marker visibility.
+- Selecting Class Building shows only red building pins and building suggestions.
+- Selecting UP Managed Dorm shows only green UP-managed dorm pins and dorm suggestions.
+- Selecting Non-UP Managed Dorm shows only orange non-UP-managed dorm pins and dorm suggestions.
+- A search with no matching buildings or dorms under the active building type filter keeps the existing empty/query fallback understandable.
 - In map edit mode, only visible building pins are draggable, and changing the filter does not imply hidden pins were edited.
 
 ## Room Side-Panel Editing

--- a/docs/editor-foundation-test-plan.md
+++ b/docs/editor-foundation-test-plan.md
@@ -34,6 +34,15 @@ Use this checklist before merging the in-app editor foundation PR.
 - On a low-bandwidth or data-saver connection, terrain copy warns that hosted elevation tiles are online-only.
 - Mobile terrain controls are reachable and do not cover the side panel, editor toolbar, or attribution.
 
+## Building Type Filter
+
+- The building type filter defaults to All and shows the same building pins and suggestions as before.
+- Selecting Administrative shows only administrative building pins and building suggestions.
+- Selecting Non-administrative shows only non-administrative building pins and building suggestions.
+- A search with no matching buildings under the active building type filter keeps the existing empty/query fallback understandable.
+- Building type filtering does not change dorm filter behavior or dorm marker visibility.
+- In map edit mode, only visible building pins are draggable, and changing the filter does not imply hidden pins were edited.
+
 ## Room Side-Panel Editing
 
 - Non-admin users only see read-only room details in the existing main app side panel.

--- a/src/components/svelte/BuildingTypeControl.svelte
+++ b/src/components/svelte/BuildingTypeControl.svelte
@@ -9,10 +9,10 @@
   import type { BuildingTypeFilter } from "../../constants/building-types";
 
   const appData = getAppData();
-  const { buildings } = $derived(appData());
+  const { buildings, dorms } = $derived(appData());
   let menuOpen = $state(false);
 
-  const options = $derived(getBuildingTypeFilterOptions(buildings));
+  const options = $derived(getBuildingTypeFilterOptions(buildings, dorms));
   const activeLabel = $derived(
     getBuildingTypeFilterLabel(buildingTypeFilter.value),
   );
@@ -39,7 +39,7 @@
         </button>
       </div>
 
-      <p class="filter-copy">Show building pins and suggestions by type.</p>
+      <p class="filter-copy">Show building and dorm pins by type.</p>
 
       <div class="filter-options">
         {#each options as option (option.value)}
@@ -52,7 +52,10 @@
             aria-checked={isActive}
             onclick={() => selectFilter(option.value)}
           >
-            <span>{option.label}</span>
+            <span class="option-label">
+              <span class={`type-dot ${option.tone}`}></span>
+              {option.label}
+            </span>
             <span class="option-count">{option.count}</span>
           </button>
         {/each}
@@ -198,5 +201,33 @@
     font-size: 0.75rem;
     font-weight: 700;
     padding: 0.125rem 0.5rem;
+  }
+
+  .option-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .type-dot {
+    width: 0.625rem;
+    height: 0.625rem;
+    border-radius: 50%;
+    background-color: hsl(0, 0%, 65%);
+    box-shadow: 0 0 0 2px white;
+    flex: 0 0 auto;
+  }
+
+  .type-dot.building,
+  .type-dot.admin {
+    background-color: hsl(5, 53%, 32%);
+  }
+
+  .type-dot.up-dorm {
+    background-color: hsl(170, 50%, 35%);
+  }
+
+  .type-dot.non-up-dorm {
+    background-color: hsl(25, 70%, 50%);
   }
 </style>

--- a/src/components/svelte/BuildingTypeControl.svelte
+++ b/src/components/svelte/BuildingTypeControl.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+  import { Building2, X } from "@lucide/svelte";
+  import {
+    getBuildingTypeFilterLabel,
+    getBuildingTypeFilterOptions,
+  } from "../../constants/building-types";
+  import { getAppData } from "../../lib/context";
+  import { buildingTypeFilter } from "../../lib/store.svelte";
+  import type { BuildingTypeFilter } from "../../constants/building-types";
+
+  const appData = getAppData();
+  const { buildings } = $derived(appData());
+  let menuOpen = $state(false);
+
+  const options = $derived(getBuildingTypeFilterOptions(buildings));
+  const activeLabel = $derived(
+    getBuildingTypeFilterLabel(buildingTypeFilter.value),
+  );
+  const hasActiveFilter = $derived(buildingTypeFilter.value !== "all");
+
+  function selectFilter(value: BuildingTypeFilter) {
+    buildingTypeFilter.set(value);
+    menuOpen = false;
+  }
+</script>
+
+<div class="building-type-control">
+  {#if menuOpen}
+    <div class="filter-panel" role="menu" aria-label="Building type filter">
+      <div class="filter-panel-header">
+        <span>Building Type</span>
+        <button
+          type="button"
+          class="close-btn"
+          onclick={() => (menuOpen = false)}
+          aria-label="Close building type filter"
+        >
+          <X size="16" />
+        </button>
+      </div>
+
+      <p class="filter-copy">Show building pins and suggestions by type.</p>
+
+      <div class="filter-options">
+        {#each options as option (option.value)}
+          {@const isActive = buildingTypeFilter.value === option.value}
+          <button
+            type="button"
+            class="filter-option"
+            class:active={isActive}
+            role="menuitemradio"
+            aria-checked={isActive}
+            onclick={() => selectFilter(option.value)}
+          >
+            <span>{option.label}</span>
+            <span class="option-count">{option.count}</span>
+          </button>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <button
+    class="filter-btn"
+    class:active={hasActiveFilter}
+    onclick={() => (menuOpen = !menuOpen)}
+    title={`Building Type: ${activeLabel}`}
+    aria-label={`Building Type: ${activeLabel}`}
+    aria-expanded={menuOpen}
+    aria-pressed={hasActiveFilter}
+  >
+    <Building2 />
+  </button>
+</div>
+
+<style>
+  .building-type-control {
+    pointer-events: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+  }
+
+  .filter-btn {
+    display: flex;
+    width: 3rem;
+    height: 3rem;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #ececec;
+    border-radius: 50%;
+    background-color: white;
+    color: hsl(5, 53%, 32%);
+    cursor: pointer;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    transition:
+      background-color 0.2s,
+      transform 0.2s;
+  }
+
+  .filter-btn:hover {
+    background-color: hsl(5, 53%, 98%);
+    transform: scale(1.05);
+  }
+
+  .filter-btn.active {
+    border-color: hsl(160, 84%, 26%);
+    background-color: hsl(160, 84%, 26%);
+    color: white;
+  }
+
+  .filter-panel {
+    display: flex;
+    width: 18rem;
+    max-width: calc(100vw - 1rem);
+    flex-direction: column;
+    gap: 0.625rem;
+    border-radius: 0.875rem;
+    background-color: white;
+    padding: 0.75rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  .filter-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.125rem 0.25rem;
+    color: hsl(0, 0%, 20%);
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+
+  .close-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 0.375rem;
+    background: transparent;
+    color: hsl(0, 0%, 40%);
+    cursor: pointer;
+    padding: 0.125rem;
+  }
+
+  .close-btn:hover {
+    background-color: hsl(0, 0%, 95%);
+  }
+
+  .filter-copy {
+    margin: 0;
+    color: hsl(0, 0%, 38%);
+    font-size: 0.75rem;
+    line-height: 1.35;
+  }
+
+  .filter-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .filter-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.625rem;
+    border: 1px solid transparent;
+    border-radius: 0.625rem;
+    background-color: hsl(0, 0%, 98%);
+    color: hsl(0, 0%, 15%);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    padding: 0.5rem 0.625rem;
+    text-align: left;
+    transition:
+      background-color 0.15s,
+      border-color 0.15s;
+  }
+
+  .filter-option:hover {
+    background-color: hsl(0, 0%, 94%);
+  }
+
+  .filter-option.active {
+    border-color: hsl(5, 53%, 75%);
+    background-color: hsl(5, 53%, 96%);
+    color: hsl(5, 53%, 32%);
+  }
+
+  .option-count {
+    border-radius: 999px;
+    background-color: white;
+    color: hsl(0, 0%, 38%);
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.125rem 0.5rem;
+  }
+</style>

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -7,7 +7,6 @@
     mapStore,
     mapEditStore,
     jeepneyStore,
-    dormFilter,
     buildingTypeFilter,
     currentRoom,
     adminAuthStore,
@@ -41,20 +40,23 @@
     TERRAIN_TILEJSON_URL,
     TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE,
   } from "../../constants/map-terrain";
+  import {
+    buildingMatchesTypeFilter,
+    dormMatchesTypeFilter,
+  } from "../../constants/building-types";
   const data = getAppData();
   const { buildings, dorms, loaded } = $derived(data());
   const filteredBuildings = $derived.by(() => {
     if (!loaded) return [];
-    if (buildingTypeFilter.value === "all") return buildings;
-    return buildings.filter(
-      (building) => building.buildingType === buildingTypeFilter.value,
+    return buildings.filter((building) =>
+      buildingMatchesTypeFilter(building, buildingTypeFilter.value),
     );
   });
   const filteredDorms = $derived.by(() => {
-    if (!loaded) return;
-    if (dormFilter.value === "all") return dorms;
-    if (dormFilter.value === "up") return dorms.filter((d) => d.isUpManaged);
-    return dorms.filter((d) => !d.isUpManaged);
+    if (!loaded) return [];
+    return dorms.filter((dorm) =>
+      dormMatchesTypeFilter(dorm, buildingTypeFilter.value),
+    );
   });
   let directions: MapLibreGlDirections | undefined = $state.raw();
 

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -8,6 +8,7 @@
     mapEditStore,
     jeepneyStore,
     dormFilter,
+    buildingTypeFilter,
     currentRoom,
     adminAuthStore,
     toastStore,
@@ -42,6 +43,13 @@
   } from "../../constants/map-terrain";
   const data = getAppData();
   const { buildings, dorms, loaded } = $derived(data());
+  const filteredBuildings = $derived.by(() => {
+    if (!loaded) return [];
+    if (buildingTypeFilter.value === "all") return buildings;
+    return buildings.filter(
+      (building) => building.buildingType === buildingTypeFilter.value,
+    );
+  });
   const filteredDorms = $derived.by(() => {
     if (!loaded) return;
     if (dormFilter.value === "all") return dorms;
@@ -1169,7 +1177,7 @@
         <div class="user-location-pin"></div>
       </Marker>
     {/if}
-    {#each buildings as building (`building:${building.id}:${isMapEditEnabled()}`)}
+    {#each filteredBuildings as building (`building:${building.id}:${isMapEditEnabled()}`)}
       {#if building.lat && building.lon}
         {@const editKey = buildingEditKey(building.id)}
         {@const position = getEditablePosition(editKey, {

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -4,11 +4,13 @@
   import {
     queryStore,
     type QueryStoreState,
-    dormFilter,
-    type DormFilterType,
     buildingTypeFilter,
   } from "../../../lib/store.svelte";
   import type { BuildingData, DormData } from "../../../lib/types";
+  import {
+    buildingMatchesTypeFilter,
+    dormMatchesTypeFilter,
+  } from "../../../constants/building-types";
   import SearchQuerySuggestion from "./SearchQuerySuggestion.svelte";
   import Suggestion from "./Suggestion.svelte";
 
@@ -16,16 +18,15 @@
   const { buildings, colleges, divisions, dorms, loaded } = $derived(appData());
 
   const filteredDorms = $derived.by(() => {
-    if (!loaded) return;
-    if (dormFilter.value === "all") return dorms;
-    if (dormFilter.value === "up") return dorms.filter((d) => d.isUpManaged);
-    return dorms.filter((d) => !d.isUpManaged);
+    if (!loaded) return [];
+    return dorms.filter((dorm) =>
+      dormMatchesTypeFilter(dorm, buildingTypeFilter.value),
+    );
   });
   const filteredBuildings = $derived.by(() => {
-    if (!loaded) return;
-    if (buildingTypeFilter.value === "all") return buildings;
-    return buildings.filter(
-      (building) => building.buildingType === buildingTypeFilter.value,
+    if (!loaded) return [];
+    return buildings.filter((building) =>
+      buildingMatchesTypeFilter(building, buildingTypeFilter.value),
     );
   });
 
@@ -87,8 +88,6 @@
 
     return nonRoomResult.slice(0, 8);
   }
-
-  const hasDormResults = $derived(suggestedResult);
   const roomsResult = $derived(getRoomSuggestions(queryStore.inputValue));
 
   async function getRoomSuggestions(searchValue: string) {
@@ -101,12 +100,6 @@
       ? roomsFetch.data.map((val) => ({ ...val, category: "room" as const }))
       : [];
   }
-
-  const filterOptions: { label: string; value: DormFilterType }[] = [
-    { label: "All", value: "all" },
-    { label: "UP-managed", value: "up" },
-    { label: "Private", value: "private" },
-  ];
 </script>
 
 <!-- class:visible={queryStore.inputValue === ""} -->
@@ -132,19 +125,6 @@
       />
     {/if}
   {:else if suggestedResult.length !== 0}
-    {#if hasDormResults}
-      <div class="filter-chips">
-        {#each filterOptions as opt (opt.value)}
-          <button
-            class="filter-chip"
-            class:active={dormFilter.value === opt.value}
-            onclick={() => dormFilter.set(opt.value)}
-          >
-            {opt.label}
-          </button>
-        {/each}
-      </div>
-    {/if}
     {#each suggestedResult as suggestion, id (id)}
       <Suggestion {...suggestion} />
     {/each}
@@ -187,35 +167,6 @@
     font-size: 1rem;
     margin-bottom: 0.5rem;
   }
-
-  .filter-chips {
-    display: flex;
-    gap: 0.375rem;
-    margin-bottom: 0.5rem;
-    flex-wrap: wrap;
-  }
-
-  .filter-chip {
-    all: unset;
-    cursor: pointer;
-    padding: 0.25rem 0.625rem;
-    border-radius: 1rem;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    background-color: hsl(0, 0%, 94%);
-    color: hsl(0, 0%, 40%);
-    transition: all 0.15s;
-  }
-
-  .filter-chip:hover {
-    background-color: hsl(0, 0%, 88%);
-  }
-
-  .filter-chip.active {
-    background-color: hsl(5, 53%, 30%);
-    color: white;
-  }
-
   @media (max-width: 425px) {
     .suggestions-header {
       margin-bottom: 0.25rem;

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -6,8 +6,9 @@
     type QueryStoreState,
     dormFilter,
     type DormFilterType,
+    buildingTypeFilter,
   } from "../../../lib/store.svelte";
-  import type { DormData } from "../../../lib/types";
+  import type { BuildingData, DormData } from "../../../lib/types";
   import SearchQuerySuggestion from "./SearchQuerySuggestion.svelte";
   import Suggestion from "./Suggestion.svelte";
 
@@ -20,6 +21,13 @@
     if (dormFilter.value === "up") return dorms.filter((d) => d.isUpManaged);
     return dorms.filter((d) => !d.isUpManaged);
   });
+  const filteredBuildings = $derived.by(() => {
+    if (!loaded) return;
+    if (buildingTypeFilter.value === "all") return buildings;
+    return buildings.filter(
+      (building) => building.buildingType === buildingTypeFilter.value,
+    );
+  });
 
   const suggestedResult = $derived(getSuggestions(queryStore.inputValue));
 
@@ -30,7 +38,7 @@
     searchString = searchString.trim().toLowerCase();
     if (searchString === "" || !loaded) return [];
     const suggestions = {
-      buildings: buildings
+      buildings: (filteredBuildings as BuildingData[])
         .filter(({ buildingName }) =>
           buildingName.toLowerCase().includes(searchString),
         )
@@ -71,12 +79,8 @@
       }[];
     };
 
-    const nonRoomResult = Array.from(Object.values(suggestions))
-      .reduce(
-        // @ts-ignore
-        (prev, curr) => [...prev, ...curr],
-        [],
-      )
+    const nonRoomResult = Object.values(suggestions)
+      .flat()
       .sort(({ value: a }, { value: b }) =>
         a.toLowerCase().localeCompare(b.toLowerCase()),
       );
@@ -116,24 +120,21 @@
       {/each}
     {:else}
       <h2 class="suggestions-header">Trending searches</h2>
-      <Suggestion value={"Physical Sciences Building"} category={"building"} />
+      <Suggestion value="Physical Sciences Building" category="building" />
+      <Suggestion value="Institute of Computer Science" category="division" />
       <Suggestion
-        value={"Institute of Computer Science"}
-        category={"division"}
+        value="Institute of Biological Sciences"
+        category="division"
       />
       <Suggestion
-        value={"Institute of Biological Sciences"}
-        category={"division"}
-      />
-      <Suggestion
-        value={"College of Engineering and Agro-Industrial Technology"}
-        category={"college"}
+        value="College of Engineering and Agro-Industrial Technology"
+        category="college"
       />
     {/if}
   {:else if suggestedResult.length !== 0}
     {#if hasDormResults}
       <div class="filter-chips">
-        {#each filterOptions as opt}
+        {#each filterOptions as opt (opt.value)}
           <button
             class="filter-chip"
             class:active={dormFilter.value === opt.value}
@@ -153,7 +154,7 @@
     {#await roomsResult}
       Loading rooms...
     {:then result}
-      {#each result as roomResult}
+      {#each result as roomResult (roomResult.value)}
         <Suggestion {...roomResult} />
       {/each}
     {/await}

--- a/src/components/svelte/sidepanel/SidePanel.svelte
+++ b/src/components/svelte/sidepanel/SidePanel.svelte
@@ -8,6 +8,7 @@
   import DormResult from "./DormResult.svelte";
   import RoomResult from "../room/RoomResult.svelte";
   import ClassQuery from "./ClassQuery.svelte";
+  import BuildingTypeControl from "../BuildingTypeControl.svelte";
   import LocationButton from "../LocationButton.svelte";
   import JeepneyMenu from "../JeepneyMenu.svelte";
   import TerrainControl from "../TerrainControl.svelte";
@@ -67,6 +68,7 @@
     class:is-collapsed={sidePanelStore.collapsed}
   >
     <div class="floating-actions">
+      <BuildingTypeControl />
       <TerrainControl />
       <JeepneyMenu />
       <LocationButton />

--- a/src/constants/building-types.ts
+++ b/src/constants/building-types.ts
@@ -1,0 +1,65 @@
+import type { BuildingData, BuildingType } from "../lib/types";
+
+export type BuildingTypeFilter = "all" | BuildingType;
+
+export type BuildingTypeFilterOption = {
+  label: string;
+  value: BuildingTypeFilter;
+  count: number;
+};
+
+const ALL_BUILDINGS_OPTION = {
+  label: "All",
+  value: "all",
+} as const;
+
+const BUILDING_TYPE_LABELS: Partial<Record<BuildingType, string>> = {
+  admin: "Administrative",
+  "non-admin": "Non-administrative",
+};
+
+function formatBuildingTypeLabel(type: BuildingType) {
+  return (
+    BUILDING_TYPE_LABELS[type] ??
+    type
+      .split("-")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ")
+  );
+}
+
+export function getBuildingTypeFilterLabel(filter: BuildingTypeFilter) {
+  if (filter === "all") return ALL_BUILDINGS_OPTION.label;
+  return formatBuildingTypeLabel(filter);
+}
+
+export function getBuildingTypeFilterOptions(
+  buildings: BuildingData[] | null,
+): BuildingTypeFilterOption[] {
+  const counts = new Map<BuildingType, number>();
+
+  for (const building of buildings ?? []) {
+    counts.set(
+      building.buildingType,
+      (counts.get(building.buildingType) ?? 0) + 1,
+    );
+  }
+
+  const typeOptions = Array.from(counts.entries())
+    .sort(([a], [b]) =>
+      formatBuildingTypeLabel(a).localeCompare(formatBuildingTypeLabel(b)),
+    )
+    .map(([value, count]) => ({
+      label: formatBuildingTypeLabel(value),
+      value,
+      count,
+    }));
+
+  return [
+    {
+      ...ALL_BUILDINGS_OPTION,
+      count: buildings?.length ?? 0,
+    },
+    ...typeOptions,
+  ];
+}

--- a/src/constants/building-types.ts
+++ b/src/constants/building-types.ts
@@ -1,65 +1,106 @@
-import type { BuildingData, BuildingType } from "../lib/types";
+import type { BuildingData, BuildingType, DormData } from "../lib/types";
 
-export type BuildingTypeFilter = "all" | BuildingType;
+export type BuildingTypeFilter =
+  | "all"
+  | "class-building"
+  | "administrative-building"
+  | "up-managed-dorm"
+  | "non-up-managed-dorm";
 
 export type BuildingTypeFilterOption = {
   label: string;
   value: BuildingTypeFilter;
   count: number;
+  tone: "all" | "building" | "admin" | "up-dorm" | "non-up-dorm";
 };
 
 const ALL_BUILDINGS_OPTION = {
   label: "All",
   value: "all",
+  tone: "all",
 } as const;
 
-const BUILDING_TYPE_LABELS: Partial<Record<BuildingType, string>> = {
-  admin: "Administrative",
-  "non-admin": "Non-administrative",
+const BUILDING_TYPE_FILTERS = {
+  admin: "administrative-building",
+  "non-admin": "class-building",
+} satisfies Record<BuildingType, BuildingTypeFilter>;
+
+const BUILDING_TYPE_LABELS: Record<BuildingTypeFilter, string> = {
+  all: "All",
+  "class-building": "Class Building",
+  "administrative-building": "Administrative Building",
+  "up-managed-dorm": "UP Managed Dorm",
+  "non-up-managed-dorm": "Non-UP Managed Dorm",
 };
 
-function formatBuildingTypeLabel(type: BuildingType) {
-  return (
-    BUILDING_TYPE_LABELS[type] ??
-    type
-      .split("-")
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(" ")
-  );
+export function getBuildingTypeFilterLabel(filter: BuildingTypeFilter) {
+  return BUILDING_TYPE_LABELS[filter];
 }
 
-export function getBuildingTypeFilterLabel(filter: BuildingTypeFilter) {
-  if (filter === "all") return ALL_BUILDINGS_OPTION.label;
-  return formatBuildingTypeLabel(filter);
+export function buildingMatchesTypeFilter(
+  building: BuildingData,
+  filter: BuildingTypeFilter,
+) {
+  if (filter === "all") return true;
+  return BUILDING_TYPE_FILTERS[building.buildingType] === filter;
+}
+
+export function dormMatchesTypeFilter(
+  dorm: DormData,
+  filter: BuildingTypeFilter,
+) {
+  if (filter === "all") return true;
+  if (filter === "up-managed-dorm") return dorm.isUpManaged;
+  if (filter === "non-up-managed-dorm") return !dorm.isUpManaged;
+  return false;
 }
 
 export function getBuildingTypeFilterOptions(
   buildings: BuildingData[] | null,
+  dorms: DormData[] | null,
 ): BuildingTypeFilterOption[] {
-  const counts = new Map<BuildingType, number>();
+  const counts = new Map<BuildingTypeFilter, number>();
 
   for (const building of buildings ?? []) {
-    counts.set(
-      building.buildingType,
-      (counts.get(building.buildingType) ?? 0) + 1,
-    );
+    const filter = BUILDING_TYPE_FILTERS[building.buildingType];
+    counts.set(filter, (counts.get(filter) ?? 0) + 1);
   }
 
-  const typeOptions = Array.from(counts.entries())
-    .sort(([a], [b]) =>
-      formatBuildingTypeLabel(a).localeCompare(formatBuildingTypeLabel(b)),
-    )
-    .map(([value, count]) => ({
-      label: formatBuildingTypeLabel(value),
-      value,
-      count,
-    }));
+  for (const dorm of dorms ?? []) {
+    const filter = dorm.isUpManaged ? "up-managed-dorm" : "non-up-managed-dorm";
+    counts.set(filter, (counts.get(filter) ?? 0) + 1);
+  }
 
-  return [
+  const options: BuildingTypeFilterOption[] = [
     {
       ...ALL_BUILDINGS_OPTION,
-      count: buildings?.length ?? 0,
+      count: (buildings?.length ?? 0) + (dorms?.length ?? 0),
     },
-    ...typeOptions,
+    {
+      label: BUILDING_TYPE_LABELS["class-building"],
+      value: "class-building",
+      count: counts.get("class-building") ?? 0,
+      tone: "building",
+    },
+    {
+      label: BUILDING_TYPE_LABELS["administrative-building"],
+      value: "administrative-building",
+      count: counts.get("administrative-building") ?? 0,
+      tone: "admin",
+    },
+    {
+      label: BUILDING_TYPE_LABELS["up-managed-dorm"],
+      value: "up-managed-dorm",
+      count: counts.get("up-managed-dorm") ?? 0,
+      tone: "up-dorm",
+    },
+    {
+      label: BUILDING_TYPE_LABELS["non-up-managed-dorm"],
+      value: "non-up-managed-dorm",
+      count: counts.get("non-up-managed-dorm") ?? 0,
+      tone: "non-up-dorm",
+    },
   ];
+
+  return options.filter((option) => option.value === "all" || option.count > 0);
 }

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -1,6 +1,7 @@
 // src/lib/store.svelte.ts
 
 import type { modalOptions } from "../constants/modal-states";
+import type { BuildingTypeFilter } from "../constants/building-types";
 import { DEFAULT_TERRAIN_EXAGGERATION } from "../constants/map-terrain";
 import { SvelteMap } from "svelte/reactivity";
 import * as maplibre from "maplibre-gl";
@@ -20,6 +21,16 @@ export const dormFilter = {
   },
   set(v: DormFilterType) {
     _dormFilter = v;
+  },
+};
+
+let _buildingTypeFilter = $state<BuildingTypeFilter>("all");
+export const buildingTypeFilter = {
+  get value() {
+    return _buildingTypeFilter;
+  },
+  set(v: BuildingTypeFilter) {
+    _buildingTypeFilter = v;
   },
 };
 

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,4 +1,8 @@
-import { dormsTable, roomPositionsTable } from "../../drizzle/schema";
+import {
+  buildingsTable,
+  dormsTable,
+  roomPositionsTable,
+} from "../../drizzle/schema";
 import type { QueryStoreState } from "./store.svelte";
 
 export type AppData = {
@@ -52,15 +56,9 @@ type RoomData = {
   updatedAt: string;
 };
 
-type BuildingData = {
-  id: number;
-  buildingName: string;
-  lat: number | null;
-  lon: number | null;
-  directions: string | null;
-  version: number;
-  updatedAt: string;
-};
+type BuildingData = typeof buildingsTable.$inferSelect;
+
+type BuildingType = BuildingData["buildingType"];
 
 type ClassMapValue = {
   courseCode: string | null;


### PR DESCRIPTION
## Summary
- Add a shared map type filter defaulting to All for building pins, dorm pins, and building/dorm search suggestions.
- Segment the filter by visible marker categories: Class Building (red), UP Managed Dorm (green), and Non-UP Managed Dorm (orange), with admin buildings surfaced only if present in data.
- Update the editor foundation manual checklist with building/dorm type filter QA coverage.

## Test plan
- bunx prettier --write edited files
- bunx eslint edited lintable source files
- bun run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side filtering and UI only; no API or auth changes. Map edit behavior intentionally limits draggable pins to visible filtered markers.
> 
> **Overview**
> Adds a **global building type filter** (default **All**) that drives both map markers and search suggestions, replacing the search-only dorm chip filter.
> 
> Shared logic in `building-types` maps class vs administrative buildings and UP vs non-UP dorms, with **data-derived option counts** (empty types hidden). A new **floating `BuildingTypeControl`** on the side panel sets `buildingTypeFilter` in the store; **Map** renders filtered building/dorm pins (including edit mode visibility), and **Suggestions** limits building/dorm matches to the active filter. **`BuildingData`** is aligned with the Drizzle schema so `buildingType` is available for filtering.
> 
> The editor foundation manual checklist gains **Building Type Filter** QA steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c3de70afc86a726d90d134412c97a9e5a3341a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->