### PR TITLE
docs(readme): tighten feature table and stack section

### DIFF
--- a/.cursor/skills/room-tba-agent-workflow/SKILL.md
+++ b/.cursor/skills/room-tba-agent-workflow/SKILL.md
@@ -42,3 +42,4 @@ Commit policy, Conventional Commits format, and GPG signing: [AGENTS.md § Commi
 3. For map/side-panel changes, confirm applicable Cursor rules were followed.
 4. **Issue sync:** for each linked `#NNN`, update AC/paths/status per [docs/issue-hygiene.md](../../docs/issue-hygiene.md); comment with the PR URL.
 5. Push with `-u origin HEAD` only when the user asked to push/open a PR.
+6. **Base branch:** feature work → `staging`. "PR to main" / prod ship → `staging` → `main` release only ([AGENTS.md § Branches and pull requests](../../AGENTS.md#branches-and-pull-requests)).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,24 @@ Read the right doc for the task — do not rely on this file alone for detailed 
 - **Preserve the dirty tree.** Do not revert unrelated user changes unless explicitly asked.
 - **Keep scope tight.** Avoid opportunistic refactors outside the request.
 - **Keep GitHub issues current** when work is tied to `#NNN` — issues hold implementation specifics that drift fast. See [docs/issue-hygiene.md](docs/issue-hygiene.md).
+- **Infer intent over typos.** User messages are often rushed — read for what they mean, not only literal wording. Common patterns:
+  - **"PR to main" / "merge to prod" / "ship it"** → promote **`staging` → `main`** (release PR), not a feature branch opened against `main`. See [Branches and pull requests](#branches-and-pull-requests).
+  - **"PR to staging"** → feature branch → `staging` (default for new work).
+  - Minor typos (`pr`, `stagign`, `mrege`, doubled letters, missing spaces) — do not ask for clarification when context makes the goal obvious.
 
-## GitHub issues
+## Branches and pull requests
+
+Default flow: **feature branch → `staging` → `main`**.
+
+| User says (approx.)               | Do this                                                | Do **not** do this                                     |
+| --------------------------------- | ------------------------------------------------------ | ------------------------------------------------------ |
+| Open a PR / PR to staging         | `gh pr create --base staging --head <feature-branch>`  | —                                                      |
+| PR to main / merge to prod / ship | Open (or merge) **`staging` → `main`** release PR only | `--base main --head <feature-branch>` for routine work |
+| Merge the feature PR              | Squash/merge into **`staging`** first                  | Skip `staging` and land features directly on `main`    |
+
+- **`main`** is production; semantic-release runs there.
+- **`staging`** is integration — feature PRs land here first unless the user explicitly asks for a hotfix straight to `main`.
+- When the user says **"PR to main"**, they usually mean **get it to production**, not "set the GitHub PR base branch to `main`." Confirm only if they truly want a feature branch targeting `main` (rare hotfix).
 
 Issues are living specs (paths, schema, acceptance criteria). When coding quickly, update them in the same session as the code:
 

--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ No account needed to browse. Editors and contributors fix data in the same app (
 
 ## What you can do (student mode)
 
-| You want to…                         | Room TBA does…                                                                  |
-| ------------------------------------ | ------------------------------------------------------------------------------- |
-| Find **PSLH 1** or **PhySci**        | Search + alias matching (`PhySci`, `HUM`, building nicknames)                   |
-| See **who's in that room this sem**  | Term-aware class schedules + timetable view                                     |
-| Figure out **where the building is** | MapLibre campus map, pins, directions, Google Maps handoff                      |
-| Survive **dead zones**               | PWA + offline cache (PGlite in the browser; map tiles after you've loaded them) |
-| Check **events & org stuff**         | Campus events on the map with locations and routes                              |
-| Ride the **jeep** without guessing   | Jeepney route overlays                                                          |
-| Get **un-lost in 3D**                | Optional building view / terrain toward Makiling (online tiles)                 |
+| Goal                          | How                                        |
+| ----------------------------- | ------------------------------------------ |
+| Find **PSLH 1** or **PhySci** | Search + aliases (`PhySci`, `HUM`, …)      |
+| Room schedule this sem        | Term filter + timetable                    |
+| Building location             | Map, pins, directions, Google Maps         |
+| Offline / bad signal          | PWA + local cache; tiles if already loaded |
+| Campus events                 | Events on map with routes                  |
+| Jeepney routes                | Route overlays on map                      |
+| 3D view                       | Buildings + Makiling terrain (online)      |
 
 <details>
 <summary><strong>Editor / contributor mode</strong> (password from the team)</summary>
@@ -83,18 +83,17 @@ flowchart LR
 
 ---
 
-## Stack (for the curious)
+## Stack
 
-| Layer     | Choice                                                                              | Why it's here                                                 |
-| --------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| App shell | [Astro 7](https://astro.build) + [Svelte 5](https://svelte.dev)                     | SEO pages for every room/building **and** a snappy map island |
-| Runtime   | [Bun](https://bun.sh)                                                               | Dev speed, tests, installs                                    |
-| Database  | [Supabase](https://supabase.com) Postgres + [Drizzle ORM](https://orm.drizzle.team) | Relational data, migrations in `drizzle/`                     |
-| Offline   | [PGlite](https://pglite.dev) (`idb://site-data`)                                    | SQL in the browser, not a hand-rolled JSON cache              |
-| Maps      | [MapLibre GL](https://maplibre.org) + OSM/MapTiler                                  | Open tiles, no vendor lock-in on basemaps                     |
-| Images    | Cloudflare R2 (optional)                                                            | Event uploads via `/api/admin/upload`                         |
-| Host      | [Vercel](https://vercel.com)                                                        | SSR + API routes                                              |
-| CI        | Prettier, unit tests, CodeQL, Dependabot                                            | See [AGENTS.md](AGENTS.md)                                    |
+- [Astro 7](https://astro.build) + [Svelte 5](https://svelte.dev)
+- [Bun](https://bun.sh)
+- [Supabase](https://supabase.com) Postgres + [Drizzle](https://orm.drizzle.team) (`drizzle/`)
+- [PGlite](https://pglite.dev) in the browser for offline data
+- [MapLibre GL](https://maplibre.org), OSM / MapTiler tiles
+- [Vercel](https://vercel.com) for SSR and API routes
+- Cloudflare R2 for event uploads (optional)
+
+Contributor notes: [AGENTS.md](AGENTS.md)
 
 ---
 


### PR DESCRIPTION
## Summary

- Shorten the student features table (Goal / How, no quippy rows)
- Replace "Stack (for the curious)" + Layer/Choice/Why table with a plain bullet list
- **AGENTS.md:** "PR to main" = `staging` → `main` release only; typo/intent guidance for agents

## Test plan

- [x] `bunx prettier --check README.md AGENTS.md`
- [ ] README renders on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> **README** trims the student “What you can do” table to **Goal / How** rows with shorter copy, and replaces the layered “Stack (for the curious)” table with a plain bullet list plus a pointer to `AGENTS.md`.
> 
> **Agent workflow** adds explicit **branch and PR rules**: default **feature → `staging` → `main`**, interpret “PR to main” / “ship” as a **`staging` → `main` release PR** (not a feature branch against `main`), and a checklist item in the room-tba workflow skill for choosing the correct base branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d30d935c24d4ae9ca66e57f47f26d3cbdaf5633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->