### PR TITLE
Clean up map UI controls

### DIFF
--- a/src/components/ReloadPrompt.astro
+++ b/src/components/ReloadPrompt.astro
@@ -14,6 +14,8 @@
     display: none;
   }
   #pwa-toast {
+    --pwa-toast-bottom-clearance: 4.25rem;
+
     visibility: hidden;
     position: fixed;
     background-color: white;
@@ -22,8 +24,9 @@
     right: 4.5rem;
     bottom: 5.5rem;
     padding: 1rem;
+    border: 1px solid #d8b9ba;
     border-radius: 1rem;
-    z-index: 1;
+    background-color: white;
     text-align: left;
     box-shadow: 0 2px 0.5rem 0 hsla(0, 0%, 0%, 0.2);
     width: min(20rem, calc(100% - (2 * 0.5rem)));
@@ -35,15 +38,27 @@
 
     .message {
       margin-bottom: 8px;
+      color: hsl(0, 0%, 15%);
       font-weight: 600;
+      line-height: 1.35;
     }
     button {
-      border: 1px solid #8885;
+      border: 1px solid #d8b9ba;
       outline: none;
-      margin-right: 5px;
       border-radius: 0.5rem;
+      background-color: white;
+      color: hsl(5, 53%, 32%);
+      cursor: pointer;
+      font-weight: 700;
       padding: 0.25rem 1rem;
       font-size: 0.875rem;
+      &:focus-visible {
+        outline: 3px solid rgba(123, 17, 19, 0.25);
+        outline-offset: 2px;
+      }
+      &:hover {
+        background-color: hsl(5, 53%, 98%);
+      }
       &:active {
         background-color: hsl(0, 0%, 95%);
       }

--- a/src/components/svelte/BuildingTypeControl.svelte
+++ b/src/components/svelte/BuildingTypeControl.svelte
@@ -5,12 +5,16 @@
     getBuildingTypeFilterOptions,
   } from "../../constants/building-types";
   import { getAppData } from "../../lib/context";
-  import { buildingTypeFilter } from "../../lib/store.svelte";
+  import {
+    buildingTypeFilter,
+    floatingControlPanelStore,
+  } from "../../lib/store.svelte";
   import type { BuildingTypeFilter } from "../../constants/building-types";
 
   const appData = getAppData();
   const { buildings, dorms } = $derived(appData());
-  let menuOpen = $state(false);
+  const panelId = "building-type";
+  const menuOpen = $derived(floatingControlPanelStore.openPanel === panelId);
 
   const options = $derived(getBuildingTypeFilterOptions(buildings, dorms));
   const activeLabel = $derived(
@@ -20,7 +24,7 @@
 
   function selectFilter(value: BuildingTypeFilter) {
     buildingTypeFilter.set(value);
-    menuOpen = false;
+    floatingControlPanelStore.close(panelId);
   }
 </script>
 
@@ -32,7 +36,7 @@
         <button
           type="button"
           class="close-btn"
-          onclick={() => (menuOpen = false)}
+          onclick={() => floatingControlPanelStore.close(panelId)}
           aria-label="Close building type filter"
         >
           <X size="16" />
@@ -66,7 +70,7 @@
   <button
     class="filter-btn"
     class:active={hasActiveFilter}
-    onclick={() => (menuOpen = !menuOpen)}
+    onclick={() => floatingControlPanelStore.toggle(panelId)}
     title={`Building Type: ${activeLabel}`}
     aria-label={`Building Type: ${activeLabel}`}
     aria-expanded={menuOpen}

--- a/src/components/svelte/CopyLinkButton.svelte
+++ b/src/components/svelte/CopyLinkButton.svelte
@@ -100,13 +100,19 @@
 
   .copy-link-btn {
     display: inline-flex;
+    min-height: 2rem;
     align-items: center;
     justify-content: center;
     gap: 0.375rem;
     border-radius: 0.5rem;
+    border: 1px solid #d8b9ba;
+    background-color: white;
+    color: #7b1113;
     font-size: 0.875rem;
-    font-weight: 500;
+    font-weight: 700;
+    line-height: 1;
     cursor: pointer;
+    white-space: nowrap;
     transition:
       background-color 0.2s,
       border-color 0.2s,
@@ -124,27 +130,26 @@
     outline-offset: 2px;
   }
 
+  .copy-link-btn :global(svg) {
+    flex: 0 0 auto;
+  }
+
   [data-variant="chip"] .copy-link-btn {
     width: max-content;
     padding: 0.375rem 0.75rem;
-    border: 1px solid #d8b9ba;
-    background-color: white;
-    color: #7b1113;
   }
 
   [data-variant="chip"] .copy-link-btn:hover:not(:disabled) {
+    border-color: #c58f91;
     background-color: #fdf3f3;
   }
 
   [data-variant="index"] .copy-link-btn {
     padding: 0.35rem 0.625rem;
-    border: 1px solid #eadfda;
-    background-color: #fffafa;
-    color: #7b1113;
   }
 
   [data-variant="index"] .copy-link-btn:hover:not(:disabled) {
-    border-color: #d8b9ba;
+    border-color: #c58f91;
     background-color: #fdf3f3;
   }
 

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -122,7 +122,9 @@
     display: flex;
     flex-direction: column;
     padding: 0.5rem;
+    padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));
     flex: 1 0 0;
+    min-height: 0;
     pointer-events: none;
     gap: 0.5rem;
   }

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -41,7 +41,7 @@
           queryStore.addRecentSearch(parsedSearch);
         }
       });
-    } catch (e) {
+    } catch {
       queryStore.recentSearches = [];
     }
     if (initialSearch) {
@@ -84,7 +84,10 @@
 <div class="app-layout">
   <Map />
   <div class="ui-layer">
-    <MapControls />
+    <div class="top-right-map-stack" aria-label="Map tools">
+      <MapControls />
+      <SyncToast stacked />
+    </div>
     <!-- <header class="top-header">
       <h2>Room TBA</h2>
     </header> -->
@@ -108,7 +111,6 @@
     <AdminLoginModal />
   {/if}
 </div>
-<SyncToast />
 
 <style>
   .app-layout {
@@ -142,8 +144,27 @@
     width: 100%;
   }
 
+  .top-right-map-stack {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 15;
+    display: flex;
+    width: min(22.5rem, calc(100% - 1rem));
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+    pointer-events: none;
+  }
+
   :global(*) {
     margin: unset;
     box-sizing: border-box;
+  }
+
+  @media (max-width: 800px) {
+    .top-right-map-stack {
+      top: 4rem;
+    }
   }
 </style>

--- a/src/components/svelte/JeepneyMenu.svelte
+++ b/src/components/svelte/JeepneyMenu.svelte
@@ -1,19 +1,30 @@
 <script lang="ts">
   import X from "@lucide/svelte/icons/x";
-  import Bus from "@lucide/svelte/icons/bus"
+  import Bus from "@lucide/svelte/icons/bus";
   import { JEEPNEY_ROUTES } from "../../constants/jeepney-routes";
-  import { jeepneyStore } from "../../lib/store.svelte";
+  import {
+    floatingControlPanelStore,
+    jeepneyStore,
+  } from "../../lib/store.svelte";
+
+  const panelId = "jeepney";
+  const menuOpen = $derived(floatingControlPanelStore.openPanel === panelId);
+
+  function selectRoute(id: string) {
+    jeepneyStore.selectRoute(id);
+    floatingControlPanelStore.close(panelId);
+  }
 </script>
 
 <div class="jeepney-menu">
-  {#if jeepneyStore.menuOpen}
+  {#if menuOpen}
     <div class="route-list" role="menu">
       <div class="route-list-header">
         <span>Jeepney Routes</span>
         <button
           type="button"
           class="close-btn"
-          onclick={() => jeepneyStore.closeMenu()}
+          onclick={() => floatingControlPanelStore.close(panelId)}
           aria-label="Close jeepney menu"
         >
           <X size="16" />
@@ -25,7 +36,7 @@
           type="button"
           class="route-option"
           class:active={isActive}
-          onclick={() => jeepneyStore.selectRoute(route.id)}
+          onclick={() => selectRoute(route.id)}
         >
           <span class="route-color" style:background-color={route.color}></span>
           <span class="route-text">
@@ -49,10 +60,10 @@
   <button
     class="jeepney-btn"
     class:active={jeepneyStore.selectedRouteId !== null}
-    onclick={() => jeepneyStore.toggleMenu()}
+    onclick={() => floatingControlPanelStore.toggle(panelId)}
     title="Jeepney Routes"
     aria-label="Jeepney Routes"
-    aria-expanded={jeepneyStore.menuOpen}
+    aria-expanded={menuOpen}
   >
     <Bus />
   </button>

--- a/src/components/svelte/LocationButton.svelte
+++ b/src/components/svelte/LocationButton.svelte
@@ -8,6 +8,7 @@
   import ShieldCheck from "@lucide/svelte/icons/shield-check";
   import {
     adminAuthStore,
+    floatingControlPanelStore,
     locationStore,
     mapEditStore,
     mapStore,
@@ -15,7 +16,10 @@
   } from "../../lib/store.svelte";
 
   let centered: boolean = $state(false);
-  let adminMenuOpen = $state(false);
+  const adminPanelId = "admin";
+  const adminMenuOpen = $derived(
+    floatingControlPanelStore.openPanel === adminPanelId,
+  );
   const adminLabel = $derived(adminAuthStore.username ?? "admin");
 
   onMount(() => {
@@ -47,7 +51,7 @@
   }
 
   async function handleLogout() {
-    adminMenuOpen = false;
+    floatingControlPanelStore.close(adminPanelId);
     mapEditStore.close();
     await adminAuthStore.logout();
     toastStore.show("Signed out.", "info");
@@ -96,7 +100,7 @@
       <button
         class="map-control-btn"
         class:active={mapEditStore.enabled}
-        onclick={() => (adminMenuOpen = !adminMenuOpen)}
+        onclick={() => floatingControlPanelStore.toggle(adminPanelId)}
         title={mapEditStore.enabled
           ? "Editor controls: map edit mode on"
           : "Editor controls"}

--- a/src/components/svelte/LocationButton.svelte
+++ b/src/components/svelte/LocationButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import Lock from "@lucide/svelte/icons/lock";
+  import LogIn from "@lucide/svelte/icons/log-in";
   import Locate from "@lucide/svelte/icons/locate";
   import LocateFixed from "@lucide/svelte/icons/locate-fixed";
   import LogOut from "@lucide/svelte/icons/log-out";
@@ -13,9 +13,11 @@
     mapStore,
     toastStore,
   } from "../../lib/store.svelte";
-    import { SquareArrowRightEnterIcon } from "@lucide/svelte";
 
   let centered: boolean = $state(false);
+  let adminMenuOpen = $state(false);
+  const adminLabel = $derived(adminAuthStore.username ?? "admin");
+
   onMount(() => {
     adminAuthStore.hydrate();
   });
@@ -45,6 +47,7 @@
   }
 
   async function handleLogout() {
+    adminMenuOpen = false;
     mapEditStore.close();
     await adminAuthStore.logout();
     toastStore.show("Signed out.", "info");
@@ -53,31 +56,60 @@
 
 <div class="map-control-stack">
   {#if adminAuthStore.isAdmin}
-    <div class="map-control-btn admin-state" title="Signed in as admin">
-      <ShieldCheck />
+    <div class="admin-control">
+      {#if adminMenuOpen}
+        <div
+          id="admin-control-menu"
+          class="admin-panel"
+          role="menu"
+          aria-label="Editor controls"
+        >
+          <div class="admin-status">
+            <ShieldCheck size={16} />
+            <span>
+              <strong>Editor signed in</strong>
+              <small>{adminLabel}</small>
+            </span>
+          </div>
+          <button
+            type="button"
+            class="admin-menu-action"
+            class:active={mapEditStore.enabled}
+            role="menuitem"
+            aria-pressed={mapEditStore.enabled}
+            onclick={toggleMapEditMode}
+          >
+            <Pencil size={16} />
+            {mapEditStore.enabled ? "Turn off map edit" : "Turn on map edit"}
+          </button>
+          <button
+            type="button"
+            class="admin-menu-action danger"
+            role="menuitem"
+            onclick={handleLogout}
+          >
+            <LogOut size={16} />
+            Sign out
+          </button>
+        </div>
+      {/if}
+      <button
+        class="map-control-btn"
+        class:active={mapEditStore.enabled}
+        onclick={() => (adminMenuOpen = !adminMenuOpen)}
+        title={mapEditStore.enabled
+          ? "Editor controls: map edit mode on"
+          : "Editor controls"}
+        aria-label={mapEditStore.enabled
+          ? "Editor controls, map edit mode on"
+          : "Editor controls"}
+        aria-expanded={adminMenuOpen}
+        aria-controls="admin-control-menu"
+        aria-pressed={mapEditStore.enabled}
+      >
+        <ShieldCheck />
+      </button>
     </div>
-    <button
-      class="map-control-btn"
-      class:active={mapEditStore.enabled}
-      onclick={toggleMapEditMode}
-      title={mapEditStore.enabled
-        ? "Disable map edit mode"
-        : "Enable map edit mode"}
-      aria-label={mapEditStore.enabled
-        ? "Disable map edit mode"
-        : "Enable map edit mode"}
-      aria-pressed={mapEditStore.enabled}
-    >
-      <Pencil />
-    </button>
-    <button
-      class="map-control-btn"
-      onclick={handleLogout}
-      title="Sign out"
-      aria-label="Sign out"
-    >
-      <LogOut />
-    </button>
   {:else}
     <button
       class="map-control-btn"
@@ -85,7 +117,7 @@
       title="Editor login"
       aria-label="Editor login"
     >
-      <SquareArrowRightEnterIcon />
+      <LogIn />
     </button>
   {/if}
 
@@ -107,14 +139,16 @@
   .map-control-stack {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-end;
     gap: 0.5rem;
     pointer-events: auto;
   }
 
-  .admin-state {
-    color: hsl(160, 84%, 26%);
-    cursor: default;
+  .admin-control {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
   }
 
   .map-control-btn {
@@ -143,5 +177,73 @@
       background-color: hsl(160, 84%, 26%);
       color: white;
     }
+  }
+
+  .admin-panel {
+    display: flex;
+    width: 15.5rem;
+    max-width: calc(100vw - 1rem);
+    flex-direction: column;
+    gap: 0.5rem;
+    border-radius: 0.875rem;
+    background-color: white;
+    padding: 0.75rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  .admin-status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: hsl(160, 84%, 22%);
+    font-size: 0.8125rem;
+  }
+
+  .admin-status span {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  .admin-status small {
+    overflow: hidden;
+    color: hsl(0, 0%, 42%);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .admin-menu-action {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.5rem;
+    border: 1px solid #d8b9ba;
+    border-radius: 0.625rem;
+    background-color: white;
+    color: hsl(5, 53%, 32%);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    padding: 0.55rem 0.625rem;
+  }
+
+  .admin-menu-action:hover,
+  .admin-menu-action:focus-visible {
+    background-color: hsl(5, 53%, 98%);
+  }
+
+  .admin-menu-action.active {
+    border-color: hsl(160, 84%, 26%);
+    background-color: hsl(160, 84%, 26%);
+    color: white;
+  }
+
+  .admin-menu-action.danger {
+    border-color: hsl(0, 70%, 88%);
+    color: hsl(0, 70%, 38%);
   }
 </style>

--- a/src/components/svelte/MapControls.svelte
+++ b/src/components/svelte/MapControls.svelte
@@ -167,10 +167,6 @@
 
 <style>
   .map-controls {
-    position: absolute;
-    right: 0.5rem;
-    top: 0.5rem;
-    z-index: 15;
     pointer-events: auto;
     display: flex;
     flex-direction: column;
@@ -247,11 +243,6 @@
        grow the tap targets to the 44px touch-friendly minimum. Native
        touch gestures (two-finger twist/drag) exist but aren't discoverable,
        so these explicit affordances stay visible on mobile too. */
-    .map-controls {
-      right: 0.5rem;
-      top: 4rem;
-    }
-
     .control {
       width: 2.75rem;
       height: 2.75rem;

--- a/src/components/svelte/MapLegend.svelte
+++ b/src/components/svelte/MapLegend.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import Info from "@lucide/svelte/icons/info";
   import X from "@lucide/svelte/icons/x";
+  import { floatingControlPanelStore } from "../../lib/store.svelte";
 
-  let open = $state(false);
+  const panelId = "legend";
+  const open = $derived(floatingControlPanelStore.openPanel === panelId);
 
   const legendItems = [
     {
@@ -36,7 +38,7 @@
         <button
           type="button"
           class="close-btn"
-          onclick={() => (open = false)}
+          onclick={() => floatingControlPanelStore.close(panelId)}
           aria-label="Close map legend"
         >
           <X size={16} />
@@ -65,7 +67,7 @@
     class="legend-btn"
     class:active={open}
     type="button"
-    onclick={() => (open = !open)}
+    onclick={() => floatingControlPanelStore.toggle(panelId)}
     title="Map Legend"
     aria-label="Map Legend"
     aria-expanded={open}

--- a/src/components/svelte/MapLegend.svelte
+++ b/src/components/svelte/MapLegend.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  import Info from "@lucide/svelte/icons/info";
+  import X from "@lucide/svelte/icons/x";
+
+  let open = $state(false);
+
+  const legendItems = [
+    {
+      key: "building",
+      label: "Building",
+      description: "Academic or campus building pin.",
+    },
+    {
+      key: "dorm",
+      label: "Dorm",
+      description: "UP-managed or private dorm pin.",
+    },
+    {
+      key: "stop",
+      label: "Route stop",
+      description: "Jeepney route stop.",
+    },
+    {
+      key: "location",
+      label: "Your location",
+      description: "Current device location when enabled.",
+    },
+  ];
+</script>
+
+<div class="map-legend">
+  {#if open}
+    <div id="map-icon-legend" class="legend-panel" aria-label="Map icon legend">
+      <div class="legend-panel-header">
+        <span>Map Legend</span>
+        <button
+          type="button"
+          class="close-btn"
+          onclick={() => (open = false)}
+          aria-label="Close map legend"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      <div class="legend-list">
+        {#each legendItems as item (item.key)}
+          <div class="legend-item">
+            <span class={`legend-swatch ${item.key}`} aria-hidden="true">
+              {#if item.key === "stop"}
+                1
+              {/if}
+            </span>
+            <span class="legend-copy">
+              <span class="legend-label">{item.label}</span>
+              <span class="legend-description">{item.description}</span>
+            </span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <button
+    class="legend-btn"
+    class:active={open}
+    type="button"
+    onclick={() => (open = !open)}
+    title="Map Legend"
+    aria-label="Map Legend"
+    aria-expanded={open}
+    aria-controls="map-icon-legend"
+  >
+    <Info />
+  </button>
+</div>
+
+<style>
+  .map-legend {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+    pointer-events: auto;
+  }
+
+  .legend-btn {
+    display: flex;
+    width: 3rem;
+    height: 3rem;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #ececec;
+    border-radius: 50%;
+    background-color: white;
+    color: hsl(5, 53%, 32%);
+    cursor: pointer;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    transition:
+      background-color 0.2s,
+      transform 0.2s;
+  }
+
+  .legend-btn:hover {
+    background-color: hsl(5, 53%, 98%);
+    transform: scale(1.05);
+  }
+
+  .legend-btn.active {
+    border-color: hsl(5, 53%, 75%);
+    background-color: hsl(5, 53%, 32%);
+    color: white;
+  }
+
+  .legend-panel {
+    display: flex;
+    width: 18rem;
+    max-width: calc(100vw - 1rem);
+    flex-direction: column;
+    gap: 0.625rem;
+    border-radius: 0.875rem;
+    background-color: white;
+    padding: 0.75rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  .legend-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.125rem 0.25rem;
+    color: hsl(0, 0%, 20%);
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+
+  .close-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 0.375rem;
+    background: transparent;
+    color: hsl(0, 0%, 40%);
+    cursor: pointer;
+    padding: 0.125rem;
+  }
+
+  .close-btn:hover {
+    background-color: hsl(0, 0%, 95%);
+  }
+
+  .legend-list {
+    display: grid;
+    gap: 0.45rem;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    border-radius: 0.625rem;
+    background-color: hsl(0, 0%, 98%);
+    padding: 0.5rem 0.625rem;
+  }
+
+  .legend-swatch {
+    display: inline-flex;
+    width: 1.35rem;
+    height: 1.35rem;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid white;
+    border-radius: 999px;
+    color: white;
+    font-size: 0.7rem;
+    font-weight: 800;
+    box-shadow: 0 2px 0.25rem rgba(0, 0, 0, 0.28);
+  }
+
+  .legend-swatch.building {
+    background-color: hsl(5, 53%, 32%);
+  }
+
+  .legend-swatch.dorm {
+    background-color: hsl(170, 50%, 35%);
+  }
+
+  .legend-swatch.stop {
+    background-color: #dc2626;
+  }
+
+  .legend-swatch.location {
+    background-color: #4285f4;
+  }
+
+  .legend-copy {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .legend-label {
+    color: hsl(0, 0%, 15%);
+    font-size: 0.8125rem;
+    font-weight: 700;
+    line-height: 1.2;
+  }
+
+  .legend-description {
+    color: hsl(0, 0%, 45%);
+    font-size: 0.75rem;
+    line-height: 1.25;
+  }
+</style>

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -96,6 +96,7 @@
     font-size: 0.875rem;
     font-weight: 600;
     gap: 1rem;
+    flex: 0 0 auto;
     background-color: white;
     padding: 0.5rem 1.5rem;
     border-radius: 1rem;

--- a/src/components/svelte/SyncToast.svelte
+++ b/src/components/svelte/SyncToast.svelte
@@ -8,17 +8,17 @@
   } from "@lucide/svelte";
   import { syncToastStore } from "../../lib/store.svelte";
   import { fly } from "svelte/transition";
-  $inspect(
-    syncToastStore.currentSyncData !== null && !syncToastStore.allSynced,
-  );
+
+  type Props = {
+    stacked?: boolean;
+  };
+
+  const { stacked = false }: Props = $props();
   let manualClosed = $state<boolean>(false);
 
   $effect(() => {
-    syncToastStore.recentlySynced;
-    syncToastStore.allSynced;
-    syncToastStore.currentSync;
-    manualClosed = false;
-    // if (syncToastStore.recentlySynced)
+    const syncStateKey = `${syncToastStore.recentlySynced}:${syncToastStore.allSynced}:${syncToastStore.currentSync}`;
+    if (syncStateKey !== "") manualClosed = false;
   });
   $effect(() => {
     let timeout: number | null = null;
@@ -52,6 +52,7 @@
     <div
       class="sync-toast"
       class:sync-toast--success={syncToastStore.allSynced}
+      class:sync-toast--stacked={stacked}
       transition:fly={{ duration: 175, y: 20 }}
     >
       {#if syncToastStore.allSynced}
@@ -98,7 +99,7 @@
           {/if}
         {/key}
       </div>
-      <button onclick={() => (manualClosed = true)}><X /></button>
+      <button type="button" onclick={() => (manualClosed = true)}><X /></button>
     </div>
   {/if}
 {/key}
@@ -148,6 +149,16 @@
     .sync-toast-subtitle {
       color: var(--Color-success-700, #07761f);
     }
+  }
+  div.sync-toast--stacked {
+    position: static;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    top: auto;
+    width: min(360px, 100%);
+    translate: none;
+    pointer-events: auto;
   }
   div.progress-bar {
     position: relative;
@@ -201,6 +212,13 @@
           display: initial;
         }
       }
+    }
+
+    div.sync-toast--stacked {
+      position: static;
+      right: auto;
+      top: auto;
+      width: min(360px, 100%);
     }
   }
 </style>

--- a/src/components/svelte/TerrainControl.svelte
+++ b/src/components/svelte/TerrainControl.svelte
@@ -7,7 +7,10 @@
     TERRAIN_EXAGGERATION_OPTIONS,
     TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE,
   } from "../../constants/map-terrain";
-  import { terrainStore } from "../../lib/store.svelte";
+  import {
+    floatingControlPanelStore,
+    terrainStore,
+  } from "../../lib/store.svelte";
 
   type NetworkInformation = EventTarget & {
     effectiveType?: string;
@@ -16,6 +19,8 @@
 
   let isOnline = $state(true);
   let lowDataConnection = $state(false);
+  const panelId = "terrain";
+  const menuOpen = $derived(floatingControlPanelStore.openPanel === panelId);
 
   const statusText = $derived.by(() => {
     if (!isOnline) return TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE;
@@ -81,14 +86,14 @@
 </script>
 
 <div class="terrain-control">
-  {#if terrainStore.menuOpen}
+  {#if menuOpen}
     <div class="terrain-panel" role="menu">
       <div class="terrain-panel-header">
         <span>Makiling Terrain</span>
         <button
           type="button"
           class="close-btn"
-          onclick={() => terrainStore.closeMenu()}
+          onclick={() => floatingControlPanelStore.close(panelId)}
           aria-label="Close terrain menu"
         >
           <X size="16" />
@@ -159,10 +164,10 @@
   <button
     class="terrain-btn"
     class:active={terrainStore.enabled}
-    onclick={() => terrainStore.toggleMenu()}
+    onclick={() => floatingControlPanelStore.toggle(panelId)}
     title="Makiling Terrain"
     aria-label="Makiling Terrain"
-    aria-expanded={terrainStore.menuOpen}
+    aria-expanded={menuOpen}
   >
     <Mountain />
   </button>

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
   import { throttle } from "es-toolkit";
+  import ChevronLeft from "@lucide/svelte/icons/chevron-left";
+  import SearchIcon from "@lucide/svelte/icons/search";
+  import { tick } from "svelte";
   import { queryStore } from "../../../lib/store.svelte";
   import Suggestions from "./Suggestions.svelte";
 
   let searchElement = $state<HTMLInputElement | null>(null);
   let typing = $state(false);
+  let searchCollapsed = $state(false);
+  let searchFocused = $state(false);
 
   const throttleSearch = throttle((searchInput: string) => {
     queryStore.inputValue = searchInput;
@@ -21,118 +26,155 @@
     queryStore.clearQuery();
     searchElement?.focus();
   }
+
+  async function expandSearch() {
+    searchCollapsed = false;
+    await tick();
+    searchElement?.focus();
+  }
+
+  function collapseSearch() {
+    if (searchFocused) return;
+    searchCollapsed = true;
+  }
+
+  function handleFocusOut(event: FocusEvent) {
+    const currentTarget = event.currentTarget as HTMLElement;
+    const nextTarget = event.relatedTarget as Node | null;
+    if (!nextTarget || !currentTarget.contains(nextTarget)) {
+      searchFocused = false;
+    }
+  }
 </script>
 
 <div
   class="search-filter-container"
   class:search-focused={queryStore.type !== "result"}
+  class:is-collapsed={searchCollapsed}
 >
-  <div class="search-filter">
-    <div class="search-container">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="20"
-        height="20"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        class="search-icon"
-        ><circle cx="11" cy="11" r="8" /><line
-          x1="21"
-          y1="21"
-          x2="16.65"
-          y2="16.65"
-        /></svg
-      >
-      <input
-        type="text"
-        id="search"
-        autocomplete="off"
-        value={queryStore.inputValue}
-        bind:this={searchElement}
-        class={typing ? "typing" : ""}
-        oninput={handleInput}
-        placeholder={"Search room, building, dorm, division..."}
-      />
-      {#if typing}
-        <div class="loading-icon">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 200 200"
-            width="20"
-            height="20"
-          >
-            <circle stroke-width="17" r="15" cx="40" cy="65"
-              ><animate
-                attributeName="cy"
-                calcMode="spline"
-                dur="0.8"
-                values="65;135;65;"
-                keySplines=".5 0 .5 1;.5 0 .5 1"
-                repeatCount="indefinite"
-                begin="-.4"
-              ></animate></circle
-            >
-            <circle stroke-width="17" r="15" cx="100" cy="65"
-              ><animate
-                attributeName="cy"
-                calcMode="spline"
-                dur="0.8"
-                values="65;135;65;"
-                keySplines=".5 0 .5 1;.5 0 .5 1"
-                repeatCount="indefinite"
-                begin="-.2"
-              ></animate></circle
-            >
-            <circle stroke-width="17" r="15" cx="160" cy="65"
-              ><animate
-                attributeName="cy"
-                calcMode="spline"
-                dur="0.8"
-                values="65;135;65;"
-                keySplines=".5 0 .5 1;.5 0 .5 1"
-                repeatCount="indefinite"
-                begin="0"
-              ></animate></circle
-            >
-          </svg>
-        </div>
-      {/if}
-    </div>
+  {#if searchCollapsed}
+    <button
+      type="button"
+      class="search-tab"
+      aria-expanded="false"
+      aria-controls="search-panel"
+      aria-label="Expand search bar"
+      onclick={expandSearch}
+    >
+      <SearchIcon size={18} />
+      <span>Search</span>
+    </button>
+  {/if}
 
-    <div class="search-buttons">
-      {#if queryStore.inputValue !== ""}
-        <button
-          onclick={closeSearchContext}
-          type="button"
-          class="clear-btn"
-          aria-label="Clear Search"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            ><line x1="18" y1="6" x2="6" y2="18"></line><line
-              x1="6"
-              y1="6"
-              x2="18"
-              y2="18"
-            ></line></svg
+  <div
+    id="search-panel"
+    class="search-panel"
+    hidden={searchCollapsed}
+    onfocusin={() => (searchFocused = true)}
+    onfocusout={handleFocusOut}
+  >
+    <div class="search-filter">
+      <div class="search-container">
+        <SearchIcon class="search-icon" size={20} />
+        <input
+          type="text"
+          id="search"
+          autocomplete="off"
+          value={queryStore.inputValue}
+          bind:this={searchElement}
+          class={typing ? "typing" : ""}
+          oninput={handleInput}
+          placeholder="Search room, building, dorm, division..."
+        />
+        {#if typing}
+          <div class="loading-icon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 200 200"
+              width="20"
+              height="20"
+            >
+              <circle stroke-width="17" r="15" cx="40" cy="65"
+                ><animate
+                  attributeName="cy"
+                  calcMode="spline"
+                  dur="0.8"
+                  values="65;135;65;"
+                  keySplines=".5 0 .5 1;.5 0 .5 1"
+                  repeatCount="indefinite"
+                  begin="-.4"
+                ></animate></circle
+              >
+              <circle stroke-width="17" r="15" cx="100" cy="65"
+                ><animate
+                  attributeName="cy"
+                  calcMode="spline"
+                  dur="0.8"
+                  values="65;135;65;"
+                  keySplines=".5 0 .5 1;.5 0 .5 1"
+                  repeatCount="indefinite"
+                  begin="-.2"
+                ></animate></circle
+              >
+              <circle stroke-width="17" r="15" cx="160" cy="65"
+                ><animate
+                  attributeName="cy"
+                  calcMode="spline"
+                  dur="0.8"
+                  values="65;135;65;"
+                  keySplines=".5 0 .5 1;.5 0 .5 1"
+                  repeatCount="indefinite"
+                  begin="0"
+                ></animate></circle
+              >
+            </svg>
+          </div>
+        {/if}
+      </div>
+
+      <div class="search-buttons">
+        {#if queryStore.inputValue !== ""}
+          <button
+            onclick={closeSearchContext}
+            type="button"
+            class="clear-btn"
+            aria-label="Clear Search"
           >
-        </button>
-      {/if}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              ><line x1="18" y1="6" x2="6" y2="18"></line><line
+                x1="6"
+                y1="6"
+                x2="18"
+                y2="18"
+              ></line></svg
+            >
+          </button>
+        {/if}
+        {#if !searchFocused}
+          <button
+            type="button"
+            class="collapse-search-btn"
+            aria-expanded="true"
+            aria-controls="search-panel"
+            aria-label="Collapse search bar"
+            onclick={collapseSearch}
+          >
+            <ChevronLeft size={18} />
+          </button>
+        {/if}
+      </div>
     </div>
+    <Suggestions />
   </div>
-  <Suggestions />
 </div>
 
 <style>
@@ -142,9 +184,39 @@
     pointer-events: auto;
   }
 
-  .search-focused:focus-within :first-child + :global(*) {
+  .search-filter-container.is-collapsed {
+    width: max-content;
+  }
+
+  .search-focused .search-panel:focus-within :global(.suggestions-container) {
     opacity: 1;
     pointer-events: auto;
+  }
+
+  .search-panel[hidden] {
+    display: none;
+  }
+
+  .search-tab {
+    display: inline-flex;
+    min-height: 2.75rem;
+    align-items: center;
+    gap: 0.5rem;
+    border: 1px solid #d8b9ba;
+    border-radius: 0 999px 999px 0;
+    background-color: white;
+    color: #7b1113;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 800;
+    padding: 0.625rem 0.875rem 0.625rem 0.75rem;
+    box-shadow: 0rem 2px 0.25rem 0rem rgba(0, 0, 0, 0.25);
+  }
+
+  .search-tab:hover,
+  .search-tab:focus-visible {
+    background-color: #fdf3f3;
   }
 
   .search-filter {
@@ -204,7 +276,8 @@
   }
 
   .clear-btn,
-  .filter-btn {
+  .filter-btn,
+  .collapse-search-btn {
     all: unset;
     cursor: pointer;
     display: flex;
@@ -216,7 +289,8 @@
   }
 
   .clear-btn:hover,
-  .filter-btn:hover {
+  .filter-btn:hover,
+  .collapse-search-btn:hover {
     background-color: #f0f0f0;
   }
 

--- a/src/components/svelte/sidepanel/SidePanel.svelte
+++ b/src/components/svelte/sidepanel/SidePanel.svelte
@@ -9,6 +9,7 @@
   import ClassQuery from "./ClassQuery.svelte";
   import BuildingTypeControl from "../BuildingTypeControl.svelte";
   import LocationButton from "../LocationButton.svelte";
+  import MapLegend from "../MapLegend.svelte";
   import JeepneyMenu from "../JeepneyMenu.svelte";
   import TerrainControl from "../TerrainControl.svelte";
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
@@ -48,6 +49,7 @@
   <Search />
   <div class="side-panel-controls">
     <div class="floating-actions">
+      <MapLegend />
       <BuildingTypeControl />
       <TerrainControl />
       <JeepneyMenu />

--- a/src/components/svelte/sidepanel/SidePanel.svelte
+++ b/src/components/svelte/sidepanel/SidePanel.svelte
@@ -112,6 +112,7 @@
     justify-content: space-between;
     gap: 0.75rem;
     flex: 1;
+    min-height: 0;
     pointer-events: none;
   }
 

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -350,6 +350,27 @@ class SidePanelStore {
   };
 }
 
+export type FloatingControlPanel =
+  | "legend"
+  | "building-type"
+  | "terrain"
+  | "jeepney"
+  | "admin";
+
+class FloatingControlPanelStore {
+  openPanel: FloatingControlPanel | null = $state(null);
+
+  toggle = (panel: FloatingControlPanel) => {
+    this.openPanel = this.openPanel === panel ? null : panel;
+  };
+
+  close = (panel?: FloatingControlPanel) => {
+    if (panel === undefined || this.openPanel === panel) {
+      this.openPanel = null;
+    }
+  };
+}
+
 class MapEditStore {
   enabled: boolean = $state(false);
 
@@ -716,6 +737,7 @@ export const toastStore = new ToastStore();
 export const locationStore = new LocationStore();
 export const mapStore = new MapStore();
 export const sidePanelStore = new SidePanelStore();
+export const floatingControlPanelStore = new FloatingControlPanelStore();
 export const mapEditStore = new MapEditStore();
 export const terrainStore = new TerrainStore();
 export const jeepneyStore = new JeepneyStore();


### PR DESCRIPTION
## Summary
- Adds a retractable search bar for map-first browsing and a compact collapsible map icon legend. Closes #193 and #194.
- Groups signed-in editor controls into a compact bottom-right menu and stacks the sync toast with the top-right map controls. Closes #195 and #196.
- Repositions the PWA offline/update prompt above the status area and themes side-panel copy link actions as bordered red chips.

## Test plan
- `./node_modules/.bin/prettier --check src/components/ReloadPrompt.astro src/components/svelte/CopyLinkButton.svelte src/components/svelte/Entry.svelte src/components/svelte/LocationButton.svelte src/components/svelte/MapControls.svelte src/components/svelte/SyncToast.svelte src/components/svelte/search/Search.svelte src/components/svelte/MapLegend.svelte src/components/svelte/sidepanel/SidePanel.svelte`
- `./node_modules/.bin/eslint src/components/ReloadPrompt.astro src/components/svelte/CopyLinkButton.svelte src/components/svelte/Entry.svelte src/components/svelte/LocationButton.svelte src/components/svelte/MapControls.svelte src/components/svelte/SyncToast.svelte src/components/svelte/search/Search.svelte src/components/svelte/MapLegend.svelte src/components/svelte/sidepanel/SidePanel.svelte`
- `bun run build` attempted; blocked during prerender because `NEON_CONNECTION_STRING` is missing in this isolated worktree environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/layout and local panel state only; admin actions remain behind existing auth APIs with no backend changes.
> 
> **Overview**
> Refactors map chrome for **map-first browsing**: a collapsible search tab/panel, a new **Map Legend** control, and a shared **`floatingControlPanelStore`** so legend, building type, terrain, jeepney, and admin menus only open one at a time.
> 
> **Layout:** `MapControls` and `SyncToast` (`stacked`) live in a top-right stack in `Entry`; admin map-edit and sign-out move into a single shield-button dropdown (`LocationButton`). **Styling:** PWA reload toast and `CopyLinkButton` get consistent maroon-bordered chip styling; safe-area padding on the bottom UI layer.
> 
> **Minor:** Removes debug `$inspect` from `SyncToast`; empty `catch` in `Entry` recent-search hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a25961cc5d03d5a1edb037c9ab48fd1929f3dc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->