### PR TITLE
fix: map attribution chrome + offline alias cache (#207 #155 follow-ups)

### DIFF
--- a/.cursor/rules/map-layout.mdc
+++ b/.cursor/rules/map-layout.mdc
@@ -2,6 +2,7 @@
 description: Map layout guardrails for Entry, SidePanel, Search, StatusBar, and Map tools
 globs:
   - src/components/svelte/Entry.svelte
+  - src/components/svelte/MapAttribution.svelte
   - src/components/svelte/sidepanel/**
   - src/components/svelte/Map.svelte
   - src/components/svelte/StatusBar.svelte
@@ -15,7 +16,7 @@ globs:
 Before adding or moving map chrome:
 
 1. Read `docs/map-ui-mode-matrix.md` and update it if you add a mode or surface.
-2. Mount UI in Entry zones (top / map / bottom / ephemeral) — no new fixed overlays in `Map.svelte` except pins and the edit dock.
+2. Mount UI in Entry zones (top / map / bottom / ephemeral) — no new fixed overlays in `Map.svelte` except pins and the edit dock. Basemap attribution belongs in `MapAttribution.svelte` on the bottom band, not on the map canvas.
 3. Use `.app-layout` CSS vars (`--status-bar-block-height`, `--edit-bar-height`, etc.) — no magic `bottom: 4.25rem`.
 4. One flyout at a time: `mapToolsStore` for Map tools; `floatingControlPanelStore` only for admin menu on LocationButton.
 5. View controls split: flyout uses `MapViewControls variant="modes"` (Pins + 2D/3D only). Desktop rotate/tilt/compass use `variant="camera"` on the map face in `Entry.svelte`, not inside the flyout. Do not mount camera variant on mobile.

--- a/docs/map-ui-mode-matrix.md
+++ b/docs/map-ui-mode-matrix.md
@@ -2,13 +2,13 @@
 
 Source of truth for which map chrome is visible in each mode.
 
-| Mode                          | Search dropdown | Event banner | Events shelf | Map tools      | Edit dock             | Sync UI    |
-| ----------------------------- | --------------- | ------------ | ------------ | -------------- | --------------------- | ---------- |
-| Browse                        | yes             | yes          | yes          | closed default | hidden                | status bar |
-| Browse (search collapsed)     | on expand       | on expand    | on expand    | closed default | hidden                | status bar |
-| Edit (`mapEditStore.enabled`) | **no**          | **no**       | **no**       | closed default | **yes (mobile dock)** | status bar |
-| Event placement               | **no**          | **no**       | **no**       | closed default | cancel dock           | status bar |
-| Terrain / jeepney active      | yes             | yes          | yes          | flyout section | hidden                | status bar |
+| Mode                          | Search dropdown | Event banner | Events shelf | Map tools      | Edit dock             | Sync UI    | Map attribution |
+| ----------------------------- | --------------- | ------------ | ------------ | -------------- | --------------------- | ---------- | --------------- |
+| Browse                        | yes             | yes          | yes          | closed default | hidden                | status bar | bottom band     |
+| Browse (search collapsed)     | on expand       | on expand    | on expand    | closed default | hidden                | status bar | bottom band     |
+| Edit (`mapEditStore.enabled`) | **no**          | **no**       | **no**       | closed default | **yes (mobile dock)** | status bar | bottom band     |
+| Event placement               | **no**          | **no**       | **no**       | closed default | cancel dock           | status bar | bottom band     |
+| Terrain / jeepney active      | yes             | yes          | yes          | flyout section | hidden                | status bar | bottom band     |
 
 Implementation: `getMapChromeVisibility()` in `src/lib/map-chrome.ts`.
 
@@ -16,10 +16,10 @@ Implementation: `getMapChromeVisibility()` in `src/lib/map-chrome.ts`.
 
 - **Top band:** search column, event banner, Map tools trigger
 - **Map face:** map canvas, location/editor FAB
-- **Bottom band:** status bar, edit dock (when editing), drawer host
+- **Bottom band:** status bar, map attribution (`MapAttribution.svelte`), location/editor FAB
 - **Ephemeral:** toast, modals
 
-New map chrome must mount in a named zone in `Entry.svelte` or its children. Do not add new `position: fixed` surfaces inside `Map.svelte` except map-attached pins/markers and the edit dock.
+MapLibre attribution is disabled on the map canvas (`attributionControl={false}`). Required basemap credits live in `MapAttribution` on the bottom band so they stay visible above the mobile detail sheet.
 
 ## CSS anchors (on `.app-layout`)
 

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -95,6 +95,8 @@
           events: await getEvents(eventCheck),
           ...(await getRoomsData()),
         };
+        await syncBuildings(buildingCheck, data.buildings ?? []);
+        await syncAliasCache();
       })
       .then(() => {
         buildings = data.buildings;
@@ -106,12 +108,10 @@
         totalRooms = data.totalRooms;
         loaded = true;
         Promise.resolve()
-          .then(() => syncBuildings(buildingCheck, data.buildings ?? []))
           .then(() => syncColleges(collegeCheck, data.colleges ?? []))
           .then(() => syncDivisions(divisionCheck, data.divisions ?? []))
           .then(() => syncDorms(dormCheck, data.dorms ?? []))
           .then(() => syncEvents(eventCheck, data.events ?? []))
-          .then(() => syncAliasCache())
           .then(() => syncToastStore.endSync());
       });
   });

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -31,6 +31,7 @@
     syncDivisions,
     syncDorms,
     syncEvents,
+    syncAliasCache,
   } from "../../lib/local/data/sync";
   import { getDB, initPGLiteDB } from "../../lib/local/data/pgliteDB";
 
@@ -110,6 +111,7 @@
           .then(() => syncDivisions(divisionCheck, data.divisions ?? []))
           .then(() => syncDorms(dormCheck, data.dorms ?? []))
           .then(() => syncEvents(eventCheck, data.events ?? []))
+          .then(() => syncAliasCache())
           .then(() => syncToastStore.endSync());
       });
   });

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -18,6 +18,7 @@
   import MapToolsFlyout from "./MapToolsFlyout.svelte";
   import MapViewControls from "./MapViewControls.svelte";
   import LocationButton from "./LocationButton.svelte";
+  import MapAttribution from "./MapAttribution.svelte";
   import StatusBar from "./StatusBar.svelte";
   import Toast from "./Toast.svelte";
   import Building3DViewer from "./Building3DViewer.svelte";
@@ -136,6 +137,7 @@
     <div class="inner-layer">
       <SidePanel />
       <div class="bottom-band">
+        <MapAttribution />
         <div
           class="location-fab-stack"
           class:drawer-lift={drawerExpanded}

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -2210,6 +2210,7 @@
     bearing={CAMPUS_DEFAULT_CAMERA.bearing}
     minZoom={13}
     class="map"
+    attributionControl={false}
   >
     {#if locationStore.coords}
       <Marker lngLat={locationStore.coords}>
@@ -2503,20 +2504,6 @@
       {/each}
     {/if}
   </MapLibre>
-  {#if terrainStore.enabled}
-    <a
-      class="maptiler-logo"
-      href="https://www.maptiler.com/"
-      target="_blank"
-      rel="noreferrer"
-      aria-label="MapTiler"
-    >
-      <img
-        src="https://api.maptiler.com/resources/logo.svg"
-        alt="MapTiler logo"
-      />
-    </a>
-  {/if}
 </div>
 
 <style>
@@ -2527,40 +2514,6 @@
     width: 100%;
     height: 100%;
     z-index: 0;
-  }
-
-  .maptiler-logo {
-    position: absolute;
-    bottom: 0.75rem;
-    left: calc(25.75rem + 1rem);
-    z-index: 5;
-    display: inline-flex;
-    align-items: center;
-    border-radius: 0.375rem;
-    background-color: rgba(255, 255, 255, 0.92);
-    padding: 0.25rem 0.375rem;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
-    pointer-events: auto;
-  }
-
-  .maptiler-logo img {
-    display: block;
-    width: auto;
-    height: 1.25rem;
-  }
-
-  /* #207: keep the required basemap attribution above the bottom map chrome
-     (status bar + location FAB row) so it is never covered by app UI. */
-  :global(.app-layout .maplibregl-ctrl-bottom-right) {
-    z-index: 11;
-    bottom: calc(
-      var(--status-bar-block-height, 2.75rem) +
-        var(--bottom-fab-inset, 3.75rem) + var(--map-ui-padding, 0.5rem) +
-        env(safe-area-inset-bottom, 0px)
-    );
-  }
-  :global(.app-layout .maplibregl-ctrl-attrib) {
-    background-color: rgba(255, 255, 255, 0.85);
   }
 
   .map-edit-toolbar {
@@ -2806,17 +2759,6 @@
 
   .edit-dock-action.cancel:hover:not(:disabled) {
     background: #5f0d0f;
-  }
-
-  @media (max-width: 48rem) {
-    .maptiler-logo {
-      bottom: calc(
-        var(--status-bar-block-height, 2.75rem) +
-          env(safe-area-inset-bottom, 0px) + 0.375rem
-      );
-      left: 0.375rem;
-      z-index: 5;
-    }
   }
 
   .user-location-pin {

--- a/src/components/svelte/MapAttribution.svelte
+++ b/src/components/svelte/MapAttribution.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import { terrainStore } from "../../lib/store.svelte";
+
+  let expanded = $state(false);
+
+  function toggleExpanded() {
+    expanded = !expanded;
+  }
+</script>
+
+<div class="map-attribution" class:expanded>
+  <button
+    type="button"
+    class="attrib-toggle"
+    aria-expanded={expanded}
+    aria-controls="map-attribution-details"
+    onclick={toggleExpanded}
+  >
+    {#if expanded}
+      Hide map data
+    {:else}
+      Map data
+    {/if}
+  </button>
+  {#if expanded}
+    <div id="map-attribution-details" class="attrib-body">
+      <a
+        href="https://www.maptiler.com/copyright/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        © MapTiler
+      </a>
+      <a
+        href="https://www.openstreetmap.org/copyright"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        © OpenStreetMap contributors
+      </a>
+      <a
+        href="https://openmaptiles.org/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        © OpenMapTiles
+      </a>
+    </div>
+  {/if}
+  {#if terrainStore.enabled}
+    <a
+      class="maptiler-logo"
+      href="https://www.maptiler.com/"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="MapTiler"
+    >
+      <img
+        src="https://api.maptiler.com/resources/logo.svg"
+        alt="MapTiler logo"
+      />
+    </a>
+  {/if}
+</div>
+
+<style>
+  .map-attribution {
+    position: relative;
+    z-index: 15;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 0.375rem;
+    align-self: flex-start;
+    max-width: calc(100% - var(--bottom-fab-inset, 0px));
+    pointer-events: auto;
+  }
+
+  .attrib-toggle {
+    border: 1px solid var(--map-chrome-border, hsl(0, 0%, 58%));
+    border-radius: 0.5rem;
+    background: rgba(255, 255, 255, 0.92);
+    color: hsl(0, 0%, 20%);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1.2;
+    padding: 0.25rem 0.5rem;
+    cursor: pointer;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+  }
+
+  .attrib-toggle:hover,
+  .attrib-toggle:focus-visible {
+    background: #fff;
+    outline: 2px solid #7b1113;
+    outline-offset: 1px;
+  }
+
+  .attrib-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    width: min(16rem, 100%);
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--map-chrome-border, hsl(0, 0%, 58%));
+    border-radius: 0.5rem;
+    background: rgba(255, 255, 255, 0.96);
+    font-size: 0.6875rem;
+    line-height: 1.35;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.14);
+  }
+
+  .attrib-body a {
+    color: hsl(0, 0%, 25%);
+    text-decoration: none;
+  }
+
+  .attrib-body a:hover,
+  .attrib-body a:focus-visible {
+    text-decoration: underline;
+  }
+
+  .maptiler-logo {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 0.375rem;
+    background-color: rgba(255, 255, 255, 0.92);
+    padding: 0.25rem 0.375rem;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+  }
+
+  .maptiler-logo img {
+    display: block;
+    width: auto;
+    height: 1.25rem;
+  }
+
+  @media (max-width: 48rem) {
+    .map-attribution {
+      margin-left: 0.5rem;
+      margin-bottom: 0.25rem;
+    }
+  }
+</style>

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -2,6 +2,7 @@
   import { getAppData } from "../../../lib/context";
   import {
     getJSONFetch,
+    searchLocalAliases,
     searchLocalRooms,
   } from "../../../lib/local/data/utils";
   import {
@@ -148,7 +149,7 @@
         )
         .map((entry) => ({ alias: entry.alias, value: entry.value }));
     } catch {
-      return [];
+      return searchLocalAliases(trimmed);
     }
   }
 </script>

--- a/src/lib/local/data/pgliteDB.ts
+++ b/src/lib/local/data/pgliteDB.ts
@@ -200,6 +200,15 @@ export async function initPGLiteDB(db: PGlite) {
 
     ALTER TABLE divisions
     ADD COLUMN IF NOT EXISTS "updated_at" text NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+    CREATE TABLE IF NOT EXISTS "aliases" (
+    "id" integer PRIMARY KEY,
+    "alias" text NOT NULL,
+    "normalized_alias" text NOT NULL,
+    "target_type" varchar(16) NOT NULL,
+    "target_id" integer NOT NULL,
+    "building_name" text
+    );
     `);
   } catch (e) {
     console.error("An error occurred", e);

--- a/src/lib/local/data/sync.ts
+++ b/src/lib/local/data/sync.ts
@@ -865,11 +865,13 @@ export async function syncAliasCache() {
       }[];
     };
     const rows = payload.data;
-    if (!Array.isArray(rows) || rows.length === 0) return;
+    if (!Array.isArray(rows)) return;
 
     const localDB = getDB();
     await localDB.waitReady;
     await localDB.exec(`DELETE FROM aliases`);
+    if (rows.length === 0) return;
+
     for (const row of rows) {
       await localDB.query(
         `

--- a/src/lib/local/data/sync.ts
+++ b/src/lib/local/data/sync.ts
@@ -848,3 +848,45 @@ export async function syncDivisionRooms(
     [id],
   );
 }
+
+/** Refresh the local alias cache from the server when online (#155 follow-up). */
+export async function syncAliasCache() {
+  try {
+    const response = await fetch("/api/aliases?export=all");
+    if (!response.ok) return;
+    const payload = (await response.json()) as {
+      data?: {
+        id: number;
+        alias: string;
+        normalizedAlias: string;
+        targetType: string;
+        targetId: number;
+        value: string | null;
+      }[];
+    };
+    const rows = payload.data;
+    if (!Array.isArray(rows) || rows.length === 0) return;
+
+    const localDB = getDB();
+    await localDB.waitReady;
+    await localDB.exec(`DELETE FROM aliases`);
+    for (const row of rows) {
+      await localDB.query(
+        `
+        INSERT INTO aliases (id, alias, normalized_alias, target_type, target_id, building_name)
+        VALUES ($1, $2, $3, $4, $5, $6);
+        `,
+        [
+          row.id,
+          row.alias,
+          row.normalizedAlias,
+          row.targetType,
+          row.targetId,
+          row.value,
+        ],
+      );
+    }
+  } catch (e) {
+    console.error(e);
+  }
+}

--- a/src/lib/local/data/utils.ts
+++ b/src/lib/local/data/utils.ts
@@ -450,11 +450,16 @@ export async function searchLocalAliases(
     await localDB.waitReady;
     const data = (await localDB.query(
       `
-      SELECT alias, building_name AS value, normalized_alias AS "normalizedAlias"
-      FROM aliases
-      WHERE building_name IS NOT NULL
-        AND (normalized_alias = $1 OR normalized_alias LIKE $2)
-      ORDER BY CASE WHEN normalized_alias = $1 THEN 0 ELSE 1 END, alias
+      SELECT
+        a.alias,
+        COALESCE(b.building_name, a.building_name) AS value,
+        a.normalized_alias AS "normalizedAlias"
+      FROM aliases AS a
+      LEFT JOIN buildings AS b
+        ON a.target_type = 'building' AND b.id = a.target_id
+      WHERE COALESCE(b.building_name, a.building_name) IS NOT NULL
+        AND (a.normalized_alias = $1 OR a.normalized_alias LIKE $2)
+      ORDER BY CASE WHEN a.normalized_alias = $1 THEN 0 ELSE 1 END, a.alias
       LIMIT 12
       `,
       [normalized, `${normalized}%`],

--- a/src/lib/local/data/utils.ts
+++ b/src/lib/local/data/utils.ts
@@ -16,6 +16,7 @@ import {
   getLocalDivisionRooms,
 } from "./sync";
 import { refreshStoredEventTiming, sortStoredEvents } from "../../event-time";
+import { normalizeAlias } from "../../site";
 import type { Results } from "@electric-sql/pglite";
 
 export async function getLocalBuildings(): Promise<BuildingData[] | undefined> {
@@ -435,5 +436,38 @@ export async function searchLocalRooms(
   } catch (e) {
     console.error(e);
     return null;
+  }
+}
+
+/** Offline alias lookup against the PGlite cache (#155 follow-up). */
+export async function searchLocalAliases(
+  searchString: string,
+): Promise<{ alias: string; value: string }[]> {
+  const normalized = normalizeAlias(searchString);
+  if (!normalized) return [];
+  try {
+    const localDB = getDB();
+    await localDB.waitReady;
+    const data = (await localDB.query(
+      `
+      SELECT alias, building_name AS value, normalized_alias AS "normalizedAlias"
+      FROM aliases
+      WHERE building_name IS NOT NULL
+        AND (normalized_alias = $1 OR normalized_alias LIKE $2)
+      ORDER BY CASE WHEN normalized_alias = $1 THEN 0 ELSE 1 END, alias
+      LIMIT 12
+      `,
+      [normalized, `${normalized}%`],
+    )) as Results<{ alias: string; value: string; normalizedAlias: string }>;
+
+    const seen = new Set<string>();
+    return data.rows.filter((row) => {
+      if (!row.value || seen.has(row.value)) return false;
+      seen.add(row.value);
+      return true;
+    });
+  } catch (e) {
+    console.error(e);
+    return [];
   }
 }

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -270,6 +270,46 @@ export type AliasMatch = {
   value: string | null;
 };
 
+export type AliasCacheRow = AliasMatch & {
+  id: number;
+  normalizedAlias: string;
+};
+
+/** All alias rows with resolved building names for PGlite cache refresh (#155). */
+export async function listAliasesForCache(): Promise<AliasCacheRow[]> {
+  try {
+    const rows = await db
+      .select({
+        id: aliasesTable.id,
+        alias: aliasesTable.alias,
+        normalizedAlias: aliasesTable.normalizedAlias,
+        targetType: aliasesTable.targetType,
+        targetId: aliasesTable.targetId,
+        buildingName: buildingsTable.buildingName,
+      })
+      .from(aliasesTable)
+      .leftJoin(
+        buildingsTable,
+        and(
+          eq(aliasesTable.targetType, "building"),
+          eq(buildingsTable.id, aliasesTable.targetId),
+        ),
+      );
+
+    return rows.map((row) => ({
+      id: row.id,
+      alias: row.alias,
+      normalizedAlias: row.normalizedAlias,
+      targetType: row.targetType,
+      targetId: row.targetId,
+      value: row.buildingName,
+    }));
+  } catch (e) {
+    console.error("Error: ", e);
+    return [];
+  }
+}
+
 /** Resolve a search term against the alias/synonym map (#155). Matches exact
  * and prefix normalized aliases, returning the (deduped) building targets. */
 export async function searchAliases(

--- a/src/pages/api/aliases.ts
+++ b/src/pages/api/aliases.ts
@@ -1,9 +1,19 @@
 import { APIRoute } from "astro";
-import { searchAliases } from "../../lib/services/map-data-service";
+import {
+  listAliasesForCache,
+  searchAliases,
+} from "../../lib/services/map-data-service";
 
 export const prerender = false;
 
 export const GET = (async ({ url }) => {
+  if (url.searchParams.get("export") === "all") {
+    const data = await listAliasesForCache();
+    return new Response(JSON.stringify({ data, success: true }), {
+      headers: { "content-type": "application/json" },
+    });
+  }
+
   const q = url.searchParams.get("q") ?? "";
   if (q.trim() === "") {
     return new Response(JSON.stringify({ data: [], success: true }), {


### PR DESCRIPTION
## Summary
- Move basemap attribution into `MapAttribution` on Entry's bottom band so credits stay visible when the mobile detail sheet is expanded (#207 structural follow-up)
- Disable MapLibre canvas attribution; terrain MapTiler logo lives in the same chrome component
- Cache aliases in PGlite with `?export=all`, refresh after building sync, and fall back to local lookup offline (#155 follow-up)

## Test plan
- [ ] Desktop / 768 / 320: "Map data" toggle visible in bottom band; expands with MapTiler/OSM/OpenMapTiles links
- [ ] Mobile with entity detail sheet **expanded**: attribution still visible above status bar
- [ ] Terrain on: MapTiler logo appears beside attribution
- [ ] Online: search `PhySci`, `HUM`, `CASA1` shows alias hints
- [ ] Offline (after one online visit): same alias hints work without API
- [ ] `bun run build` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/layout and local search cache changes with graceful API fallbacks; no auth or payment paths touched.
> 
> **Overview**
> Moves **basemap attribution** off the MapLibre canvas into a new **`MapAttribution`** component on Entry’s bottom band, with a “Map data” toggle for MapTiler/OSM/OpenMapTiles credits and the terrain **MapTiler logo** when terrain is on. **`Map.svelte`** disables the built-in attribution control and drops the old overlay logo and `maplibregl-ctrl` positioning hacks so credits stay visible above mobile chrome (e.g. detail sheet). Layout docs and map-layout rules are updated accordingly.
> 
> Adds an **offline alias search** path: PGlite **`aliases`** table, **`/api/aliases?export=all`**, **`syncAliasCache`** after building sync on startup, and **`searchLocalAliases`** when the online alias API fails in **`Suggestions.svelte`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40925792d3dd0405a47d80ed9374290d6d68059e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->