### PR TITLE
feat: map orientation controls (2D toggle + rotate/tilt/reset) — on staging

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -12,6 +12,7 @@
   import Modal from "./modal/Modal.svelte";
   import SidePanel from "./sidepanel/SidePanel.svelte";
   import Map from "./Map.svelte";
+  import MapControls from "./MapControls.svelte";
   import StatusBar from "./StatusBar.svelte";
   import Toast from "./Toast.svelte";
   import Building3DViewer from "./Building3DViewer.svelte";
@@ -82,6 +83,7 @@
 <div class="app-layout">
   <Map />
   <div class="ui-layer">
+    <MapControls />
     <!-- <header class="top-header">
       <h2>Room TBA</h2>
     </header> -->

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -825,6 +825,18 @@
 
   $effect(() => {
     const map = mapStore.mapInstance;
+    if (!map) return;
+    mapStore.stopAutoRotate = () => {
+      stopRotation();
+      map.off("moveend", startRotation);
+    };
+    return () => {
+      mapStore.stopAutoRotate = null;
+    };
+  });
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
     const enabled = terrainStore.enabled;
     const exaggeration = terrainStore.exaggeration;
     if (!map) return;

--- a/src/components/svelte/MapControls.svelte
+++ b/src/components/svelte/MapControls.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+  import Compass from "@lucide/svelte/icons/compass";
+  import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
+  import RotateCw from "@lucide/svelte/icons/rotate-cw";
+  import ChevronUp from "@lucide/svelte/icons/chevron-up";
+  import ChevronDown from "@lucide/svelte/icons/chevron-down";
+  import Box from "@lucide/svelte/icons/box";
+  import MapIcon from "@lucide/svelte/icons/map";
+  import { mapStore } from "../../lib/store.svelte";
+  import type { MapLibreMap } from "maplibre-gl";
+
+  const ROTATE_STEP = 30;
+  const PITCH_STEP = 15;
+  const MAX_PITCH = 60;
+  const THREE_D_PITCH = 60;
+  // Pitch at or below this (in degrees) is treated as a flat 2D top-down view.
+  const TWO_D_THRESHOLD = 1;
+
+  let bearing = $state(0);
+  let pitch = $state(0);
+
+  const is2D = $derived(pitch <= TWO_D_THRESHOLD);
+
+  function syncCamera() {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    bearing = map.getBearing();
+    pitch = map.getPitch();
+  }
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    syncCamera();
+    const onChange = () => syncCamera();
+    map.on("rotate", onChange);
+    map.on("pitch", onChange);
+    map.on("move", onChange);
+    return () => {
+      map.off("rotate", onChange);
+      map.off("pitch", onChange);
+      map.off("move", onChange);
+    };
+  });
+
+  function withMap(fn: (map: MapLibreMap) => void) {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    // Manual camera moves should win over the idle auto-rotation animation.
+    mapStore.stopAutoRotate?.();
+    fn(map);
+  }
+
+  const rotateLeft = () =>
+    withMap((map) =>
+      map.easeTo({ bearing: map.getBearing() - ROTATE_STEP, duration: 300 }),
+    );
+
+  const rotateRight = () =>
+    withMap((map) =>
+      map.easeTo({ bearing: map.getBearing() + ROTATE_STEP, duration: 300 }),
+    );
+
+  const tiltUp = () =>
+    withMap((map) =>
+      map.easeTo({
+        pitch: Math.min(map.getPitch() + PITCH_STEP, MAX_PITCH),
+        duration: 300,
+      }),
+    );
+
+  const tiltDown = () =>
+    withMap((map) =>
+      map.easeTo({
+        pitch: Math.max(map.getPitch() - PITCH_STEP, 0),
+        duration: 300,
+      }),
+    );
+
+  const resetNorth = () =>
+    withMap((map) => map.easeTo({ bearing: 0, duration: 400 }));
+
+  const toggleView = () =>
+    withMap((map) => {
+      if (map.getPitch() > TWO_D_THRESHOLD) {
+        // Switch to a flat, north-up top-down view.
+        map.easeTo({ pitch: 0, bearing: 0, duration: 600 });
+      } else {
+        map.easeTo({ pitch: THREE_D_PITCH, duration: 600 });
+      }
+    });
+</script>
+
+<div class="map-controls" aria-label="Map orientation controls">
+  <button
+    class="control view-toggle"
+    onclick={toggleView}
+    title={is2D ? "Switch to 3D tilted view" : "Switch to 2D top-down view"}
+    aria-label={is2D
+      ? "Switch to 3D tilted view"
+      : "Switch to 2D top-down view"}
+    aria-pressed={is2D}
+  >
+    {#if is2D}
+      <Box size={18} />
+      <span>3D</span>
+    {:else}
+      <MapIcon size={18} />
+      <span>2D</span>
+    {/if}
+  </button>
+
+  <div class="divider"></div>
+
+  <div class="rotate-row">
+    <button
+      class="control"
+      onclick={rotateLeft}
+      title="Rotate left"
+      aria-label="Rotate map left"
+    >
+      <RotateCcw size={18} />
+    </button>
+    <button
+      class="control compass"
+      onclick={resetNorth}
+      title="Reset to north"
+      aria-label="Reset map orientation to north"
+    >
+      <span class="compass-icon" style:rotate={`${-bearing}deg`}>
+        <Compass size={20} />
+      </span>
+    </button>
+    <button
+      class="control"
+      onclick={rotateRight}
+      title="Rotate right"
+      aria-label="Rotate map right"
+    >
+      <RotateCw size={18} />
+    </button>
+  </div>
+
+  <div class="divider"></div>
+
+  <div class="tilt-row">
+    <button
+      class="control"
+      onclick={tiltDown}
+      title="Tilt down (less 3D)"
+      aria-label="Decrease map tilt"
+      disabled={pitch <= 0}
+    >
+      <ChevronDown size={18} />
+    </button>
+    <button
+      class="control"
+      onclick={tiltUp}
+      title="Tilt up (more 3D)"
+      aria-label="Increase map tilt"
+      disabled={pitch >= MAX_PITCH}
+    >
+      <ChevronUp size={18} />
+    </button>
+  </div>
+</div>
+
+<style>
+  .map-controls {
+    position: absolute;
+    right: 0.5rem;
+    top: 0.5rem;
+    z-index: 15;
+    pointer-events: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.375rem;
+    padding: 0.375rem;
+    background-color: white;
+    border-radius: 0.875rem;
+    box-shadow: 0 2px 0.5rem 0 hsla(0, 0%, 0%, 0.2);
+  }
+
+  .divider {
+    height: 1px;
+    background-color: hsl(0, 0%, 90%);
+    margin: 0 0.125rem;
+  }
+
+  .rotate-row,
+  .tilt-row {
+    display: flex;
+    gap: 0.25rem;
+    justify-content: center;
+  }
+
+  .control {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: none;
+    border-radius: 0.625rem;
+    background-color: transparent;
+    color: hsl(0, 0%, 20%);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+  }
+
+  .control:hover {
+    background-color: hsla(0, 0%, 0%, 0.08);
+  }
+
+  .control:active {
+    background-color: hsla(0, 0%, 0%, 0.14);
+  }
+
+  .control:disabled {
+    color: hsl(0, 0%, 75%);
+    cursor: default;
+    background-color: transparent;
+  }
+
+  .view-toggle {
+    width: 100%;
+    height: 2.25rem;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: hsl(5, 53%, 32%);
+  }
+
+  .compass {
+    color: hsl(5, 53%, 32%);
+  }
+
+  .compass-icon {
+    display: inline-flex;
+    transition: rotate 0.2s ease;
+  }
+
+  @media (max-width: 800px) {
+    /* Drop below the full-width search box so the two never overlap, and
+       grow the tap targets to the 44px touch-friendly minimum. Native
+       touch gestures (two-finger twist/drag) exist but aren't discoverable,
+       so these explicit affordances stay visible on mobile too. */
+    .map-controls {
+      right: 0.5rem;
+      top: 4rem;
+    }
+
+    .control {
+      width: 2.75rem;
+      height: 2.75rem;
+    }
+  }
+</style>

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -320,6 +320,9 @@ class LocationStore {
 
 class MapStore {
   mapInstance: maplibre.MapLibreMap | undefined = $state.raw();
+  // Set by Map.svelte so UI controls can halt the idle auto-rotation
+  // before performing a manual camera change.
+  stopAutoRotate: (() => void) | null = null;
 }
 
 class SidePanelStore {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Re-applies the skew/rotate map controls (originally #178) on top of **`staging`** instead of `main`, per request. The matching revert of #178 from `main` is in #185.

Closes #173 and #174.

## Summary
Compact map orientation control panel in the **top-right** corner:
- **2D/3D toggle** — animates the camera to a flat north-up top-down view and back (#173).
- **Rotate left/right**, a **compass** that resets bearing to north, and **tilt up/down** (#174) — discoverable affordances for users who don't know the map gestures.

Adapted to staging's code:
- New `MapControls.svelte` (uses staging's per-icon `@lucide/svelte/icons/*` import style).
- `Entry.svelte` renders it in the UI layer.
- `Map.svelte` registers a `mapStore.stopAutoRotate` hook (staging already has the same idle auto-rotation logic) so manual moves win over the spin.
- `store.svelte.ts` adds `stopAutoRotate` to `MapStore`.

Tilt buttons disable at the 0°/60° pitch limits. On mobile the panel drops below the search box and uses 44px tap targets; native two-finger gestures remain available.

## Testing
- ✅ Dev server compiles cleanly; verified no overlap with staging's existing right-edge controls (terrain/3D/jeepney/admin buttons sit lower on the right edge).
- ✅ Manual desktop test of every control (rotate, compass reset, tilt down→up, 2D↔3D toggle) — map camera responds each time (demo below).

### Walkthrough
[map_controls_staging_demo.mp4](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmap_controls_staging_demo.mp4)

[Controls in top-right corner on staging, no overlap](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstaging_controls_top_right.webp)
[Flat 2D top-down view](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstaging_2d_view.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f22fa558-058c-4cf2-b7f5-c9271e26171f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

