### PR TITLE
Release: README mermaid and example fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # security-extended adds extra query packs beyond default
@@ -54,6 +54,6 @@ jobs:
       # Source-level JS/TS analysis still covers app logic, API routes, and libs.
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           # Fail PRs that introduce known-critical vulnerabilities
           fail-on-severity: critical

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     if: "${{ !contains(github.event.head_commit.message, '[skip ci]') }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
         if: steps.pkg.outputs.published == 'true'
         continue-on-error: true
         id: sync_pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore(release): ${{ steps.pkg.outputs.version }} [skip ci]"
           title: "chore(release): ${{ steps.pkg.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Bun](https://img.shields.io/badge/bun-1.3+-black?style=flat-square&logo=bun)](https://bun.sh)
 [![Astro](https://img.shields.io/badge/Astro-7-BC52EE?style=flat-square&logo=astro)](https://astro.build)
 
-_Schedules, buildings, jeepney routes, and “how do I even get to CASA1” — on one campus map._
+_Schedules, buildings, jeepney routes, and "where is PSLH 1?" on one campus map._
 
 [Open the map](https://room-tba.uplbtools.me) · [Report wrong data](https://github.com/uplbtools/room-tba/issues/new/choose) · [Changelog](https://room-tba.uplbtools.me/changelog)
 
@@ -17,32 +17,13 @@ _Schedules, buildings, jeepney routes, and “how do I even get to CASA1” — 
 
 ---
 
-```
-        Mt. Makiling
-            ▲
-            │     🚌 Jeepney routes (when you admit you’re lost)
-            │
-    ┌───────┴───────────────────────────────────┐
-    │  UPLB · Los Baños                         │
-    │                                           │
-    │   [ Search: "PhySci" / "ICS 314" / … ]    │
-    │              ↓                            │
-    │         📍 pin on map                     │
-    │              ↓                            │
-    │   "Ah, *there*."                          │
-    └───────────────────────────────────────────┘
-            │
-            ▼
-     (still walk fast — class started 5 min ago)
-```
-
 ## What this is
 
-**Room TBA** is a map-first web app for [UPLB](https://uplb.edu.ph) students. You search a room code, building nickname, or course; the app puts it on an interactive campus map, shows schedules when we have them, and keeps working when the signal doesn’t.
+**Room TBA** is a map-first web app for [UPLB](https://uplb.edu.ph) students. You search a room code, building nickname, or course; the app puts it on an interactive campus map, shows schedules when we have them, and keeps working when the signal drops.
 
-No account needed to browse. Editors and contributors can fix data **inside the same app** (login popup on the map — not a separate admin dungeon).
+No account needed to browse. Editors and contributors fix data in the same app (login popup on the map, not a separate admin site).
 
-> **Data note:** Room and class listings are updated each term by volunteers. Right now the default view targets **2nd Semester AY 2025–2026**. Wrong schedule? [Open an issue](https://github.com/uplbtools/room-tba/issues/new/choose) — that’s how the dataset gets better.
+> **Data note:** Room and class listings are updated each term by volunteers. The default view targets **2nd Semester AY 2025–2026**. Wrong schedule? [Open an issue](https://github.com/uplbtools/room-tba/issues/new/choose). That is how the dataset gets better.
 
 ---
 
@@ -50,10 +31,10 @@ No account needed to browse. Editors and contributors can fix data **inside the 
 
 | You want to…                         | Room TBA does…                                                                  |
 | ------------------------------------ | ------------------------------------------------------------------------------- |
-| Find **ICS 314** or **CASA1**        | Search + alias matching (`PhySci`, `HUM`, building nicknames)                   |
-| See **who’s in that room this sem**  | Term-aware class schedules + timetable view                                     |
+| Find **PSLH 1** or **PhySci**        | Search + alias matching (`PhySci`, `HUM`, building nicknames)                   |
+| See **who's in that room this sem**  | Term-aware class schedules + timetable view                                     |
 | Figure out **where the building is** | MapLibre campus map, pins, directions, Google Maps handoff                      |
-| Survive **dead zones**               | PWA + offline cache (PGlite in the browser; map tiles after you’ve loaded them) |
+| Survive **dead zones**               | PWA + offline cache (PGlite in the browser; map tiles after you've loaded them) |
 | Check **events & org stuff**         | Campus events on the map with locations and routes                              |
 | Ride the **jeep** without guessing   | Jeepney route overlays                                                          |
 | Get **un-lost in 3D**                | Optional building view / terrain toward Makiling (online tiles)                 |
@@ -61,13 +42,13 @@ No account needed to browse. Editors and contributors can fix data **inside the 
 <details>
 <summary><strong>Editor / contributor mode</strong> (password from the team)</summary>
 
-| Power                            | Where                                                                                                           |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Move building & dorm pins        | Map edit mode (pencil)                                                                                          |
-| Fix room/building/college copy   | Side panel → Edit                                                                                               |
-| Suggest edits without publishing | **Suggest an edit** → admin review queue                                                                        |
-| Upload event posters             | Event editor + R2 image upload (when configured)                                                                |
-| Undo a pin drag                  | Toolbar undo/redo (session) — durable history coming ([#202](https://github.com/uplbtools/room-tba/issues/202)) |
+| Power                            | Where                                                                                                            |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Move building & dorm pins        | Map edit mode (pencil)                                                                                           |
+| Fix room/building/college copy   | Side panel → Edit                                                                                                |
+| Suggest edits without publishing | **Suggest an edit** → admin review queue                                                                         |
+| Upload event posters             | Event editor + R2 image upload (when configured)                                                                 |
+| Undo a pin drag                  | Toolbar undo/redo (session); durable history tracked in [#202](https://github.com/uplbtools/room-tba/issues/202) |
 
 Login: **`/?editor=login`** or the shield / status bar in the app. `/admin` URLs redirect back into the map.
 
@@ -75,7 +56,7 @@ Login: **`/?editor=login`** or the shield / status bar in the app. `/admin` URLs
 
 ---
 
-## How a search actually works
+## How a search works
 
 ```mermaid
 flowchart LR
@@ -95,22 +76,22 @@ flowchart LR
   PGlite --> Map
 ```
 
-1. **First visit online** — app syncs buildings, rooms, classes, aliases, events into browser storage.
-2. **You search** — local data first; network when keys say something changed.
-3. **You pick a result** — map flies to the pin; side panel shows schedules, directions, share link.
-4. **You go offline** — last sync still answers “saan ang room na ‘to?” (map tiles need prior download / visit).
+1. **First visit online:** app syncs buildings, rooms, classes, aliases, and events into browser storage.
+2. **You search:** local data first; network when sync keys say something changed.
+3. **You pick a result:** map flies to the pin; side panel shows schedules, directions, and a share link.
+4. **You go offline:** last sync still answers "saan ang room na 'to?" (map tiles need a prior download or visit).
 
 ---
 
 ## Stack (for the curious)
 
-| Layer     | Choice                                                                              | Why it’s here                                                 |
+| Layer     | Choice                                                                              | Why it's here                                                 |
 | --------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------- |
 | App shell | [Astro 7](https://astro.build) + [Svelte 5](https://svelte.dev)                     | SEO pages for every room/building **and** a snappy map island |
 | Runtime   | [Bun](https://bun.sh)                                                               | Dev speed, tests, installs                                    |
-| Database  | [Supabase](https://supabase.com) Postgres + [Drizzle ORM](https://orm.drizzle.team) | Real relational data, migrations in `drizzle/`                |
-| Offline   | [PGlite](https://pglite.dev) (`idb://site-data`)                                    | Actual SQL in the browser, not a sad JSON blob                |
-| Maps      | [MapLibre GL](https://maplibre.org) + OSM/MapTiler                                  | Open tiles, no Mapbox invoice panic                           |
+| Database  | [Supabase](https://supabase.com) Postgres + [Drizzle ORM](https://orm.drizzle.team) | Relational data, migrations in `drizzle/`                     |
+| Offline   | [PGlite](https://pglite.dev) (`idb://site-data`)                                    | SQL in the browser, not a hand-rolled JSON cache              |
+| Maps      | [MapLibre GL](https://maplibre.org) + OSM/MapTiler                                  | Open tiles, no vendor lock-in on basemaps                     |
 | Images    | Cloudflare R2 (optional)                                                            | Event uploads via `/api/admin/upload`                         |
 | Host      | [Vercel](https://vercel.com)                                                        | SSR + API routes                                              |
 | CI        | Prettier, unit tests, CodeQL, Dependabot                                            | See [AGENTS.md](AGENTS.md)                                    |
@@ -122,7 +103,7 @@ flowchart LR
 ### You need
 
 - [Bun](https://bun.sh) 1.3+
-- A **Supabase** Postgres URL (`DATABASE_URL`) — session pooler recommended for dev
+- A **Supabase** Postgres URL (`DATABASE_URL`); session pooler recommended for dev
 - `ADMIN_PASSWORD` if you want editor login locally
 
 ### Setup
@@ -137,7 +118,7 @@ bun install
 bun dev
 ```
 
-Open **http://localhost:4321**. Without `DATABASE_URL`, the dev server starts but pages that hit the DB will 500 — that’s intentional, not a haunted build.
+Open **http://localhost:4321**. Without `DATABASE_URL`, the dev server starts but pages that hit the DB will 500. That is expected.
 
 ### Commands worth knowing
 
@@ -151,7 +132,7 @@ Open **http://localhost:4321**. Without `DATABASE_URL`, the dev server starts bu
 | `bunx drizzle-kit studio` | Browse/edit Postgres visually                      |
 | `bun run seed:aliases`    | Seed building aliases from `public/room_info.json` |
 
-Legacy **`data/info.db`** SQLite is only for old seed/export scripts — **not** what production runs on.
+Legacy **`data/info.db`** SQLite is only for old seed/export scripts. Production does not use it.
 
 Optional env vars (R2 uploads, Supabase Auth client): see [`.env.example`](.env.example).
 
@@ -159,16 +140,17 @@ Optional env vars (R2 uploads, Supabase Auth client): see [`.env.example`](.env.
 
 ## Repo map
 
-```
-room-tba/
-├── src/
-│   ├── pages/          # Astro routes + /api/* endpoints
-│   ├── components/     # Svelte UI (map, search, editor chrome)
-│   └── lib/            # Stores, services, PGlite sync, Drizzle callers
-├── drizzle/            # Postgres schema + SQL migrations (apply before deploy!)
-├── docs/               # QA checklists, map layout matrix, issue hygiene
-├── public/             # Static assets, basemap JSON, legacy room_info
-└── AGENTS.md           # How agents & contributors should work in this repo
+```mermaid
+flowchart TB
+  root[room-tba]
+  root --> src
+  root --> drizzle["drizzle/ schema + migrations"]
+  root --> docs["docs/ QA and layout notes"]
+  root --> public["public/ static assets"]
+  root --> agents[AGENTS.md]
+  src --> pages["pages/ routes + /api"]
+  src --> components["components/ Svelte UI"]
+  src --> lib["lib/ stores, services, PGlite sync"]
 ```
 
 Deep editor QA: [`docs/editor-foundation-test-plan.md`](docs/editor-foundation-test-plan.md)  
@@ -180,22 +162,22 @@ PR checklist: [`docs/agentic-qa-process.md`](docs/agentic-qa-process.md)
 
 We merge through GitHub. Rough flow:
 
-1. **Find or file an issue** — implementation details live there; keep them updated ([`docs/issue-hygiene.md`](docs/issue-hygiene.md)).
+1. **Find or file an issue.** Implementation details live there; keep them updated ([`docs/issue-hygiene.md`](docs/issue-hygiene.md)).
 2. **Branch off `staging`**, hack, run `bun test src` + Prettier.
-3. **PR to `staging`** — template asks for QA evidence; CI runs Prettier + tests.
+3. **PR to `staging`.** The template asks for QA evidence; CI runs Prettier + tests.
 4. **Human pass** for map/editor UI at 320px if you touched chrome.
 
-Commit messages: [Conventional Commits](https://www.conventionalcommits.org/) (`feat(map): …`, `fix(api): …`) — semantic-release uses them on `main`.
+Commit messages: [Conventional Commits](https://www.conventionalcommits.org/) (`feat(map): …`, `fix(api): …`). semantic-release uses them on `main`.
 
 **Good first issues:** [good first issue](https://github.com/uplbtools/room-tba/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · **Data fixes:** label `data` · **QA passes:** label `qa`
 
-No separate admin dashboard — if you can view it on the map, you should eventually edit it there.
+No separate admin dashboard. If you can view it on the map, you should eventually edit it there.
 
 ---
 
 ## Releases
 
-Version follows semver. Pushes to `main` run [semantic-release](https://semantic-release.gitbook.io/) (skip with `[skip ci]` in commit message). The in-app status bar shows `vX.Y.Z` from `package.json`.
+Version follows semver. Pushes to `main` run [semantic-release](https://semantic-release.gitbook.io/) (skip with `[skip ci]` in the commit message). The in-app status bar shows `vX.Y.Z` from `package.json`.
 
 Dry run: `bun run release:dry`
 
@@ -216,18 +198,18 @@ Dry run: `bun run release:dry`
 | Eunice Almeyda          | Logo                                   |
 | Mary Gwyneth Telmosa    | UI design                              |
 
-Org: [uplbtools](https://github.com/uplbtools) · Campus tool, not an official UPLB product — just students tired of wandering.
+Org: [uplbtools](https://github.com/uplbtools) · Campus tool, not an official UPLB product.
 
 ---
 
 ## License
 
-[MIT](LICENSE) — use it, fork it, teach with it. If you deploy a fork for another campus, change the data, not just the logo.
+[MIT](LICENSE). Use it, fork it, teach with it. If you deploy a fork for another campus, change the data, not just the logo.
 
 ---
 
 <div align="center">
 
-**[room-tba.uplbtools.me](https://room-tba.uplbtools.me)** · made for people who’ve asked “Saan ba ang ___?” at least once this week
+**[room-tba.uplbtools.me](https://room-tba.uplbtools.me)** · for people who've asked "Saan ba ang ___?" at least once this week
 
 </div>

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@astrojs/vercel": "^11.0.0",
         "@aws-sdk/client-s3": "^3.1075.0",
         "@electric-sql/pglite": "^0.5.3",
-        "@lucide/svelte": "^1.21.0",
+        "@lucide/svelte": "^1.22.0",
         "@maplibre/maplibre-gl-directions": "^0.9.1",
         "@supabase/ssr": "^0.12.0",
         "@supabase/supabase-js": "^2.108.2",
@@ -533,7 +533,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@lucide/svelte": ["@lucide/svelte@1.21.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-MEv//A7Jv3kHukZowv/DWp1MAtUzJKYwtJsmnQ7X98lCgtac3z3NbaToDl3Q6jO3gS9sougFpcD+t+YuxOkRMw=="],
+    "@lucide/svelte": ["@lucide/svelte@1.22.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-eaNC3GGu9ma7mviB9vPL6OnawXqxdvRnoAQSq5l15mBlsuwD7kozZ7pzPXSlT6OwSl7hz4qTk+ZU3OEewwi5gQ=="],
 
     "@mapbox/jsonlint-lines-primitives": ["@mapbox/jsonlint-lines-primitives@2.0.3", "", {}, "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@astrojs/vercel": "^11.0.0",
     "@aws-sdk/client-s3": "^3.1075.0",
     "@electric-sql/pglite": "^0.5.3",
-    "@lucide/svelte": "^1.21.0",
+    "@lucide/svelte": "^1.22.0",
     "@maplibre/maplibre-gl-directions": "^0.9.1",
     "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.108.2",


### PR DESCRIPTION
## Summary

Promote staging to production with README cleanup (#306): Mermaid repo diagram, no ASCII art, real search examples (PSLH 1 / PhySci).

## Test plan

- [ ] README renders on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dependency/CI pin updates only; no application or runtime logic changes.
> 
> **Overview**
> **README** is rewritten for a more neutral tone: the campus ASCII diagram is removed, the **Repo map** becomes a Mermaid tree, and student examples use **PSLH 1** / **PhySci** instead of ICS/CASA1. Wording is tightened across setup, contributing, and stack sections without changing product behavior.
> 
> **CI and release automation** bump pinned GitHub Actions: `actions/checkout` v4→v7 everywhere; CodeQL init/analyze v3→v4; `dependency-review-action` v4→v5; `create-pull-request` v6→v8 on release sync PRs.
> 
> **Dependencies:** `@lucide/svelte` **1.21.0 → 1.22.0** in `package.json` and `bun.lock` (icon-only UI dependency).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7fa0e0a348ddc5ae66e363e3a12f2a2007361e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->