### PR TITLE
Release: legal pages, community links, status bar rework

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -98,7 +98,8 @@ export default defineConfig({
 
   redirects: {
     "/contribute": "/?contribute=1",
-    "/messenger": "https://m.me/j/AbbjA1ouHCefGTkU",
+    "/discord": "https://discord.uplbtools.me",
+    "/messenger": "https://messenger.uplbtools.me",
   },
 
   // adapter: vercel(),

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,0 +1,92 @@
+---
+import {
+  COMMUNITY_LINKS,
+  LEGAL_LINKS,
+  UPLB_TOOLS_URL,
+} from "@constants/community-links";
+
+const externalCommunityLinks = COMMUNITY_LINKS.filter(
+  (link) => link.href !== UPLB_TOOLS_URL,
+);
+---
+
+<footer class="site-footer">
+  <nav class="site-footer__nav" aria-label="Site links">
+    <span class="site-footer__group">
+      {LEGAL_LINKS.map((link) => <a href={link.href}>{link.label}</a>)}
+    </span>
+    <span class="site-footer__sep" aria-hidden="true">·</span>
+    <span class="site-footer__group">
+      <a href={UPLB_TOOLS_URL} target="_blank" rel="noopener noreferrer">
+        UPLB Tools
+      </a>
+      {
+        externalCommunityLinks.map((link) => (
+          <a href={link.href} target="_blank" rel="noopener noreferrer">
+            {link.label}
+          </a>
+        ))
+      }
+    </span>
+  </nav>
+  <p class="site-footer__note">
+    Room TBA is a student-run project under
+    <a href={UPLB_TOOLS_URL} target="_blank" rel="noopener noreferrer"
+      >UPLB Tools</a
+    >. Not an official UPLB website.
+  </p>
+</footer>
+
+<style>
+  .site-footer {
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid hsl(0, 0%, 88%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    color: hsl(0, 0%, 35%);
+  }
+
+  .site-footer__nav {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.375rem 0.625rem;
+  }
+
+  .site-footer__group {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.375rem 0.625rem;
+  }
+
+  .site-footer__sep {
+    color: hsl(0, 0%, 72%);
+    user-select: none;
+  }
+
+  .site-footer a {
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .site-footer a:hover,
+  .site-footer a:focus-visible {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .site-footer__note {
+    margin: 0;
+    max-width: 36rem;
+  }
+
+  .site-footer__note a {
+    font-weight: 600;
+  }
+</style>

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -1,15 +1,9 @@
 <script lang="ts">
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
-  import GitFork from "@lucide/svelte/icons/git-fork";
-  import MessageCircle from "@lucide/svelte/icons/message-circle";
-  import { slide } from "svelte/transition";
   import { onMount } from "svelte";
   import { registerSW } from "virtual:pwa-register";
-  import { formatCatalogUpdatedDate } from "@constants/data-catalog";
-  import { APP_VERSION_LABEL } from "@constants/version";
   import { getAppData } from "@lib/context";
-  import { slideDismiss, slideReveal } from "@lib/motion";
   import {
     modalStore,
     syncToastStore,
@@ -19,15 +13,18 @@
   import OfflineMaps from "@ui/OfflineMaps.svelte";
   import SyncStatus from "@ui/SyncStatus.svelte";
   import MapChromeSession from "@ui/map-chrome/MapChromeSession.svelte";
-  import MapChromeGhostButton from "@ui/map-chrome/MapChromeGhostButton.svelte";
-  import TermSelector from "@ui/TermSelector.svelte";
+  import StatusBarDetails from "./status-bar/StatusBarDetails.svelte";
+  import StatusBarDirectionsStat from "./status-bar/StatusBarDirectionsStat.svelte";
   import "./map-chrome/map-chrome.css";
+  import "./status-bar/status-bar.css";
   import { MediaQuery } from "svelte/reactivity";
 
-  const appData = getAppData();
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
+
+  const appData = getAppData();
   const { directionCount, totalRooms } = $derived(appData());
   let isOpen = $state(false);
+
   const showFullSync = $derived(isOpen);
   const detailsCompact = $derived(!isOpen);
   const contributorSession = $derived(
@@ -50,7 +47,6 @@
   const progressPercent = $derived(
     totalRooms > 0 ? Math.floor((directionCount / totalRooms) * 100) : 0,
   );
-  const catalogUpdatedLabel = formatCatalogUpdatedDate();
   const showDirectionsProgress = $derived(
     directionCount != null &&
       totalRooms != null &&
@@ -77,12 +73,21 @@
     await adminAuthStore.logout();
     toastStore.show("Signed out.", "info");
   }
+
+  function handleNavAction(id: "contributors" | "editor-login") {
+    if (id === "contributors") {
+      modalStore.openModal("landing");
+      return;
+    }
+    adminAuthStore.openLogin();
+  }
 </script>
 
 <div class="status-bar" class:is-open={isOpen}>
-  <div class="status-head">
+  <div class="status-bar__head">
     <button
-      class="status-toggle"
+      type="button"
+      class="status-bar__toggle"
       aria-expanded={isOpen}
       aria-controls="status-bar-details"
       onclick={() => (isOpen = !isOpen)}
@@ -96,12 +101,12 @@
     </button>
 
     {#if isOpen}
-      <div class="status-utilities">
+      <div class="status-bar__utilities">
         <SyncStatus inline compact={false} expanded={showFullSync} />
-        <span class="status-sep" aria-hidden="true">·</span>
+        <span class="status-bar__sep" aria-hidden="true">·</span>
         <OfflineMaps compact={false} />
         {#if showSessionUtilities}
-          <span class="status-sep" aria-hidden="true">·</span>
+          <span class="status-bar__sep" aria-hidden="true">·</span>
           <MapChromeSession
             roleLabel={sessionRoleLabel}
             displayName={sessionDisplayName}
@@ -111,7 +116,7 @@
         {/if}
       </div>
     {:else}
-      <div class="status-primary">
+      <div class="status-bar__primary">
         <SyncStatus inline compact={detailsCompact} expanded={showFullSync} />
         <OfflineMaps compact={detailsCompact} />
         {#if showSessionChip}
@@ -124,339 +129,33 @@
           />
         {/if}
         {#if showDirectionsProgress}
-          <span class="status-sep" aria-hidden="true">·</span>
-          <span
-            class="status-collapsed-count"
-            title="{directionCount} of {totalRooms} rooms with directions"
-          >
-            <span class="status-count-wide"
-              >{directionCount} of {totalRooms} rooms with directions</span
-            >
-            <span class="status-count-narrow"
-              >{directionCount}/{totalRooms} w/ directions</span
-            >
-          </span>
+          <span class="status-bar__sep" aria-hidden="true">·</span>
+          <StatusBarDirectionsStat
+            {directionCount}
+            {totalRooms}
+            {progressPercent}
+            variant="collapsed"
+          />
         {/if}
       </div>
     {/if}
   </div>
 
   {#if isOpen}
-    <div
-      class="status-meta"
-      id="status-bar-details"
-      in:slide={slideReveal(reducedMotion.current)}
-      out:slide={slideDismiss(reducedMotion.current)}
-    >
-      {#if showDirectionsProgress}
-        <div
-          class="status-meta-progress"
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={totalRooms}
-          aria-valuenow={directionCount}
-          aria-label="{directionCount} of {totalRooms} rooms with directions"
-        >
-          <div class="map-chrome-progress">
-            <div
-              class="map-chrome-progress__value"
-              style:width={`${progressPercent}%`}
-            ></div>
-          </div>
-          <span class="status-meta-count">
-            <span class="status-count-wide"
-              >{directionCount} of {totalRooms} rooms with directions</span
-            >
-            <span class="status-count-narrow"
-              >{directionCount}/{totalRooms} w/ directions</span
-            >
-          </span>
-        </div>
-
-        <span class="status-sep" aria-hidden="true">·</span>
-      {/if}
-      <span class="status-meta-term">
-        <TermSelector />
-      </span>
-      <span class="status-sep" aria-hidden="true">·</span>
-      <span class="status-meta-updated">
-        Updated {catalogUpdatedLabel}
-      </span>
-
-      <span class="status-meta-links">
-        <span class="status-sep" aria-hidden="true">·</span>
-        <a
-          href="/messenger"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="map-chrome-ghost-link status-meta-link"
-        >
-          <MessageCircle size={14} aria-hidden="true" />
-          Contact
-        </a>
-
-        <span class="status-sep" aria-hidden="true">·</span>
-        <MapChromeGhostButton
-          variant="muted"
-          onclick={() => modalStore.openModal("landing")}
-        >
-          Contributors
-        </MapChromeGhostButton>
-
-        {#if !adminAuthStore.isLoggedIn}
-          <span class="status-sep" aria-hidden="true">·</span>
-          <MapChromeGhostButton
-            variant="muted"
-            onclick={() => adminAuthStore.openLogin()}
-          >
-            Editor sign in
-          </MapChromeGhostButton>
-        {/if}
-
-        <span class="status-sep" aria-hidden="true">·</span>
-        <a href="/changelog" class="map-chrome-ghost-link status-meta-link">
-          <GitFork size={14} aria-hidden="true" />
-          {APP_VERSION_LABEL}
-        </a>
-      </span>
-    </div>
+    <StatusBarDetails
+      reducedMotion={reducedMotion.current}
+      {directionCount}
+      {totalRooms}
+      {progressPercent}
+      {showDirectionsProgress}
+      showEditorLogin={!adminAuthStore.isLoggedIn}
+      onAction={handleNavAction}
+    />
   {/if}
 </div>
 
 <style>
   * {
     pointer-events: auto;
-  }
-
-  div.status-bar {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    justify-content: center;
-    width: 100%;
-    min-width: 0;
-    overflow: visible;
-    font-size: 0.8125rem;
-    font-weight: 600;
-    line-height: 1.2;
-    gap: 0.0625rem;
-    flex: 1 1 auto;
-    min-height: 2rem;
-    box-sizing: border-box;
-    padding: 0.0625rem 0.125rem;
-
-    &.is-open {
-      gap: 0.0625rem;
-      padding: 0.0625rem 0.125rem 0.125rem;
-    }
-
-    .status-head {
-      display: flex;
-      align-items: center;
-      gap: 0.3125rem;
-      min-width: 0;
-      min-height: 1.25rem;
-      flex-wrap: nowrap;
-    }
-
-    .status-toggle {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.375rem;
-      background: none;
-      border: none;
-      font: inherit;
-      padding: 0;
-      cursor: pointer;
-      min-width: 0;
-      flex: 0 0 auto;
-      color: inherit;
-    }
-
-    .status-toggle:focus-visible {
-      outline: 2px solid hsl(5, 53%, 32%);
-      outline-offset: 2px;
-      border-radius: 0.25rem;
-    }
-
-    .status-primary,
-    .status-utilities {
-      display: flex;
-      flex: 1 1 auto;
-      align-items: center;
-      gap: 0.3125rem;
-      min-width: 0;
-      overflow: hidden;
-      flex-wrap: nowrap;
-    }
-
-    .status-primary :global(.sync-status--inline),
-    .status-utilities :global(.sync-status--inline) {
-      border-right: none;
-      padding-right: 0;
-      margin-right: 0;
-    }
-
-    .status-utilities {
-      font-size: 0.75rem;
-      font-weight: 500;
-    }
-
-    .status-sep {
-      flex-shrink: 0;
-      color: hsl(0, 0%, 68%);
-      font-weight: 400;
-      line-height: 1;
-      user-select: none;
-    }
-
-    .status-meta {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 0.1875rem 0.3125rem;
-      width: 100%;
-      min-width: 0;
-      font-size: 0.75rem;
-      font-weight: 500;
-      line-height: 1.2;
-      color: hsl(0, 0%, 28%);
-    }
-
-    .status-meta-links {
-      display: inline-flex;
-      flex: 1 1 auto;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 0.1875rem 0.3125rem;
-      min-width: 0;
-    }
-
-    .status-meta-progress {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-      flex: 0 1 auto;
-      min-width: 0;
-      max-width: 100%;
-    }
-
-    .status-meta-progress :global(.map-chrome-progress) {
-      width: min(3rem, 11vw);
-      flex: 0 0 auto;
-      height: 0.375rem;
-    }
-
-    .status-meta-count {
-      flex-shrink: 0;
-      font-variant-numeric: tabular-nums;
-      font-weight: 600;
-      color: hsl(0, 0%, 22%);
-    }
-
-    .status-count-wide {
-      display: inline;
-    }
-
-    .status-count-narrow {
-      display: none;
-    }
-
-    .status-collapsed-count {
-      flex: 0 1 auto;
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      font-size: inherit;
-      font-weight: 600;
-      font-variant-numeric: tabular-nums;
-      color: hsl(0, 0%, 28%);
-    }
-
-    .status-meta-updated {
-      flex-shrink: 1;
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .status-meta-term {
-      flex: 1 1 auto;
-      min-width: 0;
-      max-width: 100%;
-    }
-
-    .status-meta :global(.map-chrome-ghost-link),
-    .status-meta :global(.map-chrome-ghost-btn) {
-      font-size: 0.75rem;
-      font-weight: 600;
-      padding: 0 0.1875rem;
-    }
-
-    .status-meta-link {
-      white-space: nowrap;
-    }
-  }
-
-  @media (max-width: 48rem) {
-    div.status-bar {
-      min-height: 1.75rem;
-      padding: 0.0625rem 0.0625rem;
-
-      &.is-open {
-        padding: 0.0625rem 0.0625rem 0.125rem;
-      }
-
-      .status-head {
-        gap: 0.25rem;
-      }
-
-      .status-primary {
-        gap: 0.25rem;
-        flex-wrap: nowrap;
-      }
-
-      .status-utilities {
-        gap: 0.25rem;
-        flex-wrap: nowrap;
-      }
-
-      .status-meta {
-        gap: 0.125rem 0.25rem;
-      }
-
-      .status-meta-links {
-        gap: 0.125rem 0.25rem;
-      }
-
-      .status-meta-progress {
-        flex-basis: auto;
-      }
-    }
-  }
-
-  @media (max-width: 1200px) {
-    .status-meta-updated,
-    .status-meta-updated + .status-meta-links .status-sep:first-child {
-      display: none;
-    }
-  }
-
-  @media (max-width: 22rem) {
-    .status-meta-progress :global(.map-chrome-progress) {
-      width: 2.5rem;
-    }
-
-    .status-count-wide {
-      display: none;
-    }
-
-    .status-count-narrow {
-      display: inline;
-    }
   }
 </style>

--- a/src/components/svelte/modal/LandingGuideSteps.svelte
+++ b/src/components/svelte/modal/LandingGuideSteps.svelte
@@ -101,6 +101,15 @@
       {/if}
     {/each}
   </ol>
+
+  <p class="guide-footnote">
+    Questions or want to volunteer? Use <strong>Suggest an edit</strong> on the
+    map, or reach us on
+    <a href="/discord" target="_blank" rel="noopener noreferrer">Discord</a>
+    /
+    <a href="/messenger" target="_blank" rel="noopener noreferrer">Messenger</a
+    >.
+  </p>
 </section>
 
 <style>
@@ -353,6 +362,20 @@
     color: hsl(5, 35%, 38%);
     flex-shrink: 0;
     align-self: center;
+  }
+
+  .guide-footnote {
+    margin: 0.125rem 0 0;
+    font-size: 0.6875rem;
+    line-height: 1.45;
+    color: hsl(0, 0%, 32%);
+  }
+
+  .guide-footnote a {
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
   }
 
   @media screen and (max-width: 36rem) {

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { modalStore } from "@lib/store.svelte";
   import { contributors, designers } from "@constants/contributors";
+  import { UPLB_TOOLS_URL } from "@constants/community-links";
   import {
     fetchGithubContributors,
     type GithubContributor,
@@ -136,12 +137,46 @@
 
         <p class="repo-link">
           <a
-            href="https://github.com/smmariquit/room-tba"
+            href="https://github.com/uplbtools/room-tba"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-link">View repo on GitHub</a
           >
         </p>
+
+        <section class="community-block">
+          <h3>Join the community</h3>
+          <p class="section-note">
+            Help keep campus data accurate — suggest edits in the map, chat with
+            volunteers, or say hi on our channels.
+          </p>
+          <ul class="community-links">
+            <li>
+              <a
+                href={UPLB_TOOLS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-link">UPLB Tools</a
+              >
+            </li>
+            <li>
+              <a
+                href="/discord"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-link">Discord</a
+              >
+            </li>
+            <li>
+              <a
+                href="/messenger"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-link">Messenger</a
+              >
+            </li>
+          </ul>
+        </section>
 
         <section class="people-block">
           <h3>Design</h3>
@@ -171,6 +206,11 @@
   </div>
 
   <footer class="actions">
+    <p class="legal-hint">
+      <a href="/privacy" class="inline-link">Privacy</a>
+      ·
+      <a href="/terms" class="inline-link">Terms</a>
+    </p>
     <button class="primary-btn" onclick={handleGetStarted}>Get Started</button>
     <label class="checkbox-label">
       <input type="checkbox" bind:checked={dontShowAgain} />
@@ -336,6 +376,38 @@
   .repo-link {
     margin: 0;
     font-size: 0.8125rem;
+  }
+
+  .community-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.375rem;
+    width: 100%;
+  }
+
+  .community-block h3 {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: hsl(5, 53%, 28%);
+  }
+
+  .community-links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.375rem 0.75rem;
+    font-size: 0.8125rem;
+  }
+
+  .legal-hint {
+    margin: 0;
+    font-size: 0.75rem;
+    color: hsl(0, 0%, 38%);
   }
 
   .actions {

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -17,6 +17,7 @@
   import EventCards from "./EventCards.svelte";
   import Suggestions from "./Suggestions.svelte";
   import BuildingTypeFilterBar from "@ui/BuildingTypeFilterBar.svelte";
+  import TermSelector from "@ui/TermSelector.svelte";
   import TransitFilterChip from "@ui/TransitFilterChip.svelte";
   import TransitRoutePanel from "@ui/TransitRoutePanel.svelte";
   import { jeepneyStore } from "@lib/store.svelte";
@@ -333,11 +334,12 @@
         </div>
       </div>
 
-      {#if mobile.current || chrome.showSearchSuggestions}
+      {#if mobile.current || chrome.showSearchSuggestions || chrome.editMode}
         <div class="map-search-chrome__chips">
           {#if mobile.current}
             <MapDimensionToggle compact />
           {/if}
+          <TermSelector />
           {#if chrome.showSearchSuggestions}
             {#if showIdleEventsChrome}
               <button
@@ -761,6 +763,12 @@
     flex: 0 0 auto;
     min-width: 0;
     padding: 0 !important;
+  }
+
+  .map-search-chrome__chips :global(.term-selector) {
+    flex: 0 0 auto;
+    min-width: 0;
+    max-width: min(100%, 18rem);
   }
 
   .map-search-chrome__chips :global(.transit-filter-chip) {

--- a/src/components/svelte/status-bar/StatusBarDetails.svelte
+++ b/src/components/svelte/status-bar/StatusBarDetails.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { slide } from "svelte/transition";
+  import { formatCatalogUpdatedDate } from "@constants/data-catalog";
+  import { APP_VERSION_LABEL } from "@constants/version";
+  import { statusBarNavGroups } from "@constants/status-bar-links";
+  import { slideDismiss, slideReveal } from "@lib/motion";
+  import StatusBarDirectionsStat from "./StatusBarDirectionsStat.svelte";
+  import StatusBarLinkGroups from "./StatusBarLinkGroups.svelte";
+  import type { StatusBarNavGroup } from "@constants/status-bar-links";
+
+  type Props = {
+    reducedMotion: boolean;
+    directionCount: number;
+    totalRooms: number;
+    progressPercent: number;
+    showDirectionsProgress: boolean;
+    showEditorLogin: boolean;
+    onAction: (id: "contributors" | "editor-login") => void;
+  };
+
+  const {
+    reducedMotion,
+    directionCount,
+    totalRooms,
+    progressPercent,
+    showDirectionsProgress,
+    showEditorLogin,
+    onAction,
+  }: Props = $props();
+
+  const catalogUpdatedLabel = formatCatalogUpdatedDate();
+  const navGroups = $derived<StatusBarNavGroup[]>(
+    statusBarNavGroups({
+      versionLabel: APP_VERSION_LABEL,
+      showEditorLogin,
+    }),
+  );
+</script>
+
+<div
+  class="status-bar__details"
+  id="status-bar-details"
+  in:slide={slideReveal(reducedMotion)}
+  out:slide={slideDismiss(reducedMotion)}
+>
+  {#if showDirectionsProgress}
+    <section class="status-bar__section" aria-label="Directions coverage">
+      <StatusBarDirectionsStat
+        {directionCount}
+        {totalRooms}
+        {progressPercent}
+        variant="expanded"
+      />
+    </section>
+  {/if}
+
+  <section
+    class="status-bar__section status-bar__section--catalog"
+    aria-label="Data freshness"
+  >
+    <span class="status-bar__catalog">Updated {catalogUpdatedLabel}</span>
+  </section>
+
+  <nav
+    class="status-bar__section status-bar__section--nav"
+    aria-label="App links"
+  >
+    <StatusBarLinkGroups groups={navGroups} {onAction} />
+  </nav>
+</div>

--- a/src/components/svelte/status-bar/StatusBarDirectionsStat.svelte
+++ b/src/components/svelte/status-bar/StatusBarDirectionsStat.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  type Props = {
+    directionCount: number;
+    totalRooms: number;
+    progressPercent: number;
+    variant: "collapsed" | "expanded";
+  };
+
+  const { directionCount, totalRooms, progressPercent, variant }: Props =
+    $props();
+</script>
+
+{#if variant === "expanded"}
+  <div
+    class="status-bar__directions"
+    role="progressbar"
+    aria-valuemin={0}
+    aria-valuemax={totalRooms}
+    aria-valuenow={directionCount}
+    aria-label="{directionCount} of {totalRooms} rooms with directions"
+  >
+    <div class="map-chrome-progress">
+      <div
+        class="map-chrome-progress__value"
+        style:width={`${progressPercent}%`}
+      ></div>
+    </div>
+    <span class="status-bar__directions-count">
+      <span class="status-bar__count-wide"
+        >{directionCount} of {totalRooms} rooms with directions</span
+      >
+      <span class="status-bar__count-narrow"
+        >{directionCount}/{totalRooms} w/ directions</span
+      >
+    </span>
+  </div>
+{:else}
+  <span
+    class="status-bar__directions-collapsed"
+    title="{directionCount} of {totalRooms} rooms with directions"
+  >
+    <span class="status-bar__count-wide"
+      >{directionCount} of {totalRooms} rooms with directions</span
+    >
+    <span class="status-bar__count-narrow"
+      >{directionCount}/{totalRooms} w/ directions</span
+    >
+  </span>
+{/if}

--- a/src/components/svelte/status-bar/StatusBarLinkGroups.svelte
+++ b/src/components/svelte/status-bar/StatusBarLinkGroups.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import ExternalLink from "@lucide/svelte/icons/external-link";
+  import GitFork from "@lucide/svelte/icons/git-fork";
+  import MessageCircle from "@lucide/svelte/icons/message-circle";
+  import MessagesSquare from "@lucide/svelte/icons/messages-square";
+  import MapChromeGhostButton from "@ui/map-chrome/MapChromeGhostButton.svelte";
+  import type { StatusBarNavGroup } from "@constants/status-bar-links";
+
+  type Props = {
+    groups: StatusBarNavGroup[];
+    onAction: (id: "contributors" | "editor-login") => void;
+  };
+
+  const { groups, onAction }: Props = $props();
+</script>
+
+{#each groups as group (group.id)}
+  <div class="status-bar__nav-group" data-status-nav-group={group.id}>
+    {#each group.items as item (item.id)}
+      {#if item.kind === "link"}
+        <a
+          href={item.href}
+          class="map-chrome-ghost-link status-bar__nav-link"
+          target={item.external ? "_blank" : undefined}
+          rel={item.external ? "noopener noreferrer" : undefined}
+        >
+          {#if item.icon === "external"}
+            <ExternalLink size={14} aria-hidden="true" />
+          {:else if item.icon === "discord"}
+            <MessagesSquare size={14} aria-hidden="true" />
+          {:else if item.icon === "messenger"}
+            <MessageCircle size={14} aria-hidden="true" />
+          {:else if item.icon === "version"}
+            <GitFork size={14} aria-hidden="true" />
+          {/if}
+          {item.label}
+        </a>
+      {:else}
+        <MapChromeGhostButton variant="muted" onclick={() => onAction(item.id)}>
+          {item.label}
+        </MapChromeGhostButton>
+      {/if}
+    {/each}
+  </div>
+{/each}

--- a/src/components/svelte/status-bar/status-bar.css
+++ b/src/components/svelte/status-bar/status-bar.css
@@ -1,0 +1,226 @@
+.status-bar {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
+  overflow: visible;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.2;
+  gap: 0.0625rem;
+  flex: 1 1 auto;
+  min-height: 2rem;
+  box-sizing: border-box;
+  padding: 0.0625rem 0.125rem;
+}
+
+.status-bar.is-open {
+  gap: 0.0625rem;
+  padding: 0.0625rem 0.125rem 0.125rem;
+}
+
+.status-bar__head {
+  display: flex;
+  align-items: center;
+  gap: 0.3125rem;
+  min-width: 0;
+  min-height: 1.25rem;
+  flex-wrap: nowrap;
+}
+
+.status-bar__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: none;
+  border: none;
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+  min-width: 0;
+  flex: 0 0 auto;
+  color: inherit;
+}
+
+.status-bar__toggle:focus-visible {
+  outline: 2px solid hsl(5, 53%, 32%);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}
+
+.status-bar__primary,
+.status-bar__utilities {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 0.3125rem;
+  min-width: 0;
+  overflow: hidden;
+  flex-wrap: nowrap;
+}
+
+.status-bar__primary :global(.sync-status--inline),
+.status-bar__utilities :global(.sync-status--inline) {
+  border-right: none;
+  padding-right: 0;
+  margin-right: 0;
+}
+
+.status-bar__utilities {
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.status-bar__sep {
+  flex-shrink: 0;
+  color: hsl(0, 0%, 68%);
+  font-weight: 400;
+  line-height: 1;
+  user-select: none;
+}
+
+.status-bar__details {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.375rem;
+  width: 100%;
+  min-width: 0;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.2;
+  color: hsl(0, 0%, 28%);
+}
+
+.status-bar__section {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.1875rem 0.3125rem;
+  min-width: 0;
+}
+
+.status-bar__section--nav {
+  gap: 0.25rem 0.375rem;
+}
+
+.status-bar__catalog {
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-bar__directions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.status-bar__directions :global(.map-chrome-progress) {
+  width: min(3rem, 11vw);
+  flex: 0 0 auto;
+  height: 0.375rem;
+}
+
+.status-bar__directions-count {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: hsl(0, 0%, 22%);
+}
+
+.status-bar__directions-collapsed {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: inherit;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: hsl(0, 0%, 28%);
+}
+
+.status-bar__count-wide {
+  display: inline;
+}
+
+.status-bar__count-narrow {
+  display: none;
+}
+
+.status-bar__nav-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.1875rem 0.3125rem;
+  min-width: 0;
+}
+
+.status-bar :global(.map-chrome-ghost-link),
+.status-bar :global(.map-chrome-ghost-btn) {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0 0.1875rem;
+}
+
+.status-bar__nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.1875rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 48rem) {
+  .status-bar {
+    min-height: 1.75rem;
+    padding: 0.0625rem 0.0625rem;
+  }
+
+  .status-bar.is-open {
+    padding: 0.0625rem 0.0625rem 0.125rem;
+  }
+
+  .status-bar__head {
+    gap: 0.25rem;
+  }
+
+  .status-bar__primary,
+  .status-bar__utilities {
+    gap: 0.25rem;
+    flex-wrap: nowrap;
+  }
+
+  .status-bar__details {
+    gap: 0.3125rem;
+  }
+}
+
+@media (max-width: 1200px) {
+  .status-bar__section--catalog {
+    display: none;
+  }
+}
+
+@media (max-width: 22rem) {
+  .status-bar__directions :global(.map-chrome-progress) {
+    width: 2.5rem;
+  }
+
+  .status-bar__count-wide {
+    display: none;
+  }
+
+  .status-bar__count-narrow {
+    display: inline;
+  }
+}

--- a/src/constants/community-links.ts
+++ b/src/constants/community-links.ts
@@ -1,0 +1,16 @@
+/** External UPLB Tools community and org links (also wired as short redirects in astro.config). */
+
+export const UPLB_TOOLS_URL = "https://uplbtools.me";
+export const DISCORD_URL = "https://discord.uplbtools.me";
+export const MESSENGER_URL = "https://messenger.uplbtools.me";
+
+export const COMMUNITY_LINKS = [
+  { label: "UPLB Tools", href: UPLB_TOOLS_URL },
+  { label: "Discord", href: DISCORD_URL },
+  { label: "Messenger", href: MESSENGER_URL },
+] as const;
+
+export const LEGAL_LINKS = [
+  { label: "Privacy", href: "/privacy" },
+  { label: "Terms", href: "/terms" },
+] as const;

--- a/src/constants/status-bar-links.ts
+++ b/src/constants/status-bar-links.ts
@@ -1,0 +1,104 @@
+import { LEGAL_LINKS, UPLB_TOOLS_URL } from "@constants/community-links";
+
+/** Icon keys resolved in StatusBarLinkGroup — add new icons there when extending. */
+export type StatusBarIcon = "external" | "discord" | "messenger" | "version";
+
+export type StatusBarLinkItem = {
+  kind: "link";
+  id: string;
+  label: string;
+  href: string;
+  external?: boolean;
+  icon?: StatusBarIcon;
+};
+
+export type StatusBarActionItem = {
+  kind: "action";
+  id: "contributors" | "editor-login";
+  label: string;
+};
+
+export type StatusBarNavItem = StatusBarLinkItem | StatusBarActionItem;
+
+export type StatusBarNavGroup = {
+  id: string;
+  items: StatusBarNavItem[];
+};
+
+/** Primary community + org links (external). */
+export const STATUS_BAR_COMMUNITY_GROUP: StatusBarNavGroup = {
+  id: "community",
+  items: [
+    {
+      kind: "link",
+      id: "uplb-tools",
+      label: "UPLB Tools",
+      href: UPLB_TOOLS_URL,
+      external: true,
+      icon: "external",
+    },
+    {
+      kind: "link",
+      id: "discord",
+      label: "Discord",
+      href: "/discord",
+      external: true,
+      icon: "discord",
+    },
+    {
+      kind: "link",
+      id: "messenger",
+      label: "Messenger",
+      href: "/messenger",
+      external: true,
+      icon: "messenger",
+    },
+  ],
+};
+
+/** In-app actions (rendered via StatusBar action handler). */
+export const STATUS_BAR_APP_ACTIONS: StatusBarActionItem[] = [
+  { kind: "action", id: "contributors", label: "Contributors" },
+  { kind: "action", id: "editor-login", label: "Editor sign in" },
+];
+
+/** Legal + release metadata links. */
+export function buildStatusBarMetaGroup(
+  versionLabel: string,
+): StatusBarNavGroup {
+  return {
+    id: "meta",
+    items: [
+      ...LEGAL_LINKS.map((link) => ({
+        kind: "link" as const,
+        id: link.href,
+        label: link.label,
+        href: link.href,
+      })),
+      {
+        kind: "link",
+        id: "changelog",
+        label: versionLabel,
+        href: "/changelog",
+        icon: "version",
+      },
+    ],
+  };
+}
+
+/** Groups shown in the expanded status panel (order matters). */
+export function statusBarNavGroups(options: {
+  versionLabel: string;
+  showEditorLogin: boolean;
+}): StatusBarNavGroup[] {
+  const appItems: StatusBarNavItem[] = [
+    STATUS_BAR_APP_ACTIONS[0]!,
+    ...(options.showEditorLogin ? [STATUS_BAR_APP_ACTIONS[1]!] : []),
+  ];
+
+  return [
+    STATUS_BAR_COMMUNITY_GROUP,
+    { id: "app", items: appItems },
+    buildStatusBarMetaGroup(options.versionLabel),
+  ];
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,6 +20,8 @@ type Props = {
   imagePath?: string;
   robots?: string;
   structuredData?: StructuredData[];
+  /** Map app shell only — static pages (changelog, legal) should disable this. */
+  showAppLoadingShell?: boolean;
 };
 
 const {
@@ -29,6 +31,7 @@ const {
   imagePath = "/socmed.png",
   robots = "index,follow",
   structuredData = [],
+  showAppLoadingShell = true,
 }: Props = Astro.props;
 
 const canonicalUrl = absoluteUrl(canonicalPath);
@@ -116,104 +119,117 @@ const imageUrl = absoluteUrl(imagePath);
     </style>
   </head>
   <body>
-    <div
-      id="app-loading-shell"
-      class="app-loading-shell"
-      role="status"
-      aria-live="polite"
-    >
-      <div class="app-loading-shell__card">
-        <div class="app-loading-mark" aria-hidden="true">
-          <div class="app-loading-mark__loader">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="28"
-              height="28"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              class="app-loading-spinner app-loading-spinner--spin"
-              ><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg
-            >
-          </div>
-          <div class="app-loading-mark__pin">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2.25"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              ><path
-                d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
-              ></path><circle cx="12" cy="10" r="3"></circle></svg
-            >
+    {
+      showAppLoadingShell ? (
+        <div
+          id="app-loading-shell"
+          class="app-loading-shell"
+          role="status"
+          aria-live="polite"
+        >
+          <div class="app-loading-shell__card">
+            <div class="app-loading-mark" aria-hidden="true">
+              <div class="app-loading-mark__loader">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="28"
+                  height="28"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="app-loading-spinner app-loading-spinner--spin"
+                >
+                  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                </svg>
+              </div>
+              <div class="app-loading-mark__pin">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.25"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <>
+                    <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
+                    <circle cx="12" cy="10" r="3" />
+                  </>
+                </svg>
+              </div>
+            </div>
+            <div class="app-loading-mark__context" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="app-loading-mark__context-icon"
+              >
+                <>
+                  <path d="M10 12h4" />
+                  <path d="M10 8h4" />
+                  <path d="M14 21v-3a2 2 0 0 0-4 0v3" />
+                  <path d="M6 10H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2h-2" />
+                  <path d="M6 21V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16" />
+                </>
+              </svg>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="app-loading-mark__context-icon"
+              >
+                <>
+                  <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
+                  <circle cx="12" cy="10" r="3" />
+                </>
+              </svg>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="app-loading-mark__context-icon"
+              >
+                <>
+                  <path d="M10 10v.2A3 3 0 0 1 8.8 15H5a2 2 0 0 1-2-2v-1a2 2 0 0 1 2-2z" />
+                  <path d="M14 10v.2A3 3 0 0 0 15.2 15H19a2 2 0 0 0 2-2v-1a2 2 0 0 0-2-2z" />
+                  <path d="M12 22v-3" />
+                  <path d="M12 15V9m-4 0a4 4 0 0 1 8 0v6a4 4 0 0 1-8 0Z" />
+                </>
+              </svg>
+            </div>
+            <p class="app-loading-shell__message">Loading campus data</p>
+            <p class="app-loading-shell__splash" aria-hidden="true">
+              {LOADING_SPLASH_FIRST}
+            </p>
           </div>
         </div>
-        <div class="app-loading-mark__context" aria-hidden="true">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="13"
-            height="13"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="app-loading-mark__context-icon"
-            ><path d="M10 12h4"></path><path d="M10 8h4"></path><path
-              d="M14 21v-3a2 2 0 0 0-4 0v3"></path><path
-              d="M6 10H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2h-2"
-            ></path><path d="M6 21V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16"
-            ></path></svg
-          >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="13"
-            height="13"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="app-loading-mark__context-icon"
-            ><path
-              d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
-            ></path><circle cx="12" cy="10" r="3"></circle></svg
-          >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="13"
-            height="13"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="app-loading-mark__context-icon"
-            ><path
-              d="M10 10v.2A3 3 0 0 1 8.8 15H5a2 2 0 0 1-2-2v-1a2 2 0 0 1 2-2z"
-            ></path><path
-              d="M14 10v.2A3 3 0 0 0 15.2 15H19a2 2 0 0 0 2-2v-1a2 2 0 0 0-2-2z"
-            ></path><path d="M12 22v-3"></path><path
-              d="M12 15V9m-4 0a4 4 0 0 1 8 0v6a4 4 0 0 1-8 0Z"></path></svg
-          >
-        </div>
-        <p class="app-loading-shell__message">Loading campus data</p>
-        <p class="app-loading-shell__splash" aria-hidden="true">
-          {LOADING_SPLASH_FIRST}
-        </p>
-      </div>
-    </div>
+      ) : null
+    }
     <slot />
     <Analytics />
     <script is:inline>
@@ -221,14 +237,10 @@ const imageUrl = absoluteUrl(imagePath);
         function dismissLoadingShell() {
           document.getElementById("app-loading-shell")?.remove();
         }
-        // AppRoot removes the shell on mount; if hydration never starts (e.g. dev HMR
-        // corruption), don't leave the static HTML blocker up indefinitely.
         document.addEventListener(
           "astro:before-prehydration",
           dismissLoadingShell,
-          {
-            once: true,
-          },
+          { once: true },
         );
         window.addEventListener("DOMContentLoaded", function () {
           setTimeout(dismissLoadingShell, 12_000);

--- a/src/pages/api/github/contributors.ts
+++ b/src/pages/api/github/contributors.ts
@@ -7,7 +7,7 @@ import {
 
 export const prerender = false;
 
-const GITHUB_REPO = "smmariquit/room-tba";
+const GITHUB_REPO = "uplbtools/room-tba";
 const CACHE_SECONDS = 60 * 60;
 
 type GithubApiContributor = {

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -1,6 +1,7 @@
 ---
 export const prerender = true;
 import Layout from "@layouts/Layout.astro";
+import SiteFooter from "../components/SiteFooter.astro";
 import * as changelog from "../../CHANGELOG.md";
 ---
 
@@ -8,14 +9,15 @@ import * as changelog from "../../CHANGELOG.md";
   title="Changelog | Room TBA"
   description="Track recent Room TBA updates, including room data, course offerings, and site improvements."
   canonicalPath="/changelog"
+  showAppLoadingShell={false}
 >
   <main class="changelog-page">
     <a href="/" class="back-link">Back to Room TBA</a>
 
     <header class="hero">
       <p class="eyebrow">Release notes</p>
-      <h1>Changelog</h1>
-      <p>
+      <h1 class="changelog-page__title">Changelog</h1>
+      <p class="hero__lede">
         Room TBA is a living document and is updated regularly, especially every
         term, to reflect latest changes in course offerings, room status, and
         other relevant information. Aside from the data itself, the website also
@@ -24,24 +26,37 @@ import * as changelog from "../../CHANGELOG.md";
         release.
       </p>
     </header>
-    <!-- <main> -->
-    <div set:html={changelog.compiledContent()} class="entries" />
+
+    <div class="entries" set:html={changelog.compiledContent()} />
+
+    <SiteFooter />
   </main>
+
   <script is:inline>
-    const changelogContainer = document.querySelector("div.entries");
-    const changelogArticles = document.createElement("DIV");
-    let currentArticle = null;
-    changelogContainer.childNodes.forEach((val) => {
-      if (val.nodeName == "H1" || val.nodeName == "H2") {
-        currentArticle = document.createElement("ARTICLE");
-        currentArticle.classList.add("entry");
-        changelogArticles.appendChild(currentArticle);
+    (function () {
+      const container = document.querySelector(".changelog-page div.entries");
+      if (!container) return;
+
+      const fragment = document.createDocumentFragment();
+      let article = null;
+
+      while (container.firstChild) {
+        const node = container.firstChild;
+        if (node.nodeName === "H1" || node.nodeName === "H2") {
+          article = document.createElement("article");
+          article.className = "entry";
+          fragment.appendChild(article);
+        }
+        if (!article) {
+          article = document.createElement("article");
+          article.className = "entry";
+          fragment.appendChild(article);
+        }
+        article.appendChild(node);
       }
 
-      currentArticle.appendChild(changelogContainer.removeChild(val));
-    });
-    changelogContainer.append(...changelogArticles.childNodes);
-    console.log(changelogContainer);
+      container.replaceChildren(fragment);
+    })();
   </script>
 </Layout>
 
@@ -61,10 +76,7 @@ import * as changelog from "../../CHANGELOG.md";
       Cantarell,
       "Open Sans",
       "Helvetica Neue",
-      sans-serif,
-      "Times New Roman",
-      Times,
-      serif;
+      sans-serif;
   }
 
   .back-link {
@@ -82,26 +94,26 @@ import * as changelog from "../../CHANGELOG.md";
     margin-bottom: 2rem;
   }
 
-  .eyebrow,
-  .date,
-  .version {
+  .eyebrow {
     text-transform: uppercase;
     letter-spacing: 0.08em;
     font-size: 0.75rem;
     color: hsl(0, 0%, 40%);
+    margin: 0;
   }
 
-  h1 {
+  .changelog-page__title {
     font-size: clamp(2.25rem, 5vw, 3.5rem);
     line-height: 1;
     margin: 0;
   }
 
-  .hero p:last-child {
+  .hero__lede {
     max-width: 38rem;
     color: hsl(0, 0%, 30%);
     font-size: 1rem;
     line-height: 1.6;
+    margin: 0;
   }
 
   .entries {
@@ -115,42 +127,33 @@ import * as changelog from "../../CHANGELOG.md";
     padding: 1.25rem;
     background: white;
     box-shadow: 0 2px 0.5rem 0 hsla(0, 0%, 0%, 0.06);
-    h1,
-    h2 {
-      font-size: 1.5rem;
-    }
-    > :is(h3) {
-      margin-block: 0.5rem;
-    }
-    > :is(h1, h2) {
-      margin-block: 1rem;
-    }
-    > ul {
-      margin-bottom: 1rem;
-    }
-    h3 {
-      font-size: 1rem;
-    }
   }
 
-  .entry-header {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    align-items: start;
-    margin-bottom: 1rem;
+  .entry :is(h1, h2) {
+    font-size: 1.5rem;
+    margin-block: 0 0.75rem;
   }
 
-  ul {
-    margin: 0;
+  .entry h3 {
+    font-size: 1rem;
+    margin-block: 0.75rem 0.25rem;
+  }
+
+  .entry ul {
+    margin: 0 0 1rem;
     padding-left: 1.25rem;
     color: hsl(0, 0%, 25%);
     line-height: 1.65;
   }
 
+  .entry a {
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+  }
+
   @media screen and (max-width: 600px) {
-    .entry-header {
-      flex-direction: column;
+    .changelog-page {
+      padding: 1.5rem 0.875rem 3rem;
     }
   }
 </style>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,232 @@
+---
+export const prerender = true;
+import Layout from "@layouts/Layout.astro";
+import SiteFooter from "../components/SiteFooter.astro";
+import { UPLB_TOOLS_URL } from "@constants/community-links";
+---
+
+<Layout
+  title="Privacy Policy | Room TBA"
+  description="How Room TBA handles data, analytics, editor accounts, and offline storage."
+  canonicalPath="/privacy"
+  showAppLoadingShell={false}
+>
+  <main class="legal-page">
+    <a href="/" class="back-link">Back to Room TBA</a>
+
+    <header class="hero">
+      <p class="eyebrow">Legal</p>
+      <h1>Privacy Policy</h1>
+      <p class="lede">
+        Last updated: June 29, 2026. Room TBA is operated by
+        <a href={UPLB_TOOLS_URL} target="_blank" rel="noopener noreferrer"
+          >UPLB Tools</a
+        > volunteers. This policy explains what we collect and why.
+      </p>
+    </header>
+
+    <article class="legal-body">
+      <section>
+        <h2>What Room TBA is</h2>
+        <p>
+          Room TBA is a free campus map and schedule finder for UPLB students.
+          It is <strong>not</strong> an official University of the Philippines Los
+          Baños website. Class and room data are maintained by volunteers and may
+          be incomplete or out of date.
+        </p>
+      </section>
+
+      <section>
+        <h2>Information we process</h2>
+        <h3>Browsing the map (no account)</h3>
+        <ul>
+          <li>
+            <strong>Usage analytics</strong> — We use Vercel Analytics on the public
+            site to understand traffic patterns (page views, referrers). We do not
+            intentionally collect your name or student number through analytics.
+          </li>
+          <li>
+            <strong>Device storage</strong> — The app caches campus data in your browser
+            (PGlite / IndexedDB) and may store preferences such as recent searches,
+            term selection, and “don’t show again” for the welcome modal.
+          </li>
+          <li>
+            <strong>Location (optional)</strong> — If you enable location on your
+            device, the map may use your coordinates locally to show where you are.
+            We do not persist your live GPS track on our servers.
+          </li>
+        </ul>
+
+        <h3>Contributors and editors (signed in)</h3>
+        <ul>
+          <li>
+            <strong>Account identifiers</strong> — Editor/contributor accounts store
+            a username, hashed password, role, and optional display name.
+          </li>
+          <li>
+            <strong>Edit proposals and published changes</strong> — Suggestions and
+            approved edits record who submitted or approved them (`edited_by` and
+            related audit fields).
+          </li>
+          <li>
+            <strong>Session cookies</strong> — Signed-in sessions use httpOnly cookies
+            scoped to this site.
+          </li>
+        </ul>
+
+        <h3>Server and hosting</h3>
+        <ul>
+          <li>
+            Campus data lives in a Postgres database (Supabase) accessed by our
+            API routes. Hosting and logs are provided by Vercel and our database
+            provider under their respective privacy policies.
+          </li>
+          <li>
+            Optional event image uploads may be stored in Cloudflare R2 when
+            configured.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>What we do not sell</h2>
+        <p>
+          We do not sell your personal information. We do not run third-party ad
+          networks on Room TBA.
+        </p>
+      </section>
+
+      <section>
+        <h2>Community channels</h2>
+        <p>
+          If you contact us on Discord or Messenger, those platforms handle
+          messages under their own policies. Do not send passwords or sensitive
+          personal data in public channels.
+        </p>
+      </section>
+
+      <section>
+        <h2>Your choices</h2>
+        <ul>
+          <li>Clear site data in your browser to remove local caches.</li>
+          <li>
+            Sign out of editor/contributor sessions when using shared devices.
+          </li>
+          <li>
+            Ask a maintainer to deactivate an editor account you no longer need.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Changes</h2>
+        <p>
+          We may update this policy as the app evolves. Material changes will be
+          reflected on this page with an updated date.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact</h2>
+        <p>
+          Questions about privacy? Reach the team via
+          <a href="/messenger" target="_blank" rel="noopener noreferrer"
+            >Messenger</a
+          >
+          or
+          <a href="/discord" target="_blank" rel="noopener noreferrer"
+            >Discord</a
+          >.
+        </p>
+      </section>
+    </article>
+
+    <SiteFooter />
+  </main>
+</Layout>
+
+<style>
+  .legal-page {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 2rem 1rem 4rem;
+  }
+
+  .back-link {
+    display: inline-flex;
+    margin-bottom: 1.5rem;
+    text-decoration: none;
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+  }
+
+  .hero {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    color: hsl(0, 0%, 40%);
+    margin: 0;
+  }
+
+  h1 {
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    line-height: 1.05;
+    margin: 0;
+  }
+
+  .lede {
+    margin: 0;
+    max-width: 38rem;
+    color: hsl(0, 0%, 28%);
+    line-height: 1.6;
+  }
+
+  .lede a {
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+  }
+
+  .legal-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    color: hsl(0, 0%, 22%);
+    line-height: 1.65;
+  }
+
+  .legal-body h2 {
+    font-size: 1.125rem;
+    margin: 0 0 0.375rem;
+    color: hsl(5, 53%, 28%);
+  }
+
+  .legal-body h3 {
+    font-size: 0.9375rem;
+    margin: 0.75rem 0 0.25rem;
+  }
+
+  .legal-body p,
+  .legal-body ul {
+    margin: 0;
+  }
+
+  .legal-body ul {
+    padding-left: 1.25rem;
+  }
+
+  .legal-body li + li {
+    margin-top: 0.375rem;
+  }
+
+  .legal-body a {
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+  }
+</style>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -19,6 +19,8 @@ export const GET: APIRoute = async () => {
   const urls = [
     "/",
     "/changelog",
+    "/privacy",
+    "/terms",
     "/room/",
     "/building/",
     "/division/",

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,227 @@
+---
+export const prerender = true;
+import Layout from "@layouts/Layout.astro";
+import SiteFooter from "../components/SiteFooter.astro";
+import { UPLB_TOOLS_URL } from "@constants/community-links";
+---
+
+<Layout
+  title="Terms of Service | Room TBA"
+  description="Terms for using Room TBA, contributing data, and editor accounts."
+  canonicalPath="/terms"
+  showAppLoadingShell={false}
+>
+  <main class="legal-page">
+    <a href="/" class="back-link">Back to Room TBA</a>
+
+    <header class="hero">
+      <p class="eyebrow">Legal</p>
+      <h1>Terms of Service</h1>
+      <p class="lede">
+        Last updated: June 29, 2026. By using Room TBA you agree to these terms.
+        The service is provided by
+        <a href={UPLB_TOOLS_URL} target="_blank" rel="noopener noreferrer"
+          >UPLB Tools</a
+        > volunteers.
+      </p>
+    </header>
+
+    <article class="legal-body">
+      <section>
+        <h2>The service</h2>
+        <p>
+          Room TBA helps UPLB students find rooms, buildings, schedules, and
+          campus events on a map. We provide the site <strong>as is</strong> — free
+          of charge, without guaranteed uptime, accuracy, or completeness.
+        </p>
+      </section>
+
+      <section>
+        <h2>Not official UPLB</h2>
+        <p>
+          Room TBA is a community tool. It is not affiliated with, endorsed by,
+          or operated by the University of the Philippines Los Baños. Do not
+          rely on it as your only source for enrollment, room assignments, or
+          official announcements.
+        </p>
+      </section>
+
+      <section>
+        <h2>Data accuracy</h2>
+        <p>
+          Schedules and locations are crowd-maintained and imported from sources
+          such as AMIS exports. They can be wrong, stale, or missing —
+          especially during change of matriculation. Always verify critical
+          information with your instructor, department, or official university
+          channels.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contributing and editing</h2>
+        <ul>
+          <li>
+            <strong>In-app contributions</strong> — Use “Suggest an edit” or contributor
+            tools inside the map. Do not submit false or malicious data.
+          </li>
+          <li>
+            <strong>Review</strong> — Volunteer editors may approve, reject, or request
+            changes to proposals before they go live.
+          </li>
+          <li>
+            <strong>Editor accounts</strong> — Accounts are issued at maintainer discretion.
+            Misuse may result in deactivation without notice.
+          </li>
+          <li>
+            <strong>License to published edits</strong> — By submitting approved content
+            you grant UPLB Tools a license to display and distribute that campus data
+            as part of the open project (see repository MIT license for code).
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Acceptable use</h2>
+        <p>You agree not to:</p>
+        <ul>
+          <li>Attempt to break, scrape, or overload the service.</li>
+          <li>Bypass authentication or tamper with other users’ edits.</li>
+          <li>
+            Upload illegal, harassing, or unrelated content through editor
+            tools.
+          </li>
+          <li>Impersonate official UPLB offices or staff.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Disclaimer of warranties</h2>
+        <p>
+          THE SERVICE IS PROVIDED “AS IS” WITHOUT WARRANTIES OF ANY KIND,
+          EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A
+          PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+        </p>
+      </section>
+
+      <section>
+        <h2>Limitation of liability</h2>
+        <p>
+          To the fullest extent permitted by law, UPLB Tools volunteers and
+          contributors are not liable for any indirect, incidental, or
+          consequential damages arising from your use of Room TBA — including
+          missed classes, wrong rooms, or lost data.
+        </p>
+      </section>
+
+      <section>
+        <h2>Changes</h2>
+        <p>
+          We may modify these terms or discontinue features. Continued use after
+          changes are posted constitutes acceptance of the updated terms.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact</h2>
+        <p>
+          Questions? Reach us on
+          <a href="/discord" target="_blank" rel="noopener noreferrer"
+            >Discord</a
+          >
+          or
+          <a href="/messenger" target="_blank" rel="noopener noreferrer"
+            >Messenger</a
+          >, or open an issue on
+          <a
+            href="https://github.com/uplbtools/room-tba"
+            target="_blank"
+            rel="noopener noreferrer">GitHub</a
+          >.
+        </p>
+      </section>
+    </article>
+
+    <SiteFooter />
+  </main>
+</Layout>
+
+<style>
+  .legal-page {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 2rem 1rem 4rem;
+  }
+
+  .back-link {
+    display: inline-flex;
+    margin-bottom: 1.5rem;
+    text-decoration: none;
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+  }
+
+  .hero {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    color: hsl(0, 0%, 40%);
+    margin: 0;
+  }
+
+  h1 {
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    line-height: 1.05;
+    margin: 0;
+  }
+
+  .lede {
+    margin: 0;
+    max-width: 38rem;
+    color: hsl(0, 0%, 28%);
+    line-height: 1.6;
+  }
+
+  .lede a {
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+  }
+
+  .legal-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    color: hsl(0, 0%, 22%);
+    line-height: 1.65;
+  }
+
+  .legal-body h2 {
+    font-size: 1.125rem;
+    margin: 0 0 0.375rem;
+    color: hsl(5, 53%, 28%);
+  }
+
+  .legal-body p,
+  .legal-body ul {
+    margin: 0;
+  }
+
+  .legal-body ul {
+    padding-left: 1.25rem;
+  }
+
+  .legal-body li + li {
+    margin-top: 0.375rem;
+  }
+
+  .legal-body a {
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+  }
+</style>


### PR DESCRIPTION
## Summary

Promote staging to production with legal pages (`/privacy`, `/terms`), community link footer and redirects, status bar modularization, changelog fixes, and term selector relocation.

Merged via #303.

## Test plan

- [ ] Production `/privacy`, `/terms`, `/changelog` render correctly
- [ ] Status bar and search chips at mobile widths
- [ ] `/discord` and `/messenger` redirects live

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly static content, link/redirect updates, and UI refactors with no auth or data-model changes; verify redirects and mobile search/status bar layout in production.
> 
> **Overview**
> Adds **static legal pages** at `/privacy` and `/terms`, a shared **`SiteFooter`** (legal + UPLB Tools / Discord / Messenger), and registers **`/privacy` and `/terms` in the sitemap**. Changelog and legal routes use **`showAppLoadingShell={false}`** so visitors do not see the map loading shell.
> 
> Centralizes community URLs in **`community-links.ts`** and adds Astro redirects for **`/discord`** and **`/messenger`** (Messenger moves from a raw Facebook URL to `messenger.uplbtools.me`). GitHub contributor fetching and landing/repo links point at **`uplbtools/room-tba`**.
> 
> **Refactors the status bar** into subcomponents and **`status-bar-links`**, expanding the panel with grouped community links, privacy/terms, and Discord/Messenger (replacing a single Contact link). **`TermSelector`** moves from the status bar into **search chrome chips**, with chips also shown in edit mode.
> 
> Landing modal and guide copy gain **community and legal** links; changelog entry grouping script is cleaned up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ace060a779c054dab089443774837200b70e36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->