### PR TITLE
Offline maps, sidebar drawer, and UI fixes (#171, #181)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,7 +13,19 @@ export default defineConfig({
     svelte(),
     AstroPWA({
       workbox: {
-        globPatterns: ["**/*.{js,css,ico,png,svg,webmanifest,json,jpg}"],
+        // The Vercel adapter otherwise points globDirectory at dist/server,
+        // so nothing client-side gets precached and the app can't load
+        // offline. Glob the actual client output instead.
+        globDirectory: "dist/client",
+        // Precache app assets plus the home shell (only the root index.html,
+        // not the ~650 entity SEO pages) so the app loads offline. The
+        // navigate fallback serves that shell for offline navigations.
+        globPatterns: [
+          "**/*.{js,css,ico,png,svg,webmanifest,json,jpg}",
+          "index.html",
+        ],
+        navigateFallback: "/",
+        navigateFallbackDenylist: [/^\/api\//],
         swDest: `dist/client/sw.js`,
         // Cache third-party map resources at runtime so the campus map works
         // offline once visited (or after an explicit "download offline maps").

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,7 +14,40 @@ export default defineConfig({
     AstroPWA({
       workbox: {
         globPatterns: ["**/*.{js,css,ico,png,svg,webmanifest,json,jpg}"],
-        swDest: `dist/client/sw.js`
+        swDest: `dist/client/sw.js`,
+        // Cache third-party map resources at runtime so the campus map works
+        // offline once visited (or after an explicit "download offline maps").
+        runtimeCaching: [
+          {
+            // MapTiler vector tiles + tiles.json
+            urlPattern: /^https:\/\/api\.maptiler\.com\/.*/i,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "map-tiles",
+              expiration: {
+                maxEntries: 4000,
+                maxAgeSeconds: 60 * 60 * 24 * 30,
+                purgeOnQuotaError: true,
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // Sprites, glyphs, and shaded-relief rasters used by the map style
+            urlPattern:
+              /^https:\/\/(maputnik|orangemug|klokantech)\.github\.io\/.*/i,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "map-assets",
+              expiration: {
+                maxEntries: 800,
+                maxAgeSeconds: 60 * 60 * 24 * 30,
+                purgeOnQuotaError: true,
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
       },
       includeAssets: ["favicon.ico", "apple-touch-icon.png"],
       manifest: {

--- a/src/components/ReloadPrompt.astro
+++ b/src/components/ReloadPrompt.astro
@@ -17,8 +17,10 @@
     visibility: hidden;
     position: fixed;
     background-color: white;
-    right: 0.5rem;
-    bottom: 0.5rem;
+    /* Sit to the left of the right-side button column and clear of the
+       bottom status bar (which can wrap to two rows on mid-width screens). */
+    right: 4.5rem;
+    bottom: 5.5rem;
     padding: 1rem;
     border-radius: 1rem;
     z-index: 1;
@@ -64,6 +66,15 @@
     #pwa-close {
       background-color: hsl(5, 53%, 32%);
       color: white;
+    }
+  }
+
+  @media (max-width: 800px) {
+    #pwa-toast {
+      left: 0.5rem;
+      right: 4rem;
+      bottom: 5rem;
+      width: auto;
     }
   }
 </style>

--- a/src/components/svelte/OfflineMaps.svelte
+++ b/src/components/svelte/OfflineMaps.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import DownloadCloud from "@lucide/svelte/icons/download-cloud";
+  import { offlineStore } from "../../lib/store.svelte";
+
+  let open = $state(false);
+
+  onMount(() => {
+    offlineStore.prepareEstimate();
+  });
+
+  function fmtBytes(bytes: number | null): string {
+    if (bytes == null) return "—";
+    const mb = bytes / 1024 / 1024;
+    if (mb >= 1) return `${mb.toFixed(1)} MB`;
+    return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  }
+
+  const pct = $derived(Math.round(offlineStore.progress * 100));
+</script>
+
+<div class="offline-maps">
+  <button
+    class="offline-trigger"
+    type="button"
+    aria-expanded={open}
+    onclick={() => (open = !open)}
+    title="Download the campus map for offline use"
+  >
+    <DownloadCloud size={16} />
+    <span>Offline maps</span>
+  </button>
+
+  {#if open}
+    <div class="offline-popover" role="dialog" aria-label="Offline maps">
+      {#if offlineStore.status === "downloading"}
+        <p class="offline-line">
+          Downloading campus map… {pct}%
+        </p>
+        <div class="offline-bar" aria-hidden="true">
+          <div class="offline-bar__value" style:width={`${pct}%`}></div>
+        </div>
+        <p class="offline-sub">
+          {offlineStore.tilesDone} / {offlineStore.tilesTotal} tiles ·
+          {fmtBytes(offlineStore.bytesDownloaded)}
+        </p>
+        <button class="offline-btn ghost" onclick={() => offlineStore.cancel()}>
+          Cancel
+        </button>
+      {:else if offlineStore.status === "done"}
+        <p class="offline-line">Campus map saved for offline use.</p>
+        <p class="offline-sub">
+          {offlineStore.tilesTotal} tiles · {fmtBytes(
+            offlineStore.bytesDownloaded,
+          )} downloaded
+        </p>
+        <button class="offline-btn ghost" onclick={() => offlineStore.clear()}>
+          Clear offline maps
+        </button>
+      {:else}
+        <p class="offline-line">Download the campus map for offline use.</p>
+        <p class="offline-sub">
+          Estimated download: ~{fmtBytes(offlineStore.estimatedBytes)}
+          ({offlineStore.tilesTotal} tiles)
+        </p>
+        {#if offlineStore.status === "error" && offlineStore.error}
+          <p class="offline-error">{offlineStore.error}</p>
+        {/if}
+        <button
+          class="offline-btn"
+          onclick={() => offlineStore.downloadCampus()}
+        >
+          Download offline maps
+        </button>
+      {/if}
+
+      <p class="offline-storage">
+        On this device: {fmtBytes(offlineStore.storageUsed)}
+      </p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .offline-maps {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .offline-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: none;
+    border: none;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.5rem;
+    white-space: nowrap;
+  }
+  .offline-trigger:hover {
+    background-color: hsla(0, 0%, 0%, 0.1);
+  }
+
+  .offline-popover {
+    position: absolute;
+    bottom: calc(100% + 0.5rem);
+    right: 0;
+    z-index: 40;
+    width: 16rem;
+    background-color: white;
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+    box-shadow: 0 2px 0.75rem 0 hsla(0, 0%, 0%, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    text-align: left;
+    cursor: default;
+  }
+
+  .offline-line {
+    margin: 0;
+    font-weight: 600;
+    font-size: 0.8125rem;
+    color: black;
+  }
+  .offline-sub {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: hsl(0, 0%, 40%);
+  }
+  .offline-error {
+    margin: 0;
+    font-size: 0.75rem;
+    color: hsl(5, 53%, 38%);
+  }
+
+  .offline-bar {
+    height: 0.5rem;
+    border-radius: 0.5rem;
+    background-color: #ddd;
+    overflow: hidden;
+  }
+  .offline-bar__value {
+    height: 100%;
+    background-color: #7b1113;
+    border-radius: 0.5rem;
+    transition: width 0.2s ease;
+  }
+
+  .offline-btn {
+    margin-top: 0.125rem;
+    border: none;
+    border-radius: 0.5rem;
+    padding: 0.375rem 0.625rem;
+    background-color: hsl(5, 53%, 32%);
+    color: white;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .offline-btn:hover {
+    background-color: hsl(5, 53%, 40%);
+  }
+  .offline-btn.ghost {
+    background-color: white;
+    color: hsl(5, 53%, 32%);
+    border: 1px solid hsl(5, 53%, 75%);
+  }
+  .offline-btn.ghost:hover {
+    background-color: hsl(5, 53%, 97%);
+  }
+
+  .offline-storage {
+    margin: 0.125rem 0 0;
+    padding-top: 0.375rem;
+    border-top: 1px solid hsl(0, 0%, 92%);
+    font-size: 0.6875rem;
+    color: hsl(0, 0%, 55%);
+  }
+</style>

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import ChevronDown from "@lucide/svelte/icons/chevron-down"
-  import ChevronRight from "@lucide/svelte/icons/chevron-right"
-  import MessageCircle from "@lucide/svelte/icons/message-circle"
+  import ChevronDown from "@lucide/svelte/icons/chevron-down";
+  import ChevronRight from "@lucide/svelte/icons/chevron-right";
+  import MessageCircle from "@lucide/svelte/icons/message-circle";
   import { APP_VERSION_LABEL } from "../../constants/version";
   import { getAppData } from "../../lib/context";
   import { modalStore } from "../../lib/store.svelte";
@@ -40,7 +40,12 @@
         <strong>June 2026.</strong>
       </div>
       <div>
-        <a href="/messenger" target="_blank" rel="noopener noreferrer" class="messenger-link">
+        <a
+          href="/messenger"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="messenger-link"
+        >
           <MessageCircle size={18} />
           <div>Contact</div>
         </a>
@@ -108,13 +113,18 @@
       display: flex;
       gap: 1rem;
       flex: 1;
+      min-width: 0;
+      flex-wrap: wrap;
     }
 
     .metadata {
       margin-left: auto;
-      flex: 0 0 auto;
+      flex: 0 1 auto;
+      min-width: 0;
       display: flex;
       align-items: center;
+      flex-wrap: wrap;
+      row-gap: 0.25rem;
       & > *:not(:last-child) {
         border-right: 2px solid #aaa;
         padding-right: 0.75rem;
@@ -153,6 +163,7 @@
       .changelog-link {
         display: flex;
         gap: 0.25rem;
+        white-space: nowrap;
         color: unset;
         text-decoration: unset;
         padding: 0.125rem 0.375rem;
@@ -169,7 +180,8 @@
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      flex: 0 0 24rem;
+      flex: 1 1 24rem;
+      min-width: 12rem;
       .progress-bar {
         height: 0.75rem;
         flex: 1 0 0;

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -5,6 +5,7 @@
   import { APP_VERSION_LABEL } from "../../constants/version";
   import { getAppData } from "../../lib/context";
   import { modalStore } from "../../lib/store.svelte";
+  import OfflineMaps from "./OfflineMaps.svelte";
 
   const appData = getAppData();
   const { directionCount, totalRooms } = $derived(appData());
@@ -38,6 +39,9 @@
       <div class="data-updated">
         Course and room information is updated regularly. Last updated:
         <strong>June 2026.</strong>
+      </div>
+      <div>
+        <OfflineMaps />
       </div>
       <div>
         <a

--- a/src/components/svelte/sidepanel/SidePanel.svelte
+++ b/src/components/svelte/sidepanel/SidePanel.svelte
@@ -231,14 +231,14 @@
       transform: translateY(100%);
     }
     .drawer-handle {
-      top: -1.875rem;
+      top: -1.75rem;
       right: auto;
       left: 50%;
       translate: -50% 0;
-      width: 4rem;
-      height: 1.875rem;
-      border-radius: 0.75rem 0.75rem 0 0;
-      box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.2);
+      width: 5.5rem;
+      height: 1.75rem;
+      border-radius: 0.875rem 0.875rem 0 0;
+      box-shadow: 0 -3px 8px 0 rgba(0, 0, 0, 0.22);
     }
   }
 

--- a/src/components/svelte/sidepanel/SidePanel.svelte
+++ b/src/components/svelte/sidepanel/SidePanel.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import Search from "../search/Search.svelte";
   import { queryStore, sidePanelStore } from "../../../lib/store.svelte";
-  import type { QueryStoreState } from "../../../lib/store.svelte";
   import BuildingResult from "./BuildingResult.svelte";
   import CollegeResult from "./CollegeResult.svelte";
   import DivisionResult from "./DivisionResult.svelte";
@@ -12,23 +11,11 @@
   import LocationButton from "../LocationButton.svelte";
   import JeepneyMenu from "../JeepneyMenu.svelte";
   import TerrainControl from "../TerrainControl.svelte";
-  import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
-  import { cubicOut } from "svelte/easing";
+  import ChevronUp from "@lucide/svelte/icons/chevron-up";
+  import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import { MediaQuery } from "svelte/reactivity";
-  import { fly } from "svelte/transition";
-
-  type ResultCategory = Exclude<QueryStoreState["category"], null>;
-
-  const categoryLabels: Record<ResultCategory, string> = {
-    building: "Building",
-    college: "College",
-    division: "Division",
-    room: "Room",
-    class: "Class search",
-    dorm: "Dorm",
-  };
 
   const mobile = new MediaQuery("max-width:48rem");
   let lastPanelIdentity = $state<string | null>(null);
@@ -37,17 +24,13 @@
       ? null
       : `${queryStore.category}:${queryStore.queryValue}`,
   );
-  const summaryLabel = $derived.by(() => {
-    const category = queryStore.category;
-    return category === null ? "" : categoryLabels[category];
-  });
-  const summaryValue = $derived(queryStore.queryValue || queryStore.inputValue);
   const toggleLabel = $derived(
     sidePanelStore.collapsed
       ? "Expand details panel"
       : "Collapse details panel",
   );
 
+  // A new result always re-opens the drawer.
   $effect(() => {
     const identity = panelIdentity;
     if (identity === lastPanelIdentity) return;
@@ -63,10 +46,7 @@
 
 <div class="side-panel-wrapper">
   <Search />
-  <div
-    class="side-panel-controls"
-    class:is-collapsed={sidePanelStore.collapsed}
-  >
+  <div class="side-panel-controls">
     <div class="floating-actions">
       <BuildingTypeControl />
       <TerrainControl />
@@ -74,56 +54,48 @@
       <LocationButton />
     </div>
     {#if queryStore.category !== null}
-      <div
-        class="side-panel-content"
-        class:is-collapsed={sidePanelStore.collapsed}
-        in:fly={{ x: -12, duration: 160, easing: cubicOut }}
-        out:fly={{ x: -12, duration: 120 }}
-      >
-        <div class="side-panel-summary">
-          <div class="summary-copy">
-            <span class="summary-label">{summaryLabel}</span>
-            <span class="summary-title">{summaryValue}</span>
-          </div>
-          <button
-            class="panel-toggle"
-            type="button"
-            aria-expanded={!sidePanelStore.collapsed}
-            aria-controls="side-panel-details"
-            aria-label={toggleLabel}
-            on:click={togglePanel}
-          >
-            {#if sidePanelStore.collapsed}
-              <ChevronRight size={18} />
-              <span>Expand</span>
-            {:else}
-              {#if mobile.current}
-                <ChevronDown size={18} />
-              {:else}
-                <ChevronLeft size={18} />
-              {/if}
-              <span>Collapse</span>
-            {/if}
-          </button>
-        </div>
-        <div
-          id="side-panel-details"
-          class="side-panel-details"
-          hidden={sidePanelStore.collapsed}
+      <div class="drawer" class:is-collapsed={sidePanelStore.collapsed}>
+        <button
+          class="drawer-handle"
+          type="button"
+          aria-expanded={!sidePanelStore.collapsed}
+          aria-controls="side-panel-details"
+          aria-label={toggleLabel}
+          title={toggleLabel}
+          onclick={togglePanel}
         >
-          {#if queryStore.category === "building"}
-            <BuildingResult />
-          {:else if queryStore.category === "college"}
-            <CollegeResult />
-          {:else if queryStore.category === "division"}
-            <DivisionResult />
-          {:else if queryStore.category === "room"}
-            <RoomResult />
-          {:else if queryStore.category === "class"}
-            <ClassQuery />
-          {:else if queryStore.category === "dorm"}
-            <DormResult />
+          {#if mobile.current}
+            {#if sidePanelStore.collapsed}
+              <ChevronUp size={20} />
+            {:else}
+              <ChevronDown size={20} />
+            {/if}
+          {:else if sidePanelStore.collapsed}
+            <ChevronRight size={20} />
+          {:else}
+            <ChevronLeft size={20} />
           {/if}
+        </button>
+        <div class="drawer-card">
+          <div
+            id="side-panel-details"
+            class="side-panel-details"
+            aria-hidden={sidePanelStore.collapsed}
+          >
+            {#if queryStore.category === "building"}
+              <BuildingResult />
+            {:else if queryStore.category === "college"}
+              <CollegeResult />
+            {:else if queryStore.category === "division"}
+              <DivisionResult />
+            {:else if queryStore.category === "room"}
+              <RoomResult />
+            {:else if queryStore.category === "class"}
+              <ClassQuery />
+            {:else if queryStore.category === "dorm"}
+              <DormResult />
+            {/if}
+          </div>
         </div>
       </div>
     {/if}
@@ -140,122 +112,18 @@
     flex: 1;
     pointer-events: none;
   }
-  .side-panel-content {
-    background-color: white;
-    border-radius: 0.8125rem; /* 24px */
-    padding: 1.125rem; /* 18px top/bottom, 24px left/right */
-    pointer-events: auto;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    height: 100%;
-    flex: 0 0 min(25.75rem, calc(50% - 4rem));
-    box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.25);
-    overflow: hidden;
-    animation: panel-settle-in 160ms cubic-bezier(0.22, 1, 0.36, 1);
-    &.is-collapsed {
-      position: absolute;
-      top: 50%;
-      left: -0.5rem;
-      z-index: 2;
-      translate: 0 -50%;
-      width: min(9.75rem, calc(100vw - 1rem));
-      height: auto;
-      flex: none;
-      padding: 0.5rem 0.75rem 0.5rem 0.625rem;
-      border-radius: 0 999px 999px 0;
-      animation: tab-peek-left 180ms cubic-bezier(0.22, 1, 0.36, 1);
-    }
-    .side-panel-details > :global(*) {
-      scrollbar-width: thin;
-      scrollbar-color: hsl(6, 63%, 48%) hsl(0, 0%, 98%);
-    }
-  }
-  .side-panel-summary {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    min-width: 0;
-    flex-shrink: 0;
-  }
-  .side-panel-content:not(.is-collapsed) .side-panel-summary {
-    justify-content: flex-end;
-    margin-bottom: -0.25rem;
-  }
-  .side-panel-content:not(.is-collapsed) .summary-copy {
-    display: none;
-  }
-  .summary-copy {
-    display: flex;
-    flex-direction: column;
-    gap: 0.125rem;
-    min-width: 0;
-  }
-  .summary-label {
-    color: #7b1113;
-    font-size: 0.6875rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    line-height: 1;
-    text-transform: uppercase;
-  }
-  .summary-title {
-    color: black;
-    font-size: 0.9375rem;
-    font-weight: 700;
-    line-height: 1.2;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .panel-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    flex: 0 0 auto;
-    border: 1px solid #d8b9ba;
-    border-radius: 999px;
-    background-color: white;
-    color: #7b1113;
-    cursor: pointer;
-    font: inherit;
-    font-size: 0.75rem;
-    font-weight: 700;
-    padding: 0.375rem 0.625rem;
-    transition:
-      background-color 0.2s,
-      border-color 0.2s;
-  }
-  .panel-toggle:hover,
-  .panel-toggle:focus-visible {
-    background-color: #fdf3f3;
-    border-color: #c58f91;
-  }
-  .panel-toggle:focus-visible {
-    outline: 2px solid #7b1113;
-    outline-offset: 2px;
-  }
-  .side-panel-details {
-    display: flex;
-    flex: 1 1 0;
-    min-height: 0;
-  }
-  .side-panel-details[hidden] {
-    display: none;
-  }
+
   .side-panel-controls {
+    position: relative;
     display: flex;
-    /* flex-direction: column; */
     flex: 1;
     align-items: flex-end;
     flex-direction: row-reverse;
     justify-content: space-between;
     gap: 1rem;
+    min-height: 0;
   }
-  .side-panel-controls.is-collapsed {
-    align-items: flex-end;
-  }
+
   .floating-actions {
     display: flex;
     flex-direction: column;
@@ -263,45 +131,73 @@
     gap: 0.5rem;
     pointer-events: none;
   }
-  .side-panel-content.is-collapsed .side-panel-summary {
-    gap: 0.5rem;
+
+  /* Full-height drawer that slides out of view when retracted, leaving a
+     persistent middle handle on its outer edge to pull it back. */
+  .drawer {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: min(25.75rem, calc(50% - 4rem));
+    z-index: 2;
+    pointer-events: none;
+    transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
   }
-  .side-panel-content.is-collapsed .summary-label {
-    font-size: 0.625rem;
+  .drawer.is-collapsed {
+    transform: translateX(-100%);
   }
-  .side-panel-content.is-collapsed .summary-title {
-    font-size: 0.8125rem;
+
+  .drawer-card {
+    pointer-events: auto;
+    height: 100%;
+    background-color: white;
+    border-radius: 0.8125rem;
+    padding: 1.125rem;
+    box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
   }
-  .side-panel-content.is-collapsed .panel-toggle {
+
+  .side-panel-details {
+    display: flex;
+    flex: 1 1 0;
+    min-height: 0;
+  }
+  .side-panel-details > :global(*) {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(6, 63%, 48%) hsl(0, 0%, 98%);
+  }
+
+  .drawer-handle {
+    position: absolute;
+    top: 50%;
+    right: -1.875rem;
+    translate: 0 -50%;
     width: 1.875rem;
-    height: 1.875rem;
+    height: 4rem;
+    display: flex;
+    align-items: center;
     justify-content: center;
-    padding: 0;
+    pointer-events: auto;
+    border: none;
+    border-radius: 0 0.75rem 0.75rem 0;
+    background-color: white;
+    color: #7b1113;
+    cursor: pointer;
+    box-shadow: 2px 0 4px 0 rgba(0, 0, 0, 0.2);
   }
-  .side-panel-content.is-collapsed .panel-toggle span {
-    display: none;
+  .drawer-handle:hover,
+  .drawer-handle:focus-visible {
+    background-color: #fdf3f3;
   }
-  @keyframes panel-settle-in {
-    from {
-      opacity: 0.92;
-      transform: translateX(-0.5rem) scale(0.99);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(0) scale(1);
-    }
+  .drawer-handle:focus-visible {
+    outline: 2px solid #7b1113;
+    outline-offset: 2px;
   }
-  @keyframes tab-peek-left {
-    from {
-      opacity: 0.9;
-      transform: translateX(-1rem) scale(0.98);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(0) scale(1);
-    }
-  }
-  /* Mobile responsiveness for side panel */
+
+  /* Mobile: drawer becomes a bottom sheet that slides down to retract. */
   @media screen and (max-width: 48rem) {
     .side-panel-wrapper {
       position: relative;
@@ -309,48 +205,45 @@
       width: 100%;
       max-width: 100%;
       flex: 1;
-      pointer-events: none; /* Let clicks pass through empty space */
+      pointer-events: none;
       display: flex;
       flex-direction: column;
-      justify-content: space-between; /* Space between search top and panel bottom */
+      justify-content: space-between;
     }
     .side-panel-controls {
       flex-direction: column;
       justify-content: flex-end;
-      /* align-items: flex-end; */
     }
-
-    .side-panel-content {
+    .floating-actions {
+      position: absolute;
+      right: 0;
+      bottom: calc(50% + 1.5rem);
+    }
+    .drawer {
+      top: auto;
+      bottom: 0;
+      left: 0;
+      right: 0;
       width: 100%;
-      flex: 0 0 50%;
+      height: 50%;
     }
-    .side-panel-content.is-collapsed {
-      top: 50%;
-      bottom: auto;
-      left: -0.5rem;
-      translate: 0 -50%;
-      width: min(9.75rem, calc(100vw - 1rem));
-      max-height: 5.5rem;
-      flex: none;
-      padding: 0.5rem 0.75rem 0.5rem 0.625rem;
-      border-radius: 0 999px 999px 0;
-      animation: tab-peek-left 180ms cubic-bezier(0.22, 1, 0.36, 1);
+    .drawer.is-collapsed {
+      transform: translateY(100%);
     }
-    /* .side-panel-content {
-      flex: none;
-      margin-top: auto;
-      max-height: 45vh;
-      box-shadow: 0px -4px 12px rgba(0, 0, 0, 0.1);
-    } */
+    .drawer-handle {
+      top: -1.875rem;
+      right: auto;
+      left: 50%;
+      translate: -50% 0;
+      width: 4rem;
+      height: 1.875rem;
+      border-radius: 0.75rem 0.75rem 0 0;
+      box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.2);
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .side-panel-content,
-    .side-panel-content.is-collapsed {
-      animation: none;
-    }
-
-    .panel-toggle {
+    .drawer {
       transition: none;
     }
   }

--- a/src/lib/local/offline-maps.ts
+++ b/src/lib/local/offline-maps.ts
@@ -15,8 +15,9 @@ export const MIN_ZOOM = 13;
 // openmaptiles is 14 — higher zooms are overzoomed client-side, so requesting
 // them just 4xx's). Resolved dynamically in getTileTemplate().
 export const MAX_ZOOM = 14;
-// Rough per-tile size, only used for the pre-download size estimate.
-export const AVG_TILE_BYTES = 80 * 1024;
+// Rough per-tile size, only used for the pre-download size estimate. Tuned to
+// observed campus z13-14 vector tiles (a mix of small and ~150KB tiles).
+export const AVG_TILE_BYTES = 40 * 1024;
 
 export const OFFLINE_TILE_CACHE = "map-tiles";
 export const OFFLINE_ASSET_CACHE = "map-assets";

--- a/src/lib/local/offline-maps.ts
+++ b/src/lib/local/offline-maps.ts
@@ -11,9 +11,12 @@ const CAMPUS_BOUNDS = {
 };
 
 export const MIN_ZOOM = 13;
-export const MAX_ZOOM = 17;
+// Hard ceiling; the real cap comes from the tile source's maxzoom (MapTiler
+// openmaptiles is 14 — higher zooms are overzoomed client-side, so requesting
+// them just 4xx's). Resolved dynamically in getTileTemplate().
+export const MAX_ZOOM = 14;
 // Rough per-tile size, only used for the pre-download size estimate.
-export const AVG_TILE_BYTES = 28 * 1024;
+export const AVG_TILE_BYTES = 80 * 1024;
 
 export const OFFLINE_TILE_CACHE = "map-tiles";
 export const OFFLINE_ASSET_CACHE = "map-assets";
@@ -51,27 +54,38 @@ export function getCampusTileCoords(
   return coords;
 }
 
-let cachedTemplate: string | null = null;
+export type TileSource = { template: string; maxZoom: number };
+
+let cachedSource: TileSource | null = null;
 
 /**
- * Resolve the MapTiler vector-tile URL template from the map style, following
- * the tiles.json indirection. Reuses the existing key in the style file.
+ * Resolve the MapTiler vector-tile URL template and the source's maxzoom from
+ * the map style, following the tiles.json indirection. Reuses the existing key
+ * in the style file. Zoom levels above maxZoom are overzoomed client-side, so
+ * they must not be prefetched.
  */
-export async function getTileTemplate(): Promise<string | null> {
-  if (cachedTemplate) return cachedTemplate;
+export async function getTileTemplate(): Promise<TileSource | null> {
+  if (cachedSource) return cachedSource;
   try {
     const style = await (await fetch("/liberty-customized.json")).json();
     const src = style?.sources?.openmaptiles;
     if (!src) return null;
+
     if (Array.isArray(src.tiles) && src.tiles[0]) {
-      cachedTemplate = src.tiles[0];
-      return cachedTemplate;
+      cachedSource = {
+        template: src.tiles[0],
+        maxZoom: clampMaxZoom(src.maxzoom),
+      };
+      return cachedSource;
     }
     if (typeof src.url === "string") {
       const tj = await (await fetch(src.url)).json();
       if (Array.isArray(tj?.tiles) && tj.tiles[0]) {
-        cachedTemplate = tj.tiles[0];
-        return cachedTemplate;
+        cachedSource = {
+          template: tj.tiles[0],
+          maxZoom: clampMaxZoom(tj.maxzoom),
+        };
+        return cachedSource;
       }
     }
     return null;
@@ -79,6 +93,11 @@ export async function getTileTemplate(): Promise<string | null> {
     console.error("Failed to resolve tile template:", e);
     return null;
   }
+}
+
+function clampMaxZoom(sourceMaxZoom: unknown): number {
+  const z = Number(sourceMaxZoom);
+  return Number.isFinite(z) ? Math.min(MAX_ZOOM, z) : MAX_ZOOM;
 }
 
 export function tileUrl(template: string, { z, x, y }: TileCoord): string {

--- a/src/lib/local/offline-maps.ts
+++ b/src/lib/local/offline-maps.ts
@@ -1,0 +1,109 @@
+// Helpers for downloading the campus map tiles for offline use and for
+// reporting how much data is involved. Tiles are fetched from the page so the
+// service worker's `map-tiles` runtime cache stores them (see astro.config.mjs).
+
+// Campus bounds — mirrors `maxBounds` in src/components/svelte/Map.svelte.
+const CAMPUS_BOUNDS = {
+  minLon: 121.22951431520816,
+  minLat: 14.143739048514412,
+  maxLon: 121.28117994803134,
+  maxLat: 14.18059150108623,
+};
+
+export const MIN_ZOOM = 13;
+export const MAX_ZOOM = 17;
+// Rough per-tile size, only used for the pre-download size estimate.
+export const AVG_TILE_BYTES = 28 * 1024;
+
+export const OFFLINE_TILE_CACHE = "map-tiles";
+export const OFFLINE_ASSET_CACHE = "map-assets";
+
+export type TileCoord = { z: number; x: number; y: number };
+
+function lonToTileX(lon: number, z: number): number {
+  return Math.floor(((lon + 180) / 360) * 2 ** z);
+}
+
+function latToTileY(lat: number, z: number): number {
+  const rad = (lat * Math.PI) / 180;
+  return Math.floor(
+    ((1 - Math.log(Math.tan(rad) + 1 / Math.cos(rad)) / Math.PI) / 2) * 2 ** z,
+  );
+}
+
+/** All XYZ tiles covering the campus bounds across the configured zoom range. */
+export function getCampusTileCoords(
+  minZoom = MIN_ZOOM,
+  maxZoom = MAX_ZOOM,
+): TileCoord[] {
+  const coords: TileCoord[] = [];
+  for (let z = minZoom; z <= maxZoom; z++) {
+    const xA = lonToTileX(CAMPUS_BOUNDS.minLon, z);
+    const xB = lonToTileX(CAMPUS_BOUNDS.maxLon, z);
+    const yA = latToTileY(CAMPUS_BOUNDS.maxLat, z);
+    const yB = latToTileY(CAMPUS_BOUNDS.minLat, z);
+    for (let x = Math.min(xA, xB); x <= Math.max(xA, xB); x++) {
+      for (let y = Math.min(yA, yB); y <= Math.max(yA, yB); y++) {
+        coords.push({ z, x, y });
+      }
+    }
+  }
+  return coords;
+}
+
+let cachedTemplate: string | null = null;
+
+/**
+ * Resolve the MapTiler vector-tile URL template from the map style, following
+ * the tiles.json indirection. Reuses the existing key in the style file.
+ */
+export async function getTileTemplate(): Promise<string | null> {
+  if (cachedTemplate) return cachedTemplate;
+  try {
+    const style = await (await fetch("/liberty-customized.json")).json();
+    const src = style?.sources?.openmaptiles;
+    if (!src) return null;
+    if (Array.isArray(src.tiles) && src.tiles[0]) {
+      cachedTemplate = src.tiles[0];
+      return cachedTemplate;
+    }
+    if (typeof src.url === "string") {
+      const tj = await (await fetch(src.url)).json();
+      if (Array.isArray(tj?.tiles) && tj.tiles[0]) {
+        cachedTemplate = tj.tiles[0];
+        return cachedTemplate;
+      }
+    }
+    return null;
+  } catch (e) {
+    console.error("Failed to resolve tile template:", e);
+    return null;
+  }
+}
+
+export function tileUrl(template: string, { z, x, y }: TileCoord): string {
+  return template
+    .replace("{z}", String(z))
+    .replace("{x}", String(x))
+    .replace("{y}", String(y));
+}
+
+/** Bytes currently used by the browser for this origin (caches + IndexedDB). */
+export async function getStorageUsage(): Promise<number | null> {
+  try {
+    if (navigator.storage?.estimate) {
+      const est = await navigator.storage.estimate();
+      return est.usage ?? null;
+    }
+  } catch {
+    // ignore — Storage API unavailable
+  }
+  return null;
+}
+
+/** Delete the offline map caches. */
+export async function clearMapCaches(): Promise<void> {
+  if (!("caches" in window)) return;
+  await caches.delete(OFFLINE_TILE_CACHE);
+  await caches.delete(OFFLINE_ASSET_CACHE);
+}

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -7,6 +7,14 @@ import { SvelteMap } from "svelte/reactivity";
 import * as maplibre from "maplibre-gl";
 import { RoomData, type RecentSearch } from "./types";
 import { getJSONFetch, getLocalRoomByCode } from "./local/data/utils";
+import {
+  AVG_TILE_BYTES,
+  clearMapCaches,
+  getCampusTileCoords,
+  getStorageUsage,
+  getTileTemplate,
+  tileUrl,
+} from "./local/offline-maps";
 
 export type DormFilterType = "all" | "up" | "private";
 export type SyncInfo = {
@@ -599,13 +607,103 @@ class SyncToastStore {
   }
 
   endSync() {
-      this.allSynced = true;
-      if (this.recentlySynced === null)
-        this.recentlySynced = false;
+    this.allSynced = true;
+    if (this.recentlySynced === null) this.recentlySynced = false;
   }
 }
 
+type OfflineStatus = "idle" | "downloading" | "done" | "error" | "cancelled";
+
+class OfflineStore {
+  status = $state<OfflineStatus>("idle");
+  tilesTotal = $state(0);
+  tilesDone = $state(0);
+  bytesDownloaded = $state(0);
+  storageUsed = $state<number | null>(null);
+  error = $state<string | null>(null);
+  private cancelRequested = false;
+
+  progress = $derived(
+    this.tilesTotal === 0 ? 0 : Math.min(1, this.tilesDone / this.tilesTotal),
+  );
+  estimatedBytes = $derived(this.tilesTotal * AVG_TILE_BYTES);
+
+  // Compute the tile count up front so the size estimate shows before download.
+  prepareEstimate = () => {
+    if (this.tilesTotal === 0) this.tilesTotal = getCampusTileCoords().length;
+    void this.refreshStorage();
+  };
+
+  refreshStorage = async () => {
+    this.storageUsed = await getStorageUsage();
+  };
+
+  cancel = () => {
+    this.cancelRequested = true;
+  };
+
+  downloadCampus = async () => {
+    if (this.status === "downloading") return;
+    this.cancelRequested = false;
+    this.error = null;
+    this.tilesDone = 0;
+    this.bytesDownloaded = 0;
+    this.status = "downloading";
+
+    const template = await getTileTemplate();
+    if (!template) {
+      this.status = "error";
+      this.error = "Could not resolve the map tile source.";
+      return;
+    }
+
+    const coords = getCampusTileCoords();
+    this.tilesTotal = coords.length;
+
+    let index = 0;
+    const worker = async () => {
+      while (index < coords.length && !this.cancelRequested) {
+        const coord = coords[index++];
+        if (!coord) break;
+        try {
+          const res = await fetch(tileUrl(template, coord), { mode: "cors" });
+          const len = Number(res.headers.get("content-length"));
+          if (Number.isFinite(len) && len > 0) {
+            this.bytesDownloaded += len;
+          } else {
+            const buf = await res.clone().arrayBuffer();
+            this.bytesDownloaded += buf.byteLength;
+          }
+        } catch {
+          // Skip individual tile failures; keep the overall download going.
+        }
+        this.tilesDone++;
+      }
+    };
+
+    try {
+      // Modest concurrency to fill the cache quickly without hammering the API.
+      await Promise.all(Array.from({ length: 6 }, () => worker()));
+      await this.refreshStorage();
+      this.status = this.cancelRequested ? "cancelled" : "done";
+    } catch (e) {
+      console.error("Offline map download failed:", e);
+      this.status = "error";
+      this.error = "Download failed. Check your connection and try again.";
+    }
+  };
+
+  clear = async () => {
+    await clearMapCaches();
+    this.tilesDone = 0;
+    this.bytesDownloaded = 0;
+    this.status = "idle";
+    await this.refreshStorage();
+  };
+}
+
 export const queryStore = new QueryStore();
+export const offlineStore = new OfflineStore();
 export const modalStore = new ModalStore();
 export const toastStore = new ToastStore();
 export const locationStore = new LocationStore();

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -13,6 +13,7 @@ import {
   getCampusTileCoords,
   getStorageUsage,
   getTileTemplate,
+  MIN_ZOOM,
   tileUrl,
 } from "./local/offline-maps";
 
@@ -629,9 +630,11 @@ class OfflineStore {
   estimatedBytes = $derived(this.tilesTotal * AVG_TILE_BYTES);
 
   // Compute the tile count up front so the size estimate shows before download.
-  prepareEstimate = () => {
-    if (this.tilesTotal === 0) this.tilesTotal = getCampusTileCoords().length;
+  prepareEstimate = async () => {
     void this.refreshStorage();
+    if (this.tilesTotal !== 0) return;
+    const source = await getTileTemplate();
+    this.tilesTotal = getCampusTileCoords(MIN_ZOOM, source?.maxZoom).length;
   };
 
   refreshStorage = async () => {
@@ -650,14 +653,14 @@ class OfflineStore {
     this.bytesDownloaded = 0;
     this.status = "downloading";
 
-    const template = await getTileTemplate();
-    if (!template) {
+    const source = await getTileTemplate();
+    if (!source) {
       this.status = "error";
       this.error = "Could not resolve the map tile source.";
       return;
     }
 
-    const coords = getCampusTileCoords();
+    const coords = getCampusTileCoords(MIN_ZOOM, source.maxZoom);
     this.tilesTotal = coords.length;
 
     let index = 0;
@@ -666,13 +669,17 @@ class OfflineStore {
         const coord = coords[index++];
         if (!coord) break;
         try {
-          const res = await fetch(tileUrl(template, coord), { mode: "cors" });
-          const len = Number(res.headers.get("content-length"));
-          if (Number.isFinite(len) && len > 0) {
-            this.bytesDownloaded += len;
-          } else {
-            const buf = await res.clone().arrayBuffer();
-            this.bytesDownloaded += buf.byteLength;
+          const res = await fetch(tileUrl(source.template, coord), {
+            mode: "cors",
+          });
+          if (res.ok) {
+            const len = Number(res.headers.get("content-length"));
+            if (Number.isFinite(len) && len > 0) {
+              this.bytesDownloaded += len;
+            } else {
+              const buf = await res.clone().arrayBuffer();
+              this.bytesDownloaded += buf.byteLength;
+            }
           }
         } catch {
           // Skip individual tile failures; keep the overall download going.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the approved plan on `staging`, and makes the PWA genuinely work offline.

## Changes
- **#171 — version overflow** (`StatusBar.svelte`): progress bar shrinks, metadata wraps, version stays on one line.
- **Offline toast** (`ReloadPrompt.astro`): repositioned left of the right-side buttons and above the status bar (+ mobile rule).
- **#181 — sidebar drawer** (`SidePanel.svelte`): retraction is now a full-height drawer that slides out of view with a persistent middle handle; mobile is a slide-down bottom sheet.
- **Offline maps (option B)**: Workbox `runtimeCaching` for MapTiler tiles + sprite/glyph hosts (`astro.config.mjs`); campus tile prefetch capped to the source maxzoom (`offline-maps.ts`); `offlineStore` (tiles/bytes/progress + `storage.estimate`); `OfflineMaps.svelte` status-bar control.
- **PWA offline fix** (`astro.config.mjs`): Workbox `globDirectory` was pointing at `dist/server` (Vercel adapter), so nothing client-side was precached and the app couldn't load offline at all. Point it at `dist/client`, precache the home shell (root `index.html` only), and add a navigate fallback.

## Code review fixes (last pass)
- Tightened the offline size estimate (`AVG_TILE_BYTES` 80KB → 40KB) to better match observed tile sizes.
- Widened the mobile bottom-sheet handle for discoverability.

## Note on the earlier "SW unbuildable" concern
False alarm from a stale local `node_modules`. A clean `bun install --frozen-lockfile` resolves babel's nested `lru-cache@5` correctly (already in `bun.lock`); no dependency change needed.

## Testing
- ✅ **#171** at 900px: `v1.7.3` fully visible, nothing clipped.
- ✅ **Toast**: above the status bar, left of the buttons, no overlap.
- ✅ **#181 drawer (desktop)**: slides fully out of view (handle remains) and back.
- ✅ **#181 drawer (mobile, 400px)**: reflows to a bottom sheet; the top handle slides it down out of view and back up; right-side buttons stay visible.
- ✅ **Offline download**: estimate → progress bar → done (~18 tiles · ~528 KB; z13–14 only).
- ✅ **Offline end-to-end** (production build): with Network=Offline, reload loads the app shell and renders campus tiles served by the **ServiceWorker** (0 B transferred).
- ✅ `bun run build` completes and emits `sw.js` + `workbox-*.js` (43 precache entries).

### Walkthrough
Offline end-to-end (Network=Offline, tiles served by ServiceWorker, 0 B transferred):
[Campus map offline; DevTools shows tiles from ServiceWorker, 0 B transferred](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foffline_tiles_from_sw.webp)
[offline_map_works_demo.mp4](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foffline_map_works_demo.mp4)

Mobile bottom-sheet drawer (400px):
[Sidebar as a bottom sheet on mobile](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_drawer_bottom_sheet.webp)

Offline maps control + drawer (desktop) + #171 + toast:
[Offline download complete](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foffline_done.webp)
[Drawer slid out, handle remains](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_drawer_collapsed.webp)
[Version visible at 900px](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fversion_overflow_fixed_900px.webp)
[Offline toast above status bar, left of buttons](https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foffline_toast_repositioned.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f22fa558-058c-4cf2-b7f5-c9271e26171f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f22fa558-058c-4cf2-b7f5-c9271e26171f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

