### PR TITLE
docs(ci): improve agentic workflow and add PR CI

### DIFF
--- a/.cursor/rules/data-and-migrations.mdc
+++ b/.cursor/rules/data-and-migrations.mdc
@@ -1,0 +1,21 @@
+---
+description: Drizzle schema, SQL migrations, admin APIs, and PGlite offline sync
+globs:
+  - drizzle/**
+  - src/pages/api/**
+  - src/lib/services/**
+  - src/lib/local/data/**
+  - src/lib/db.ts
+---
+
+# Data and migrations
+
+Before changing schema, APIs, or offline sync:
+
+1. **Server schema:** edit [`drizzle/schema.ts`](drizzle/schema.ts) and add a matching SQL migration in `drizzle/`. Apply to Supabase before deploying dependent code.
+2. **PGlite drift:** update [`src/lib/local/data/pgliteDB.ts`](src/lib/local/data/pgliteDB.ts) (or generated init SQL) and verify [`src/lib/local/data/sync.ts`](src/lib/local/data/sync.ts) still reads/writes expected columns.
+3. **Do not edit** `drizzle-migrations/` — archived SQLite history only.
+4. **Admin writes:** routes under `/api/admin/*` must keep auth via `require-editor.ts`. Every publish/write should refresh the entity's sync key.
+5. **PATCH routes:** field-level partial updates only; send/validate `version` for optimistic concurrency; return `409 Conflict` with the latest row when stale.
+6. **History:** reverts create new `editor_history` entries — do not rewrite or delete audit rows.
+7. **Queries:** use Drizzle + `DATABASE_URL` for Postgres. Supabase JS client is for Auth/client features only unless the feature explicitly requires it.

--- a/.cursor/rules/svelte-stores.mdc
+++ b/.cursor/rules/svelte-stores.mdc
@@ -1,0 +1,17 @@
+---
+description: Svelte 5 client stores and shared reactive state
+globs:
+  - src/lib/store.svelte.ts
+  - src/lib/stores/**
+---
+
+# Svelte stores
+
+Before adding or changing client state:
+
+1. **Extend existing stores** in [`src/lib/store.svelte.ts`](src/lib/store.svelte.ts) (or `src/lib/stores/` if split) — do not introduce parallel global state (new context providers, ad-hoc module singletons) without a strong reason.
+2. **Import via barrel:** components use `@lib/store.svelte` exports; keep public API stable when refactoring internals.
+3. **Map mode exclusivity:** enabling edit, routes, or terrain should go through `deactivateMapModesExcept` so only one exclusive mode is active.
+4. **Flyouts:** one Map tools flyout (`mapToolsStore`); contributor menu on LocationButton (`floatingControlPanelStore`); editor chrome via `editorChromeStore`.
+5. **Offline/sync:** table sync and PGlite writes live in `src/lib/local/data/*`; stores orchestrate UI — avoid duplicating sync logic in components.
+6. **Auth UI:** `adminAuthStore` hydrates from `/api/admin/auth`; do not bypass it for editor session state.

--- a/.cursor/skills/room-tba-agent-workflow/SKILL.md
+++ b/.cursor/skills/room-tba-agent-workflow/SKILL.md
@@ -5,7 +5,9 @@ description: Guides agentic coding workflow in Room TBA, including scoped edits,
 
 # Room TBA Agent Workflow
 
-## Coding Practices
+Policy (commits, verification tiers, architecture, product rules) lives in [AGENTS.md](../../AGENTS.md). This skill covers **session execution**.
+
+## Coding practices
 
 - Read the relevant existing code paths and local conventions before editing.
 - Keep changes narrowly scoped to the user request; avoid opportunistic refactors.
@@ -13,20 +15,29 @@ description: Guides agentic coding workflow in Room TBA, including scoped edits,
 - Prefer existing helpers, stores, API patterns, styles, and data contracts over new abstractions.
 - When behavior touches editor/admin flows, keep the main app as the editing surface and avoid rebuilding `/admin` pages.
 - Use clear progress updates while working, especially before edits and long-running checks.
-- **Do not underestimate agent throughput.** Human timelines in training data do not apply here. If a task looks like “a few files and a build,” do it in one session without hedging or asking permission to proceed.
+- **Do not underestimate agent throughput.** If a task looks like “a few files and a build,” do it in one session without hedging or asking permission to proceed.
 
-## Verification Cadence
+## Verification cadence
 
-- During iterative edits, prefer focused checks such as formatting, targeted type/lint checks, or relevant tests for the files changed.
+Follow [AGENTS.md § Verify before done](../../AGENTS.md#verify-before-done) for the canonical checklist. Session tips:
+
+- During iterative edits, prefer targeted lint/tests on changed files — not full repo lint every edit.
 - Do not run `bun run build` after every small edit.
-- Run `bun run build` once before the final commit or before opening/updating a PR, unless the user explicitly asks to skip it or run it earlier.
-- If a full build was already run after the final code changes, do not repeat it before committing unless new substantive changes are made.
-- If lint or test tooling is blocked by repository configuration, report the blocker and use the lightest reliable verification available.
+- Run `bun run build` once before the final commit or PR, unless the user asks to skip it.
+- If a full build already passed after the final code changes, do not repeat it before committing unless new substantive changes were made.
+- If lint or test tooling is blocked, report the blocker and use the lightest reliable verification available.
 
-## Commits And PRs
+## Commits and PRs
 
-- **Finish with a signed atomic commit** when a scoped task is done and verified (`git commit -S`). One logical change set per commit unless the user asks to split or batch differently.
+Commit policy, Conventional Commits format, and GPG signing: [AGENTS.md § Commits](../../AGENTS.md#commits).
+
 - Do not end a session with uncommitted completed work unless the user explicitly deferred commit or a hook/blocker prevented it — report the blocker.
-- Make small, reviewable commits when the user asks for commits or a PR.
-- Before opening a PR, summarize the full branch diff, not just the latest commit.
+- Before opening a PR, summarize the **full branch diff**, not just the latest commit.
 - In final summaries, call out what changed, what was verified, and any blockers or residual risk.
+
+### PR prep checklist
+
+1. Read [docs/agentic-qa-process.md](../../docs/agentic-qa-process.md) and run applicable automated checks.
+2. Use the PR template QA summary (automated vs manual browser vs known gaps).
+3. For map/side-panel changes, confirm applicable Cursor rules were followed.
+4. Push with `-u origin HEAD` only when the user asked to push/open a PR.

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Supabase Postgres connection string (Settings → Database → Connection string).
 DATABASE_URL=
 ADMIN_PASSWORD=
+# Preferred signing secret for admin_session cookies (falls back to ADMIN_PASSWORD if unset).
+ADMIN_SESSION_SECRET=
 
 # Supabase JS client (Settings → API). Used for Auth/Realtime/Storage — not Drizzle queries.
 PUBLIC_SUPABASE_URL=

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- What changed and why (1–3 sentences). -->
+
+## QA Summary
+
+Automated:
+
+- [ ] Prettier passed: `bunx prettier --check .` (PR CI)
+- [ ] Unit tests passed: `bun test src` (PR CI)
+- [ ] Full lint passed (local): `bun run lint`
+- [ ] Build passed (local): `bun run build` — requires `DATABASE_URL`; not run in PR CI
+- [ ] Admin redirects verified (if auth/routing touched): `/admin`, `/admin/login`
+- [ ] Migration applied on Supabase (if `drizzle/` changed)
+
+Manual browser (if map chrome, editor, or side panel changed):
+
+- [ ] Verified at 320px and/or 768px per [map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md)
+- [ ] Editor/login/drag-save flows (see [editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md))
+
+Known gaps:
+
+- <!-- Anything not tested and why -->
+
+Follow-up:
+
+- <!-- Issues or PRs to file next -->
+
+## Test plan
+
+<!-- Optional: steps a reviewer can run locally. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - staging
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Prettier
+        run: bunx prettier --check .
+
+      - name: Unit tests
+        run: bun test src

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,39 @@
 # Room TBA Agent Guide
 
-## Agent execution
+## Doc map
 
-- **Bias toward action.** Training data reflects human pacing; in this repo you can read, edit, verify, and commit much faster. Do not pad estimates, over-explain tradeoffs, or defer work that is clearly scoped.
+Read the right doc for the task — do not rely on this file alone for detailed checklists.
+
+| When                                             | Read                                                                                                                    |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Starting a coding session, commit, or PR         | [.cursor/skills/room-tba-agent-workflow/SKILL.md](.cursor/skills/room-tba-agent-workflow/SKILL.md)                      |
+| Map chrome, Entry zones, flyouts, 320/768 layout | [.cursor/rules/map-layout.mdc](.cursor/rules/map-layout.mdc) + [docs/map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md) |
+| Side panel / entity detail views                 | [.cursor/rules/side-panel.mdc](.cursor/rules/side-panel.mdc)                                                            |
+| Drizzle, API routes, migrations, PGlite          | [.cursor/rules/data-and-migrations.mdc](.cursor/rules/data-and-migrations.mdc)                                          |
+| Stores and client state                          | [.cursor/rules/svelte-stores.mdc](.cursor/rules/svelte-stores.mdc)                                                      |
+| PR QA evidence and reporting                     | [docs/agentic-qa-process.md](docs/agentic-qa-process.md)                                                                |
+| Editor manual checklist                          | [docs/editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md)                                              |
+
+## How to work
+
+- **Bias toward action.** Do not pad estimates, over-explain tradeoffs, or defer work that is clearly scoped.
 - **Default to implementing** when the request is concrete and the codebase path is discoverable. Ask only when a product decision is genuinely ambiguous or irreversible.
-- **One pass is often enough.** Prefer a focused implementation plus build/lint over long planning loops or repeated “want me to…?” prompts.
-- **Adjust verification to change size.** Small UI or store tweaks need targeted checks; run `bun run build` once before committing substantive work.
+- **One pass is often enough.** Prefer a focused implementation plus verification over long planning loops or repeated “want me to…?” prompts.
+- **Preserve the dirty tree.** Do not revert unrelated user changes unless explicitly asked.
+- **Keep scope tight.** Avoid opportunistic refactors outside the request.
+
+## Verify before done
+
+Adjust checks to change size. PR CI runs **Prettier + unit tests** (no `DATABASE_URL`); full `bun run lint` (includes ESLint) and build remain local/agent responsibilities before merge.
+
+| Step                                                         | When                                                                   |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| `bun run lint` (or targeted prettier/eslint on edited files) | Always before commit/PR                                                |
+| `bun test src` (or targeted test files)                      | When logic, lib, or API behavior changed                               |
+| `bun run build`                                              | Once before commit/PR on substantive changes (requires `DATABASE_URL`) |
+| Manual browser / editor checklist                            | Map chrome, editor drag/save, side panel UX                            |
+
+Do not run full build after every small edit. See the workflow skill for session cadence.
 
 ## Commits
 
@@ -15,14 +43,23 @@
 - Stage only files that belong together; write a message that states _why_, not a file list.
 - Do not push unless asked. Do not amend or force-push unless the user’s git rules allow it.
 
-## Product Direction
+## Architecture (short)
+
+- **App:** Astro 7 SSR + Svelte 5 islands, Vercel adapter, Bun.
+- **Server data:** Supabase Postgres via Drizzle ([`src/lib/db.ts`](src/lib/db.ts), [`drizzle/schema.ts`](drizzle/schema.ts), migrations in `drizzle/`).
+- **Client offline cache:** PGlite in IndexedDB ([`src/lib/local/data/pgliteDB.ts`](src/lib/local/data/pgliteDB.ts)) — schema is maintained separately and **can drift** from Drizzle; update both when changing tables.
+- **Client state:** [`src/lib/store.svelte.ts`](src/lib/store.svelte.ts) (monolithic store module; import via `@lib/store.svelte`).
+- **Auth:** HMAC cookie `admin_session` + bcrypt `admin_users` gates `/api/admin/*`. Supabase Auth ([`src/lib/supabase/*`](src/lib/supabase/)) is additive in middleware; intended long-term consolidation target.
+- **Do not edit:** `drizzle-migrations/` (archived SQLite history). Do not add browser `/admin` pages as the editor surface.
+
+## Product direction
 
 - Prefer editing in the main app over building a separate admin dashboard.
 - The editor login should use the in-app popup. `/admin` browser pages should redirect into the main app login flow.
 - Keep the read and edit experiences colocated: if a user can view an entity in the app, an editor should eventually edit it there.
-- Treat the current PR as the editor foundation: map pin editing, admin entry, optimistic concurrency, version history, undo/redo, and manual verification.
+- Editor capabilities (map pin editing, proposals, optimistic concurrency, version history, undo/redo) live in the main map app — extend in place.
 
-## Editor UX Rules
+## Editor UX rules
 
 - No decorative or attention-seeking animations. Do not add pulsing/“live” dots, blinking badges, glowing rings, bouncing elements, or similar gimmicks. Keep the UI calm and static; only animate when it communicates real state (e.g. a spinner during a save).
 - Layout must never overflow or overlap. Buttons and chips must stay inside their container, controls must wrap gracefully on narrow widths, and text must truncate (ellipsis) instead of colliding with neighbors. Verify the header/action rows at narrow widths before finishing.
@@ -32,23 +69,14 @@
 - Error messages should name the exact entity that failed without repeating generic wording.
 - Support common shortcuts in map edit mode: `Ctrl+Z` / `Cmd+Z` for undo, `Ctrl+Y` / `Cmd+Y` and `Shift+Ctrl+Z` / `Shift+Cmd+Z` for redo.
 
-## Map layout guardrails
+## UI guardrails
 
-- Map chrome mounts in Entry zones (top / map / bottom / ephemeral). See `docs/map-ui-mode-matrix.md`.
-- Use `.app-layout` CSS vars for spacing — no magic fixed offsets.
-- Map chrome contrast tokens (`--map-chrome-surface`, borders, shadows) live on `.app-layout` in `Entry.svelte`. Surfaces use a warm off-white tint so controls float above light basemap tiles; tune there rather than per-component whites.
-- New fixed overlays outside Entry zones require updating the mode matrix.
-- One Map tools flyout (`mapToolsStore`); contributor propose menu on LocationButton; editor tools via `editorChromeStore` (top-bar chip + shelf; shield FAB opens the same shelf).
-- Before merge on map chrome changes: verify 320px + 768px browse, edit mode, and map tools open.
+Map and side-panel layout rules are detailed in glob-scoped Cursor rules — read them before editing matched files.
 
-## Side panel guardrails
+- **Map chrome:** Entry zones only; one Map tools flyout; verify 320px + 768px. See [map-layout.mdc](.cursor/rules/map-layout.mdc) and [map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md).
+- **Side panel:** Header → body → directions → footer; parity across Room/Building/Dorm results. See [side-panel.mdc](.cursor/rules/side-panel.mdc).
 
-- Entity detail views live in the MainControls drawer (`controls/*Result*.svelte`, `room/RoomResult.svelte`). See `.cursor/rules/side-panel.mdc`.
-- Layout zones: **header** (title, context, one actions row) → **body** → **directions** (merged) → **footer** (subtle links). Shared styles in `controls/entity-detail.css`.
-- Do not add new full-width button rows or colored boxes without consolidating existing ones. Match map-chrome action chip patterns.
-- Check RoomResult + BuildingResult + DormResult for parity when changing any entity detail view.
-
-## Data Integrity
+## Data integrity
 
 - Use optimistic concurrency for editor writes. Send the version the client last saw, and return `409 Conflict` with the latest row if it is stale.
 - Missing client versions are a transitional compatibility fallback only; new editor surfaces should send versions.
@@ -56,21 +84,21 @@
 - Reverts should create new history entries instead of rewriting or deleting old history.
 - Every admin write should refresh the relevant sync key so clients can detect changed data.
 
-## Database And APIs
+## Database and APIs
 
-- Supabase Postgres is the runtime source of truth via `DATABASE_URL` (not `NEON_CONNECTION_STRING`). Code, Drizzle, seeds, and the Astro env schema all use `DATABASE_URL`. On Vercel, name the env var `DATABASE_URL` — rename any legacy `NEON_CONNECTION_STRING`.
+- Supabase Postgres is the runtime source of truth via `DATABASE_URL` (not `NEON_CONNECTION_STRING`). Code, Drizzle, seeds, and the Astro env schema all use `DATABASE_URL`. On Vercel, name the env var `DATABASE_URL`.
 - Supabase JS (`@supabase/supabase-js` + `@supabase/ssr`) is additive: `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_PUBLISHABLE_KEY` power Auth/client features via `src/lib/supabase/*`. Keep using Drizzle + `DATABASE_URL` for existing Postgres queries unless a feature explicitly needs the JS client.
 - Drizzle schema changes need a matching SQL migration in `drizzle/`. Apply pending migrations to Supabase before deploying code that depends on them — skipped migrations cause runtime query failures (e.g. missing `0007_add_event_image_url.sql` leaves out `events.image_url` and breaks event loading).
+- **PGlite drift:** offline tables in `pgliteDB.ts` must stay aligned with server schema and with [`src/lib/local/data/sync.ts`](src/lib/local/data/sync.ts) consumers.
 - Admin API routes live under `/api/admin/*` and must keep auth checks.
-- Browser-facing `/admin` pages are intentionally not the default editor surface.
 - Keep PATCH routes field-level and partial so unrelated edits do not clobber each other.
 
 ## Verification
 
-- After substantive changes, run formatting, lints for edited files, and `bun run build`.
-- For editor changes, also use `docs/editor-foundation-test-plan.md` as the manual PR checklist.
-- For PR QA, follow `docs/agentic-qa-process.md` and separate automated evidence from browser-only checks.
-- Avoid testing by mutating production-like server data unless the change is intentional and reversible. Restore any accidental test mutations immediately.
+- After substantive changes: lint, relevant unit tests, and `bun run build` (local).
+- For editor changes: [docs/editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md).
+- For PR QA: [docs/agentic-qa-process.md](docs/agentic-qa-process.md) — separate automated evidence from browser-only checks.
+- Avoid mutating production-like server data unless intentional and reversible. Restore accidental test mutations immediately.
 
 ## Cursor Cloud specific instructions
 
@@ -79,6 +107,7 @@
 - **Refreshing local `.env`:** Production/preview `DATABASE_URL` lives in Vercel env vars. When `.env` is empty or stale: `vercel env pull .env.vercel --environment=development --yes` (requires Vercel CLI linked to `stimmie/saan-ang-room` — room-tba.stimmie.dev — not a separate empty `room-tba` project; see `.vercel/project.json`), merge `DATABASE_URL` into `.env`, keep local `ADMIN_PASSWORD` if already set. `vercel env pull` often returns empty `""` for encrypted vars like `DATABASE_URL` — copy from Vercel UI (Settings → Environment Variables) or Supabase dashboard instead. Use the Supabase **session pooler** URL (`*.pooler.supabase.com`) for local dev. Or provide `DATABASE_URL` via Cursor Secrets.
 - **`bun dev` without `DATABASE_URL`:** Server starts but SSR returns HTTP 500 (`EnvInvalidVariables: DATABASE_URL is missing`). Set a valid Supabase connection string in `.env` and restart.
 - **Optional R2:** Image upload (`/api/admin/upload`) needs `R2_*` vars (see `.env.example`, `wrangler.jsonc`). App runs without them; upload UI shows a not-configured message.
-- This is **Astro 6 SSR** (Vercel adapter). API routes under `src/pages/api/*` are server-rendered (`prerender = false`), and the SSG entity pages (e.g. `/room/[slug]`) also query the DB at build time — so even `bun run build` fails without a working `DATABASE_URL`.
+- This is **Astro 7 SSR** (Vercel adapter). API routes under `src/pages/api/*` are server-rendered (`prerender = false`), and SSG entity pages (e.g. `/room/[slug]`) query the DB at build time — so `bun run build` fails without a working `DATABASE_URL`.
 - `@electric-sql/pglite` (`idb://site-data`) is a **browser-side cache only**, not a server/dev database fallback.
-- Standard scripts live in `package.json`: `bun dev` (dev server on `http://localhost:4321/`), `bun run build`, `bun preview`, `bun run lint` (`prettier --check . && eslint .`), `bun run format`. There is no automated test suite; verify changes via build + manual browser testing.
+- **PWA:** Workbox precaches `dist/client`; large client bundles affect offline install. See `astro.config.mjs` PWA config before adding heavy dependencies.
+- Standard scripts: `bun dev` (`http://localhost:4321/`), `bun run build`, `bun preview`, `bun run lint`, `bun run format`, `bun test src`. PR CI runs Prettier check + unit tests; run full lint and build locally before merge.

--- a/README.md
+++ b/README.md
@@ -18,29 +18,35 @@ Course and room listings are maintained for UPLB students and updated each term;
 
 ## Development/Contribution
 
-To run locally, you need to download [Bun.js](https://bun.sh/) and run the following command:
+Install [Bun](https://bun.sh/), copy [`.env.example`](.env.example) to `.env`, and set `DATABASE_URL` to your Supabase Postgres connection string (session pooler recommended). `ADMIN_PASSWORD` enables the in-app editor login.
 
-```
+```sh
+bun install
 bun dev
 ```
 
-The data is stored in the info.db file, and may be accessed using sqlite. If you are not familiar with using SQL, you may run the following command to open up drizzle studio and start correcting data:
+Common commands:
 
-```
-bunx drizzle-kit studio
+```sh
+bun run lint          # prettier + eslint
+bun test src          # unit tests (no DATABASE_URL required)
+bun run build         # production build (requires DATABASE_URL)
+bunx drizzle-kit studio   # inspect/edit Postgres via Drizzle
 ```
 
-After that, you may open a pull request and describe the changes.
+Runtime data lives in **Supabase Postgres**. The legacy `data/info.db` SQLite file is only used by local seed/export scripts, not by the app at runtime.
+
+Agent and contributor workflow: see [AGENTS.md](AGENTS.md) and [docs/agentic-qa-process.md](docs/agentic-qa-process.md). PR CI runs Prettier + unit tests; verify full lint and build locally before merge.
 
 ## Project structure
 
-This project uses [Astro](https://astro.build), and may have the following folders:
+This project uses [Astro](https://astro.build) with Svelte islands:
 
-- `/public` - All the static assets that can be requested by the route
-- `/src/routes` - All of the routes used by the website
-- `/src/components` - All of the frontend components used by the website
-- `/src/assets` - All other internal assets used by the program
-- `/src/lib` - where helper Typescript functions are located
+- `/public` — static assets
+- `/src/pages` — routes (Astro pages + API endpoints under `/src/pages/api`)
+- `/src/components` — UI components (mostly Svelte)
+- `/src/lib` — shared TypeScript helpers, stores, services
+- `/drizzle` — Postgres schema and SQL migrations
 
 ## Releases and versioning
 

--- a/docs/agentic-qa-process.md
+++ b/docs/agentic-qa-process.md
@@ -2,10 +2,12 @@
 
 Use this process when preparing an editor-focused PR for review. The goal is to let agents verify everything they can with evidence, while clearly marking browser-only checks that still need a human pass.
 
+**Related docs:** [AGENTS.md](../AGENTS.md) (policy), [editor-foundation-test-plan.md](editor-foundation-test-plan.md) (manual editor checklist), [.cursor/rules/map-layout.mdc](../.cursor/rules/map-layout.mdc) and [side-panel.mdc](../.cursor/rules/side-panel.mdc) for UI layout.
+
 ## Roles
 
 - **QA coordinator:** owns the run, keeps scope tight, and writes the final PR QA summary.
-- **Static verifier:** checks formatting, lints, build, git status, redirects, and database/schema presence.
+- **Static verifier:** checks formatting, lints, unit tests, build, git status, redirects, and database/schema presence.
 - **Runtime verifier:** runs targeted API checks against the local dev server and confirms auth/redirect behavior.
 - **Human browser verifier:** performs drag/drop and visual checks that cannot be trusted from shell output alone.
 
@@ -18,13 +20,27 @@ One agent can play multiple roles, but the report must separate automated eviden
 - Current test checklist: `docs/editor-foundation-test-plan.md`.
 - A running local dev server on the expected port, usually `http://localhost:4321`.
 
+## Change-type matrix
+
+Run only what applies to the PR scope:
+
+| Change type             | lint | `bun test src`    | build (local) | browser                               |
+| ----------------------- | ---- | ----------------- | ------------- | ------------------------------------- |
+| Lib/helper only         | yes  | yes (or targeted) | yes           | skip                                  |
+| Map chrome / side panel | yes  | yes               | yes           | 320px + 768px                         |
+| Editor / admin API      | yes  | yes               | yes           | auth + one PATCH                      |
+| Drizzle migration       | yes  | yes               | yes           | confirm migration applied on Supabase |
+
+PR CI (GitHub Actions) runs **Prettier check + unit tests** — no `DATABASE_URL` required. Run full `bun run lint` (ESLint + Prettier) and `bun run build` locally before merge when the change is substantive.
+
 ## Automated Checks
 
 Run these before asking for browser QA:
 
 ```sh
 git status --short --branch
-bunx prettier --check .
+bun run lint
+bun test src
 bun run build
 curl -I http://localhost:4321/admin
 curl -I http://localhost:4321/admin/login
@@ -39,11 +55,13 @@ bun -e 'import { config } from "dotenv"; import pg from "pg"; config({ path: ".e
 
 Expected automated evidence for the current editor foundation:
 
+- `bunx prettier --check .` passes (PR CI).
+- `bun test src` passes (PR CI).
 - `/admin` redirects to `/?editor=login`.
 - `/admin/login` redirects to `/?editor=login`.
 - `/?editor=login` returns `200`.
 - The rendered layout includes `name="viewport"` with `initial-scale=1`.
-- `bun run build` passes.
+- `bun run build` passes (local, with `DATABASE_URL`).
 - `editor_history` exists when history code is in scope.
 - Working tree is clean before updating or merging the PR.
 
@@ -91,22 +109,25 @@ Do not leave test coordinates changed. Restore the entity or test against dispos
 
 ## Reporting Format
 
-Use this structure in the PR comment or PR body:
+Use this structure in the PR comment or PR body (also in [.github/pull_request_template.md](../.github/pull_request_template.md)):
 
 ```md
 ## QA Summary
 
 Automated:
 
-- [x] Build passed: `<command/output summary>`
-- [x] Admin redirects verified: `/admin`, `/admin/login`
-- [x] Editor history table verified: `editor_history`
-- [x] Mobile viewport metadata verified
+- [ ] Prettier passed: `bunx prettier --check .` (PR CI)
+- [ ] Unit tests passed: `bun test src` (PR CI)
+- [ ] Full lint passed (local): `bun run lint`
+- [ ] Build passed (local): `bun run build`
+- [ ] Admin redirects verified: `/admin`, `/admin/login`
+- [ ] Editor history table verified: `editor_history` (if in scope)
+- [ ] Mobile viewport metadata verified (if UI in scope)
 
 Manual browser:
 
-- [x] Login popup opens
-- [x] Building drag save works
+- [ ] Login popup opens
+- [ ] Building drag save works
 - [ ] Dorm drag save not tested
 - [ ] Mobile touch drag not tested
 

--- a/public/liberty-customized.json
+++ b/public/liberty-customized.json
@@ -39,14 +39,8 @@
         "raster-opacity": {
           "base": 1.5,
           "stops": [
-            [
-              0,
-              0.6
-            ],
-            [
-              6,
-              0.1
-            ]
+            [0, 0.6],
+            [6, 0.1]
           ]
         }
       }
@@ -68,10 +62,7 @@
       "source": "openmaptiles",
       "source-layer": "park",
       "paint": {
-        "line-dasharray": [
-          1,
-          1.5
-        ],
+        "line-dasharray": [1, 1.5],
         "line-color": "#a8c8a4"
       }
     },
@@ -81,23 +72,13 @@
       "source": "openmaptiles",
       "source-layer": "landuse",
       "maxzoom": 8,
-      "filter": [
-        "==",
-        "class",
-        "residential"
-      ],
+      "filter": ["==", "class", "residential"],
       "paint": {
         "fill-color": {
           "base": 1,
           "stops": [
-            [
-              9,
-              "hsla(0, 3%, 85%, 0.84)"
-            ],
-            [
-              12,
-              "hsla(220, 3%, 88%, 0.49)"
-            ]
+            [9, "hsla(0, 3%, 85%, 0.84)"],
+            [12, "hsla(220, 3%, 88%, 0.49)"]
           ]
         }
       }
@@ -107,9 +88,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landcover",
-      "filter": [
-        "all"
-      ],
+      "filter": ["all"],
       "paint": {
         "fill-antialias": false,
         "fill-color": "rgba(62, 96, 58, 0.48)",
@@ -121,14 +100,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landcover",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "grass"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "grass"]],
       "paint": {
         "fill-antialias": false,
         "fill-color": "rgba(124, 184, 122, 1)",
@@ -140,14 +112,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landcover",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "ice"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "ice"]],
       "paint": {
         "fill-antialias": false,
         "fill-color": "rgba(224, 236, 236, 1)",
@@ -160,14 +125,7 @@
       "source": "openmaptiles",
       "source-layer": "landcover",
       "minzoom": 12,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "wetland"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "wetland"]],
       "paint": {
         "fill-antialias": true,
         "fill-opacity": 0.8,
@@ -180,11 +138,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": [
-        "==",
-        "class",
-        "pitch"
-      ],
+      "filter": ["==", "class", "pitch"],
       "paint": {
         "fill-color": "rgba(143, 191, 138, 0.85)"
       }
@@ -194,11 +148,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": [
-        "==",
-        "class",
-        "track"
-      ],
+      "filter": ["==", "class", "track"],
       "paint": {
         "fill-color": "#b8c8b4"
       }
@@ -208,11 +158,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": [
-        "==",
-        "class",
-        "cemetery"
-      ],
+      "filter": ["==", "class", "cemetery"],
       "paint": {
         "fill-color": "hsl(220, 3%, 82%)"
       }
@@ -222,11 +168,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": [
-        "==",
-        "class",
-        "hospital"
-      ],
+      "filter": ["==", "class", "hospital"],
       "paint": {
         "fill-color": "#fde"
       }
@@ -236,11 +178,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": [
-        "==",
-        "class",
-        "school"
-      ],
+      "filter": ["==", "class", "school"],
       "paint": {
         "fill-color": "rgb(240, 245, 238)"
       }
@@ -250,44 +188,22 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "waterway",
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "brunnel", "tunnel"]],
       "paint": {
         "line-color": "#6ba3b8",
-        "line-dasharray": [
-          3,
-          3
-        ],
+        "line-dasharray": [3, 3],
         "line-gap-width": {
           "stops": [
-            [
-              12,
-              0
-            ],
-            [
-              20,
-              6
-            ]
+            [12, 0],
+            [20, 6]
           ]
         },
         "line-opacity": 1,
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              8,
-              1
-            ],
-            [
-              20,
-              2
-            ]
+            [8, 1],
+            [20, 2]
           ]
         }
       }
@@ -297,19 +213,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "waterway",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "river"
-        ],
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "river"], ["!=", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "round"
       },
@@ -318,14 +222,8 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              20,
-              6
-            ]
+            [11, 0.5],
+            [20, 6]
           ]
         }
       }
@@ -335,19 +233,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "waterway",
-      "filter": [
-        "all",
-        [
-          "!=",
-          "class",
-          "river"
-        ],
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["!=", "class", "river"], ["!=", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "round"
       },
@@ -356,14 +242,8 @@
         "line-width": {
           "base": 1.3,
           "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              20,
-              6
-            ]
+            [13, 0.5],
+            [20, 6]
           ]
         }
       }
@@ -373,14 +253,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "water",
-      "filter": [
-        "all",
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["!=", "brunnel", "tunnel"]],
       "paint": {
         "fill-color": "rgba(107, 163, 184, 1)",
         "fill-outline-color": "rgba(80, 130, 150, 0.45)"
@@ -391,14 +264,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landcover",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "sand"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "sand"]],
       "paint": {
         "fill-color": "rgba(247, 239, 195, 1)"
       }
@@ -409,11 +275,7 @@
       "source": "openmaptiles",
       "source-layer": "aeroway",
       "minzoom": 11,
-      "filter": [
-        "==",
-        "$type",
-        "Polygon"
-      ],
+      "filter": ["==", "$type", "Polygon"],
       "paint": {
         "fill-color": "rgba(229, 228, 224, 1)",
         "fill-opacity": 0.7
@@ -427,30 +289,16 @@
       "minzoom": 11,
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "==",
-          "class",
-          "runway"
-        ]
+        ["==", "$type", "LineString"],
+        ["==", "class", "runway"]
       ],
       "paint": {
         "line-color": "#f0ede9",
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              20,
-              16
-            ]
+            [11, 3],
+            [20, 16]
           ]
         }
       }
@@ -463,30 +311,16 @@
       "minzoom": 11,
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "==",
-          "class",
-          "taxiway"
-        ]
+        ["==", "$type", "LineString"],
+        ["==", "class", "taxiway"]
       ],
       "paint": {
         "line-color": "#f0ede9",
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              20,
-              6
-            ]
+            [11, 0.5],
+            [20, 6]
           ]
         }
       }
@@ -498,50 +332,23 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
       "layout": {
         "line-join": "round"
       },
       "paint": {
         "line-color": "#e9ac77",
-        "line-dasharray": [
-          0.5,
-          0.25
-        ],
+        "line-dasharray": [0.5, 0.25],
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
+            [12, 1],
+            [13, 3],
+            [14, 4],
+            [20, 15]
           ]
         }
       }
@@ -553,42 +360,21 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "service",
-          "track"
-        ]
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "service", "track"]
       ],
       "layout": {
         "line-join": "round"
       },
       "paint": {
         "line-color": "#cfcdca",
-        "line-dasharray": [
-          0.5,
-          0.25
-        ],
+        "line-dasharray": [0.5, 0.25],
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              20,
-              11
-            ]
+            [15, 1],
+            [16, 4],
+            [20, 11]
           ]
         }
       }
@@ -598,19 +384,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-join": "round"
       },
@@ -619,22 +393,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
+            [12, 1],
+            [13, 3],
+            [14, 4],
+            [20, 15]
           ]
         }
       }
@@ -646,17 +408,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "street",
-          "street_limited"
-        ]
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "street", "street_limited"]
       ],
       "layout": {
         "line-join": "round"
@@ -665,35 +418,17 @@
         "line-color": "#cfcdca",
         "line-opacity": {
           "stops": [
-            [
-              12,
-              0
-            ],
-            [
-              12.5,
-              1
-            ]
+            [12, 0],
+            [12.5, 1]
           ]
         },
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              0.5
-            ],
-            [
-              13,
-              1
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
+            [12, 0.5],
+            [13, 1],
+            [14, 4],
+            [20, 15]
           ]
         }
       }
@@ -705,17 +440,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
       ],
       "layout": {
         "line-join": "round"
@@ -725,14 +451,8 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              8,
-              1.5
-            ],
-            [
-              20,
-              17
-            ]
+            [8, 1.5],
+            [20, 17]
           ]
         }
       }
@@ -744,17 +464,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "primary", "trunk"]
       ],
       "layout": {
         "line-join": "round"
@@ -764,22 +475,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.7
-            ],
-            [
-              7,
-              1.75
-            ],
-            [
-              20,
-              22
-            ]
+            [5, 0.4],
+            [6, 0.7],
+            [7, 1.75],
+            [20, 22]
           ]
         }
       }
@@ -791,50 +490,23 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
       "layout": {
         "line-join": "round"
       },
       "paint": {
         "line-color": "#e9ac77",
-        "line-dasharray": [
-          0.5,
-          0.25
-        ],
+        "line-dasharray": [0.5, 0.25],
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.7
-            ],
-            [
-              7,
-              1.75
-            ],
-            [
-              20,
-              22
-            ]
+            [5, 0.4],
+            [6, 0.7],
+            [7, 1.75],
+            [20, 22]
           ]
         }
       }
@@ -846,40 +518,18 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "path",
-          "pedestrian"
-        ]
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "path", "pedestrian"]
       ],
       "paint": {
         "line-color": "rgba(197, 197, 192, 0.72)",
-        "line-dasharray": [
-          1,
-          0.75
-        ],
+        "line-dasharray": [1, 0.75],
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              14,
-              0.5
-            ],
-            [
-              20,
-              10
-            ]
+            [14, 0.5],
+            [20, 10]
           ]
         }
       }
@@ -891,21 +541,9 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
       "layout": {
         "line-join": "round"
@@ -915,22 +553,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
+            [12.5, 0],
+            [13, 1.5],
+            [14, 2.5],
+            [20, 11.5]
           ]
         }
       }
@@ -942,17 +568,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "service",
-          "track"
-        ]
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "service", "track"]
       ],
       "layout": {
         "line-join": "round"
@@ -962,18 +579,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              15.5,
-              0
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              20,
-              7.5
-            ]
+            [15.5, 0],
+            [16, 2],
+            [20, 7.5]
           ]
         }
       }
@@ -983,19 +591,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-join": "round"
       },
@@ -1004,22 +600,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
+            [12.5, 0],
+            [13, 1.5],
+            [14, 2.5],
+            [20, 11.5]
           ]
         }
       }
@@ -1029,19 +613,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "minor"
-        ]
-      ],
+      "filter": ["all", ["==", "brunnel", "tunnel"], ["in", "class", "minor"]],
       "layout": {
         "line-join": "round"
       },
@@ -1050,18 +622,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              13.5,
-              0
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
+            [13.5, 0],
+            [14, 2.5],
+            [20, 11.5]
           ]
         }
       }
@@ -1073,17 +636,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
       ],
       "layout": {
         "line-join": "round"
@@ -1093,18 +647,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              10
-            ]
+            [6.5, 0],
+            [7, 0.5],
+            [20, 10]
           ]
         }
       }
@@ -1116,17 +661,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "primary", "trunk"]
       ],
       "layout": {
         "line-join": "round"
@@ -1136,18 +672,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0
-            ],
-            [
-              7,
-              1
-            ],
-            [
-              20,
-              18
-            ]
+            [5, 0],
+            [7, 1],
+            [20, 18]
           ]
         }
       }
@@ -1159,21 +686,9 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
       "layout": {
         "line-join": "round"
@@ -1183,18 +698,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0
-            ],
-            [
-              7,
-              1
-            ],
-            [
-              20,
-              18
-            ]
+            [5, 0],
+            [7, 1],
+            [20, 18]
           ]
         }
       }
@@ -1204,36 +710,15 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "rail"
-        ]
-      ],
+      "filter": ["all", ["==", "brunnel", "tunnel"], ["in", "class", "rail"]],
       "paint": {
         "line-color": "#bbb",
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              15,
-              0.75
-            ],
-            [
-              20,
-              2
-            ]
+            [14, 0.4],
+            [15, 0.75],
+            [20, 2]
           ]
         }
       }
@@ -1243,40 +728,16 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "rail"
-        ]
-      ],
+      "filter": ["all", ["==", "brunnel", "tunnel"], ["==", "class", "rail"]],
       "paint": {
         "line-color": "#bbb",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
+        "line-dasharray": [0.2, 8],
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              20,
-              8
-            ]
+            [14.5, 0],
+            [15, 3],
+            [20, 8]
           ]
         }
       }
@@ -1288,34 +749,17 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "transit"
-        ]
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "transit"]
       ],
       "paint": {
         "line-color": "#bbb",
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              15,
-              0.75
-            ],
-            [
-              20,
-              2
-            ]
+            [14, 0.4],
+            [15, 0.75],
+            [20, 2]
           ]
         }
       }
@@ -1327,38 +771,18 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "transit"
-        ]
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "transit"]
       ],
       "paint": {
         "line-color": "#bbb",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
+        "line-dasharray": [0.2, 8],
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              20,
-              8
-            ]
+            [14.5, 0],
+            [15, 3],
+            [20, 8]
           ]
         }
       }
@@ -1368,14 +792,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ]
-      ],
+      "filter": ["all", ["==", "$type", "Polygon"]],
       "paint": {
         "fill-pattern": "pedestrian_polygon"
       }
@@ -1388,22 +805,9 @@
       "minzoom": 12,
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1]
       ],
       "layout": {
         "line-cap": "round",
@@ -1414,22 +818,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
+            [12, 1],
+            [13, 3],
+            [14, 4],
+            [20, 15]
           ]
         }
       }
@@ -1441,18 +833,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "service",
-          "track"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "service", "track"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1463,18 +845,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              20,
-              11
-            ]
+            [15, 1],
+            [16, 4],
+            [20, 11]
           ]
         }
       }
@@ -1487,26 +860,9 @@
       "minzoom": 13,
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "!in",
-          "class",
-          "pedestrian",
-          "path",
-          "track",
-          "service",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["!in", "class", "pedestrian", "path", "track", "service", "motorway"],
+        ["==", "ramp", 1]
       ],
       "layout": {
         "line-cap": "round",
@@ -1517,22 +873,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
+            [12, 1],
+            [13, 3],
+            [14, 4],
+            [20, 15]
           ]
         }
       }
@@ -1544,27 +888,10 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "minor"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ]
+        ["==", "$type", "LineString"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "minor"],
+        ["!=", "ramp", 1]
       ],
       "layout": {
         "line-cap": "round",
@@ -1574,35 +901,17 @@
         "line-color": "rgba(176, 176, 170, 0.75)",
         "line-opacity": {
           "stops": [
-            [
-              12,
-              0
-            ],
-            [
-              12.5,
-              1
-            ]
+            [12, 0],
+            [12.5, 1]
           ]
         },
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              0.5
-            ],
-            [
-              13,
-              1
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              20
-            ]
+            [12, 0.5],
+            [13, 1],
+            [14, 4],
+            [20, 20]
           ]
         }
       }
@@ -1614,23 +923,9 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "secondary", "tertiary"],
+        ["!=", "ramp", 1]
       ],
       "layout": {
         "line-cap": "round",
@@ -1641,14 +936,8 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              8,
-              1.5
-            ],
-            [
-              20,
-              17
-            ]
+            [8, 1.5],
+            [20, 17]
           ]
         }
       }
@@ -1660,18 +949,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "primary", "trunk"]
       ],
       "layout": {
         "line-join": "round"
@@ -1681,22 +960,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.7
-            ],
-            [
-              7,
-              1.75
-            ],
-            [
-              20,
-              22
-            ]
+            [5, 0.4],
+            [6, 0.7],
+            [7, 1.75],
+            [20, 22]
           ]
         }
       }
@@ -1709,22 +976,9 @@
       "minzoom": 5,
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1]
       ],
       "layout": {
         "line-cap": "round",
@@ -1735,22 +989,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.7
-            ],
-            [
-              7,
-              1.75
-            ],
-            [
-              20,
-              22
-            ]
+            [5, 0.4],
+            [6, 0.7],
+            [7, 1.75],
+            [20, 22]
           ]
         }
       }
@@ -1763,44 +1005,21 @@
       "minzoom": 14,
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "path",
-          "pedestrian"
-        ]
+        ["==", "$type", "LineString"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "path", "pedestrian"]
       ],
       "layout": {
         "line-join": "round"
       },
       "paint": {
         "line-color": "rgba(197, 197, 192, 0.72)",
-        "line-dasharray": [
-          1,
-          0.7
-        ],
+        "line-dasharray": [1, 0.7],
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              14,
-              1
-            ],
-            [
-              20,
-              10
-            ]
+            [14, 1],
+            [20, 10]
           ]
         }
       }
@@ -1813,22 +1032,9 @@
       "minzoom": 12,
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1]
       ],
       "layout": {
         "line-cap": "round",
@@ -1839,22 +1045,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
+            [12.5, 0],
+            [13, 1.5],
+            [14, 2.5],
+            [20, 11.5]
           ]
         }
       }
@@ -1866,18 +1060,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "service",
-          "track"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "service", "track"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1888,18 +1072,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              15.5,
-              0
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              20,
-              7.5
-            ]
+            [15.5, 0],
+            [16, 2],
+            [20, 7.5]
           ]
         }
       }
@@ -1912,26 +1087,9 @@
       "minzoom": 13,
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ],
-        [
-          "!in",
-          "class",
-          "pedestrian",
-          "path",
-          "track",
-          "service",
-          "motorway"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "ramp", 1],
+        ["!in", "class", "pedestrian", "path", "track", "service", "motorway"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1942,22 +1100,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
+            [12.5, 0],
+            [13, 1.5],
+            [14, 2.5],
+            [20, 11.5]
           ]
         }
       }
@@ -1969,22 +1115,9 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "minor"
-        ]
+        ["==", "$type", "LineString"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "minor"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1995,18 +1128,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              13.5,
-              0
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              18
-            ]
+            [13.5, 0],
+            [14, 2.5],
+            [20, 18]
           ]
         }
       }
@@ -2018,18 +1142,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
       ],
       "layout": {
         "line-cap": "round",
@@ -2040,18 +1154,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              8,
-              0.5
-            ],
-            [
-              20,
-              13
-            ]
+            [6.5, 0],
+            [8, 0.5],
+            [20, 13]
           ]
         }
       }
@@ -2063,18 +1168,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "primary", "trunk"]
       ],
       "layout": {
         "line-join": "round"
@@ -2084,18 +1179,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0
-            ],
-            [
-              7,
-              1
-            ],
-            [
-              20,
-              18
-            ]
+            [5, 0],
+            [7, 1],
+            [20, 18]
           ]
         }
       }
@@ -2108,22 +1194,9 @@
       "minzoom": 5,
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1]
       ],
       "layout": {
         "line-cap": "round",
@@ -2134,18 +1207,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0
-            ],
-            [
-              7,
-              1
-            ],
-            [
-              20,
-              18
-            ]
+            [5, 0],
+            [7, 1],
+            [20, 18]
           ]
         }
       }
@@ -2157,35 +1221,17 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "rail"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "rail"]
       ],
       "paint": {
         "line-color": "#bbb",
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              15,
-              0.75
-            ],
-            [
-              20,
-              2
-            ]
+            [14, 0.4],
+            [15, 0.75],
+            [20, 2]
           ]
         }
       }
@@ -2197,39 +1243,18 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "rail"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "rail"]
       ],
       "paint": {
         "line-color": "#bbb",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
+        "line-dasharray": [0.2, 8],
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              20,
-              8
-            ]
+            [14.5, 0],
+            [15, 3],
+            [20, 8]
           ]
         }
       }
@@ -2241,35 +1266,17 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "transit"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "transit"]
       ],
       "paint": {
         "line-color": "#bbb",
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              15,
-              0.75
-            ],
-            [
-              20,
-              2
-            ]
+            [14, 0.4],
+            [15, 0.75],
+            [20, 2]
           ]
         }
       }
@@ -2281,39 +1288,18 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "transit"
-        ]
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "transit"]
       ],
       "paint": {
         "line-color": "#bbb",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
+        "line-dasharray": [0.2, 8],
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              20,
-              8
-            ]
+            [14.5, 0],
+            [15, 3],
+            [20, 8]
           ]
         }
       }
@@ -2324,11 +1310,7 @@
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 16,
-      "filter": [
-        "==",
-        "oneway",
-        1
-      ],
+      "filter": ["==", "oneway", 1],
       "layout": {
         "icon-image": "arrow",
         "symbol-placement": "line"
@@ -2340,11 +1322,7 @@
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 16,
-      "filter": [
-        "==",
-        "oneway",
-        -1
-      ],
+      "filter": ["==", "oneway", -1],
       "layout": {
         "icon-image": "arrow",
         "symbol-placement": "line",
@@ -2358,21 +1336,9 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
       "layout": {
         "line-join": "round"
@@ -2382,22 +1348,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
+            [12, 1],
+            [13, 3],
+            [14, 4],
+            [20, 15]
           ]
         }
       }
@@ -2409,17 +1363,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "service",
-          "track"
-        ]
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "service", "track"]
       ],
       "layout": {
         "line-join": "round"
@@ -2429,18 +1374,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              20,
-              11
-            ]
+            [15, 1],
+            [16, 4],
+            [20, 11]
           ]
         }
       }
@@ -2450,19 +1386,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "link"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "link"], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-join": "round"
       },
@@ -2471,22 +1395,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
+            [12, 1],
+            [13, 3],
+            [14, 4],
+            [20, 15]
           ]
         }
       }
@@ -2498,17 +1410,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "street",
-          "street_limited"
-        ]
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "street", "street_limited"]
       ],
       "layout": {
         "line-join": "round"
@@ -2517,35 +1420,17 @@
         "line-color": "hsl(36, 6%, 74%)",
         "line-opacity": {
           "stops": [
-            [
-              12,
-              0
-            ],
-            [
-              12.5,
-              1
-            ]
+            [12, 0],
+            [12.5, 1]
           ]
         },
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              0.5
-            ],
-            [
-              13,
-              1
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              25
-            ]
+            [12, 0.5],
+            [13, 1],
+            [14, 4],
+            [20, 25]
           ]
         }
       }
@@ -2557,40 +1442,18 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "path",
-          "pedestrian"
-        ]
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "path", "pedestrian"]
       ],
       "paint": {
         "line-color": "hsl(220, 3%, 80%)",
-        "line-dasharray": [
-          1,
-          0
-        ],
+        "line-dasharray": [1, 0],
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              14,
-              1.5
-            ],
-            [
-              20,
-              18
-            ]
+            [14, 1.5],
+            [20, 18]
           ]
         }
       }
@@ -2602,17 +1465,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "secondary", "tertiary"]
       ],
       "layout": {
         "line-join": "round"
@@ -2622,14 +1476,8 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              8,
-              1.5
-            ],
-            [
-              20,
-              17
-            ]
+            [8, 1.5],
+            [20, 17]
           ]
         }
       }
@@ -2641,17 +1489,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "primary", "trunk"]
       ],
       "layout": {
         "line-join": "round"
@@ -2661,22 +1500,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.7
-            ],
-            [
-              7,
-              1.75
-            ],
-            [
-              20,
-              22
-            ]
+            [5, 0.4],
+            [6, 0.7],
+            [7, 1.75],
+            [20, 22]
           ]
         }
       }
@@ -2688,21 +1515,9 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
       "layout": {
         "line-join": "round"
@@ -2712,22 +1527,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.7
-            ],
-            [
-              7,
-              1.75
-            ],
-            [
-              20,
-              22
-            ]
+            [5, 0.4],
+            [6, 0.7],
+            [7, 1.75],
+            [20, 22]
           ]
         }
       }
@@ -2739,40 +1542,18 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "path",
-          "pedestrian"
-        ]
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "path", "pedestrian"]
       ],
       "paint": {
         "line-color": "hsl(220, 3%, 93%)",
-        "line-dasharray": [
-          1,
-          0.3
-        ],
+        "line-dasharray": [1, 0.3],
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              14,
-              0.5
-            ],
-            [
-              20,
-              10
-            ]
+            [14, 0.5],
+            [20, 10]
           ]
         }
       }
@@ -2784,21 +1565,9 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
       "layout": {
         "line-join": "round"
@@ -2808,22 +1577,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
+            [12.5, 0],
+            [13, 1.5],
+            [14, 2.5],
+            [20, 11.5]
           ]
         }
       }
@@ -2835,17 +1592,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "service",
-          "track"
-        ]
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "service", "track"]
       ],
       "layout": {
         "line-join": "round"
@@ -2855,18 +1603,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              15.5,
-              0
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              20,
-              7.5
-            ]
+            [15.5, 0],
+            [16, 2],
+            [20, 7.5]
           ]
         }
       }
@@ -2876,19 +1615,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "link"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "link"], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-join": "round"
       },
@@ -2897,22 +1624,10 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
+            [12.5, 0],
+            [13, 1.5],
+            [14, 2.5],
+            [20, 11.5]
           ]
         }
       }
@@ -2922,19 +1637,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "minor"
-        ]
-      ],
+      "filter": ["all", ["==", "brunnel", "bridge"], ["in", "class", "minor"]],
       "layout": {
         "line-join": "round"
       },
@@ -2943,18 +1646,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              13.5,
-              0
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              18
-            ]
+            [13.5, 0],
+            [14, 2.5],
+            [20, 18]
           ]
         }
       }
@@ -2966,17 +1660,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "secondary", "tertiary"]
       ],
       "layout": {
         "line-join": "round"
@@ -2986,18 +1671,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              10
-            ]
+            [6.5, 0],
+            [7, 0.5],
+            [20, 10]
           ]
         }
       }
@@ -3009,17 +1685,8 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "primary", "trunk"]
       ],
       "layout": {
         "line-join": "round"
@@ -3029,18 +1696,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0
-            ],
-            [
-              7,
-              1
-            ],
-            [
-              20,
-              18
-            ]
+            [5, 0],
+            [7, 1],
+            [20, 18]
           ]
         }
       }
@@ -3052,21 +1710,9 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
       "layout": {
         "line-join": "round"
@@ -3076,18 +1722,9 @@
         "line-width": {
           "base": 1.2,
           "stops": [
-            [
-              5,
-              0
-            ],
-            [
-              7,
-              1
-            ],
-            [
-              20,
-              18
-            ]
+            [5, 0],
+            [7, 1],
+            [20, 18]
           ]
         }
       }
@@ -3097,36 +1734,15 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "bridge"]],
       "paint": {
         "line-color": "#bbb",
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              15,
-              0.75
-            ],
-            [
-              20,
-              2
-            ]
+            [14, 0.4],
+            [15, 0.75],
+            [20, 2]
           ]
         }
       }
@@ -3136,40 +1752,16 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "bridge"]],
       "paint": {
         "line-color": "#bbb",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
+        "line-dasharray": [0.2, 8],
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              20,
-              8
-            ]
+            [14.5, 0],
+            [15, 3],
+            [20, 8]
           ]
         }
       }
@@ -3181,34 +1773,17 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "transit"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "transit"],
+        ["==", "brunnel", "bridge"]
       ],
       "paint": {
         "line-color": "#bbb",
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              15,
-              0.75
-            ],
-            [
-              20,
-              2
-            ]
+            [14, 0.4],
+            [15, 0.75],
+            [20, 2]
           ]
         }
       }
@@ -3220,38 +1795,18 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "transit"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "transit"],
+        ["==", "brunnel", "bridge"]
       ],
       "paint": {
         "line-color": "#bbb",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
+        "line-dasharray": [0.2, 8],
         "line-width": {
           "base": 1.4,
           "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              20,
-              8
-            ]
+            [14.5, 0],
+            [15, 3],
+            [20, 8]
           ]
         }
       }
@@ -3330,39 +1885,19 @@
       "source": "openmaptiles",
       "source-layer": "boundary",
       "minzoom": 8,
-      "filter": [
-        "all",
-        [
-          "in",
-          "admin_level",
-          3,
-          4
-        ]
-      ],
+      "filter": ["all", ["in", "admin_level", 3, 4]],
       "layout": {
         "line-join": "round"
       },
       "paint": {
         "line-color": "#9e9cab",
-        "line-dasharray": [
-          5,
-          1
-        ],
+        "line-dasharray": [5, 1],
         "line-width": {
           "base": 1,
           "stops": [
-            [
-              4,
-              0.4
-            ],
-            [
-              5,
-              1
-            ],
-            [
-              12,
-              1.8
-            ]
+            [4, 0.4],
+            [5, 1],
+            [12, 1.8]
           ]
         }
       }
@@ -3373,18 +1908,7 @@
       "source": "openmaptiles",
       "source-layer": "boundary",
       "maxzoom": 5,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          2
-        ],
-        [
-          "!has",
-          "claimed_by"
-        ]
-      ],
+      "filter": ["all", ["==", "admin_level", 2], ["!has", "claimed_by"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -3394,31 +1918,16 @@
         "line-opacity": {
           "base": 1,
           "stops": [
-            [
-              0,
-              0.4
-            ],
-            [
-              4,
-              1
-            ]
+            [0, 0.4],
+            [4, 1]
           ]
         },
         "line-width": {
           "base": 1,
           "stops": [
-            [
-              3,
-              1
-            ],
-            [
-              5,
-              1.2
-            ],
-            [
-              12,
-              3
-            ]
+            [3, 1],
+            [5, 1.2],
+            [12, 3]
           ]
         }
       }
@@ -3429,14 +1938,7 @@
       "source": "openmaptiles",
       "source-layer": "boundary",
       "minzoom": 5,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          2
-        ]
-      ],
+      "filter": ["all", ["==", "admin_level", 2]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -3446,31 +1948,16 @@
         "line-opacity": {
           "base": 1,
           "stops": [
-            [
-              0,
-              0.4
-            ],
-            [
-              4,
-              1
-            ]
+            [0, 0.4],
+            [4, 1]
           ]
         },
         "line-width": {
           "base": 1,
           "stops": [
-            [
-              3,
-              1
-            ],
-            [
-              5,
-              1.2
-            ],
-            [
-              12,
-              3
-            ]
+            [3, 1],
+            [5, 1.2],
+            [12, 3]
           ]
         }
       }
@@ -3480,19 +1967,10 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "waterway",
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ]
-      ],
+      "filter": ["all", ["==", "$type", "LineString"]],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Roboto Regular"
-        ],
+        "text-font": ["Roboto Regular"],
         "text-max-width": 5,
         "text-size": 12,
         "symbol-placement": "line"
@@ -3508,16 +1986,10 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "water_name",
-      "filter": [
-        "==",
-        "$type",
-        "Point"
-      ],
+      "filter": ["==", "$type", "Point"],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Roboto Regular"
-        ],
+        "text-font": ["Roboto Regular"],
         "text-max-width": 5,
         "text-size": 12
       },
@@ -3533,51 +2005,20 @@
       "source": "openmaptiles",
       "source-layer": "poi",
       "minzoom": 16,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          ">=",
-          "rank",
-          20
-        ]
-      ],
+      "filter": ["all", ["==", "$type", "Point"], [">=", "rank", 20]],
       "layout": {
         "icon-image": [
           "match",
-          [
-            "get",
-            "subclass"
-          ],
-          [
-            "florist",
-            "furniture",
-            "soccer",
-            "tennis"
-          ],
-          [
-            "get",
-            "subclass"
-          ],
-          [
-            "get",
-            "class"
-          ]
+          ["get", "subclass"],
+          ["florist", "furniture", "soccer", "tennis"],
+          ["get", "subclass"],
+          ["get", "class"]
         ],
         "text-anchor": "top",
         "text-field": "{name}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 9,
-        "text-offset": [
-          0,
-          0.6
-        ],
+        "text-offset": [0, 0.6],
         "text-size": 12
       },
       "paint": {
@@ -3595,54 +2036,23 @@
       "minzoom": 15,
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          ">=",
-          "rank",
-          7
-        ],
-        [
-          "<",
-          "rank",
-          20
-        ]
+        ["==", "$type", "Point"],
+        [">=", "rank", 7],
+        ["<", "rank", 20]
       ],
       "layout": {
         "icon-image": [
           "match",
-          [
-            "get",
-            "subclass"
-          ],
-          [
-            "florist",
-            "furniture",
-            "soccer",
-            "tennis"
-          ],
-          [
-            "get",
-            "subclass"
-          ],
-          [
-            "get",
-            "class"
-          ]
+          ["get", "subclass"],
+          ["florist", "furniture", "soccer", "tennis"],
+          ["get", "subclass"],
+          ["get", "class"]
         ],
         "text-anchor": "top",
         "text-field": "{name}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 9,
-        "text-offset": [
-          0,
-          0.6
-        ],
+        "text-offset": [0, 0.6],
         "text-size": 12
       },
       "paint": {
@@ -3660,54 +2070,23 @@
       "minzoom": 14,
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          ">=",
-          "rank",
-          1
-        ],
-        [
-          "<",
-          "rank",
-          7
-        ]
+        ["==", "$type", "Point"],
+        [">=", "rank", 1],
+        ["<", "rank", 7]
       ],
       "layout": {
         "icon-image": [
           "match",
-          [
-            "get",
-            "subclass"
-          ],
-          [
-            "florist",
-            "furniture",
-            "soccer",
-            "tennis"
-          ],
-          [
-            "get",
-            "subclass"
-          ],
-          [
-            "get",
-            "class"
-          ]
+          ["get", "subclass"],
+          ["florist", "furniture", "soccer", "tennis"],
+          ["get", "subclass"],
+          ["get", "class"]
         ],
         "text-anchor": "top",
         "text-field": "{name}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 9,
-        "text-offset": [
-          0,
-          0.6
-        ],
+        "text-offset": [0, 0.6],
         "text-size": 12
       },
       "paint": {
@@ -3722,28 +2101,14 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "poi",
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "bus",
-          "rail",
-          "airport"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "bus", "rail", "airport"]],
       "layout": {
         "icon-image": "{class}",
         "text-anchor": "left",
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 9,
-        "text-offset": [
-          0.9,
-          0
-        ],
+        "text-offset": [0.9, 0],
         "text-size": 12
       },
       "paint": {
@@ -3758,31 +2123,18 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "transportation_name",
-      "filter": [
-        "all"
-      ],
+      "filter": ["all"],
       "layout": {
         "symbol-placement": "line",
         "text-anchor": "center",
         "text-field": "{name}",
-        "text-font": [
-          "Roboto Regular"
-        ],
-        "text-offset": [
-          0,
-          0.15
-        ],
+        "text-font": ["Roboto Regular"],
+        "text-offset": [0, 0.15],
         "text-size": {
           "base": 1,
           "stops": [
-            [
-              13,
-              12
-            ],
-            [
-              14,
-              13
-            ]
+            [13, 12],
+            [14, 13]
           ]
         }
       },
@@ -3798,39 +2150,21 @@
       "source": "openmaptiles",
       "source-layer": "transportation_name",
       "minzoom": 7,
-      "filter": [
-        "all",
-        [
-          "<=",
-          "ref_length",
-          6
-        ]
-      ],
+      "filter": ["all", ["<=", "ref_length", 6]],
       "layout": {
         "icon-image": "default_{ref_length}",
         "icon-rotation-alignment": "viewport",
         "symbol-placement": {
           "base": 1,
           "stops": [
-            [
-              10,
-              "point"
-            ],
-            [
-              11,
-              "line"
-            ]
+            [10, "point"],
+            [11, "line"]
           ]
         },
         "symbol-spacing": 500,
         "text-field": "{ref}",
-        "text-font": [
-          "Roboto Regular"
-        ],
-        "text-offset": [
-          0,
-          0.1
-        ],
+        "text-font": ["Roboto Regular"],
+        "text-offset": [0, 0.1],
         "text-rotation-alignment": "viewport",
         "text-size": 10,
         "icon-size": 0.8
@@ -3856,22 +2190,14 @@
       ],
       "layout": {
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-letter-spacing": 0.1,
         "text-max-width": 9,
         "text-size": {
           "base": 1.2,
           "stops": [
-            [
-              12,
-              10
-            ],
-            [
-              15,
-              14
-            ]
+            [12, 10],
+            [15, 14]
           ]
         },
         "text-transform": "uppercase"
@@ -3887,31 +2213,16 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "village"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "village"]],
       "layout": {
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Regular"
-        ],
+        "text-font": ["Roboto Regular"],
         "text-max-width": 8,
         "text-size": {
           "base": 1.2,
           "stops": [
-            [
-              10,
-              12
-            ],
-            [
-              15,
-              22
-            ]
+            [10, 12],
+            [15, 22]
           ]
         }
       },
@@ -3926,49 +2237,25 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "town"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "town"]],
       "layout": {
         "icon-image": {
           "base": 1,
           "stops": [
-            [
-              0,
-              "dot_9"
-            ],
-            [
-              8,
-              ""
-            ]
+            [0, "dot_9"],
+            [8, ""]
           ]
         },
         "text-anchor": "bottom",
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Regular"
-        ],
+        "text-font": ["Roboto Regular"],
         "text-max-width": 8,
-        "text-offset": [
-          0,
-          0
-        ],
+        "text-offset": [0, 0],
         "text-size": {
           "base": 1.2,
           "stops": [
-            [
-              7,
-              12
-            ],
-            [
-              11,
-              16
-            ]
+            [7, 12],
+            [11, 16]
           ]
         }
       },
@@ -3984,49 +2271,25 @@
       "source": "openmaptiles",
       "source-layer": "place",
       "minzoom": 5,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "city"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "city"]],
       "layout": {
         "icon-image": {
           "base": 1,
           "stops": [
-            [
-              0,
-              "dot_9"
-            ],
-            [
-              8,
-              ""
-            ]
+            [0, "dot_9"],
+            [8, ""]
           ]
         },
         "text-anchor": "bottom",
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Medium"
-        ],
+        "text-font": ["Roboto Medium"],
         "text-max-width": 8,
-        "text-offset": [
-          0,
-          0
-        ],
+        "text-offset": [0, 0],
         "text-size": {
           "base": 1.2,
           "stops": [
-            [
-              7,
-              14
-            ],
-            [
-              11,
-              24
-            ]
+            [7, 14],
+            [11, 24]
           ]
         },
         "icon-allow-overlap": true,
@@ -4044,29 +2307,14 @@
       "source": "openmaptiles",
       "source-layer": "place",
       "maxzoom": 6,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "state"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "state"]],
       "layout": {
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-size": {
           "stops": [
-            [
-              4,
-              11
-            ],
-            [
-              6,
-              15
-            ]
+            [4, 11],
+            [6, 15]
           ]
         },
         "text-transform": "uppercase"
@@ -4082,35 +2330,15 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          ">=",
-          "rank",
-          3
-        ],
-        [
-          "==",
-          "class",
-          "country"
-        ]
-      ],
+      "filter": ["all", [">=", "rank", 3], ["==", "class", "country"]],
       "layout": {
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 6.25,
         "text-size": {
           "stops": [
-            [
-              3,
-              11
-            ],
-            [
-              7,
-              17
-            ]
+            [3, 11],
+            [7, 17]
           ]
         },
         "text-transform": "none"
@@ -4127,35 +2355,15 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          "==",
-          "rank",
-          2
-        ],
-        [
-          "==",
-          "class",
-          "country"
-        ]
-      ],
+      "filter": ["all", ["==", "rank", 2], ["==", "class", "country"]],
       "layout": {
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 6.25,
         "text-size": {
           "stops": [
-            [
-              2,
-              11
-            ],
-            [
-              5,
-              17
-            ]
+            [2, 11],
+            [5, 17]
           ]
         },
         "text-transform": "none"
@@ -4172,35 +2380,15 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          "==",
-          "rank",
-          1
-        ],
-        [
-          "==",
-          "class",
-          "country"
-        ]
-      ],
+      "filter": ["all", ["==", "rank", 1], ["==", "class", "country"]],
       "layout": {
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 6.25,
         "text-size": {
           "stops": [
-            [
-              1,
-              11
-            ],
-            [
-              4,
-              17
-            ]
+            [1, 11],
+            [4, 17]
           ]
         },
         "text-transform": "none"
@@ -4218,19 +2406,10 @@
       "source": "openmaptiles",
       "source-layer": "place",
       "maxzoom": 1,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "continent"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "continent"]],
       "layout": {
         "text-field": "{name_en}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-size": 13,
         "text-transform": "uppercase",
         "text-justify": "center"

--- a/src/components/svelte/AdminLoginModal.svelte
+++ b/src/components/svelte/AdminLoginModal.svelte
@@ -54,10 +54,7 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div
-  class="login-overlay"
-  transition:fade={overlayFade(reducedMotion.current)}
->
+<div class="login-overlay" transition:fade={overlayFade(reducedMotion.current)}>
   <div
     bind:this={loginFrameEl}
     class="login-frame"

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -163,7 +163,7 @@
 
       syncToastStore.beginFetchingCampus(6);
 
-      const trackFetch = <T>(promise: Promise<T>) =>
+      const trackFetch = <T,>(promise: Promise<T>) =>
         promise.finally(() => {
           syncToastStore.reportFetchComplete();
         });

--- a/src/components/svelte/Building3DViewer.svelte
+++ b/src/components/svelte/Building3DViewer.svelte
@@ -954,7 +954,10 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="viewer-overlay" transition:fade={overlayFade(reducedMotion.current)}>
+<div
+  class="viewer-overlay"
+  transition:fade={overlayFade(reducedMotion.current)}
+>
   <div
     class="viewer-frame"
     in:fly={modalContentReveal(reducedMotion.current)}

--- a/src/components/svelte/EditorShelf.svelte
+++ b/src/components/svelte/EditorShelf.svelte
@@ -75,7 +75,9 @@
       <small>{adminLabel}</small>
     </div>
     {#if proposalsStore.pendingCount > 0}
-      <span class="editor-shelf-badge">{proposalsStore.pendingCount} pending</span>
+      <span class="editor-shelf-badge"
+        >{proposalsStore.pendingCount} pending</span
+      >
     {/if}
   </div>
 
@@ -113,7 +115,11 @@
 
   <ProposalReviewPanel />
 
-  <button type="button" class="editor-shelf-action danger" onclick={handleLogout}>
+  <button
+    type="button"
+    class="editor-shelf-action danger"
+    onclick={handleLogout}
+  >
     <LogOut size={16} aria-hidden="true" />
     Sign out
   </button>

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -356,8 +356,7 @@
       -1 * (var(--map-ui-padding, 0.5rem) + env(safe-area-inset-bottom, 0px))
     );
     height: calc(
-      6rem + var(--map-ui-padding, 0.5rem) +
-        env(safe-area-inset-bottom, 0px)
+      6rem + var(--map-ui-padding, 0.5rem) + env(safe-area-inset-bottom, 0px)
     );
     background: linear-gradient(
       to top,
@@ -560,7 +559,8 @@
       gap: 0.375rem;
     }
 
-    .top-right-map-stack :global(.map-tools-panel .map-chrome-accordion-toggle) {
+    .top-right-map-stack
+      :global(.map-tools-panel .map-chrome-accordion-toggle) {
       min-height: 2.75rem;
       padding: 0.625rem 0.75rem;
       font-size: 0.9375rem;

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -588,11 +588,7 @@
   function disableTerrain(map: mapGl.MapLibreMap) {
     map.setTerrain(null);
     setTerrainHillshadeVisible(map, false);
-    syncBuildingLayersForDimension(
-      map,
-      isMap2DPitch(map.getPitch()),
-      false,
-    );
+    syncBuildingLayersForDimension(map, isMap2DPitch(map.getPitch()), false);
   }
 
   function restoreFlatMapCamera(map: mapGl.MapLibreMap) {
@@ -1378,11 +1374,7 @@
         ensureTerrainRendering(map);
         map.setTerrain({ source: TERRAIN_SOURCE_ID, exaggeration });
         setTerrainHillshadeVisible(map, true);
-        syncBuildingLayersForDimension(
-          map,
-          isMap2DPitch(map.getPitch()),
-          true,
-        );
+        syncBuildingLayersForDimension(map, isMap2DPitch(map.getPitch()), true);
         if (!terrainModeWasEnabled) {
           flyToCamera(map, MAKILING_TERRAIN_CAMERA);
         }
@@ -2472,10 +2464,10 @@
                       <div class="event-stack-list">
                         {#each group.entries as entry (`event-stack:${entry.event.id}:${entry.location.id}`)}
                           {@const image = getEventImage(
-                    entry.event.slug,
-                    entry.event.imageUrl,
-                    entry.event.title,
-                  )}
+                            entry.event.slug,
+                            entry.event.imageUrl,
+                            entry.event.title,
+                          )}
                           <button
                             type="button"
                             class="event-stack-item"
@@ -2674,8 +2666,8 @@
     min-width: 0;
     max-width: calc(
       100% - var(--map-search-chrome-width, min(31rem, calc(100vw - 15rem))) -
-        var(--map-ui-padding, 0.5rem) * 2 -
-        var(--bottom-fab-inset, 3.75rem) - var(--bottom-fab-gap, 0.5rem) * 2
+        var(--map-ui-padding, 0.5rem) * 2 - var(--bottom-fab-inset, 3.75rem) -
+        var(--bottom-fab-gap, 0.5rem) * 2
     );
     min-height: 2.5rem;
     padding: 0.25rem 0.25rem 0.25rem 0.625rem;
@@ -2775,8 +2767,8 @@
     min-width: 0;
     max-width: calc(
       100% - var(--map-search-chrome-width, min(31rem, calc(100vw - 15rem))) -
-        var(--map-ui-padding, 0.5rem) * 2 -
-        var(--bottom-fab-inset, 3.75rem) - var(--bottom-fab-gap, 0.5rem) * 2
+        var(--map-ui-padding, 0.5rem) * 2 - var(--bottom-fab-inset, 3.75rem) -
+        var(--bottom-fab-gap, 0.5rem) * 2
     );
     min-height: 2.5rem;
     padding: 0.25rem 0.25rem 0.25rem 0.625rem;

--- a/src/components/svelte/MapAttribution.svelte
+++ b/src/components/svelte/MapAttribution.svelte
@@ -8,7 +8,12 @@
   }
 </script>
 
-<div class="map-attribution" class:expanded role="region" aria-label="Map attribution">
+<div
+  class="map-attribution"
+  class:expanded
+  role="region"
+  aria-label="Map attribution"
+>
   <button
     type="button"
     class="attrib-toggle"
@@ -149,5 +154,4 @@
     width: auto;
     height: 1.25rem;
   }
-
 </style>

--- a/src/components/svelte/MapDimensionToggle.svelte
+++ b/src/components/svelte/MapDimensionToggle.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { mapStore, terrainStore } from "@lib/store.svelte";
-  import {
-    THREE_D_PITCH,
-    isMap2DPitch,
-  } from "@constants/map-dimension";
+  import { THREE_D_PITCH, isMap2DPitch } from "@constants/map-dimension";
   import {
     enterFlatMapDimension,
     enterTiltedMapDimension,

--- a/src/components/svelte/MapToolsFlyout.svelte
+++ b/src/components/svelte/MapToolsFlyout.svelte
@@ -61,40 +61,40 @@
         title="Map tools"
         onclose={() => mapToolsStore.close()}
       >
-      {#each sections as section (section.id)}
-        <div class="accordion-section">
-          <button
-            type="button"
-            class="map-chrome-accordion-toggle"
-            aria-expanded={isExpanded(section.id)}
-            aria-controls={`map-tools-section-${section.id}`}
-            onclick={() => toggleSection(section.id)}
-          >
-            {#if isExpanded(section.id)}
-              <ChevronDown size={18} aria-hidden="true" />
-            {:else}
-              <ChevronRight size={18} aria-hidden="true" />
-            {/if}
-            <span>{section.label}</span>
-          </button>
-          {#if isExpanded(section.id)}
-            <div
-              id={`map-tools-section-${section.id}`}
-              class="map-chrome-accordion-body map-chrome-accordion-body--enter"
+        {#each sections as section (section.id)}
+          <div class="accordion-section">
+            <button
+              type="button"
+              class="map-chrome-accordion-toggle"
+              aria-expanded={isExpanded(section.id)}
+              aria-controls={`map-tools-section-${section.id}`}
+              onclick={() => toggleSection(section.id)}
             >
-              {#if section.id === "view"}
-                <MapViewControls embedded variant="modes" />
-              {:else if section.id === "legend"}
-                <MapLegend embedded />
-              {:else if section.id === "terrain"}
-                <TerrainControl embedded />
-              {:else if section.id === "jeepney"}
-                <JeepneyMenu embedded />
+              {#if isExpanded(section.id)}
+                <ChevronDown size={18} aria-hidden="true" />
+              {:else}
+                <ChevronRight size={18} aria-hidden="true" />
               {/if}
-            </div>
-          {/if}
-        </div>
-      {/each}
+              <span>{section.label}</span>
+            </button>
+            {#if isExpanded(section.id)}
+              <div
+                id={`map-tools-section-${section.id}`}
+                class="map-chrome-accordion-body map-chrome-accordion-body--enter"
+              >
+                {#if section.id === "view"}
+                  <MapViewControls embedded variant="modes" />
+                {:else if section.id === "legend"}
+                  <MapLegend embedded />
+                {:else if section.id === "terrain"}
+                  <TerrainControl embedded />
+                {:else if section.id === "jeepney"}
+                  <JeepneyMenu embedded />
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
       </MapChromePanel>
     </div>
   {/if}

--- a/src/components/svelte/MapViewControls.svelte
+++ b/src/components/svelte/MapViewControls.svelte
@@ -8,10 +8,7 @@
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
   import MapIcon from "@lucide/svelte/icons/map";
   import { mapStore, mapViewStore, terrainStore } from "@lib/store.svelte";
-  import {
-    THREE_D_PITCH,
-    isMap2DPitch,
-  } from "@constants/map-dimension";
+  import { THREE_D_PITCH, isMap2DPitch } from "@constants/map-dimension";
   import {
     enterFlatMapDimension,
     enterTiltedMapDimension,

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -459,5 +459,4 @@
       display: inline;
     }
   }
-
 </style>

--- a/src/components/svelte/SyncStatus.svelte
+++ b/src/components/svelte/SyncStatus.svelte
@@ -305,7 +305,9 @@
           role="progressbar"
           aria-valuemin="0"
           aria-valuemax="100"
-          aria-valuenow={showProgress ? syncToastStore.progressPercent : undefined}
+          aria-valuenow={showProgress
+            ? syncToastStore.progressPercent
+            : undefined}
           aria-label={displayedLabel}
         >
           {#if showProgress}
@@ -314,7 +316,8 @@
               style:width={`${syncToastStore.progressPercent}%`}
             ></div>
           {:else}
-            <div class="progress-bar-value progress-bar-value--indeterminate"
+            <div
+              class="progress-bar-value progress-bar-value--indeterminate"
             ></div>
           {/if}
         </div>
@@ -343,7 +346,8 @@
           role="progressbar"
           aria-label={displayedLabel}
         >
-          <div class="progress-bar-value progress-bar-value--indeterminate"
+          <div
+            class="progress-bar-value progress-bar-value--indeterminate"
           ></div>
         </div>
       {/if}

--- a/src/components/svelte/TransitRoutePanel.svelte
+++ b/src/components/svelte/TransitRoutePanel.svelte
@@ -39,7 +39,9 @@
       <span class="transit-route-option__copy">
         <span class="transit-route-option__name">{route.name}</span>
         {#if !compact}
-          <span class="transit-route-option__description">{route.description}</span>
+          <span class="transit-route-option__description"
+            >{route.description}</span
+          >
         {/if}
       </span>
     </button>
@@ -90,7 +92,8 @@
       border-color 0.15s ease;
   }
 
-  .transit-route-panel:not(.transit-route-panel--compact) .transit-route-option {
+  .transit-route-panel:not(.transit-route-panel--compact)
+    .transit-route-option {
     width: 100%;
     border-radius: 0.625rem;
     background-color: hsl(0, 0%, 98%);

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -289,7 +289,9 @@
 
       <div class="entity-actions">
         {#if hasMapPin}
-          <MapChromeActionChip onclick={() => building3DStore.open(building.buildingName)}>
+          <MapChromeActionChip
+            onclick={() => building3DStore.open(building.buildingName)}
+          >
             <Box size={14} aria-hidden="true" />
             3D view
           </MapChromeActionChip>
@@ -325,7 +327,9 @@
     {#if editing}
       <section
         class="entity-editor"
-        aria-label={canPublish ? "Edit building details" : "Suggest building edits"}
+        aria-label={canPublish
+          ? "Edit building details"
+          : "Suggest building edits"}
       >
         <EntityEditorPanel
           {canPublish}
@@ -401,8 +405,7 @@
                     id="building-directions-editor"
                     bind:value={directionsDraft}
                     disabled={savingField !== null}
-                    rows="3"
-                  ></textarea>
+                    rows="3"></textarea>
                 {/snippet}
               </EntityEditorField>
 

--- a/src/components/svelte/controls/CollegeResult.svelte
+++ b/src/components/svelte/controls/CollegeResult.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-  import {
-    adminAuthStore,
-    queryStore,
-    toastStore,
-  } from "@lib/store.svelte";
+  import { adminAuthStore, queryStore, toastStore } from "@lib/store.svelte";
   import { persistEntityChange } from "@lib/proposals/client";
   import { handlePersistEntityResult } from "@lib/editor/handle-persist-result";
   import {

--- a/src/components/svelte/controls/DivisionResult.svelte
+++ b/src/components/svelte/controls/DivisionResult.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-  import {
-    adminAuthStore,
-    queryStore,
-    toastStore,
-  } from "@lib/store.svelte";
+  import { adminAuthStore, queryStore, toastStore } from "@lib/store.svelte";
   import { persistEntityChange } from "@lib/proposals/client";
   import { handlePersistEntityResult } from "@lib/editor/handle-persist-result";
   import {
@@ -273,7 +269,8 @@
               >
                 <option value="">No college</option>
                 {#each colleges as college (college.id)}
-                  <option value={String(college.id)}>{college.collegeName}</option
+                  <option value={String(college.id)}
+                    >{college.collegeName}</option
                   >
                 {/each}
               </select>

--- a/src/components/svelte/controls/DormEditorPanel.svelte
+++ b/src/components/svelte/controls/DormEditorPanel.svelte
@@ -4,7 +4,11 @@
   import EntityEditorField from "@ui/editor/EntityEditorField.svelte";
   import EntityEditorCheckboxField from "@ui/editor/EntityEditorCheckboxField.svelte";
   import { entityEditorSavedMessage } from "@lib/editor/field-action-label";
-  import { adminAuthStore, mapEditStore, mapProposalStore } from "@lib/store.svelte";
+  import {
+    adminAuthStore,
+    mapEditStore,
+    mapProposalStore,
+  } from "@lib/store.svelte";
   import "../editor/entity-editor.css";
 
   type DormEditableField =
@@ -146,8 +150,7 @@
         id="dorm-description-editor"
         bind:value={descriptionDraft}
         {disabled}
-        rows="3"
-      ></textarea>
+        rows="3"></textarea>
     {/snippet}
   </EntityEditorField>
 
@@ -270,8 +273,7 @@
         bind:value={contactPhoneDraft}
         {disabled}
         rows="3"
-        placeholder="One phone number per line"
-      ></textarea>
+        placeholder="One phone number per line"></textarea>
     {/snippet}
   </EntityEditorField>
 
@@ -291,8 +293,7 @@
         bind:value={amenitiesDraft}
         {disabled}
         rows="4"
-        placeholder="One amenity per line"
-      ></textarea>
+        placeholder="One amenity per line"></textarea>
     {/snippet}
   </EntityEditorField>
 

--- a/src/components/svelte/controls/EventsList.svelte
+++ b/src/components/svelte/controls/EventsList.svelte
@@ -177,7 +177,11 @@
     {#if tabEvents.length > 0}
       <div class="events-list">
         {#each pageEvents as event (event.id)}
-          {@const image = getEventImage(event.slug, event.imageUrl, event.title)}
+          {@const image = getEventImage(
+            event.slug,
+            event.imageUrl,
+            event.title,
+          )}
           {@const primaryLocation =
             event.locations.find((location) => location.isPrimary) ??
             event.locations[0] ??

--- a/src/components/svelte/editor/EntityEditorPinRow.svelte
+++ b/src/components/svelte/editor/EntityEditorPinRow.svelte
@@ -18,12 +18,7 @@
 
 <div class="entity-editor-pin-row">
   <span class="entity-editor-pin-label">{label}</span>
-  <button
-    type="button"
-    class="field-save-btn"
-    {disabled}
-    {onclick}
-  >
+  <button type="button" class="field-save-btn" {disabled} {onclick}>
     {pickLabel}
   </button>
 </div>

--- a/src/components/svelte/editor/EntityEditorSubmitButton.svelte
+++ b/src/components/svelte/editor/EntityEditorSubmitButton.svelte
@@ -21,9 +21,7 @@
     onclick,
   }: Props = $props();
 
-  const text = $derived(
-    saving && savingLabel ? savingLabel : label,
-  );
+  const text = $derived(saving && savingLabel ? savingLabel : label);
 </script>
 
 <button

--- a/src/components/svelte/editor/EntityReviewActions.svelte
+++ b/src/components/svelte/editor/EntityReviewActions.svelte
@@ -8,8 +8,12 @@
     onreject: () => void;
   };
 
-  let { disabled = false, onapprove, onrequestChanges, onreject }: Props =
-    $props();
+  let {
+    disabled = false,
+    onapprove,
+    onrequestChanges,
+    onreject,
+  }: Props = $props();
 </script>
 
 <div class="entity-review-actions">

--- a/src/components/svelte/editor/ImageUpload.svelte
+++ b/src/components/svelte/editor/ImageUpload.svelte
@@ -83,8 +83,7 @@
       if (res.status === 503) {
         uploadConfigured = false;
         throw new Error(
-          data.error ??
-            "Image uploads are not configured on this server yet.",
+          data.error ?? "Image uploads are not configured on this server yet.",
         );
       }
       if (!res.ok || !data.url) {

--- a/src/components/svelte/map-chrome/EventPlacementImageField.svelte
+++ b/src/components/svelte/map-chrome/EventPlacementImageField.svelte
@@ -3,9 +3,7 @@
   import { adminAuthStore, eventPlacementStore } from "@lib/store.svelte";
 
   const draft = $derived(eventPlacementStore.draft);
-  const uploadPrefix = $derived(
-    draft ? `events/${draft.slug}` : "events",
-  );
+  const uploadPrefix = $derived(draft ? `events/${draft.slug}` : "events");
 </script>
 
 {#if draft && adminAuthStore.isLoggedIn}
@@ -38,8 +36,8 @@
     z-index: 18;
     max-width: calc(
       100% - var(--map-search-chrome-width, min(31rem, calc(100vw - 15rem))) -
-        var(--map-ui-padding, 0.5rem) * 2 -
-        var(--bottom-fab-inset, 3.75rem) - var(--bottom-fab-gap, 0.5rem) * 2
+        var(--map-ui-padding, 0.5rem) * 2 - var(--bottom-fab-inset, 3.75rem) -
+        var(--bottom-fab-gap, 0.5rem) * 2
     );
     max-height: min(12rem, 30dvh);
     overflow: auto;

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -37,11 +37,7 @@
   import Classes from "./Classes.svelte";
 
   type RoomEditableField =
-    | "roomCode"
-    | "directions"
-    | "buildingId"
-    | "collegeId"
-    | "divisionId";
+    "roomCode" | "directions" | "buildingId" | "collegeId" | "divisionId";
 
   type RoomPatchResponse = {
     success?: boolean;
@@ -490,8 +486,7 @@
                 id="room-directions-editor"
                 bind:value={directionsDraft}
                 disabled={savingField !== null}
-                rows="3"
-              ></textarea>
+                rows="3"></textarea>
             {/snippet}
           </EntityEditorField>
 
@@ -578,8 +573,8 @@
           {#if mergePrompt}
             <div class="merge-prompt" role="status">
               <p>
-                A room named <strong>{mergePrompt.candidate.code}</strong> already
-                exists{#if mergePrompt.candidate.building?.name}
+                A room named <strong>{mergePrompt.candidate.code}</strong>
+                already exists{#if mergePrompt.candidate.building?.name}
                   in {mergePrompt.candidate.building.name}{/if}. Merge
                 <strong>{currentRoom.value.code}</strong> into it? Classes and map
                 pins move to the kept room; empty fields are filled from the merged

--- a/src/components/svelte/search/EventCards.svelte
+++ b/src/components/svelte/search/EventCards.svelte
@@ -210,7 +210,11 @@
     {#if visibleEvents.length > 0}
       <div class="event-list">
         {#each visibleEvents as event (event.id)}
-          {@const image = getEventImage(event.slug, event.imageUrl, event.title)}
+          {@const image = getEventImage(
+            event.slug,
+            event.imageUrl,
+            event.title,
+          )}
           {@const primaryLocation =
             event.locations.find((location) => location.isPrimary) ??
             event.locations[0] ??

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -312,7 +312,9 @@
               aria-controls={mobile.current
                 ? "editor-screen"
                 : "editor-shelf-panel"}
-              aria-label={showEditorSheet ? "Close editor tools" : editorOpenLabel}
+              aria-label={showEditorSheet
+                ? "Close editor tools"
+                : editorOpenLabel}
               title={showEditorSheet ? "Close editor tools" : editorChipLabel}
               onclick={(event) => {
                 event.preventDefault();
@@ -455,9 +457,15 @@
     box-sizing: border-box;
     overflow-x: clip;
     padding: calc(env(safe-area-inset-top, 0px) + 0.4375rem)
-      max(var(--map-search-inline-pad, 0.625rem), env(safe-area-inset-right, 0px))
+      max(
+        var(--map-search-inline-pad, 0.625rem),
+        env(safe-area-inset-right, 0px)
+      )
       0.4375rem
-      max(var(--map-search-inline-pad, 0.625rem), env(safe-area-inset-left, 0px));
+      max(
+        var(--map-search-inline-pad, 0.625rem),
+        env(safe-area-inset-left, 0px)
+      );
     background: linear-gradient(
       180deg,
       var(--map-chrome-band-backdrop, hsla(5, 22%, 96%, 0.82)) 0%,

--- a/src/constants/map-basemap-palette.ts
+++ b/src/constants/map-basemap-palette.ts
@@ -191,8 +191,10 @@ export const MAP_BASEMAP_BUILDING_SIZE_COLORS = true;
  * Smaller footprints read lighter cream; taller blocks read grey-limestone on green lawn.
  */
 export function buildingSizeColorExpression(
-  palette: Pick<typeof uplbRefreshing, "buildingFill" | "buildingExtrusion"> =
-    MAP_BASEMAP_PALETTE,
+  palette: Pick<
+    typeof uplbRefreshing,
+    "buildingFill" | "buildingExtrusion"
+  > = MAP_BASEMAP_PALETTE,
 ): ExpressionSpecification {
   return [
     "interpolate",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -116,7 +116,12 @@ const imageUrl = absoluteUrl(imagePath);
     </style>
   </head>
   <body>
-    <div id="app-loading-shell" class="app-loading-shell" role="status" aria-live="polite">
+    <div
+      id="app-loading-shell"
+      class="app-loading-shell"
+      role="status"
+      aria-live="polite"
+    >
       <div class="app-loading-shell__card">
         <div class="app-loading-mark" aria-hidden="true">
           <div class="app-loading-mark__loader">
@@ -145,7 +150,8 @@ const imageUrl = absoluteUrl(imagePath);
               stroke-width="2.25"
               stroke-linecap="round"
               stroke-linejoin="round"
-              ><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
+              ><path
+                d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
               ></path><circle cx="12" cy="10" r="3"></circle></svg
             >
           </div>
@@ -162,10 +168,11 @@ const imageUrl = absoluteUrl(imagePath);
             stroke-linecap="round"
             stroke-linejoin="round"
             class="app-loading-mark__context-icon"
-            ><path d="M10 12h4"></path><path d="M10 8h4"></path><path d="M14 21v-3a2 2 0 0 0-4 0v3"
-            ></path><path
+            ><path d="M10 12h4"></path><path d="M10 8h4"></path><path
+              d="M14 21v-3a2 2 0 0 0-4 0v3"></path><path
               d="M6 10H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2h-2"
-            ></path><path d="M6 21V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16"></path></svg
+            ></path><path d="M6 21V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16"
+            ></path></svg
           >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -178,7 +185,8 @@ const imageUrl = absoluteUrl(imagePath);
             stroke-linecap="round"
             stroke-linejoin="round"
             class="app-loading-mark__context-icon"
-            ><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
+            ><path
+              d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
             ></path><circle cx="12" cy="10" r="3"></circle></svg
           >
           <svg
@@ -192,14 +200,18 @@ const imageUrl = absoluteUrl(imagePath);
             stroke-linecap="round"
             stroke-linejoin="round"
             class="app-loading-mark__context-icon"
-            ><path d="M10 10v.2A3 3 0 0 1 8.8 15H5a2 2 0 0 1-2-2v-1a2 2 0 0 1 2-2z"></path><path
-              d="M14 10v.2A3 3 0 0 0 15.2 15H19a2 2 0 0 0 2-2v-1a2 2 0 0 0-2-2z"></path><path
-              d="M12 22v-3"></path><path
+            ><path
+              d="M10 10v.2A3 3 0 0 1 8.8 15H5a2 2 0 0 1-2-2v-1a2 2 0 0 1 2-2z"
+            ></path><path
+              d="M14 10v.2A3 3 0 0 0 15.2 15H19a2 2 0 0 0 2-2v-1a2 2 0 0 0-2-2z"
+            ></path><path d="M12 22v-3"></path><path
               d="M12 15V9m-4 0a4 4 0 0 1 8 0v6a4 4 0 0 1-8 0Z"></path></svg
           >
         </div>
         <p class="app-loading-shell__message">Loading campus data</p>
-        <p class="app-loading-shell__splash" aria-hidden="true">{LOADING_SPLASH_FIRST}</p>
+        <p class="app-loading-shell__splash" aria-hidden="true">
+          {LOADING_SPLASH_FIRST}
+        </p>
       </div>
     </div>
     <slot />
@@ -211,9 +223,13 @@ const imageUrl = absoluteUrl(imagePath);
         }
         // AppRoot removes the shell on mount; if hydration never starts (e.g. dev HMR
         // corruption), don't leave the static HTML blocker up indefinitely.
-        document.addEventListener("astro:before-prehydration", dismissLoadingShell, {
-          once: true,
-        });
+        document.addEventListener(
+          "astro:before-prehydration",
+          dismissLoadingShell,
+          {
+            once: true,
+          },
+        );
         window.addEventListener("DOMContentLoaded", function () {
           setTimeout(dismissLoadingShell, 12_000);
         });

--- a/src/lib/app-data.ts
+++ b/src/lib/app-data.ts
@@ -25,12 +25,7 @@ import type {
 } from "@lib/types";
 
 export type SearchCategory =
-  | "building"
-  | "division"
-  | "college"
-  | "room"
-  | "dorm"
-  | "event";
+  "building" | "division" | "college" | "room" | "dorm" | "event";
 
 export type InitialSearchState = {
   category: SearchCategory;

--- a/src/lib/editor/field-action-label.test.ts
+++ b/src/lib/editor/field-action-label.test.ts
@@ -8,18 +8,18 @@ import {
 
 describe("fieldSaveActionLabel", () => {
   test("uses publish vs suggest wording", () => {
-    expect(
-      fieldSaveActionLabel({ canPublish: true, isSaving: false }),
-    ).toBe("Save");
-    expect(
-      fieldSaveActionLabel({ canPublish: false, isSaving: false }),
-    ).toBe("Submit");
-    expect(
-      fieldSaveActionLabel({ canPublish: true, isSaving: true }),
-    ).toBe("Saving...");
-    expect(
-      fieldSaveActionLabel({ canPublish: false, isSaving: true }),
-    ).toBe("Submitting...");
+    expect(fieldSaveActionLabel({ canPublish: true, isSaving: false })).toBe(
+      "Save",
+    );
+    expect(fieldSaveActionLabel({ canPublish: false, isSaving: false })).toBe(
+      "Submit",
+    );
+    expect(fieldSaveActionLabel({ canPublish: true, isSaving: true })).toBe(
+      "Saving...",
+    );
+    expect(fieldSaveActionLabel({ canPublish: false, isSaving: true })).toBe(
+      "Submitting...",
+    );
   });
 });
 

--- a/src/lib/entity-urls.test.ts
+++ b/src/lib/entity-urls.test.ts
@@ -42,7 +42,9 @@ describe("entity-urls", () => {
   });
 
   it("builds canonical entity paths", () => {
-    expect(getBuildingCanonicalPath("Baker Hall")).toBe("/building/baker-hall/");
+    expect(getBuildingCanonicalPath("Baker Hall")).toBe(
+      "/building/baker-hall/",
+    );
     expect(getRoomCanonicalPath({ id: 12, code: "ICS 260" })).toBe(
       "/room/ics-260-12/",
     );
@@ -80,18 +82,17 @@ describe("entity-urls", () => {
 
   it("returns null for room paths without async room lookup", () => {
     expect(
-      resolveQueryFromEntityPath(
-        { category: "room", slug: "ics-260-12" },
-        {},
-      ),
+      resolveQueryFromEntityPath({ category: "room", slug: "ics-260-12" }, {}),
     ).toBeNull();
   });
 
   it("builds paths from query state when entity context is present", () => {
     expect(
-      getEntityCanonicalPath(
-        { type: "result", category: "building", value: "Baker Hall" },
-      ),
+      getEntityCanonicalPath({
+        type: "result",
+        category: "building",
+        value: "Baker Hall",
+      }),
     ).toBe("/building/baker-hall/");
 
     expect(
@@ -102,9 +103,7 @@ describe("entity-urls", () => {
     ).toBe("/room/ics-260-12/");
 
     expect(
-      getEntityCanonicalPath(
-        { type: "query", category: null, value: "" },
-      ),
+      getEntityCanonicalPath({ type: "query", category: null, value: "" }),
     ).toBeNull();
   });
 });

--- a/src/lib/entity-urls.ts
+++ b/src/lib/entity-urls.ts
@@ -141,14 +141,22 @@ export function resolveQueryFromEntityPath(
         (entry) => getBuildingSlug(entry) === slug,
       );
       if (!building) return null;
-      return { type: "result", category: "building", value: building.buildingName };
+      return {
+        type: "result",
+        category: "building",
+        value: building.buildingName,
+      };
     }
     case "college": {
       const college = context.colleges?.find(
         (entry) => getCollegeSlug(entry) === slug,
       );
       if (!college) return null;
-      return { type: "result", category: "college", value: college.collegeName };
+      return {
+        type: "result",
+        category: "college",
+        value: college.collegeName,
+      };
     }
     case "division": {
       const division = context.divisions?.find(

--- a/src/lib/event-time.ts
+++ b/src/lib/event-time.ts
@@ -27,10 +27,7 @@ const CAMPUS_UTC_OFFSET = "+08:00";
 export const UPCOMING_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
 
 export type EventRecurrence =
-  | "none"
-  | "annual"
-  | "every_1st_sem"
-  | "every_2nd_sem";
+  "none" | "annual" | "every_1st_sem" | "every_2nd_sem";
 
 export type StoredEventTiming = {
   startsAt: string;

--- a/src/lib/map-edit/patch-api.ts
+++ b/src/lib/map-edit/patch-api.ts
@@ -1,8 +1,5 @@
 import type { EventData } from "@lib/types";
-import {
-  ClientEditConflictError,
-  ClientEventConflictError,
-} from "./errors";
+import { ClientEditConflictError, ClientEventConflictError } from "./errors";
 import type {
   EditableConflictResponse,
   EditableCoords,
@@ -32,8 +29,7 @@ export async function patchPosition(
 
   if (!res.ok) {
     const data = (await res.json().catch(() => ({}))) as
-      | EditableConflictResponse
-      | { error?: string };
+      EditableConflictResponse | { error?: string };
     if (res.status === 409) {
       const conflict = data as EditableConflictResponse;
       throw new ClientEditConflictError(
@@ -64,8 +60,7 @@ export async function patchEventLocations(
     body: JSON.stringify({ version, locations }),
   });
   const data = (await res.json().catch(() => ({}))) as
-    | EventLocationsPatchResponse
-    | { error?: string };
+    EventLocationsPatchResponse | { error?: string };
 
   if (!res.ok) {
     if (res.status === 409) {

--- a/src/lib/r2-upload-core.ts
+++ b/src/lib/r2-upload-core.ts
@@ -44,7 +44,9 @@ export function detectImageContentType(bytes: Uint8Array): string | null {
   return null;
 }
 
-export function sanitizeUploadPrefix(prefix: string | null | undefined): string {
+export function sanitizeUploadPrefix(
+  prefix: string | null | undefined,
+): string {
   if (!prefix?.trim()) return "uploads";
   const cleaned = prefix
     .trim()
@@ -75,7 +77,10 @@ export function buildUploadKey(
   return `${sanitizeUploadPrefix(prefix)}/${id}.${extension}`;
 }
 
-export function publicUrlForKey(key: string, publicBaseUrl?: string | null): string {
+export function publicUrlForKey(
+  key: string,
+  publicBaseUrl?: string | null,
+): string {
   if (publicBaseUrl) {
     return `${publicBaseUrl.replace(/\/$/, "")}/${key}`;
   }

--- a/src/lib/r2-upload.test.ts
+++ b/src/lib/r2-upload.test.ts
@@ -20,14 +20,12 @@ describe("sanitizeUploadPrefix", () => {
 
 describe("detectImageContentType", () => {
   test("detects jpeg, png, and webp signatures", () => {
-    expect(detectImageContentType(new Uint8Array([0xff, 0xd8, 0xff, 0x00]))).toBe(
-      "image/jpeg",
-    );
+    expect(
+      detectImageContentType(new Uint8Array([0xff, 0xd8, 0xff, 0x00])),
+    ).toBe("image/jpeg");
     expect(
       detectImageContentType(
-        new Uint8Array([
-          0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00,
-        ]),
+        new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]),
       ),
     ).toBe("image/png");
     expect(
@@ -67,9 +65,7 @@ describe("parseEventImageUrl", () => {
       ok: false,
       error: "Event image URL must use HTTPS",
     });
-    expect(
-      parseEventImageUrl("https://cdn.example.com/events/a.jpg"),
-    ).toEqual({
+    expect(parseEventImageUrl("https://cdn.example.com/events/a.jpg")).toEqual({
       ok: false,
       error:
         "Event image URL requires upload storage (R2_PUBLIC_URL) to be configured",

--- a/src/lib/r2-upload.ts
+++ b/src/lib/r2-upload.ts
@@ -24,10 +24,7 @@ export {
 
 export function isR2Configured(): boolean {
   return Boolean(
-    R2_ACCOUNT_ID &&
-      R2_ACCESS_KEY_ID &&
-      R2_SECRET_ACCESS_KEY &&
-      R2_BUCKET_NAME,
+    R2_ACCOUNT_ID && R2_ACCESS_KEY_ID && R2_SECRET_ACCESS_KEY && R2_BUCKET_NAME,
   );
 }
 

--- a/src/lib/services/event-service.ts
+++ b/src/lib/services/event-service.ts
@@ -1,5 +1,8 @@
 import { asc, eq, inArray } from "drizzle-orm";
-import { getStoredEventOccurrence, getStoredEventStatus } from "@lib/event-time";
+import {
+  getStoredEventOccurrence,
+  getStoredEventStatus,
+} from "@lib/event-time";
 import {
   buildingsTable,
   dormsTable,

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -430,11 +430,7 @@ class MainControlsStore {
 }
 
 export type FloatingControlPanel =
-  | "legend"
-  | "building-type"
-  | "terrain"
-  | "admin"
-  | "suggest-addition";
+  "legend" | "building-type" | "terrain" | "admin" | "suggest-addition";
 
 class FloatingControlPanelStore {
   openPanel: FloatingControlPanel | null = $state(null);
@@ -450,11 +446,7 @@ class FloatingControlPanelStore {
   };
 }
 
-export type MapToolsSection =
-  | "view"
-  | "legend"
-  | "terrain"
-  | "jeepney";
+export type MapToolsSection = "view" | "legend" | "terrain" | "jeepney";
 
 class MapToolsStore {
   open = $state(false);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,7 +15,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
     pathname.startsWith("/api/admin") && pathname !== "/api/admin/auth";
 
   if (isAdminPage) {
-    return applySupabaseCacheHeaders(context.redirect("/?editor=login"), context);
+    return applySupabaseCacheHeaders(
+      context.redirect("/?editor=login"),
+      context,
+    );
   }
 
   if (isAdminApi) {

--- a/src/pages/api/admin/buildings/[id].ts
+++ b/src/pages/api/admin/buildings/[id].ts
@@ -1,10 +1,7 @@
 import type { APIRoute } from "astro";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
 import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
-import {
-  EditConflictError,
-  updateBuilding,
-} from "@lib/services/admin-service";
+import { EditConflictError, updateBuilding } from "@lib/services/admin-service";
 
 export const prerender = false;
 

--- a/src/pages/api/admin/colleges/[id].ts
+++ b/src/pages/api/admin/colleges/[id].ts
@@ -1,10 +1,7 @@
 import type { APIRoute } from "astro";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
 import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
-import {
-  EditConflictError,
-  updateCollege,
-} from "@lib/services/admin-service";
+import { EditConflictError, updateCollege } from "@lib/services/admin-service";
 
 export const prerender = false;
 

--- a/src/pages/api/admin/dorms/[id].ts
+++ b/src/pages/api/admin/dorms/[id].ts
@@ -1,10 +1,7 @@
 import type { APIRoute } from "astro";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
 import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
-import {
-  EditConflictError,
-  updateDorm,
-} from "@lib/services/admin-service";
+import { EditConflictError, updateDorm } from "@lib/services/admin-service";
 
 export const prerender = false;
 


### PR DESCRIPTION
## Summary

- Restructure **AGENTS.md** with a doc map, architecture blurb, Astro 7 / test-suite fixes, and pointers to glob-scoped Cursor rules instead of duplicated UI detail.
- Align **workflow skill** and **agentic-qa-process** (change-type matrix, Prettier + tests in CI, local lint/build expectations).
- Add **Cursor rules** for data/migrations and Svelte stores.
- Add **PR template**, **CI workflow** (Prettier + `bun test src` on PRs to `main`/`staging`).
- Sync **README** and **`.env.example`** (`ADMIN_SESSION_SECRET`).
- Apply **Prettier baseline** on staging so CI passes (44 files were already drifting).

## QA Summary

Automated:

- [x] Prettier passed: `bunx prettier --check .`
- [x] Unit tests passed: `bun test src` (48 tests)
- [ ] Full lint (ESLint) — pre-existing debt on staging; not in CI yet
- [ ] Build — not in CI (requires `DATABASE_URL`)

Manual browser:

- [ ] N/A — docs/CI only

Known gaps:

- ESLint still fails locally (`bun run lint`); follow-up to fix or gate CI on eslint once clean.

## Test plan

- [x] `bunx prettier --check .`
- [x] `bun test src`
- [ ] Confirm GitHub Actions CI passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and CI; runtime risk is limited to Prettier-only formatting, with no auth or data-path logic changes in this diff.
> 
> **Overview**
> This PR **restructures contributor and agent guidance** and **adds automated PR checks**, plus a **Prettier baseline** so CI can pass on staging.
> 
> **AGENTS.md** becomes a hub with a doc map, a short architecture section (Astro 7, Supabase/Drizzle, PGlite drift), a **verify-before-done** table, and pointers to glob-scoped Cursor rules instead of long duplicated UI guardrails. **room-tba-agent-workflow** defers policy to AGENTS.md and adds a PR prep checklist tied to **docs/agentic-qa-process.md** (change-type matrix, what runs in CI vs locally).
> 
> New **Cursor rules** cover **data/migrations** (Drizzle, PGlite, admin PATCH/versioning) and **Svelte stores**. **README** and **.env.example** are updated for Supabase/Bun workflow and documented **`ADMIN_SESSION_SECRET`**.
> 
> **GitHub Actions CI** on PRs/pushes to `main` and `staging` runs **`bunx prettier --check .`** and **`bun test src`** (no `DATABASE_URL`). A **PR template** standardizes QA evidence. Many files—including **`public/liberty-customized.json`** and assorted Svelte/TS sources—are reformatted only so Prettier check succeeds; no intended behavior change there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1349771c8b50c7fb3a3d869c2ee70fdd47f73c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->