### PR TITLE
fix(map): remove orphan editor WIP

### DIFF
--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -54,7 +54,7 @@
     buildingMatchesTypeFilter,
     dormMatchesTypeFilter,
   } from "../../constants/building-types";
-  import { getEventPoster } from "../../lib/entity-image-display";
+  import { getEventImage } from "../../lib/event-images";
   import {
     formatCampusDateShort,
     formatCampusTime,
@@ -2110,47 +2110,6 @@
           type="button"
           disabled={eventPlacementStore.creating}
           onclick={() => eventPlacementStore.cancel()}
-        >
-          Cancel
-        </button>
-      </div>
-    {/if}
-  {:else if buildingPlacementStore.active}
-    {#if md.current}
-      <div
-        class="edit-dock event-placement-dock"
-        role="status"
-        aria-live="polite"
-      >
-        <p class="edit-dock-status">
-          {buildingPlacementStore.creating
-            ? "Creating building…"
-            : "Tap the map to place the building"}
-        </p>
-        <button
-          class="edit-dock-action cancel"
-          type="button"
-          disabled={buildingPlacementStore.creating}
-          onclick={() => buildingPlacementStore.cancel()}
-        >
-          Cancel
-        </button>
-      </div>
-    {:else}
-      <div class="event-placement-toolbar" role="status" aria-live="polite">
-        <div class="event-placement-copy">
-          <strong>Choose building location on the map</strong>
-          <span>
-            {buildingPlacementStore.creating
-              ? "Creating the building at the selected map point..."
-              : "Click or tap the map point where this building should appear."}
-          </span>
-        </div>
-        <button
-          class="event-placement-cancel"
-          type="button"
-          disabled={buildingPlacementStore.creating}
-          onclick={() => buildingPlacementStore.cancel()}
         >
           Cancel
         </button>


### PR DESCRIPTION
## Summary

- Removes half-finished building-placement map chrome that referenced `buildingPlacementStore` (never defined or imported).
- Restores `getEventImage` from `event-images.ts`; HEAD imported `getEventPoster` from an untracked/missing `entity-image-display.ts` while the template still called `getEventImage`.
- Reverts uncommitted `RoomResult` `EntityEditorHistory` usage (component never landed).

This was orphan WIP from an incomplete editor-continuation pass, not a merge conflict.

## Test plan

- [x] `bun run build`
- [ ] Map loads without console errors on browse + event placement
- [ ] Event pin stack images still render via slug map

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file cleanup with no API or auth changes; risk is limited to map UI chrome and event thumbnail resolution via the restored helper.
> 
> **Overview**
> Cleans up incomplete map-editor work in **`Map.svelte`** so the map compiles and the overlay logic stays consistent with what actually exists in the app.
> 
> The script import is switched from the broken **`getEventPoster`** / `entity-image-display` path back to **`getEventImage`** from `event-images.ts`, matching the template’s event pin and stack thumbnails.
> 
> A whole **`{:else if buildingPlacementStore.active}`** branch (mobile dock + desktop toolbar for “place building on map”) is removed. That UI referenced **`buildingPlacementStore`**, which is not defined or imported anywhere, so it was dead/broken WIP rather than shipped behavior. Event placement and map-edit toolbars are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b707fa77859db622fa4dcd73c8be7acc278a4457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->