### PR TITLE
Fix event review bugs from staging release audit

### DIFF
--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -119,10 +119,17 @@
     replaceEvent: (updated) => {
       if (!events) return;
       const index = events.findIndex((event) => event.id === updated.id);
-      if (index === -1) return;
+      if (index === -1) {
+        events = [updated, ...events];
+        return;
+      }
       const next = events.slice();
       next[index] = updated;
       events = next;
+    },
+    removeEvent: (eventId) => {
+      if (!events) return;
+      events = events.filter((event) => event.id !== eventId);
     },
   });
 </script>

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -30,9 +30,18 @@
   const { initialSearch, suppressLandingModal = false }: Props = $props();
   const appData = getAppData();
   const { events, loaded } = $derived(appData());
-  const activeEvent = $derived(
-    loaded ? (events.find((event) => event.status === "active") ?? null) : null,
+  const activeEvents = $derived(
+    loaded ? events.filter((event) => event.status === "active") : [],
   );
+
+  function openActiveEvent(event: (typeof activeEvents)[number]) {
+    queryStore.updateQuery({
+      category: "event",
+      type: "result",
+      value: event.title,
+      eventSlug: event.slug,
+    });
+  }
 
   const updateData = (queryHistory: RecentSearch[]) => {
     localStorage.setItem("recent-search", JSON.stringify(queryHistory));
@@ -91,25 +100,24 @@
 <div class="app-layout">
   <Map />
   <div class="ui-layer">
-    {#if activeEvent && queryStore.category !== "event" && queryStore.category !== "events"}
-      <button
-        class="event-banner"
-        type="button"
-        aria-label={`${activeEvent.title} is happening now. Tap to see it on the map.`}
-        onclick={() =>
-          queryStore.updateQuery({
-            category: "event",
-            type: "result",
-            value: activeEvent.title,
-            eventSlug: activeEvent.slug,
-          })}
-      >
-        <span class="event-banner-copy">
-          <span class="event-banner-label">Happening now</span>
-          <span class="event-banner-title">{activeEvent.title}</span>
-        </span>
-        <span class="event-banner-cta" aria-hidden="true">See on map ›</span>
-      </button>
+    {#if activeEvents.length > 0 && queryStore.category !== "event" && queryStore.category !== "events"}
+      <div class="event-banner-stack" role="status" aria-live="polite">
+        {#each activeEvents as activeEvent (activeEvent.slug)}
+          <button
+            class="event-banner"
+            type="button"
+            aria-label={`${activeEvent.title} is happening now. Tap to see it on the map.`}
+            onclick={() => openActiveEvent(activeEvent)}
+          >
+            <span class="event-banner-copy">
+              <span class="event-banner-label">Happening now</span>
+              <span class="event-banner-title">{activeEvent.title}</span>
+            </span>
+            <span class="event-banner-cta" aria-hidden="true">See on map ›</span
+            >
+          </button>
+        {/each}
+      </div>
     {/if}
     <div class="top-right-map-stack" aria-label="Map tools">
       <MapControls />
@@ -173,16 +181,24 @@
     width: 100%;
   }
 
-  .event-banner {
+  .event-banner-stack {
     position: absolute;
     top: 0.75rem;
     left: 50%;
     z-index: 12;
     translate: -50% 0;
     display: flex;
+    width: min(32rem, calc(100% - 1rem));
+    flex-direction: column;
+    gap: 0.45rem;
+    pointer-events: none;
+  }
+
+  .event-banner {
+    display: flex;
     align-items: center;
     gap: 0.625rem;
-    max-width: min(32rem, calc(100% - 1rem));
+    width: 100%;
     border: 1px solid #d8b9ba;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.96);

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { MapLibre, Marker } from "svelte-maplibre";
-  import { getAppData } from "../../lib/context";
+  import { getAppActions, getAppData } from "../../lib/context";
   import {
     queryStore,
     locationStore,
@@ -66,6 +66,7 @@
     type VersionedMapMove,
   } from "../../lib/map-move-history";
   const data = getAppData();
+  const appActions = getAppActions();
   const { buildings, dorms, events, loaded } = $derived(data());
   const filteredBuildings = $derived.by(() => {
     if (!loaded) return [];
@@ -323,6 +324,22 @@
     return { type: "LineString", coordinates };
   }
 
+  function buildSelectedEventRouteFeatures(
+    event: EventData,
+  ): FeatureCollection<LineString>["features"] {
+    return event.routes.flatMap((route) => {
+      const geometry = buildEventRouteGeometry(route);
+      if (!geometry) return [];
+      return [
+        {
+          type: "Feature" as const,
+          geometry,
+          properties: { eventId: event.id, routeId: route.id },
+        },
+      ];
+    });
+  }
+
   function fitMapToRoute(map: mapGl.MapLibreMap, route: JeepneyRoute) {
     if (route.stops.length === 0) return;
     let minLng = Infinity;
@@ -444,7 +461,7 @@
         throw new Error(data.error ?? `Create failed (${res.status})`);
       }
 
-      events.unshift(data.event);
+      appActions.replaceEvent(data.event);
       queryStore.updateQuery({
         category: "event",
         type: "result",
@@ -877,8 +894,7 @@
   }
 
   function setLocalEvent(updated: EventData) {
-    const index = events.findIndex((event) => event.id === updated.id);
-    if (index !== -1) events[index] = updated;
+    appActions.replaceEvent(updated);
 
     const key = eventLocationEditKey(updated.id);
     const editable = getEditableEventLocation(updated);
@@ -1516,14 +1532,10 @@
         : null;
     if (!map) return;
 
-    const route = selectedEvent?.routes[0] ?? null;
-    if (!route) {
-      clearEventRouteLayers(map);
-      return;
-    }
-
-    const geometry = buildEventRouteGeometry(route);
-    if (!geometry) {
+    const routeFeatures = selectedEvent
+      ? buildSelectedEventRouteFeatures(selectedEvent)
+      : [];
+    if (routeFeatures.length === 0) {
       clearEventRouteLayers(map);
       return;
     }
@@ -1535,13 +1547,7 @@
         | undefined;
       const featureCollection: FeatureCollection<LineString> = {
         type: "FeatureCollection",
-        features: [
-          {
-            type: "Feature",
-            geometry,
-            properties: { eventId: selectedEvent?.id },
-          },
-        ],
+        features: routeFeatures,
       };
       source?.setData(featureCollection);
     };
@@ -1750,9 +1756,15 @@
     if (
       !isMapEditEnabled() ||
       queryStore.category !== "event" ||
-      queryStore.type !== "result" ||
-      queryStore.inputValue !== event.title
+      queryStore.type !== "result"
     ) {
+      return false;
+    }
+
+    const slug = queryStore.selectedEventSlug;
+    if (slug) {
+      if (slug !== event.slug) return false;
+    } else if (queryStore.inputValue !== event.title) {
       return false;
     }
 
@@ -1780,7 +1792,13 @@
     >();
 
     for (const event of events) {
-      if (event.status !== "active" && event.status !== "upcoming") continue;
+      if (
+        event.status !== "active" &&
+        event.status !== "upcoming" &&
+        event.status !== "past"
+      ) {
+        continue;
+      }
       for (const location of event.locations) {
         if (isSelectedEditableEventLocation(event, location)) continue;
         const key = getEventLocationKey(location);
@@ -1927,10 +1945,11 @@
   let selectedEventRouteStops = $derived.by(() => {
     if (!loaded || queryStore.category !== "event") return [];
     const selectedEvent = findSelectedEvent(events);
-    return (
-      selectedEvent?.routes[0]?.stops.filter(
+    if (!selectedEvent) return [];
+    return selectedEvent.routes.flatMap((route) =>
+      route.stops.filter(
         (stop) => stop.resolvedLon !== null && stop.resolvedLat !== null,
-      ) ?? []
+      ),
     );
   });
 </script>
@@ -2551,28 +2570,6 @@
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
     position: relative;
     z-index: 70;
-  }
-  .user-location-pin::after {
-    content: "";
-    position: absolute;
-    top: -5px;
-    left: -5px;
-    right: -5px;
-    bottom: -5px;
-    border-radius: 50%;
-    border: 2px solid #4285f4;
-    animation: pulsate 2s ease-out infinite;
-    opacity: 0;
-  }
-  @keyframes pulsate {
-    0% {
-      transform: scale(0.5);
-      opacity: 1;
-    }
-    100% {
-      transform: scale(1.5);
-      opacity: 0;
-    }
   }
 
   .event-marker-anchor {

--- a/src/components/svelte/MapLegend.svelte
+++ b/src/components/svelte/MapLegend.svelte
@@ -1,40 +1,87 @@
 <script lang="ts">
   import Info from "@lucide/svelte/icons/info";
   import X from "@lucide/svelte/icons/x";
-  import { floatingControlPanelStore } from "../../lib/store.svelte";
+  import { getAppData } from "../../lib/context";
+  import {
+    floatingControlPanelStore,
+    mapViewStore,
+    queryStore,
+  } from "../../lib/store.svelte";
 
   const panelId = "legend";
   const open = $derived(floatingControlPanelStore.openPanel === panelId);
 
-  const legendItems = [
+  const appData = getAppData();
+  const { events, loaded } = $derived(appData());
+
+  const showEventSection = $derived(
+    loaded &&
+      (events.length > 0 ||
+        mapViewStore.eventsOnly ||
+        queryStore.category === "event" ||
+        queryStore.category === "events"),
+  );
+
+  const placeItems = [
     {
       key: "building",
       label: "Building",
-      description: "Academic or campus building pin.",
+      description: "Academic or campus building.",
     },
     {
       key: "dorm",
       label: "Dorm",
-      description: "UP-managed or private dorm pin.",
-    },
-    {
-      key: "stop",
-      label: "Route stop",
-      description: "Jeepney route stop.",
+      description: "UP-managed or private dorm.",
     },
     {
       key: "location",
       label: "Your location",
-      description: "Current device location when enabled.",
+      description: "Device location when enabled.",
     },
-  ];
+  ] as const;
+
+  const routeItems = [
+    {
+      key: "jeepney-stop",
+      label: "Jeepney stop",
+      description: "Stop on a jeepney route.",
+    },
+  ] as const;
+
+  const eventItems = [
+    {
+      key: "event-active",
+      label: "Active event",
+      description: "Happening now.",
+    },
+    {
+      key: "event-upcoming",
+      label: "Upcoming event",
+      description: "Scheduled soon.",
+    },
+    {
+      key: "event-past",
+      label: "Past event",
+      description: "Already ended.",
+    },
+    {
+      key: "event-route-stop",
+      label: "Event route stop",
+      description: "Numbered stop on an event path.",
+    },
+    {
+      key: "event-linked",
+      label: "Event-linked place",
+      description: "Building or dorm tied to a live event.",
+    },
+  ] as const;
 </script>
 
 <div class="map-legend">
   {#if open}
     <div id="map-icon-legend" class="legend-panel" aria-label="Map icon legend">
       <div class="legend-panel-header">
-        <span>Map Legend</span>
+        <span>Map legend</span>
         <button
           type="button"
           class="close-btn"
@@ -45,20 +92,60 @@
         </button>
       </div>
 
-      <div class="legend-list">
-        {#each legendItems as item (item.key)}
-          <div class="legend-item">
-            <span class={`legend-swatch ${item.key}`} aria-hidden="true">
-              {#if item.key === "stop"}
-                1
-              {/if}
-            </span>
-            <span class="legend-copy">
-              <span class="legend-label">{item.label}</span>
-              <span class="legend-description">{item.description}</span>
-            </span>
+      <div class="legend-sections">
+        <section class="legend-section" aria-labelledby="legend-places">
+          <h3 id="legend-places" class="legend-section-title">Places</h3>
+          <div class="legend-list">
+            {#each placeItems as item (item.key)}
+              <div class="legend-item">
+                <span class={`legend-swatch ${item.key}`} aria-hidden="true"
+                ></span>
+                <span class="legend-copy">
+                  <span class="legend-label">{item.label}</span>
+                  <span class="legend-description">{item.description}</span>
+                </span>
+              </div>
+            {/each}
           </div>
-        {/each}
+        </section>
+
+        {#if showEventSection}
+          <section class="legend-section" aria-labelledby="legend-events">
+            <h3 id="legend-events" class="legend-section-title">Events</h3>
+            <div class="legend-list">
+              {#each eventItems as item (item.key)}
+                <div class="legend-item">
+                  <span class={`legend-swatch ${item.key}`} aria-hidden="true">
+                    {#if item.key === "event-route-stop"}
+                      1
+                    {/if}
+                  </span>
+                  <span class="legend-copy">
+                    <span class="legend-label">{item.label}</span>
+                    <span class="legend-description">{item.description}</span>
+                  </span>
+                </div>
+              {/each}
+            </div>
+          </section>
+        {/if}
+
+        <section class="legend-section" aria-labelledby="legend-routes">
+          <h3 id="legend-routes" class="legend-section-title">Routes</h3>
+          <div class="legend-list">
+            {#each routeItems as item (item.key)}
+              <div class="legend-item">
+                <span class={`legend-swatch ${item.key}`} aria-hidden="true">
+                  1
+                </span>
+                <span class="legend-copy">
+                  <span class="legend-label">{item.label}</span>
+                  <span class="legend-description">{item.description}</span>
+                </span>
+              </div>
+            {/each}
+          </div>
+        </section>
       </div>
     </div>
   {/if}
@@ -68,8 +155,8 @@
     class:active={open}
     type="button"
     onclick={() => floatingControlPanelStore.toggle(panelId)}
-    title="Map Legend"
-    aria-label="Map Legend"
+    title="Map legend"
+    aria-label="Map legend"
     aria-expanded={open}
     aria-controls="map-icon-legend"
   >
@@ -118,16 +205,19 @@
     display: flex;
     width: 18rem;
     max-width: calc(100vw - 1rem);
+    max-height: min(70vh, 22rem);
     flex-direction: column;
     gap: 0.625rem;
     border-radius: 0.875rem;
     background-color: white;
     padding: 0.75rem;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
   }
 
   .legend-panel-header {
     display: flex;
+    flex-shrink: 0;
     align-items: center;
     justify-content: space-between;
     padding: 0.125rem 0.25rem;
@@ -152,9 +242,34 @@
     background-color: hsl(0, 0%, 95%);
   }
 
+  .legend-sections {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+    gap: 0.75rem;
+    overflow-y: auto;
+    padding-right: 0.125rem;
+  }
+
+  .legend-section {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .legend-section-title {
+    margin: 0;
+    padding: 0 0.25rem;
+    color: hsl(0, 0%, 45%);
+    font-size: 0.6875rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
   .legend-list {
     display: grid;
-    gap: 0.45rem;
+    gap: 0.35rem;
   }
 
   .legend-item {
@@ -163,7 +278,7 @@
     gap: 0.625rem;
     border-radius: 0.625rem;
     background-color: hsl(0, 0%, 98%);
-    padding: 0.5rem 0.625rem;
+    padding: 0.45rem 0.625rem;
   }
 
   .legend-swatch {
@@ -189,19 +304,46 @@
     background-color: hsl(170, 50%, 35%);
   }
 
-  .legend-swatch.stop {
+  .legend-swatch.location {
+    background-color: #4285f4;
+  }
+
+  .legend-swatch.jeepney-stop {
     background-color: #dc2626;
   }
 
-  .legend-swatch.location {
-    background-color: #4285f4;
+  .legend-swatch.event-active {
+    background-color: #7b1113;
+  }
+
+  .legend-swatch.event-upcoming {
+    border-color: #d8b9ba;
+    background-color: #f8fafc;
+    color: #7b1113;
+  }
+
+  .legend-swatch.event-past {
+    border-color: #d4d4d8;
+    background-color: #f4f4f5;
+    color: #71717a;
+  }
+
+  .legend-swatch.event-route-stop {
+    background-color: #7b1113;
+  }
+
+  .legend-swatch.event-linked {
+    background-color: hsl(5, 53%, 32%);
+    box-shadow:
+      0 0 0 0.14rem rgba(250, 204, 21, 0.88),
+      0 2px 0.25rem rgba(0, 0, 0, 0.28);
   }
 
   .legend-copy {
     display: flex;
     min-width: 0;
     flex-direction: column;
-    gap: 0.125rem;
+    gap: 0.05rem;
   }
 
   .legend-label {
@@ -213,7 +355,18 @@
 
   .legend-description {
     color: hsl(0, 0%, 45%);
-    font-size: 0.75rem;
+    font-size: 0.6875rem;
     line-height: 1.25;
+  }
+
+  @media (max-width: 30rem) {
+    .legend-panel {
+      width: min(17rem, calc(100vw - 1rem));
+      max-height: min(55vh, 18rem);
+    }
+
+    .legend-description {
+      display: none;
+    }
   }
 </style>

--- a/src/components/svelte/SyncToast.svelte
+++ b/src/components/svelte/SyncToast.svelte
@@ -12,6 +12,13 @@
   import { syncToastStore } from "../../lib/store.svelte";
   import { fly } from "svelte/transition";
 
+  type Props = {
+    /** When true, toast flows in the map-controls stack instead of fixed. */
+    stacked?: boolean;
+  };
+
+  let { stacked = false }: Props = $props();
+
   let manualClosed = $state<boolean>(false);
   let reloading = $state<boolean>(false);
 
@@ -76,6 +83,7 @@
 {#if syncToastStore.needRefresh}
   <div
     class="sync-toast sync-toast--update"
+    class:sync-toast--stacked={stacked}
     role="status"
     aria-live="polite"
     transition:fly={{ duration: 175, y: 20 }}
@@ -108,6 +116,7 @@
   {#if (syncToastStore.recentlySynced === null || syncToastStore.recentlySynced) && !manualClosed && !syncToastStore.needRefresh}
     <div
       class="sync-toast"
+      class:sync-toast--stacked={stacked}
       class:sync-toast--success={syncToastStore.allSynced}
       role="status"
       aria-live="polite"
@@ -274,6 +283,17 @@
       rotate: 1 1 1 360deg;
     }
   }
+  div.sync-toast--stacked {
+    position: relative;
+    left: unset;
+    right: unset;
+    bottom: unset;
+    top: unset;
+    translate: unset;
+    width: min(360px, calc(100vw - 1rem));
+    z-index: unset;
+  }
+
   @media (width >= 48rem) {
     div.sync-toast {
       /* Keep the sync status out of the top-right map orientation stack. */

--- a/src/components/svelte/map/EventMapPin.svelte
+++ b/src/components/svelte/map/EventMapPin.svelte
@@ -49,6 +49,7 @@
   class:anchored
   class:expanded
   class:group={isGroup}
+  class:past={status === "past"}
   class:upcoming={status === "upcoming"}
   {title}
   aria-label={ariaLabel}
@@ -130,6 +131,13 @@
     border-color: #d8b9ba;
     background: #f8fafc;
     color: #7b1113;
+  }
+
+  .event-map-pin.past {
+    border-color: #d4d4d8;
+    background: #f4f4f5;
+    color: #71717a;
+    opacity: 0.92;
   }
 
   .event-map-pin.active,

--- a/src/components/svelte/search/EventCards.svelte
+++ b/src/components/svelte/search/EventCards.svelte
@@ -144,7 +144,10 @@
       <div class="event-list">
         {#each visibleEvents as event (event.id)}
           {@const image = getEventImage(event.slug)}
-          {@const primaryLocation = event.locations[0] ?? null}
+          {@const primaryLocation =
+            event.locations.find((location) => location.isPrimary) ??
+            event.locations[0] ??
+            null}
           {@const shareUrl = getEventShareUrl(event.slug)}
           <div class="event-card">
             <button

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -11,7 +11,7 @@
   const throttleSearch = throttle((searchInput: string) => {
     queryStore.inputValue = searchInput;
     queryStore.setType("query");
-  }, 1500);
+  }, 400);
 
   function handleInput(
     event: Event & { currentTarget: EventTarget & HTMLInputElement },
@@ -61,7 +61,7 @@
         bind:this={searchElement}
         class={typing ? "typing" : ""}
         oninput={handleInput}
-        placeholder="Search room, building, dorm, division..."
+        placeholder="Search room, building, dorm, event, division..."
       />
       {#if typing}
         <div class="loading-icon">

--- a/src/components/svelte/sidepanel/EventResult.svelte
+++ b/src/components/svelte/sidepanel/EventResult.svelte
@@ -33,7 +33,7 @@
 
   const appData = getAppData();
   const appActions = getAppActions();
-  const { events, loaded } = $derived(appData());
+  const { events, loaded, buildings, dorms } = $derived(appData());
   const event = $derived(
     loaded
       ? queryStore.selectedEventSlug
@@ -55,6 +55,7 @@
   let editing = $state(false);
   let saving = $state(false);
   let savingLocation = $state(false);
+  let deactivating = $state(false);
   let form = $state({
     title: "",
     description: "",
@@ -62,11 +63,28 @@
     startsAt: "",
     endsAt: "",
     sourceUrl: "",
+    recurrence: "none" as EventData["recurrence"],
+    includeInSeo: true,
   });
+  let locationForm = $state({
+    anchorType: "custom" as EventData["locations"][number]["anchorType"],
+    buildingId: "" as number | "",
+    dormId: "" as number | "",
+    label: "",
+  });
+  let routeForms = $state<{ id: number; name: string; description: string }[]>(
+    [],
+  );
 
   $effect(() => {
     if (!event || editing) return;
     form = eventToForm(event);
+    syncLocationForm(event);
+    routeForms = event.routes.map((route) => ({
+      id: route.id,
+      name: route.name,
+      description: route.description ?? "",
+    }));
   });
 
   $effect(() => {
@@ -80,10 +98,99 @@
       title: event.title,
       description: event.description ?? "",
       category: event.category,
-      startsAt: instantToCampusInput(event.occurrenceStartsAt),
-      endsAt: instantToCampusInput(event.occurrenceEndsAt),
+      startsAt: instantToCampusInput(event.startsAt),
+      endsAt: instantToCampusInput(event.endsAt),
       sourceUrl: event.sourceUrl ?? "",
+      recurrence: event.recurrence,
+      includeInSeo: event.includeInSeo,
     };
+  }
+
+  function syncLocationForm(event: EventData) {
+    const primary =
+      event.locations.find((location) => location.isPrimary) ??
+      event.locations[0] ??
+      null;
+    if (!primary) {
+      locationForm = {
+        anchorType: "custom",
+        buildingId: "",
+        dormId: "",
+        label: "",
+      };
+      return;
+    }
+    locationForm = {
+      anchorType: primary.anchorType,
+      buildingId: primary.buildingId ?? "",
+      dormId: primary.dormId ?? "",
+      label: primary.label,
+    };
+  }
+
+  function applyConflictLatest(data: { latest?: EventData | null }) {
+    if (data.latest) appActions.replaceEvent(data.latest);
+  }
+
+  function serializeRoutesForSave(event: EventData) {
+    return event.routes.map((route) => {
+      const edited = routeForms.find((item) => item.id === route.id);
+      return {
+        id: route.id,
+        name: edited?.name.trim() || route.name,
+        description: edited?.description.trim() || route.description,
+        sortOrder: route.sortOrder,
+        stops: route.stops.map((stop) => ({
+          id: stop.id,
+          eventLocationId: stop.eventLocationId,
+          label: stop.label,
+          lat: stop.lat,
+          lon: stop.lon,
+          sortOrder: stop.sortOrder,
+        })),
+      };
+    });
+  }
+
+  function buildPrimaryLocationPayload(event: EventData) {
+    const primary =
+      event.locations.find((location) => location.isPrimary) ??
+      event.locations[0] ??
+      null;
+    const buildingId =
+      locationForm.anchorType === "building" && locationForm.buildingId !== ""
+        ? Number(locationForm.buildingId)
+        : null;
+    const dormId =
+      locationForm.anchorType === "dorm" && locationForm.dormId !== ""
+        ? Number(locationForm.dormId)
+        : null;
+
+    const nextPrimary = {
+      anchorType: locationForm.anchorType,
+      buildingId,
+      dormId,
+      label: locationForm.label.trim() || "Event marker",
+      lat:
+        locationForm.anchorType === "custom"
+          ? (primary?.lat ?? primary?.resolvedLat ?? null)
+          : null,
+      lon:
+        locationForm.anchorType === "custom"
+          ? (primary?.lon ?? primary?.resolvedLon ?? null)
+          : null,
+      highlightPriority: primary?.highlightPriority ?? 0,
+      sortOrder: primary?.sortOrder ?? 0,
+      isPrimary: true,
+      ...(primary?.id ? { id: primary.id } : {}),
+    };
+
+    if (!primary) return [nextPrimary];
+    return event.locations.map((location) =>
+      location.id === primary.id
+        ? { ...serializeLocation(location), ...nextPrimary }
+        : serializeLocation(location, { isPrimary: false }),
+    );
   }
 
   async function saveEvent() {
@@ -102,18 +209,30 @@
           startsAt: campusInputToWallString(form.startsAt),
           endsAt: campusInputToWallString(form.endsAt),
           sourceUrl: form.sourceUrl || null,
-          includeInSeo: true,
+          recurrence: form.recurrence,
+          includeInSeo: form.includeInSeo,
+          routes: serializeRoutesForSave(event),
         }),
       });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(data.error ?? `Save failed (${res.status})`);
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        event?: EventData;
+        latest?: EventData | null;
+      };
 
-      if (data.event) appActions.replaceEvent(data.event);
+      if (!res.ok || !data.event) {
+        if (res.status === 409 && data.latest) {
+          applyConflictLatest(data);
+        }
+        throw new Error(data.error ?? `Save failed (${res.status})`);
+      }
+
+      appActions.replaceEvent(data.event);
       queryStore.updateQuery({
         category: "event",
         type: "result",
-        value: data.event?.title ?? form.title,
-        eventSlug: data.event?.slug ?? event.slug,
+        value: data.event.title,
+        eventSlug: data.event.slug,
       });
       editing = false;
       toastStore.show(`${form.title} saved.`, "success");
@@ -124,6 +243,92 @@
       );
     } finally {
       saving = false;
+    }
+  }
+
+  async function savePrimaryLocationAnchor() {
+    if (!event || savingLocation) return;
+    savingLocation = true;
+    try {
+      const res = await fetch(`/api/admin/events/${event.id}/locations`, {
+        method: "PATCH",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          version: event.version,
+          locations: buildPrimaryLocationPayload(event),
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        event?: EventData;
+        latest?: EventData | null;
+      };
+
+      if (!res.ok || !data.event) {
+        if (res.status === 409 && data.latest) {
+          applyConflictLatest(data);
+        }
+        throw new Error(data.error ?? `Location save failed (${res.status})`);
+      }
+
+      appActions.replaceEvent(data.event);
+      syncLocationForm(data.event);
+      toastStore.show(`${data.event.title} location updated.`, "success");
+    } catch (error) {
+      toastStore.show(
+        error instanceof Error
+          ? error.message
+          : `Failed to save location for ${event.title}.`,
+        "error",
+      );
+    } finally {
+      savingLocation = false;
+    }
+  }
+
+  async function deactivateEvent() {
+    if (!event || deactivating) return;
+    if (
+      !window.confirm(
+        `Deactivate "${event.title}"? It will be hidden from the public map and lists.`,
+      )
+    ) {
+      return;
+    }
+
+    deactivating = true;
+    try {
+      const res = await fetch(`/api/admin/events/${event.id}`, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ version: event.version }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        latest?: EventData | null;
+      };
+
+      if (!res.ok) {
+        if (res.status === 409 && data.latest) {
+          applyConflictLatest(data);
+        }
+        throw new Error(data.error ?? `Deactivate failed (${res.status})`);
+      }
+
+      appActions.removeEvent(event.id);
+      queryStore.clearQuery();
+      toastStore.show(`${event.title} deactivated.`, "success");
+    } catch (error) {
+      toastStore.show(
+        error instanceof Error
+          ? error.message
+          : `Failed to deactivate ${event.title}.`,
+        "error",
+      );
+    } finally {
+      deactivating = false;
     }
   }
 
@@ -219,7 +424,7 @@
 
       if (!res.ok || !data.event) {
         if (res.status === 409 && data.latest) {
-          appActions.replaceEvent(data.latest);
+          applyConflictLatest(data);
         }
         throw new Error(data.error ?? `Location save failed (${res.status})`);
       }
@@ -398,6 +603,88 @@
               /></label
             >
             <label>Source URL <input bind:value={form.sourceUrl} /></label>
+            <label>
+              Recurrence
+              <select bind:value={form.recurrence}>
+                <option value="none">None</option>
+                <option value="annual">Annual</option>
+                <option value="every_1st_sem">Every 1st semester</option>
+                <option value="every_2nd_sem">Every 2nd semester</option>
+              </select>
+            </label>
+            <label class="checkbox-row">
+              <input type="checkbox" bind:checked={form.includeInSeo} />
+              Include in SEO pages
+            </label>
+            {#if routeForms.length > 0}
+              <div class="route-editor-card">
+                <strong>Routes</strong>
+                {#each routeForms as routeForm, index (routeForm.id)}
+                  <label>
+                    Route name
+                    <input bind:value={routeForms[index]!.name} required />
+                  </label>
+                  <label>
+                    Route description
+                    <textarea bind:value={routeForms[index]!.description}
+                    ></textarea>
+                  </label>
+                {/each}
+              </div>
+            {/if}
+            <div class="location-editor-card">
+              <div>
+                <strong>Primary location anchor</strong>
+                <p>
+                  Choose whether the primary marker follows a building, dorm, or
+                  custom map coordinates.
+                </p>
+              </div>
+              <label>
+                Anchor type
+                <select bind:value={locationForm.anchorType}>
+                  <option value="custom">Custom map point</option>
+                  <option value="building">Building</option>
+                  <option value="dorm">Dorm</option>
+                </select>
+              </label>
+              {#if locationForm.anchorType === "building"}
+                <label>
+                  Building
+                  <select bind:value={locationForm.buildingId} required>
+                    <option value="">Select a building</option>
+                    {#each buildings as building (building.id)}
+                      <option value={building.id}
+                        >{building.buildingName}</option
+                      >
+                    {/each}
+                  </select>
+                </label>
+              {:else if locationForm.anchorType === "dorm"}
+                <label>
+                  Dorm
+                  <select bind:value={locationForm.dormId} required>
+                    <option value="">Select a dorm</option>
+                    {#each dorms as dorm (dorm.id)}
+                      <option value={dorm.id}>{dorm.dormName}</option>
+                    {/each}
+                  </select>
+                </label>
+              {/if}
+              <label
+                >Location label <input bind:value={locationForm.label} /></label
+              >
+              <div class="location-editor-actions">
+                <button
+                  class="secondary-action"
+                  type="button"
+                  disabled={savingLocation}
+                  onclick={savePrimaryLocationAnchor}
+                >
+                  {savingLocation ? "Saving anchor..." : "Save location anchor"}
+                </button>
+              </div>
+            </div>
             <div class="location-editor-card">
               <div>
                 <strong>Event location</strong>
@@ -441,6 +728,14 @@
             </div>
             <button class="primary-action" type="submit" disabled={saving}>
               {saving ? "Saving..." : "Save event"}
+            </button>
+            <button
+              class="danger-action"
+              type="button"
+              disabled={deactivating}
+              onclick={deactivateEvent}
+            >
+              {deactivating ? "Deactivating..." : "Deactivate event"}
             </button>
           </form>
         {/if}
@@ -547,7 +842,8 @@
   }
 
   .primary-action,
-  .secondary-action {
+  .secondary-action,
+  .danger-action {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -573,7 +869,30 @@
     color: #7b1113;
   }
 
-  .primary-action:disabled {
+  .danger-action {
+    border: 1px solid #fecaca;
+    background: #fef2f2;
+    color: #991b1b;
+  }
+
+  .checkbox-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .route-editor-card {
+    display: grid;
+    gap: 0.45rem;
+    padding: 0.65rem;
+    border: 1px solid #e4e4e7;
+    border-radius: 0.5rem;
+    background: #fafafa;
+  }
+
+  .primary-action:disabled,
+  .secondary-action:disabled,
+  .danger-action:disabled {
     cursor: progress;
     opacity: 0.65;
   }

--- a/src/components/svelte/sidepanel/SidePanel.svelte
+++ b/src/components/svelte/sidepanel/SidePanel.svelte
@@ -25,7 +25,9 @@
   const panelIdentity = $derived(
     queryStore.category === null
       ? null
-      : `${queryStore.category}:${queryStore.queryValue}`,
+      : queryStore.category === "event" && queryStore.selectedEventSlug
+        ? `event:${queryStore.selectedEventSlug}`
+        : `${queryStore.category}:${queryStore.queryValue}`,
   );
   const toggleLabel = $derived(
     sidePanelStore.collapsed

--- a/src/lib/campus-calendar.ts
+++ b/src/lib/campus-calendar.ts
@@ -1,0 +1,18 @@
+import type { EventRecurrence } from "./event-time";
+
+export type SemesterRecurrence = Extract<
+  EventRecurrence,
+  "every_1st_sem" | "every_2nd_sem"
+>;
+
+/**
+ * Campus semester month windows for recurrence projection.
+ * Update these when the official UP academic calendar changes.
+ */
+export const CAMPUS_SEMESTER_MONTHS: Record<
+  SemesterRecurrence,
+  readonly number[]
+> = {
+  every_1st_sem: [8, 9, 10, 11, 12],
+  every_2nd_sem: [1, 2, 3, 4, 5],
+};

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -31,6 +31,7 @@ export type DBData = Omit<AppContextData, "loaded">;
 
 export type AppActions = {
   replaceEvent: (event: EventData) => void;
+  removeEvent: (eventId: number) => void;
 };
 
 export const [getAppData, setAppData] = createContext<() => AppContextData>();

--- a/src/lib/event-time.ts
+++ b/src/lib/event-time.ts
@@ -14,6 +14,13 @@
  *  - `datetime-local` inputs are treated as Asia/Manila wall-clock time.
  */
 
+import {
+  CAMPUS_SEMESTER_MONTHS,
+  type SemesterRecurrence,
+} from "./campus-calendar";
+
+export type { SemesterRecurrence } from "./campus-calendar";
+
 export const CAMPUS_TIME_ZONE = "Asia/Manila";
 const CAMPUS_UTC_OFFSET = "+08:00";
 
@@ -130,13 +137,6 @@ export function projectCampusOccurrence(
   return { startsAt: projectedStart, endsAt: projectedEnd };
 }
 
-export type SemesterRecurrence = "every_1st_sem" | "every_2nd_sem";
-
-const SEMESTER_MONTHS: Record<SemesterRecurrence, readonly number[]> = {
-  every_1st_sem: [8, 9, 10, 11, 12],
-  every_2nd_sem: [1, 2, 3, 4, 5],
-};
-
 /** Project a semester-recurring event into the current-or-next semester window. */
 export function projectCampusSemesterOccurrence(
   startWall: string,
@@ -152,7 +152,7 @@ export function projectCampusSemesterOccurrence(
   const nowParts = getCampusParts(now);
   if (!startParts || !nowParts) return { startsAt: start, endsAt: end };
 
-  const months = SEMESTER_MONTHS[semester];
+  const months = CAMPUS_SEMESTER_MONTHS[semester];
   const inWindow = months.includes(Number(startParts.month));
   const month = inWindow
     ? startParts.month

--- a/src/lib/services/admin-service.ts
+++ b/src/lib/services/admin-service.ts
@@ -30,6 +30,16 @@ export class EditConflictError<TLatest> extends Error {
   }
 }
 
+export class DuplicateSlugError extends Error {
+  slug: string;
+
+  constructor(slug: string) {
+    super(`An event with slug "${slug}" already exists.`);
+    this.name = "DuplicateSlugError";
+    this.slug = slug;
+  }
+}
+
 /** Refresh the sync key for a table so viewers detect the change and re-sync. */
 export async function refreshSyncKey(tableName: string): Promise<void> {
   await db
@@ -666,6 +676,16 @@ export async function createEvent(
   input: EventWriteInput,
   editedBy = "admin",
 ): Promise<EventData | null> {
+  const slug = input.slug ?? "";
+  if (slug) {
+    const [existing] = await db
+      .select({ id: eventsTable.id })
+      .from(eventsTable)
+      .where(eq(eventsTable.slug, slug))
+      .limit(1);
+    if (existing) throw new DuplicateSlugError(slug);
+  }
+
   const [inserted] = await db
     .insert(eventsTable)
     .values({
@@ -710,6 +730,8 @@ export async function updateEvent(
   editedBy = "admin",
 ): Promise<EventData | null> {
   const before = await getEventById(id, { includeInactive: true });
+  if (!before) return null;
+
   const updates = getEventUpdates(input);
   const shouldReplaceChildren =
     input.locations !== undefined || input.routes !== undefined;

--- a/src/lib/services/event-service.ts
+++ b/src/lib/services/event-service.ts
@@ -1,4 +1,4 @@
-import { asc, eq } from "drizzle-orm";
+import { asc, eq, inArray } from "drizzle-orm";
 import { getStoredEventOccurrence, getStoredEventStatus } from "../event-time";
 import {
   buildingsTable,
@@ -111,33 +111,63 @@ async function hydrateEvents(
   now = new Date(),
 ): Promise<EventData[]> {
   if (events.length === 0) return [];
-  const eventIds = new Set(events.map((event) => event.id));
-  const [locations, routes, stops, buildings, dorms] = await Promise.all([
+  const eventIds = events.map((event) => event.id);
+  const [locations, routes] = await Promise.all([
     db
       .select()
       .from(eventLocationsTable)
+      .where(inArray(eventLocationsTable.eventId, eventIds))
       .orderBy(asc(eventLocationsTable.sortOrder)),
-    db.select().from(eventRoutesTable).orderBy(asc(eventRoutesTable.sortOrder)),
     db
       .select()
-      .from(eventRouteStopsTable)
-      .orderBy(asc(eventRouteStopsTable.sortOrder)),
-    db.select().from(buildingsTable),
-    db.select().from(dormsTable),
+      .from(eventRoutesTable)
+      .where(inArray(eventRoutesTable.eventId, eventIds))
+      .orderBy(asc(eventRoutesTable.sortOrder)),
+  ]);
+
+  const routeIds = routes.map((route) => route.id);
+  const stops =
+    routeIds.length === 0
+      ? []
+      : await db
+          .select()
+          .from(eventRouteStopsTable)
+          .where(inArray(eventRouteStopsTable.routeId, routeIds))
+          .orderBy(asc(eventRouteStopsTable.sortOrder));
+
+  const buildingIds = [
+    ...new Set(
+      locations
+        .map((location) => location.buildingId)
+        .filter((id): id is number => id !== null),
+    ),
+  ];
+  const dormIds = [
+    ...new Set(
+      locations
+        .map((location) => location.dormId)
+        .filter((id): id is number => id !== null),
+    ),
+  ];
+
+  const [buildings, dorms] = await Promise.all([
+    buildingIds.length === 0
+      ? Promise.resolve([])
+      : db
+          .select()
+          .from(buildingsTable)
+          .where(inArray(buildingsTable.id, buildingIds)),
+    dormIds.length === 0
+      ? Promise.resolve([])
+      : db.select().from(dormsTable).where(inArray(dormsTable.id, dormIds)),
   ]);
 
   const buildingMap = new Map(
     buildings.map((building) => [building.id, building]),
   );
   const dormMap = new Map(dorms.map((dorm) => [dorm.id, dorm]));
-  const locationsByEvent = groupBy(
-    locations.filter((location) => eventIds.has(location.eventId)),
-    (location) => location.eventId,
-  );
-  const routesByEvent = groupBy(
-    routes.filter((route) => eventIds.has(route.eventId)),
-    (route) => route.eventId,
-  );
+  const locationsByEvent = groupBy(locations, (location) => location.eventId);
+  const routesByEvent = groupBy(routes, (route) => route.eventId);
   const stopsByRoute = groupBy(stops, (stop) => stop.routeId);
 
   return events

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -195,11 +195,17 @@ class QueryStore {
   };
 
   addRecentSearch(recentSearch: RecentSearch) {
-    const qIndex = this.recentSearches.findIndex(
-      (query) =>
-        query.value === recentSearch.value &&
-        query.category === recentSearch.category,
-    );
+    const qIndex = this.recentSearches.findIndex((query) => {
+      if (query.category !== recentSearch.category) return false;
+      if (
+        recentSearch.category === "event" &&
+        recentSearch.eventSlug &&
+        query.eventSlug
+      ) {
+        return query.eventSlug === recentSearch.eventSlug;
+      }
+      return query.value === recentSearch.value;
+    });
     if (qIndex !== -1) this.recentSearches.splice(qIndex, 1);
     else if (this.recentSearches.length > 4) this.recentSearches.pop();
 

--- a/src/pages/api/admin/events/[id].ts
+++ b/src/pages/api/admin/events/[id].ts
@@ -44,8 +44,11 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
     const updates: EventWriteInput = { ...body };
     if (updates.slug) updates.slug = slugifySegment(updates.slug);
     if (updates.title) updates.title = updates.title.trim();
-    updates.includeInSeo = true;
+    if (typeof body.includeInSeo === "boolean") {
+      updates.includeInSeo = body.includeInSeo;
+    }
     const event = await updateEvent(id, updates, expectedVersion);
+    if (!event) return json({ error: "Event not found" }, 404);
     return json({ success: true, event });
   } catch (err) {
     return handleEventError(err);

--- a/src/pages/api/admin/events/[id]/locations.ts
+++ b/src/pages/api/admin/events/[id]/locations.ts
@@ -41,6 +41,7 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
       body.locations,
       Number.isInteger(body.version) ? body.version : undefined,
     );
+    if (!event) return json({ error: "Event not found" }, 404);
     return json({ success: true, event });
   } catch (err) {
     if (err instanceof EditConflictError) {

--- a/src/pages/api/admin/events/[id]/routes.ts
+++ b/src/pages/api/admin/events/[id]/routes.ts
@@ -41,6 +41,7 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
       { routes: body.routes },
       Number.isInteger(body.version) ? body.version : undefined,
     );
+    if (!event) return json({ error: "Event not found" }, 404);
     return json({ success: true, event });
   } catch (err) {
     if (err instanceof EditConflictError) {

--- a/src/pages/api/admin/events/index.ts
+++ b/src/pages/api/admin/events/index.ts
@@ -3,7 +3,10 @@ import {
   ADMIN_COOKIE_NAME,
   verifySessionToken,
 } from "../../../../lib/admin/auth";
-import { createEvent } from "../../../../lib/services/admin-service";
+import {
+  createEvent,
+  DuplicateSlugError,
+} from "../../../../lib/services/admin-service";
 import { slugifySegment } from "../../../../lib/site";
 
 export const prerender = false;
@@ -26,17 +29,28 @@ export const POST: APIRoute = async ({ cookies, request }) => {
     return json({ error: "Event start and end timestamps are required" }, 400);
   }
 
-  const event = await createEvent({
-    ...body,
-    title,
-    includeInSeo: true,
-    slug:
-      typeof body.slug === "string" && body.slug.trim()
-        ? slugifySegment(body.slug)
-        : slugifySegment(title),
-  });
+  const slug =
+    typeof body.slug === "string" && body.slug.trim()
+      ? slugifySegment(body.slug)
+      : slugifySegment(title);
 
-  return json({ success: true, event }, 201);
+  try {
+    const event = await createEvent({
+      ...body,
+      title,
+      slug,
+      includeInSeo:
+        typeof body.includeInSeo === "boolean" ? body.includeInSeo : true,
+    });
+
+    return json({ success: true, event }, 201);
+  } catch (err) {
+    if (err instanceof DuplicateSlugError) {
+      return json({ error: err.message }, 409);
+    }
+    console.error("Failed to create event:", err);
+    return json({ error: "Failed to create event" }, 500);
+  }
 };
 
 function json(body: unknown, status = 200) {

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -8,22 +8,30 @@ import {
 export const prerender = false;
 
 export const GET: APIRoute = async ({ url }) => {
-  const activeOnly = url.searchParams.get("active") === "1";
-  const upcomingOnly = url.searchParams.get("upcoming") === "1";
+  try {
+    const activeOnly = url.searchParams.get("active") === "1";
+    const upcomingOnly = url.searchParams.get("upcoming") === "1";
 
-  if (activeOnly) {
-    return new Response(JSON.stringify(await getActiveEvents()), {
+    if (activeOnly) {
+      return new Response(JSON.stringify(await getActiveEvents()), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (upcomingOnly) {
+      return new Response(JSON.stringify(await getUpcomingEvents()), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify(await getAllEvents()), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("Failed to load events:", error);
+    return new Response(JSON.stringify({ error: "Failed to load events" }), {
+      status: 500,
       headers: { "Content-Type": "application/json" },
     });
   }
-
-  if (upcomingOnly) {
-    return new Response(JSON.stringify(await getUpcomingEvents()), {
-      headers: { "Content-Type": "application/json" },
-    });
-  }
-
-  return new Response(JSON.stringify(await getAllEvents()), {
-    headers: { "Content-Type": "application/json" },
-  });
 };


### PR DESCRIPTION
## Summary

Fixes all bugs flagged in the staging → main release review (#200 audit), spanning identity handling, editor conflict paths, map UX, API errors, and search polish.

### Identity & state consistency
- `isSelectedEditableEventLocation` gates on `eventSlug`, not title
- Side panel `panelIdentity` includes slug for event results
- Recent search dedup compares `eventSlug` for events
- `replaceEvent` upserts new events; `setLocalEvent` / map create use it consistently

### Editor (`EventResult`)
- Metadata save handles 409 with server `latest`
- Form edits stored `startsAt`/`endsAt` (not projected occurrence)
- Recurrence selector + include-in-SEO toggle (no longer forced true)
- Structured primary location editor (building/dorm/custom anchor pickers)
- Route name/description editing in form
- Deactivate event button (DELETE API)

### Map UX
- Past events render map pins (muted styling)
- All event routes drawn + stop pins (not just `routes[0]`)
- Multiple active events shown in banner stack
- Removed decorative user-location pulsate animation

### API & data layer
- `GET /api/events` try/catch → 500 JSON
- Duplicate slug on create → 409 (not 500)
- Missing event ID on PATCH → 404
- `includeInSeo` respects request body on create/update
- `hydrateEvents()` scopes child/building/dorm queries by event IDs
- Semester windows extracted to `src/lib/campus-calendar.ts`

### Search & PWA
- Search throttle 1500ms → 400ms; placeholder mentions events
- `EventCards` uses `isPrimary` location
- `SyncToast` `stacked` prop flows in map-controls column (no duplicate fixed positioning)

## Test plan

- [ ] Select event with duplicate-title scenario → edit pin appears correctly
- [ ] Save event metadata from two tabs → 409 applies latest row
- [ ] Edit recurrence + SEO toggle → persists correctly
- [ ] Change primary location to building anchor → saves and pin moves
- [ ] Edit route name → saves with event PATCH
- [ ] Deactivate event → removed from map/lists
- [ ] Past event from EventsList → map pin visible (muted) + fly-to works
- [ ] Event with multiple routes → all polylines + stops render
- [ ] Two concurrent active events → both banners shown
- [ ] Create event with existing slug → 409 error message
- [ ] PWA/sync toast sits below map controls on desktop (stacked layout)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin event write/delete paths, optimistic local event state, and map selection by slug—user-visible if regressions slip through, but changes are mostly bug fixes with version/conflict handling already in place.
> 
> **Overview**
> Addresses bugs from the staging → main release audit around **events**, **map UX**, **admin editing**, and **API behavior**.
> 
> **Identity and client state** now key off `eventSlug` where titles collide: map edit targeting, side panel identity, and recent-search dedup. `replaceEvent` upserts missing rows; `removeEvent` supports deactivation; map create/update paths use shared app actions instead of mutating `events` in place.
> 
> **Map and discovery**: multiple **active** events get stacked “happening now” banners; **past** events show muted pins; selected events draw **all** route polylines and stops (not only the first route). The legend is split into Places / Events / Routes with conditional event icons. `SyncToast` can render **stacked** in the map-controls column.
> 
> **Admin `EventResult`**: saves use stored `startsAt`/`endsAt`, recurrence and **includeInSeo** (no longer forced true), route metadata, primary location anchor (building/dorm/custom), 409 conflict refresh via `latest`, and a **deactivate** (DELETE) flow that clears the query and drops the event from local state.
> 
> **Backend**: `hydrateEvents` scopes child and anchor queries by event IDs; duplicate slug on create → **409**; missing events → **404**; `GET /api/events` returns **500** JSON on failure; semester month windows live in `campus-calendar.ts`. Search throttle is **400ms** and the placeholder mentions events; event cards prefer **isPrimary** locations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fe584a8b968ec38af53ab48aeb0513114aaee18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->