### PR TITLE
Add building copy links

### DIFF
--- a/src/components/seo/EntityIndexPage.astro
+++ b/src/components/seo/EntityIndexPage.astro
@@ -1,10 +1,13 @@
 ---
 import Layout from "../../layouts/Layout.astro";
+import CopyLinkButton from "../svelte/CopyLinkButton.svelte";
 
 type Item = {
   href: string;
   label: string;
   description?: string;
+  copyUrl?: string;
+  copyLabel?: string;
 };
 
 type Props = {
@@ -42,8 +45,27 @@ const {
         {
           items.map((item) => (
             <li>
-              <a href={item.href}>{item.label}</a>
-              {item.description && <span>{item.description}</span>}
+              <div class="entity-index-page__item-main">
+                <a href={item.href}>{item.label}</a>
+                {item.description && (
+                  <span class="entity-index-page__description">
+                    {item.description}
+                  </span>
+                )}
+              </div>
+              {item.copyUrl && (
+                <div class="entity-index-page__item-actions">
+                  <CopyLinkButton
+                    url={item.copyUrl}
+                    ariaLabel={item.copyLabel ?? `Copy link to ${item.label}`}
+                    successMessage="Link copied."
+                    errorMessage={`Could not copy link for ${item.label}.`}
+                    variant="index"
+                    feedback="inline"
+                    client:load
+                  />
+                </div>
+              )}
             </li>
           ))
         }
@@ -87,11 +109,23 @@ const {
 
   li {
     display: grid;
-    gap: 0.125rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.75rem;
     padding: 1rem;
     border: 1px solid #eadfda;
     border-radius: 0.875rem;
     background: white;
+  }
+
+  .entity-index-page__item-main {
+    display: grid;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .entity-index-page__item-actions {
+    justify-self: end;
   }
 
   a {
@@ -100,9 +134,19 @@ const {
     text-decoration: none;
   }
 
-  span {
+  .entity-index-page__description {
     color: #555;
     font-size: 0.95rem;
     line-height: 1.5;
+  }
+
+  @media (max-width: 640px) {
+    li {
+      grid-template-columns: 1fr;
+    }
+
+    .entity-index-page__item-actions {
+      justify-self: stretch;
+    }
   }
 </style>

--- a/src/components/svelte/CopyLinkButton.svelte
+++ b/src/components/svelte/CopyLinkButton.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import Copy from "@lucide/svelte/icons/copy";
+  import { onDestroy } from "svelte";
+  import { copyTextToClipboard } from "../../lib/clipboard";
+
+  type FeedbackMode = "inline" | "none";
+  type Variant = "index" | "chip";
+
+  let {
+    url,
+    label = "Copy link",
+    ariaLabel = label,
+    successMessage = "Link copied.",
+    errorMessage = "Could not copy link.",
+    feedback = "inline",
+    variant = "index",
+    onsuccess,
+    onerror,
+  } = $props<{
+    url: string;
+    label?: string;
+    ariaLabel?: string;
+    successMessage?: string;
+    errorMessage?: string;
+    feedback?: FeedbackMode;
+    variant?: Variant;
+    onsuccess?: () => void;
+    onerror?: () => void;
+  }>();
+
+  let statusMessage = $state("");
+  let copying = $state(false);
+  let statusTimer: ReturnType<typeof setTimeout> | null = null;
+
+  onDestroy(() => {
+    if (statusTimer) {
+      clearTimeout(statusTimer);
+    }
+  });
+
+  function showInlineStatus(message: string) {
+    if (feedback !== "inline") return;
+
+    statusMessage = message;
+
+    if (statusTimer) {
+      clearTimeout(statusTimer);
+    }
+
+    statusTimer = setTimeout(() => {
+      statusMessage = "";
+      statusTimer = null;
+    }, 2500);
+  }
+
+  async function handleCopy() {
+    if (copying) return;
+
+    copying = true;
+    try {
+      await copyTextToClipboard(url);
+      onsuccess?.();
+      showInlineStatus(successMessage);
+    } catch {
+      onerror?.();
+      showInlineStatus(errorMessage);
+    } finally {
+      copying = false;
+    }
+  }
+</script>
+
+<span class="copy-link-wrapper" data-variant={variant}>
+  <button
+    type="button"
+    class="copy-link-btn"
+    aria-label={ariaLabel}
+    aria-busy={copying}
+    title={ariaLabel}
+    disabled={copying}
+    onclick={handleCopy}
+  >
+    <span>{label}</span>
+    <Copy size={16} aria-hidden="true" />
+  </button>
+  {#if feedback === "inline"}
+    <span class="copy-link-status" role="status" aria-live="polite">
+      {statusMessage}
+    </span>
+  {/if}
+</span>
+
+<style>
+  .copy-link-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .copy-link-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background-color 0.2s,
+      border-color 0.2s,
+      color 0.2s,
+      opacity 0.2s;
+  }
+
+  .copy-link-btn:disabled {
+    cursor: progress;
+    opacity: 0.7;
+  }
+
+  .copy-link-btn:focus-visible {
+    outline: 3px solid rgba(123, 17, 19, 0.25);
+    outline-offset: 2px;
+  }
+
+  [data-variant="chip"] .copy-link-btn {
+    width: max-content;
+    padding: 0.375rem 0.75rem;
+    border: 1px solid #d8b9ba;
+    background-color: white;
+    color: #7b1113;
+  }
+
+  [data-variant="chip"] .copy-link-btn:hover:not(:disabled) {
+    background-color: #fdf3f3;
+  }
+
+  [data-variant="index"] .copy-link-btn {
+    padding: 0.35rem 0.625rem;
+    border: 1px solid #eadfda;
+    background-color: #fffafa;
+    color: #7b1113;
+  }
+
+  [data-variant="index"] .copy-link-btn:hover:not(:disabled) {
+    border-color: #d8b9ba;
+    background-color: #fdf3f3;
+  }
+
+  .copy-link-status {
+    min-width: 4.5rem;
+    color: #065f46;
+    font-size: 0.8125rem;
+    font-weight: 500;
+  }
+
+  @media (max-width: 640px) {
+    .copy-link-wrapper,
+    .copy-link-btn {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/components/svelte/Toast.svelte
+++ b/src/components/svelte/Toast.svelte
@@ -22,6 +22,8 @@
 
 <div
   class="toast {type}"
+  role="status"
+  aria-live="polite"
   in:fly={{ y: 20, duration: 300 }}
   out:fade={{ duration: 200 }}
 >

--- a/src/components/svelte/sidepanel/BuildingResult.svelte
+++ b/src/components/svelte/sidepanel/BuildingResult.svelte
@@ -3,18 +3,21 @@
     queryStore,
     locationStore,
     building3DStore,
+    toastStore,
   } from "../../../lib/store.svelte";
   import { getAppData } from "../../../lib/context";
   import CornerRightUp from "@lucide/svelte/icons/corner-right-up";
   import Box from "@lucide/svelte/icons/box";
   import type { RoomData } from "../../../lib/types";
   import ResultDisplay from "./ResultDisplay.svelte";
+  import CopyLinkButton from "../CopyLinkButton.svelte";
   import { onMount } from "svelte";
   import { getBuildingRooms } from "../../../lib/local/data/utils";
   import {
     checkLocalBuildingRoom,
     syncBuildingRooms,
   } from "../../../lib/local/data/sync";
+  import { getBuildingShareUrl } from "../../../lib/share-links";
 
   const appData = getAppData();
   const { buildings, loaded } = $derived(appData());
@@ -23,6 +26,9 @@
     loaded
       ? buildings.find((b) => b.buildingName === queryStore.queryValue)
       : null,
+  );
+  const buildingShareUrl = $derived(
+    building ? getBuildingShareUrl(building.buildingName) : "",
   );
   let buildingRooms = $state<RoomData[] | null>(null);
 
@@ -41,8 +47,8 @@
       {#if building.directions}
         <p class="building-desc">{building.directions}</p>
       {/if}
-      {#if building.lon && building.lat}
-        <div class="building-actions">
+      <div class="building-actions">
+        {#if building.lon && building.lat}
           <button
             class="get-directions-btn"
             onclick={() => {
@@ -63,8 +69,26 @@
             View in 3D
             <Box size={18} />
           </button>
-        </div>
-      {/if}
+        {/if}
+        <CopyLinkButton
+          url={buildingShareUrl}
+          ariaLabel={`Copy link to ${building.buildingName}`}
+          successMessage={`Copied link for ${building.buildingName}.`}
+          errorMessage={`Could not copy link for ${building.buildingName}.`}
+          feedback="none"
+          variant="chip"
+          onsuccess={() =>
+            toastStore.show(
+              `Copied link for ${building.buildingName}.`,
+              "success",
+            )}
+          onerror={() =>
+            toastStore.show(
+              `Could not copy link for ${building.buildingName}.`,
+              "error",
+            )}
+        />
+      </div>
     </div>
   {:else}
     <p>Loading data...</p>

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,40 @@
+export async function copyTextToClipboard(text: string) {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Fall back for browsers that expose Clipboard API but reject the call.
+    }
+  }
+
+  fallbackCopyTextToClipboard(text);
+}
+
+function fallbackCopyTextToClipboard(text: string) {
+  if (typeof document === "undefined") {
+    throw new Error("Clipboard copy is not available.");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+
+  document.body.append(textarea);
+
+  try {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    if (!document.execCommand("copy")) {
+      throw new Error("Clipboard copy failed.");
+    }
+  } finally {
+    textarea.remove();
+  }
+}

--- a/src/lib/share-links.ts
+++ b/src/lib/share-links.ts
@@ -1,0 +1,5 @@
+import { absoluteUrl, slugifySegment } from "./site";
+
+export function getBuildingShareUrl(buildingName: string) {
+  return absoluteUrl(`/building/${slugifySegment(buildingName)}/`);
+}

--- a/src/pages/building/index.astro
+++ b/src/pages/building/index.astro
@@ -1,7 +1,12 @@
 ---
 import EntityIndexPage from "../../components/seo/EntityIndexPage.astro";
 import { getBuildingSlug, loadAppData } from "../../lib/app-data";
-import { breadcrumbSchema, jsonLd, webpageSchema } from "../../lib/site";
+import {
+  absoluteUrl,
+  breadcrumbSchema,
+  jsonLd,
+  webpageSchema,
+} from "../../lib/site";
 
 const { buildings, rooms } = await loadAppData();
 
@@ -12,11 +17,14 @@ const items = buildings
     const roomCount = rooms.filter(
       (room) => room.building?.name === building.buildingName,
     ).length;
+    const href = `/building/${getBuildingSlug(building)}/`;
 
     return {
-      href: `/building/${getBuildingSlug(building)}/`,
+      href,
       label: building.buildingName,
       description: `${roomCount} room${roomCount === 1 ? "" : "s"} listed${building.directions ? " · includes directions" : ""}`,
+      copyUrl: absoluteUrl(href),
+      copyLabel: `Copy link to ${building.buildingName}`,
     };
   });
 


### PR DESCRIPTION
## Summary
- Add reusable building share URL and clipboard helpers for canonical `/building/{slug}/` links.
- Add accessible Copy link controls to building index rows and the in-app building result header.
- Announce in-app copy feedback via the existing toast live region and use inline status feedback on the static building index.

## Test plan
- `bunx prettier --check "src/lib/share-links.ts" "src/lib/clipboard.ts" "src/components/svelte/CopyLinkButton.svelte" "src/components/svelte/Toast.svelte" "src/components/seo/EntityIndexPage.astro" "src/pages/building/index.astro" "src/components/svelte/sidepanel/BuildingResult.svelte"`
- `bunx eslint "src/lib/share-links.ts" "src/lib/clipboard.ts" "src/components/svelte/CopyLinkButton.svelte" "src/components/svelte/Toast.svelte" "src/components/seo/EntityIndexPage.astro" "src/pages/building/index.astro" "src/components/svelte/sidepanel/BuildingResult.svelte"`
- `bun run build`
- Browser check on `/building/` and `/building/physical-sciences-building/` for copy controls, keyboard focusability, and mobile wrapping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only clipboard and link-sharing changes with no auth, data, or API impact.
> 
> **Overview**
> Adds **copy canonical building links** on the static `/building/` index and in the in-app building side panel.
> 
> New **`copyTextToClipboard`** (Clipboard API with `execCommand` fallback) and **`getBuildingShareUrl`** build absolute `/building/{slug}/` URLs. A reusable **`CopyLinkButton`** supports **inline** status on the index and **toast** feedback in the app (`Toast` gets `role="status"` / `aria-live="polite"`).
> 
> **`EntityIndexPage`** accepts optional `copyUrl` / `copyLabel` per row with a two-column layout; **`building/index.astro`** supplies absolute copy URLs. **`BuildingResult`** shows copy alongside directions/3D when coords exist, and copy is available even without lat/lon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24f3ab2ec16340b43924b427def541ab2430d0e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->