### PR TITLE
docs(agents): require GitHub issue hygiene during fast iteration

### DIFF
--- a/.cursor/skills/room-tba-agent-workflow/SKILL.md
+++ b/.cursor/skills/room-tba-agent-workflow/SKILL.md
@@ -40,4 +40,5 @@ Commit policy, Conventional Commits format, and GPG signing: [AGENTS.md § Commi
 1. Read [docs/agentic-qa-process.md](../../docs/agentic-qa-process.md) and run applicable automated checks.
 2. Use the PR template QA summary (automated vs manual browser vs known gaps).
 3. For map/side-panel changes, confirm applicable Cursor rules were followed.
-4. Push with `-u origin HEAD` only when the user asked to push/open a PR.
+4. **Issue sync:** for each linked `#NNN`, update AC/paths/status per [docs/issue-hygiene.md](../../docs/issue-hygiene.md); comment with the PR URL.
+5. Push with `-u origin HEAD` only when the user asked to push/open a PR.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Room TBA repo
+    url: https://github.com/uplbtools/room-tba
+    about: Open issues and PRs on GitHub

--- a/.github/ISSUE_TEMPLATE/implementation_task.md
+++ b/.github/ISSUE_TEMPLATE/implementation_task.md
@@ -1,0 +1,40 @@
+---
+name: Implementation task
+about: Feature or refactor with concrete acceptance criteria and file pointers
+title: "[TASK] "
+labels: enhancement
+assignees: ""
+---
+
+**Status:** proposed  
+**Last verified against staging:** <!-- YYYY-MM-DD; update whenever paths or AC change -->
+
+## Problem
+
+<!-- What hurts today? Link related issues. -->
+
+## Proposal
+
+<!-- Approach, constraints, non-goals. -->
+
+## Implementation pointers
+
+<!-- Keep these current — agents trust them literally -->
+
+- **Files / routes:**
+- **Schema / migrations:**
+- **Commands / env:**
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+
+## Related
+
+- #
+- PR #
+
+## Superseded
+
+<!-- Move obsolete paragraphs here instead of deleting -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 
 <!-- What changed and why (1–3 sentences). -->
 
+**Linked issues:** Closes # / Refs # <!-- update issue bodies + AC per docs/issue-hygiene.md -->
+
 ## QA Summary
 
 Automated:
@@ -25,6 +27,12 @@ Known gaps:
 Follow-up:
 
 - <!-- Issues or PRs to file next -->
+
+## Issues updated
+
+- [ ] Linked issue(s) commented with this PR
+- [ ] Acceptance criteria checkboxes / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
+- [ ] `Last verified against staging:` date set on linked issues
 
 ## Test plan
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Read the right doc for the task — do not rely on this file alone for detailed 
 | Stores and client state                          | [.cursor/rules/svelte-stores.mdc](.cursor/rules/svelte-stores.mdc)                                                      |
 | PR QA evidence and reporting                     | [docs/agentic-qa-process.md](docs/agentic-qa-process.md)                                                                |
 | Editor manual checklist                          | [docs/editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md)                                              |
+| Issue-linked work / keeping specs current        | [docs/issue-hygiene.md](docs/issue-hygiene.md)                                                                          |
 
 ## How to work
 
@@ -21,6 +22,18 @@ Read the right doc for the task — do not rely on this file alone for detailed 
 - **One pass is often enough.** Prefer a focused implementation plus verification over long planning loops or repeated “want me to…?” prompts.
 - **Preserve the dirty tree.** Do not revert unrelated user changes unless explicitly asked.
 - **Keep scope tight.** Avoid opportunistic refactors outside the request.
+- **Keep GitHub issues current** when work is tied to `#NNN` — issues hold implementation specifics that drift fast. See [docs/issue-hygiene.md](docs/issue-hygiene.md).
+
+## GitHub issues
+
+Issues are living specs (paths, schema, acceptance criteria). When coding quickly, update them in the same session as the code:
+
+- **Before starting:** `gh issue view N` — verify cited files/APIs still exist; fix stale body text first.
+- **While implementing:** if the approach changes, edit the issue — don't leave wrong paths for the next agent.
+- **With the PR:** comment on the issue with the PR link; check off completed AC; set `Last verified against staging: YYYY-MM-DD` and `Status:` at the top.
+- **After merge:** close if done, or trim the body and file follow-ups. Move obsolete text under `## Superseded`, don't delete history.
+
+Full checklist: [docs/issue-hygiene.md](docs/issue-hygiene.md).
 
 ## Verify before done
 

--- a/docs/agentic-qa-process.md
+++ b/docs/agentic-qa-process.md
@@ -2,7 +2,7 @@
 
 Use this process when preparing an editor-focused PR for review. The goal is to let agents verify everything they can with evidence, while clearly marking browser-only checks that still need a human pass.
 
-**Related docs:** [AGENTS.md](../AGENTS.md) (policy), [editor-foundation-test-plan.md](editor-foundation-test-plan.md) (manual editor checklist), [.cursor/rules/map-layout.mdc](../.cursor/rules/map-layout.mdc) and [side-panel.mdc](../.cursor/rules/side-panel.mdc) for UI layout.
+**Related docs:** [AGENTS.md](../AGENTS.md) (policy), [issue-hygiene.md](issue-hygiene.md) (GitHub issue upkeep), [editor-foundation-test-plan.md](editor-foundation-test-plan.md) (manual editor checklist), [.cursor/rules/map-layout.mdc](../.cursor/rules/map-layout.mdc) and [side-panel.mdc](../.cursor/rules/side-panel.mdc) for UI layout.
 
 ## Roles
 
@@ -19,6 +19,18 @@ One agent can play multiple roles, but the report must separate automated eviden
 - Local `.env` with `DATABASE_URL` and `ADMIN_PASSWORD`.
 - Current test checklist: `docs/editor-foundation-test-plan.md`.
 - A running local dev server on the expected port, usually `http://localhost:4321`.
+- Linked GitHub issue number(s), if any — re-read with `gh issue view N` before coding; see [issue-hygiene.md](issue-hygiene.md).
+
+## GitHub issue sync (PR prep)
+
+When the PR implements or partially implements an issue:
+
+1. Re-read the issue; grep for every path/command cited in the body.
+2. Edit the issue body: check off completed AC, fix stale paths, update `Status:` and `Last verified against staging:`.
+3. Comment on the issue with the PR link and which AC items this PR covers.
+4. In the PR body, use `Closes #N` / `Refs #N` and fill the **Issues updated** checklist in the PR template.
+
+Do not close issues with unchecked AC or outdated implementation notes.
 
 ## Change-type matrix
 

--- a/docs/issue-hygiene.md
+++ b/docs/issue-hygiene.md
@@ -1,0 +1,54 @@
+# GitHub Issue Hygiene
+
+Issues in this repo often contain **implementation specifics** — file paths, table names, API routes, acceptance checklists, and design decisions. When agents ship code quickly, those details go stale within days. Treat issues as living specs, not write-once tickets.
+
+Use `gh issue view <n> --repo uplbtools/room-tba` before and after issue-scoped work.
+
+## When to update an issue
+
+| Moment                      | Action                                                                                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Starting work** on `#NNN` | Re-read the issue; grep the codebase for paths/APIs cited in the body. If anything moved or shipped already, edit the issue first (or note what's obsolete). |
+| **Mid-implementation**      | If you change the agreed approach (different script name, schema shape, UI surface), update the issue body — don't only reflect it in code.                  |
+| **Opening a PR**            | Comment on `#NNN` with the PR link and a one-line status. Use `Closes #NNN` / `Refs #NNN` in the PR body when appropriate.                                   |
+| **Before merge**            | Check off completed acceptance criteria in the issue. Update file paths, env vars, and commands to match what actually merged.                               |
+| **After merge**             | Close the issue if scope is fully delivered. Otherwise trim done items, add a **Remaining** section, and file spin-off issues for deferred work.             |
+| **Discovering drift**       | If you find an issue describing code that no longer exists, fix the issue even when you're working on something else (quick edit + `Last verified` date).    |
+
+## What to keep current
+
+Priority order when editing an issue body:
+
+1. **Acceptance criteria** — checkboxes reflect reality (`[x]` done, `[ ]` still open).
+2. **Implementation pointers** — paths (`src/...`, `drizzle/...`), CLI commands, env vars, table/column names.
+3. **Status header** — short line at the top: `Status: in progress | blocked | partially shipped | done`.
+4. **Last verified** — `Last verified against staging: YYYY-MM-DD (@commit or PR #)` so the next agent knows whether to re-audit.
+5. **Related links** — PRs, parent/child issues, docs that replaced the spec.
+
+Do **not** delete historical context — strike through or move obsolete paragraphs under `## Superseded` instead of erasing decisions.
+
+## Issue comment vs body edit
+
+- **Comments:** progress pings, PR links, questions, blockers needing human input.
+- **Body edits:** anything the next implementer must trust (paths, AC, commands, schema).
+
+## Agent session checklist (issue-linked work)
+
+1. `gh issue view N --json title,body,state,labels`
+2. Verify cited files/routes exist; update issue if not.
+3. Implement; commit with `type(scope): summary (refs #N)` when tied to an issue.
+4. Update issue AC + `Last verified` before or immediately after opening the PR.
+5. PR description lists which AC items this PR satisfies and which remain.
+
+## Examples of drift (fix these when you see them)
+
+- Issue says `src/seed-classes.ts` + `info.db` but runtime is Supabase + `scripts/import-….ts`.
+- Issue references `#203` as "current PR" but multi-user auth already merged.
+- Checklist items duplicated in a parent issue and sub-issues — parent should point to children, not repeat stale AC.
+- Open design questions that were decided in code but never marked resolved in the issue.
+
+## Non-goals
+
+- Rewriting every open issue in one pass.
+- Long narrative changelogs in issue bodies — link to PR/`CHANGELOG.md` instead.
+- Closing issues without verifying AC because "we probably done that."


### PR DESCRIPTION
## Summary

Issues hold implementation specifics (paths, schema, AC) that go stale when agents ship fast. This adds explicit upkeep rules and templates.

- **`docs/issue-hygiene.md`** — when/how to update issues (before start, with PR, after merge)
- **`AGENTS.md`** — GitHub issues section + doc map entry
- **Workflow skill + QA process + PR template** — issue sync checklist
- **Implementation task issue template** — Status, Last verified, pointers, AC, Superseded section

## Issues updated

- [x] N/A — meta workflow PR

## Test plan

- [x] `bun test src`
- [x] Prettier on changed markdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and GitHub templates only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`docs/issue-hygiene.md`** as the canonical guide for treating GitHub issues as living specs (when to update AC, paths, status, and `Last verified against staging`, plus comment vs body edits and a `## Superseded` pattern).
> 
> **`AGENTS.md`** gains a doc-map row, a “keep issues current” rule, and a **GitHub issues** section with a before/during/PR/after workflow. The agent workflow skill, **`docs/agentic-qa-process.md`**, and **`.github/pull_request_template.md`** now require issue sync at PR prep (linked issues, AC updates, comments). The PR template adds **Linked issues** and an **Issues updated** checklist.
> 
> New GitHub scaffolding: **Implementation task** issue template (Status, pointers, AC, Superseded) and **`config.yml`** contact link to the repo; blank issues stay enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921b10851813eeddd94abd36a0a009741e4fbdc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->