### PR TITLE
ci(security): add Dependabot, CodeQL, and dependency review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot keeps npm/Bun and GitHub Actions dependencies current.
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      astro:
+        patterns:
+          - "@astrojs/*"
+          - "astro"
+      svelte:
+        patterns:
+          - "svelte*"
+          - "@lucide/svelte"
+      drizzle:
+        patterns:
+          - "drizzle-*"
+      dev-tooling:
+        dependency-type: development
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+  pull_request:
+    branches:
+      - main
+      - staging
+  schedule:
+    # Weekly security scan (Monday 06:00 UTC)
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended adds extra query packs beyond default
+          queries: security-extended
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Astro SSG queries Postgres at build time — skip `bun run build` in CI.
+      # Source-level JS/TS analysis still covers app logic, API routes, and libs.
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: Review dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          # Fail PRs that introduce known-critical vulnerabilities
+          fail-on-severity: critical
+          # Allow a comment summary on the PR for high/moderate findings
+          comment-summary-in-pr: on-failure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,14 +39,28 @@ Full checklist: [docs/issue-hygiene.md](docs/issue-hygiene.md).
 
 Adjust checks to change size. PR CI runs **Prettier + unit tests** (no `DATABASE_URL`); full `bun run lint` (includes ESLint) and build remain local/agent responsibilities before merge.
 
-| Step                                                         | When                                                                   |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| `bun run lint` (or targeted prettier/eslint on edited files) | Always before commit/PR                                                |
-| `bun test src` (or targeted test files)                      | When logic, lib, or API behavior changed                               |
-| `bun run build`                                              | Once before commit/PR on substantive changes (requires `DATABASE_URL`) |
-| Manual browser / editor checklist                            | Map chrome, editor drag/save, side panel UX                            |
+| Step                                                         | When                                                                      |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `bun run lint` (or targeted prettier/eslint on edited files) | Always before commit/PR                                                   |
+| `bun test src` (or targeted test files)                      | When logic, lib, or API behavior changed                                  |
+| `bun run build`                                              | Once before commit/PR on substantive changes (requires `DATABASE_URL`)    |
+| Manual browser / editor checklist                            | Map chrome, editor drag/save, side panel UX                               |
+| **Dependabot PRs**                                           | Run Prettier + tests before merge; read CodeQL / dependency-review checks |
 
 Do not run full build after every small edit. See the workflow skill for session cadence.
+
+## Security automation (GitHub)
+
+Production readiness is backed by repo automation — do not disable without replacing:
+
+| Tool                  | Config                                                                               | What it does                                     |
+| --------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| **Dependabot**        | [`.github/dependabot.yml`](.github/dependabot.yml)                                   | Weekly Bun + GitHub Actions version PRs          |
+| **CodeQL**            | [`.github/workflows/codeql.yml`](.github/workflows/codeql.yml)                       | Static analysis on push/PR + weekly schedule     |
+| **Dependency Review** | [`.github/workflows/dependency-review.yml`](.github/workflows/dependency-review.yml) | Blocks PRs introducing critical CVEs in new deps |
+| **CI**                | [`.github/workflows/ci.yml`](.github/workflows/ci.yml)                               | Prettier + unit tests                            |
+
+Enable **Dependabot security updates** and **secret scanning** in GitHub repo Settings → Code security if not already on (org defaults may apply). CodeQL SARIF appears under Security → Code scanning.
 
 ## Commits
 


### PR DESCRIPTION
## Summary

Production-prep security automation:

- **Dependabot** (`.github/dependabot.yml`) — weekly Bun + GitHub Actions updates, grouped PRs
- **CodeQL** — JS/TS static analysis on push/PR to `main`/`staging` + weekly schedule
- **Dependency Review** — fails PRs that add dependencies with **critical** CVEs

Also documents the stack in `AGENTS.md`.

## Notes

- CodeQL skips `bun run build` (SSG needs `DATABASE_URL`); source-level analysis still covers app/API/lib code.
- Enable **Dependabot security updates** + **secret scanning** in repo Settings if org defaults don't already.

## Test plan

- [ ] CI `verify` passes
- [ ] CodeQL workflow completes on this PR
- [ ] Dependabot config valid (first version PRs may appear Monday)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/security config and agent docs; no application runtime or auth logic is modified.
> 
> **Overview**
> Adds **GitHub security automation** for production readiness: weekly **Dependabot** for Bun (grouped Astro/Svelte/Drizzle/dev deps) and GitHub Actions, **CodeQL** on push/PR to `main`/`staging` plus a Monday schedule (JS/TS with `security-extended`, `bun install` only—no build because SSG needs `DATABASE_URL`), and **Dependency Review** on PRs that **fails on critical** new dependency CVEs with optional PR comments on failure.
> 
> **`AGENTS.md`** documents this stack alongside existing CI, adds a **Dependabot PR** merge checklist (Prettier/tests + CodeQL/dependency-review), and notes enabling Dependabot security updates and secret scanning in repo settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a773adaede563c26d5531d3976372035ec4c0fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->