### PR TITLE
feat: term selector for class schedules (#162)

### DIFF
--- a/drizzle/0003_add_terms.sql
+++ b/drizzle/0003_add_terms.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS "terms" (
+  "id" integer PRIMARY KEY,
+  "label" text NOT NULL,
+  "school_year" varchar(16),
+  "semester" varchar(12),
+  "starts_on" timestamp,
+  "ends_on" timestamp,
+  "is_default" boolean NOT NULL DEFAULT false,
+  "is_active" boolean NOT NULL DEFAULT true,
+  "sort_order" integer NOT NULL DEFAULT 0,
+  "version" integer NOT NULL DEFAULT 1,
+  "updated_at" timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+-- Enforce a single default term for anonymous visitors.
+CREATE UNIQUE INDEX IF NOT EXISTS "terms_single_default"
+  ON "terms" ("is_default") WHERE "is_default";
+--> statement-breakpoint
+-- Seed the known UPLB terms. `id` mirrors the CRS/SAIS term_id already stored
+-- on classes.term_id (e.g. 1252). Idempotent so re-running is safe.
+INSERT INTO "terms" ("id", "label", "school_year", "semester", "is_default", "is_active", "sort_order")
+VALUES
+  (1251, 'AY 2025-2026 1st Semester', '2025-2026', '1', false, true, 10),
+  (1252, 'AY 2025-2026 2nd Semester', '2025-2026', '2', true, true, 20)
+ON CONFLICT ("id") DO NOTHING;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   pgTable,
   integer,
@@ -11,9 +12,38 @@ import {
   uuid,
   pgEnum,
   jsonb,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 export const buildingEnum = pgEnum("building_type", ["admin", "non-admin"]);
+
+// Academic terms. `id` mirrors the CRS/SAIS term_id (e.g. 1252) rather than
+// being auto-generated, so it matches the `term_id` already stored on classes.
+export const termsTable = pgTable(
+  "terms",
+  {
+    id: integer().primaryKey(),
+    label: text().notNull(),
+    schoolYear: varchar("school_year", { length: 16 }),
+    // "1" | "2" | "midyear"
+    semester: varchar({ length: 12 }),
+    startsOn: timestamp("starts_on", { mode: "string" }),
+    endsOn: timestamp("ends_on", { mode: "string" }),
+    isDefault: boolean("is_default").default(false).notNull(),
+    isActive: boolean("is_active").default(true).notNull(),
+    sortOrder: integer("sort_order").default(0).notNull(),
+    version: integer().default(1).notNull(),
+    updatedAt: timestamp("updated_at", { mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    // At most one term may be the default for anonymous visitors.
+    uniqueIndex("terms_single_default")
+      .on(table.isDefault)
+      .where(sql`${table.isDefault}`),
+  ],
+);
 
 export const dormsTable = pgTable("dorms", {
   id: integer().primaryKey().generatedByDefaultAsIdentity({

--- a/scripts/export-for-deep-research.ts
+++ b/scripts/export-for-deep-research.ts
@@ -22,9 +22,12 @@ import {
   divisionsTable,
   dormsTable,
   roomsTable,
+  termsTable,
 } from "../drizzle/schema";
 
 const OUT_DIR = join(import.meta.dir, "..", "exports", "deep-research");
+// Fallback term label used when the terms table is unavailable (e.g. the
+// legacy SQLite export path). The Postgres path reads the default term.
 const TERM = "AY 2025-2026 2nd Semester";
 const EXPORTED_AT = new Date().toISOString();
 
@@ -46,6 +49,18 @@ function writeJson(name: string, data: unknown) {
 async function exportFromPostgres(connectionString: string) {
   const pool = new pg.Pool({ connectionString });
   const db = drizzlePg(pool);
+
+  let termLabel = TERM;
+  try {
+    const [defaultTerm] = await db
+      .select()
+      .from(termsTable)
+      .where(eq(termsTable.isDefault, true))
+      .limit(1);
+    if (defaultTerm?.label) termLabel = defaultTerm.label;
+  } catch {
+    // terms table not migrated yet — keep the fallback label.
+  }
 
   const buildings = await db.select().from(buildingsTable);
   const colleges = await db.select().from(collegesTable);
@@ -83,7 +98,7 @@ async function exportFromPostgres(connectionString: string) {
 
   await pool.end();
 
-  return { buildings, colleges, divisions, dorms, rooms, classes };
+  return { buildings, colleges, divisions, dorms, rooms, classes, termLabel };
 }
 
 function exportFromSqlite(sqlitePath: string) {
@@ -128,7 +143,15 @@ function exportFromSqlite(sqlitePath: string) {
 
   client.close();
 
-  return { buildings, colleges, divisions, dorms, rooms, classes };
+  return {
+    buildings,
+    colleges,
+    divisions,
+    dorms,
+    rooms,
+    classes,
+    termLabel: TERM,
+  };
 }
 
 function roomCodeStats(classes: { room_code: string | null }[]) {
@@ -168,7 +191,7 @@ const files = [
 
 const manifest: ExportManifest = {
   exported_at: EXPORTED_AT,
-  term_target: TERM,
+  term_target: data.termLabel,
   source,
   counts: {
     buildings: data.buildings.length,
@@ -180,8 +203,20 @@ const manifest: ExportManifest = {
   },
   files,
   schema_notes: {
-    buildings: ["building_name", "lat", "lon", "directions", "type (admin|non-admin)"],
-    rooms: ["room_code", "directions", "building_name", "college_name", "division_name"],
+    buildings: [
+      "building_name",
+      "lat",
+      "lon",
+      "directions",
+      "type (admin|non-admin)",
+    ],
+    rooms: [
+      "room_code",
+      "directions",
+      "building_name",
+      "college_name",
+      "division_name",
+    ],
     classes: [
       "course_code",
       "section",

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import ChevronDown from "@lucide/svelte/icons/chevron-down"
-  import ChevronRight from "@lucide/svelte/icons/chevron-right"
-  import MessageCircle from "@lucide/svelte/icons/message-circle"
+  import ChevronDown from "@lucide/svelte/icons/chevron-down";
+  import ChevronRight from "@lucide/svelte/icons/chevron-right";
+  import MessageCircle from "@lucide/svelte/icons/message-circle";
   import { APP_VERSION_LABEL } from "../../constants/version";
   import { getAppData } from "../../lib/context";
   import { modalStore } from "../../lib/store.svelte";
+  import TermSelector from "./TermSelector.svelte";
 
   const appData = getAppData();
   const { directionCount, totalRooms } = $derived(appData());
@@ -35,12 +36,20 @@
       </div>
     </div>
     <div class="metadata">
+      <div class="term-selector-item">
+        <TermSelector />
+      </div>
       <div class="data-updated">
         Course and room information is updated regularly. Last updated:
         <strong>June 2026.</strong>
       </div>
       <div>
-        <a href="/messenger" target="_blank" rel="noopener noreferrer" class="messenger-link">
+        <a
+          href="/messenger"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="messenger-link"
+        >
           <MessageCircle size={18} />
           <div>Contact</div>
         </a>

--- a/src/components/svelte/TermSelector.svelte
+++ b/src/components/svelte/TermSelector.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import GraduationCap from "@lucide/svelte/icons/graduation-cap";
+  import { termStore } from "../../lib/store.svelte";
+
+  onMount(() => {
+    termStore.init();
+  });
+
+  const active = $derived(termStore.activeTerm);
+
+  function onChange(event: Event) {
+    const value = Number((event.currentTarget as HTMLSelectElement).value);
+    if (Number.isFinite(value)) termStore.setTerm(value);
+  }
+</script>
+
+{#if termStore.terms.length > 0}
+  <div class="term-selector" title="Academic term for class schedules">
+    <GraduationCap size={16} />
+    <span class="term-selector__prefix">Schedules:</span>
+    <label class="visually-hidden" for="term-select">Academic term</label>
+    <select
+      id="term-select"
+      value={String(termStore.activeTermId)}
+      onchange={onChange}
+    >
+      {#each termStore.terms as term (term.id)}
+        <option value={String(term.id)}>{term.label}</option>
+      {/each}
+    </select>
+    {#if active}
+      {#if active.classCount > 0}
+        <span class="term-selector__count">{active.classCount} classes</span>
+      {:else}
+        <a
+          class="term-selector__empty"
+          href="/contribute"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          No schedules yet — report
+        </a>
+      {/if}
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .term-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    flex-wrap: wrap;
+    color: inherit;
+  }
+
+  .term-selector__prefix {
+    font-weight: 600;
+  }
+
+  #term-select {
+    font: inherit;
+    font-weight: 600;
+    color: hsl(5, 53%, 32%);
+    background-color: transparent;
+    border: 1px solid hsl(0, 0%, 85%);
+    border-radius: 0.5rem;
+    padding: 0.125rem 0.375rem;
+    cursor: pointer;
+    max-width: 14rem;
+  }
+
+  #term-select:hover {
+    background-color: hsla(0, 0%, 0%, 0.04);
+  }
+
+  .term-selector__count {
+    color: hsl(0, 0%, 40%);
+    font-weight: 500;
+  }
+
+  .term-selector__empty {
+    color: hsl(5, 53%, 32%);
+    font-weight: 500;
+    text-decoration: underline;
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/src/components/svelte/modal/ScheduleModal.svelte
+++ b/src/components/svelte/modal/ScheduleModal.svelte
@@ -1,12 +1,64 @@
-<script>
-  import { getAppData } from "../../../lib/context";
-  import { queryStore } from "../../../lib/store.svelte";
+<script lang="ts">
+  import {
+    currentRoom,
+    roomClassesStore,
+    termStore,
+  } from "../../../lib/store.svelte";
   import ScheduleRender from "../room/ScheduleRender.svelte";
-  const appData = getAppData();
-  const { classesMap } = $derived(appData());
-  // const classes = $derived(classesMap.get(queryStore.inputValue) ?? []);
+
+  const room = $derived(currentRoom.value);
+  const classes = $derived(roomClassesStore.classes);
+  const termLabel = $derived(termStore.activeTerm?.label ?? null);
 </script>
 
-<!-- {#if queryStore.category === "room" && queryStore.type === "result"}
-  <ScheduleRender roomCode={queryStore.inputValue} {classes} />
-{/if} -->
+<div class="schedule-modal">
+  <div class="schedule-modal__header">
+    <h2>{room ? `Schedule — ${room.code}` : "Schedule"}</h2>
+    {#if termLabel}
+      <span class="schedule-modal__term">{termLabel}</span>
+    {/if}
+  </div>
+  {#if room && classes.length > 0}
+    <ScheduleRender roomCode={room.code} {classes} />
+  {:else}
+    <p class="schedule-modal__empty">
+      No classes to display for this room{termLabel ? ` in ${termLabel}` : ""}.
+    </p>
+  {/if}
+</div>
+
+<style>
+  .schedule-modal {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.5rem;
+  }
+
+  .schedule-modal__header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.625rem;
+    flex-wrap: wrap;
+  }
+
+  .schedule-modal__header h2 {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: black;
+  }
+
+  .schedule-modal__term {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: hsl(5, 53%, 32%);
+  }
+
+  .schedule-modal__empty {
+    margin: 0;
+    padding: 1.5rem 0.5rem;
+    color: hsl(0, 0%, 45%);
+    font-size: 0.875rem;
+  }
+</style>

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import {
     adminAuthStore,
     currentRoom,
     locationStore,
     modalStore,
     queryStore,
+    roomClassesStore,
+    termStore,
   } from "../../../lib/store.svelte";
   import { getAppData } from "../../../lib/context";
   import CornerRightUp from "@lucide/svelte/icons/corner-right-up";
   import type { RoomData } from "../../../lib/types";
-  // import Classes from "./Classes.svelte";
+  import Classes from "./Classes.svelte";
 
   type RoomEditableField =
     | "roomCode"
@@ -159,6 +162,24 @@
       value: buildingName,
     });
   }
+
+  onMount(() => {
+    termStore.init();
+  });
+
+  // Load the current room's classes for the active term, re-fetching whenever
+  // the room or the selected term changes.
+  $effect(() => {
+    const code = currentRoom.value?.code;
+    const termId = termStore.activeTermId;
+    if (!code) {
+      roomClassesStore.clear();
+      return;
+    }
+    roomClassesStore.load(code, termId);
+  });
+
+  const activeTermLabel = $derived(termStore.activeTerm?.label ?? null);
 </script>
 
 <div class="room-details-container">
@@ -393,27 +414,54 @@
 
     <div class="schedule-section">
       <div class="schedule-section__header">
-        <h3>Classes in this room</h3>
-        <button
-          onclick={() => modalStore.openModal("schedule-expand")}
-          class="schedule-section__opener"
-          >Open schedule <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            ><line x1="7" y1="17" x2="17" y2="7"></line><polyline
-              points="7 7 17 7 17 17"
-            ></polyline></svg
-          ></button
-        >
+        <h3>
+          Classes in this room
+          {#if !roomClassesStore.loading}
+            <span class="schedule-section__count"
+              >({roomClassesStore.classes.length})</span
+            >
+          {/if}
+        </h3>
+        {#if roomClassesStore.classes.length > 0}
+          <button
+            onclick={() => modalStore.openModal("schedule-expand")}
+            class="schedule-section__opener"
+            >Open schedule <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              ><line x1="7" y1="17" x2="17" y2="7"></line><polyline
+                points="7 7 17 7 17 17"
+              ></polyline></svg
+            ></button
+          >
+        {/if}
       </div>
-      <!-- <Classes classes={classesData} /> -->
+      {#if activeTermLabel}
+        <p class="schedule-section__term">{activeTermLabel}</p>
+      {/if}
+      {#if roomClassesStore.loading}
+        <p class="schedule-section__empty">Loading classes…</p>
+      {:else if roomClassesStore.classes.length > 0}
+        <Classes classes={roomClassesStore.classes} />
+      {:else}
+        <p class="schedule-section__empty">
+          No classes listed for this room{activeTermLabel
+            ? ` in ${activeTermLabel}`
+            : ""}.
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLSdius5C7OyC1klraq71fFwWPZNvNk_iDLFyhCNir_ccC07Q7Q/viewform?usp=dialog"
+            target="_blank"
+            rel="noreferrer">Report outdated data</a
+          >
+        </p>
+      {/if}
     </div>
   {:else}
     <p>Room not found.</p>
@@ -657,6 +705,28 @@
     line-height: 1.25rem;
     color: black;
     margin: 0;
+  }
+
+  .schedule-section__count {
+    color: hsl(0, 0%, 45%);
+    font-weight: 500;
+  }
+
+  .schedule-section__term {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: hsl(5, 53%, 32%);
+  }
+
+  .schedule-section__empty {
+    margin: 0;
+    font-size: 0.875rem;
+    color: hsl(0, 0%, 45%);
+  }
+
+  .schedule-section__empty a {
+    color: hsl(5, 53%, 32%);
   }
 
   .map-links {

--- a/src/lib/app-data.ts
+++ b/src/lib/app-data.ts
@@ -10,8 +10,16 @@ import {
   roomsTable,
 } from "../../drizzle/schema";
 import { db } from "./db";
+import { getDefaultTerm } from "./services/term-service";
 import { slugifySegment } from "./site";
-import { BuildingData, ClassMapValue, CollegeData, DivisionData, DormData, RoomData } from "./types";
+import {
+  BuildingData,
+  ClassMapValue,
+  CollegeData,
+  DivisionData,
+  DormData,
+  RoomData,
+} from "./types";
 
 export type SearchCategory =
   | "building"
@@ -34,6 +42,9 @@ export type AppPageData = {
   classesMap: Map<string, ClassMapValue[]>;
   totalRooms: number;
   directionCount: number;
+  // The term whose schedules `classesMap` reflects (default term), or null
+  // when no terms are configured yet.
+  activeTermId: number | null;
 };
 
 let appDataPromise: Promise<AppPageData> | undefined;
@@ -66,6 +77,10 @@ async function fetchAppData(): Promise<AppPageData> {
     .leftJoin(divisionsTable, eq(divisionsTable.id, roomsTable.divisionId))
     .leftJoin(collegesTable, eq(collegesTable.id, roomsTable.collegeId));
 
+  // Class counts/maps reflect the default term so SSG/SEO pages stay
+  // consistent with the term the interactive UI shows by default.
+  const defaultTerm = await getDefaultTerm();
+
   const classes = await db
     .select({
       courseCode: classesTable.courseCode,
@@ -77,7 +92,8 @@ async function fetchAppData(): Promise<AppPageData> {
       courseTitle: classesTable.courseTitle,
     })
     .from(classesTable)
-    .leftJoin(roomsTable, eq(roomsTable.id, classesTable.roomId));
+    .leftJoin(roomsTable, eq(roomsTable.id, classesTable.roomId))
+    .where(defaultTerm ? eq(classesTable.termId, defaultTerm.id) : undefined);
 
   const buildings = await db.select().from(buildingsTable);
   const colleges = await db.select().from(collegesTable);
@@ -120,6 +136,7 @@ async function fetchAppData(): Promise<AppPageData> {
     classesMap,
     totalRooms,
     directionCount,
+    activeTermId: defaultTerm?.id ?? null,
   };
 }
 
@@ -127,9 +144,7 @@ export function getRoomSlug(room: Pick<RoomData, "code">) {
   return slugifySegment(room.code);
 }
 
-export function getRoomRouteSlug(
-  room: Pick<RoomData, "id" | "code">,
-) {
+export function getRoomRouteSlug(room: Pick<RoomData, "id" | "code">) {
   const baseSlug = getRoomSlug(room);
 
   return `${baseSlug}-${room.id}`;
@@ -151,9 +166,7 @@ export function getDormSlug(dorm: Pick<DormData, "dormName">) {
   return slugifySegment(dorm.dormName);
 }
 
-export function getDormRouteSlug(
-  dorm: Pick<DormData, "id" | "dormName">,
-) {
+export function getDormRouteSlug(dorm: Pick<DormData, "id" | "dormName">) {
   const baseSlug = getDormSlug(dorm);
 
   return `${baseSlug}-${dorm.id}`;

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -236,7 +236,7 @@ export async function getAllDivisions(): Promise<DivisionData[]> {
   }
 }
 
-export async function getAllClasses(): Promise<ClassMapValue[]> {
+export async function getAllClasses(termId?: number): Promise<ClassMapValue[]> {
   try {
     const data = await db
       .select({
@@ -252,7 +252,8 @@ export async function getAllClasses(): Promise<ClassMapValue[]> {
         courseTitle: classesTable.courseTitle,
       })
       .from(classesTable)
-      .leftJoin(roomsTable, eq(roomsTable.id, classesTable.roomId));
+      .leftJoin(roomsTable, eq(roomsTable.id, classesTable.roomId))
+      .where(termId != null ? eq(classesTable.termId, termId) : undefined);
     return data;
   } catch (e) {
     console.error("Error: ", e);

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -1,4 +1,4 @@
-import { eq, like } from "drizzle-orm";
+import { and, eq, like } from "drizzle-orm";
 import {
   buildingsTable,
   classesTable,
@@ -258,6 +258,39 @@ export async function getAllClasses(termId?: number): Promise<ClassMapValue[]> {
   } catch (e) {
     console.error("Error: ", e);
     throw new Error("Failed to fetch data for classes");
+  }
+}
+
+export async function getClassesForRoom(
+  roomCode: string,
+  termId?: number,
+): Promise<ClassMapValue[]> {
+  try {
+    const data = await db
+      .select({
+        id: classesTable.id,
+        termId: classesTable.termId,
+        roomId: classesTable.roomId,
+        courseCode: classesTable.courseCode,
+        roomCode: roomsTable.roomCode,
+        section: classesTable.section,
+        type: classesTable.type,
+        schedule: classesTable.schedule,
+        directions: roomsTable.directions,
+        courseTitle: classesTable.courseTitle,
+      })
+      .from(classesTable)
+      .leftJoin(roomsTable, eq(roomsTable.id, classesTable.roomId))
+      .where(
+        and(
+          eq(roomsTable.roomCode, roomCode),
+          termId != null ? eq(classesTable.termId, termId) : undefined,
+        ),
+      );
+    return data;
+  } catch (e) {
+    console.error("Error: ", e);
+    throw new Error("Failed to fetch classes for room");
   }
 }
 

--- a/src/lib/services/term-service.ts
+++ b/src/lib/services/term-service.ts
@@ -1,0 +1,64 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import { classesTable, termsTable } from "../../../drizzle/schema";
+import { db } from "../db";
+import type { Term, TermWithCount } from "../types";
+
+/**
+ * All terms with the number of classes tagged to each, ordered for display
+ * (newest/most relevant first). Returns an empty list if the terms table is
+ * missing (e.g. migration not yet applied) so callers can degrade gracefully.
+ */
+export async function getAllTerms(): Promise<TermWithCount[]> {
+  try {
+    const rows = await db
+      .select({
+        id: termsTable.id,
+        label: termsTable.label,
+        schoolYear: termsTable.schoolYear,
+        semester: termsTable.semester,
+        startsOn: termsTable.startsOn,
+        endsOn: termsTable.endsOn,
+        isDefault: termsTable.isDefault,
+        isActive: termsTable.isActive,
+        sortOrder: termsTable.sortOrder,
+        version: termsTable.version,
+        updatedAt: termsTable.updatedAt,
+        classCount: sql<number>`count(${classesTable.id})::int`,
+      })
+      .from(termsTable)
+      .leftJoin(classesTable, eq(classesTable.termId, termsTable.id))
+      .groupBy(termsTable.id)
+      .orderBy(desc(termsTable.sortOrder), desc(termsTable.id));
+    return rows;
+  } catch (e) {
+    console.error("Failed to fetch terms:", e);
+    return [];
+  }
+}
+
+/**
+ * The single default term for anonymous visitors. Falls back to the newest
+ * active term, then null. Never throws so SSG/SSR data loading stays resilient
+ * when the terms table is empty or not yet migrated.
+ */
+export async function getDefaultTerm(): Promise<Term | null> {
+  try {
+    const [byFlag] = await db
+      .select()
+      .from(termsTable)
+      .where(and(eq(termsTable.isDefault, true), eq(termsTable.isActive, true)))
+      .limit(1);
+    if (byFlag) return byFlag;
+
+    const [newestActive] = await db
+      .select()
+      .from(termsTable)
+      .where(eq(termsTable.isActive, true))
+      .orderBy(desc(termsTable.sortOrder), desc(termsTable.id))
+      .limit(1);
+    return newestActive ?? null;
+  } catch (e) {
+    console.error("Failed to resolve default term:", e);
+    return null;
+  }
+}

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -3,7 +3,12 @@
 import type { modalOptions } from "../constants/modal-states";
 import { SvelteMap } from "svelte/reactivity";
 import * as maplibre from "maplibre-gl";
-import { RoomData, type RecentSearch, type TermWithCount } from "./types";
+import {
+  RoomData,
+  type ClassMapValue,
+  type RecentSearch,
+  type TermWithCount,
+} from "./types";
 import { getJSONFetch, getLocalRoomByCode } from "./local/data/utils";
 
 export type DormFilterType = "all" | "up" | "private";
@@ -578,8 +583,55 @@ class TermStore {
   };
 }
 
+/**
+ * Classes for the currently viewed room, scoped to the active term. Results are
+ * cached per `${roomCode}::${termId}` key so switching back and forth between
+ * terms/rooms doesn't refetch (a clear, term-aware client cache).
+ */
+class RoomClassesStore {
+  classes = $state<ClassMapValue[]>([]);
+  loading = $state(false);
+  private _cache = new Map<string, ClassMapValue[]>();
+  private _requestKey: string | null = null;
+
+  load = async (roomCode: string, termId: number | null) => {
+    const key = `${roomCode}::${termId ?? "all"}`;
+    this._requestKey = key;
+
+    const cached = this._cache.get(key);
+    if (cached) {
+      this.classes = cached;
+      this.loading = false;
+      return;
+    }
+
+    this.loading = true;
+    try {
+      const params = new URLSearchParams({ room_code: roomCode });
+      if (termId != null) params.set("term_id", String(termId));
+      const data = await getJSONFetch<ClassMapValue[]>(
+        `/api/classes?${params.toString()}`,
+      );
+      this._cache.set(key, data);
+      // Ignore responses for a room/term the user has since navigated away from.
+      if (this._requestKey === key) this.classes = data;
+    } catch (e) {
+      console.error("Failed to load room classes:", e);
+      if (this._requestKey === key) this.classes = [];
+    } finally {
+      if (this._requestKey === key) this.loading = false;
+    }
+  };
+
+  clear = () => {
+    this.classes = [];
+    this._requestKey = null;
+  };
+}
+
 export const queryStore = new QueryStore();
 export const termStore = new TermStore();
+export const roomClassesStore = new RoomClassesStore();
 export const modalStore = new ModalStore();
 export const toastStore = new ToastStore();
 export const locationStore = new LocationStore();

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -3,7 +3,7 @@
 import type { modalOptions } from "../constants/modal-states";
 import { SvelteMap } from "svelte/reactivity";
 import * as maplibre from "maplibre-gl";
-import { RoomData, type RecentSearch } from "./types";
+import { RoomData, type RecentSearch, type TermWithCount } from "./types";
 import { getJSONFetch, getLocalRoomByCode } from "./local/data/utils";
 
 export type DormFilterType = "all" | "up" | "private";
@@ -530,7 +530,56 @@ class SyncToastStore {
   }
 }
 
+const ACTIVE_TERM_LS_KEY = "active-term-id";
+
+class TermStore {
+  terms = $state<TermWithCount[]>([]);
+  activeTermId = $state<number | null>(null);
+  loaded = $state(false);
+  private _hydrated = false;
+
+  activeTerm = $derived(
+    this.terms.find((t) => t.id === this.activeTermId) ?? null,
+  );
+
+  init = async () => {
+    if (this._hydrated) return;
+    this._hydrated = true;
+    try {
+      const terms = await getJSONFetch<TermWithCount[]>("/api/terms");
+      this.terms = terms;
+
+      const storedRaw = localStorage.getItem(ACTIVE_TERM_LS_KEY);
+      const stored = storedRaw !== null ? Number(storedRaw) : NaN;
+      const storedValid =
+        Number.isFinite(stored) && terms.some((t) => t.id === stored);
+
+      const fallback =
+        terms.find((t) => t.isDefault) ??
+        terms.find((t) => t.isActive) ??
+        terms[0] ??
+        null;
+
+      this.activeTermId = storedValid ? stored : (fallback?.id ?? null);
+      this.loaded = true;
+    } catch (e) {
+      console.error("Failed to load terms:", e);
+    }
+  };
+
+  setTerm = (id: number) => {
+    this.activeTermId = id;
+    try {
+      localStorage.setItem(ACTIVE_TERM_LS_KEY, String(id));
+    } catch {
+      // localStorage may be unavailable (private mode); selection still works
+      // for the current session.
+    }
+  };
+}
+
 export const queryStore = new QueryStore();
+export const termStore = new TermStore();
 export const modalStore = new ModalStore();
 export const toastStore = new ToastStore();
 export const locationStore = new LocationStore();

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,4 +1,8 @@
-import { dormsTable, roomPositionsTable } from "../../drizzle/schema";
+import {
+  dormsTable,
+  roomPositionsTable,
+  termsTable,
+} from "../../drizzle/schema";
 import type { QueryStoreState } from "./store.svelte";
 
 export type AppData = {
@@ -86,6 +90,11 @@ type DivisionData = {
 };
 
 type DormData = typeof dormsTable.$inferSelect;
+
+type Term = typeof termsTable.$inferSelect;
+
+// A term plus how many classes are tagged with it, for the term selector UI.
+type TermWithCount = Term & { classCount: number };
 
 type RoomPosition = typeof roomPositionsTable.$inferSelect;
 

--- a/src/pages/api/classes.ts
+++ b/src/pages/api/classes.ts
@@ -1,5 +1,8 @@
 import { APIRoute } from "astro";
-import { getAllClasses } from "../../lib/services/map-data-service";
+import {
+  getAllClasses,
+  getClassesForRoom,
+} from "../../lib/services/map-data-service";
 
 export const prerender = false;
 
@@ -7,7 +10,13 @@ export const GET = (async ({ url }) => {
   const termParam = url.searchParams.get("term_id");
   const parsed = termParam !== null ? Number(termParam) : NaN;
   const termId = Number.isFinite(parsed) ? parsed : undefined;
-  const data = await getAllClasses(termId);
+
+  const roomCode = url.searchParams.get("room_code");
+
+  const data = roomCode
+    ? await getClassesForRoom(roomCode, termId)
+    : await getAllClasses(termId);
+
   return new Response(JSON.stringify(data), {
     headers: { "content-type": "application/json" },
   });

--- a/src/pages/api/classes.ts
+++ b/src/pages/api/classes.ts
@@ -3,7 +3,12 @@ import { getAllClasses } from "../../lib/services/map-data-service";
 
 export const prerender = false;
 
-export const GET = (async (_) => {
-  const data = await getAllClasses();
-  return new Response(JSON.stringify(data));
+export const GET = (async ({ url }) => {
+  const termParam = url.searchParams.get("term_id");
+  const parsed = termParam !== null ? Number(termParam) : NaN;
+  const termId = Number.isFinite(parsed) ? parsed : undefined;
+  const data = await getAllClasses(termId);
+  return new Response(JSON.stringify(data), {
+    headers: { "content-type": "application/json" },
+  });
 }) satisfies APIRoute;

--- a/src/pages/api/terms.ts
+++ b/src/pages/api/terms.ts
@@ -1,0 +1,11 @@
+import { APIRoute } from "astro";
+import { getAllTerms } from "../../lib/services/term-service";
+
+export const prerender = false;
+
+export const GET = (async () => {
+  const data = await getAllTerms();
+  return new Response(JSON.stringify(data), {
+    headers: { "content-type": "application/json" },
+  });
+}) satisfies APIRoute;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #162.

Makes the active academic term explicit and selectable, end-to-end: a normalized `terms` table, term-aware class queries/APIs, a term selector in the status bar, and the **room schedule (list + weekly timetable) now filtered by the selected term**.

Targets **`staging`**.

## Changes

**Schema / DB**
- New `terms` table — `id` mirrors the CRS/SAIS `term_id` (e.g. `1252`), plus `label`, `school_year`, `semester`, `starts_on`/`ends_on`, `is_default`, `is_active`, `sort_order`, `version`/`updated_at`.
- Partial unique index (`terms_single_default`) enforces **one default term**.
- Migration `drizzle/0003_add_terms.sql` creates the table/index and idempotently seeds the known UPLB terms (1251, 1252 default).
- `Term` / `TermWithCount` types.

**Data layer / API**
- `term-service.ts`: `getAllTerms()` (with per-term class counts) and `getDefaultTerm()` — degrade gracefully if the table isn't migrated.
- `getAllClasses(termId?)` filters by term; **`getClassesForRoom(roomCode, termId?)`** for the room view.
- `GET /api/terms`; `GET /api/classes?term_id=&room_code=`.
- `loadAppData()` filters class counts by the default term and exposes `activeTermId`.

**UI**
- `termStore`: fetches `/api/terms`, persists selection (`localStorage`), default fallback.
- `TermSelector.svelte`: compact "Schedules:" dropdown in the status bar (active term + class count, empty-state link).
- **`roomClassesStore`**: fetches the current room's classes for the active term, cached per `roomCode::termId` (a clear, term-aware client cache).
- **`RoomResult`**: shows the term-filtered class count, term label, and class list (with empty state); re-fetches when the room or term changes.
- **`ScheduleModal`**: renders the weekly timetable (`ScheduleRender`) for the active term.

**Scripts**
- `export-for-deep-research.ts`: manifest `term_target` now reads the default term label from the DB (Postgres), falling back to the constant for the SQLite path.

## Acceptance criteria
- [x] User can switch term; **the room schedule panel updates accordingly** (list + timetable), and the selection persists.
- [x] Only one term can be default (DB-enforced).
- [x] Server API filters classes by term (and by room).
- [x] Client cache is keyed per term (`roomCode::termId`) — no cross-term collisions.
- [x] Export manifest names the active term explicitly.

> Note on PGlite: classes are fetched per room+term from the server with a term-keyed client cache (rather than the bulk PGlite entity sync used for buildings/rooms). The PGlite `classes` table already carries `term_id`, so a future bulk class sync can key by term the same way; deferred here to keep the change focused.

## Testing
Validated against a local Postgres seeded from a **read-only** copy of the production Neon data (term 1252 = 4351 classes) plus a synthesized term 1251 (870). No production data mutated.

- ✅ `GET /api/terms` → 1252 (default, 4351), 1251 (870)
- ✅ `GET /api/classes?term_id=1252` → 4351; `?term_id=1251` → 870; none → 5221
- ✅ `GET /api/classes?room_code=PSLH%20A&term_id=1252` → 33; `&term_id=1251` → 7; none → 40
- ✅ Migration applies on a fresh DB; single-default index rejects a second default
- ✅ Export script run reads `term_target` from the DB (`AY 2025-2026 2nd Semester`)
- ✅ Manual UI (desktop): open room `PSLH A` → classes (33) for 2nd sem → switch term → updates to (7) for 1st sem (label + list) → switch back → (33) → "Open schedule" renders the weekly timetable with colored class blocks

### Walkthrough
[room_schedule_by_term_demo.mp4](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froom_schedule_by_term_demo.mp4)

Room classes for the default term (2nd sem):
[PSLH A, 33 classes, 2nd Semester](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froom_classes_2nd_sem.webp)

After switching to 1st sem (count + list update):
[PSLH A, 7 classes, 1st Semester](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froom_classes_1st_sem.webp)

Weekly timetable for the active term:
[Weekly timetable with colored class blocks](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froom_schedule_timetable.webp)

Status-bar term selector (from the original term-selector commits):
[Status bar term selector](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fterm_selector_1st_sem.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f22fa558-058c-4cf2-b7f5-c9271e26171f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

