### PR TITLE
docs(contributing): multi-audience hub for campus, devs, and agents

### DIFF
--- a/.cursor/skills/room-tba-agent-workflow/SKILL.md
+++ b/.cursor/skills/room-tba-agent-workflow/SKILL.md
@@ -42,3 +42,5 @@ Commit policy, Conventional Commits format, and GPG signing: [AGENTS.md § Commi
 3. For map/side-panel changes, confirm applicable Cursor rules were followed.
 4. **Issue sync:** for each linked `#NNN`, update AC/paths/status per [docs/issue-hygiene.md](../../docs/issue-hygiene.md); comment with the PR URL.
 5. Push with `-u origin HEAD` only when the user asked to push/open a PR.
+6. **Base branch:** feature work → `staging`. "PR to main" / prod ship → `staging` → `main` release only ([AGENTS.md § Branches and pull requests](../../AGENTS.md#branches-and-pull-requests)).
+7. **`data` / `qa` issues:** reporter does not PR; implement and link the PR on the issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,9 @@ assignees: ""
 **Describe the bug**
 A clear and concise description of what the bug is.
 
+**Entity (optional)**
+Room/building name, search query, or share URL from the app.
+
 **To Reproduce**
 Steps to reproduce the behavior:
 

--- a/.github/ISSUE_TEMPLATE/campus_qa.yml
+++ b/.github/ISSUE_TEMPLATE/campus_qa.yml
@@ -1,0 +1,51 @@
+name: Campus QA
+description: Manual testing on a phone or laptop — layout, search, schedules, offline
+title: "[QA] "
+labels:
+  - qa
+body:
+  - type: markdown
+    value: |
+      **No pull request required.** Describe what you tested and what broke or looked wrong.
+
+      See the [contributing guide](https://github.com/uplbtools/room-tba/blob/staging/CONTRIBUTING.md#campus-qa) for ideas.
+  - type: input
+    id: url
+    attributes:
+      label: URL tested
+      description: Production or staging link, or describe how you opened the app
+      placeholder: https://room-tba.uplbtools.me
+  - type: input
+    id: device
+    attributes:
+      label: Device and browser
+      placeholder: Android Chrome, iPhone Safari, laptop Firefox
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps you took
+      placeholder: |
+        1. Searched PSLH 1
+        2. Opened schedule
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (optional)
+      description: Drag images into the comment after filing, or paste links here

--- a/.github/ISSUE_TEMPLATE/coding_task.yml
+++ b/.github/ISSUE_TEMPLATE/coding_task.yml
@@ -1,0 +1,49 @@
+name: Coding task
+description: Bug fix or feature for developers — no file paths required upfront
+title: "[CODE] "
+labels:
+  - help wanted
+body:
+  - type: markdown
+    value: |
+      For **developers** who will open a PR to `staging`. See [CONTRIBUTING.md](../CONTRIBUTING.md#developers-no-ai-required).
+
+      Campus volunteers reporting wrong data should use the **Data correction** template instead (no PR needed).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What should change from a user perspective?
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the app (optional)
+      options:
+        - Map / search
+        - Side panel / entity detail
+        - Editor / proposals
+        - API / data
+        - Docs / tooling
+        - Not sure
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Plain checklist — what must be true when this is done?
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,14 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Discord
+    url: https://discord.uplbtools.me
+    about: Chat with the team and report issues
+  - name: Messenger
+    url: https://messenger.uplbtools.me
+    about: Message the team
+  - name: Contributing guide
+    url: https://github.com/uplbtools/room-tba/blob/staging/CONTRIBUTING.md
+    about: Pick your path — report data, QA, or code
   - name: Room TBA repo
     url: https://github.com/uplbtools/room-tba
-    about: Open issues and PRs on GitHub
+    about: Open issues and pull requests on GitHub

--- a/.github/ISSUE_TEMPLATE/data_correction.yml
+++ b/.github/ISSUE_TEMPLATE/data_correction.yml
@@ -1,0 +1,60 @@
+name: Data correction
+description: Wrong schedule, pin, directions, or missing room/building info
+title: "[DATA] "
+labels:
+  - data
+body:
+  - type: markdown
+    value: |
+      **No pull request required.** A developer or maintainer will implement the fix. Thank you for keeping campus data accurate.
+
+      Prefer the [in-app suggest flow](https://room-tba.uplbtools.me) if you have contributor access.
+  - type: dropdown
+    id: entity_type
+    attributes:
+      label: What is wrong?
+      options:
+        - Room schedule
+        - Building location / pin
+        - Directions text
+        - Missing room or building
+        - Event
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: entity_name
+    attributes:
+      label: Room or building name
+      description: e.g. PSLH 1, PhySci, CAS Annex 1
+      placeholder: PSLH 1
+    validations:
+      required: true
+  - type: input
+    id: term
+    attributes:
+      label: Term (if schedule-related)
+      description: e.g. 2nd Sem AY 2025-2026 — leave blank if not applicable
+  - type: textarea
+    id: wrong
+    attributes:
+      label: What is wrong?
+      description: What you see now
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should it be?
+    validations:
+      required: true
+  - type: textarea
+    id: verified
+    attributes:
+      label: How did you verify?
+      description: Walked there, SAIS, org page, photo, etc.
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot or link (optional)
+      description: Paste a link or describe what you would attach

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,3 +17,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+---
+
+_You do not need to implement this yourself. A developer or maintainer may pick it up from the issue._

--- a/.github/ISSUE_TEMPLATE/implementation_task.md
+++ b/.github/ISSUE_TEMPLATE/implementation_task.md
@@ -1,6 +1,6 @@
 ---
 name: Implementation task
-about: Feature or refactor with concrete acceptance criteria and file pointers
+about: Detailed spec with file pointers — for epics, maintainers, or experienced devs
 title: "[TASK] "
 labels: enhancement
 assignees: ""
@@ -19,7 +19,7 @@ assignees: ""
 
 ## Implementation pointers
 
-<!-- Keep these current — agents trust them literally -->
+<!-- Keep these current for anyone implementing (human dev or maintainer) -->
 
 - **Files / routes:**
 - **Schema / migrations:**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,22 @@
+## Who are you?
+
+- [ ] **Campus / data / QA only** — no code in this PR? Comment on the issue instead; skip the rest of this template.
+- [ ] **Developer** — code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
+- [ ] **Maintainer / agent** — full QA below + issue hygiene for linked specs.
+
 ## Summary
 
 <!-- What changed and why (1–3 sentences). -->
 
-**Linked issues:** Closes # / Refs # <!-- update issue bodies + AC per docs/issue-hygiene.md -->
+**Linked issues:** Closes # / Refs #
 
-## QA Summary
+## Developer checklist
+
+- [ ] `bun test src`
+- [ ] `bun run lint` (or Prettier on touched files)
+- [ ] Linked issue commented with this PR URL
+
+## QA Summary (code changes)
 
 Automated:
 
@@ -12,10 +24,13 @@ Automated:
 - [ ] Unit tests passed: `bun test src` (PR CI)
 - [ ] Full lint passed (local): `bun run lint`
 - [ ] Build passed (local): `bun run build` — requires `DATABASE_URL`; not run in PR CI
-- [ ] Admin redirects verified (if auth/routing touched): `/admin`, `/admin/login`
+
+If auth, routing, or schema changed:
+
+- [ ] Admin redirects verified: `/admin`, `/admin/login`
 - [ ] Migration applied on Supabase (if `drizzle/` changed)
 
-Manual browser (if map chrome, editor, or side panel changed):
+If map chrome, editor, or side panel changed:
 
 - [ ] Verified at 320px and/or 768px per [map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md)
 - [ ] Editor/login/drag-save flows (see [editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md))
@@ -28,10 +43,10 @@ Follow-up:
 
 - <!-- Issues or PRs to file next -->
 
-## Issues updated
+## Issues updated (maintainers / detailed specs)
 
 - [ ] Linked issue(s) commented with this PR
-- [ ] Acceptance criteria checkboxes / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
+- [ ] Acceptance criteria / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
 - [ ] `Last verified against staging:` date set on linked issues
 
 ## Test plan

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,15 @@
 # Room TBA Agent Guide
 
+**Human developers and campus volunteers:** start with [CONTRIBUTING.md](CONTRIBUTING.md). You do not need this file.
+
 ## Doc map
 
 Read the right doc for the task — do not rely on this file alone for detailed checklists.
 
 | When                                             | Read                                                                                                                    |
 | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Human volunteers, developers (default)           | [CONTRIBUTING.md](CONTRIBUTING.md)                                                                                      |
+| Developer setup detail                           | [docs/developer-guide.md](docs/developer-guide.md)                                                                      |
 | Starting a coding session, commit, or PR         | [.cursor/skills/room-tba-agent-workflow/SKILL.md](.cursor/skills/room-tba-agent-workflow/SKILL.md)                      |
 | Map chrome, Entry zones, flyouts, 320/768 layout | [.cursor/rules/map-layout.mdc](.cursor/rules/map-layout.mdc) + [docs/map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md) |
 | Side panel / entity detail views                 | [.cursor/rules/side-panel.mdc](.cursor/rules/side-panel.mdc)                                                            |
@@ -13,7 +17,10 @@ Read the right doc for the task — do not rely on this file alone for detailed 
 | Stores and client state                          | [.cursor/rules/svelte-stores.mdc](.cursor/rules/svelte-stores.mdc)                                                      |
 | PR QA evidence and reporting                     | [docs/agentic-qa-process.md](docs/agentic-qa-process.md)                                                                |
 | Editor manual checklist                          | [docs/editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md)                                              |
+| When                                             | Read                                                                                                                    |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | Issue-linked work / keeping specs current        | [docs/issue-hygiene.md](docs/issue-hygiene.md)                                                                          |
+| Volunteer triage                                 | [docs/volunteer-triage.md](docs/volunteer-triage.md)                                                                    |
 
 ## How to work
 
@@ -23,6 +30,25 @@ Read the right doc for the task — do not rely on this file alone for detailed 
 - **Preserve the dirty tree.** Do not revert unrelated user changes unless explicitly asked.
 - **Keep scope tight.** Avoid opportunistic refactors outside the request.
 - **Keep GitHub issues current** when work is tied to `#NNN` — issues hold implementation specifics that drift fast. See [docs/issue-hygiene.md](docs/issue-hygiene.md).
+- **Infer intent over typos.** User messages are often rushed — read for what they mean, not only literal wording. Common patterns:
+  - **"PR to main" / "merge to prod" / "ship it"** → promote **`staging` → `main`** (release PR), not a feature branch opened against `main`. See [Branches and pull requests](#branches-and-pull-requests).
+  - **"PR to staging"** → feature branch → `staging` (default for new work).
+  - Minor typos (`pr`, `stagign`, `mrege`, doubled letters) — do not ask for clarification when context makes the goal obvious.
+- **`data` / `qa` issues:** reporters do not open PRs. Implement on their behalf; credit in issue comments.
+
+## Branches and pull requests
+
+Default flow: **feature branch → `staging` → `main`**.
+
+| User says (approx.)               | Do this                                                | Do **not** do this                                     |
+| --------------------------------- | ------------------------------------------------------ | ------------------------------------------------------ |
+| Open a PR / PR to staging         | `gh pr create --base staging --head <feature-branch>`  | —                                                      |
+| PR to main / merge to prod / ship | Open (or merge) **`staging` → `main`** release PR only | `--base main --head <feature-branch>` for routine work |
+| Merge the feature PR              | Squash/merge into **`staging`** first                  | Skip `staging` and land features directly on `main`    |
+
+- **`main`** is production; semantic-release runs there.
+- **`staging`** is integration — feature PRs land here first unless the user explicitly asks for a hotfix straight to `main`.
+- When the user says **"PR to main"**, they usually mean **get it to production**, not "set the GitHub PR base branch to `main`."
 
 ## GitHub issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to Room TBA
+
+Thanks for helping UPLB students find rooms. You do **not** need to clone this repo unless you are writing code.
+
+**Start here:** pick the path that fits you.
+
+| Path                                                                                                         | Who               | What to do                              | Open a PR? |
+| ------------------------------------------------------------------------------------------------------------ | ----------------- | --------------------------------------- | ---------- |
+| [Report wrong data](#report-wrong-data)                                                                      | Anyone on campus  | File a data issue or use in-app suggest | No         |
+| [Campus QA](#campus-qa)                                                                                      | Testers           | Verify the app on your phone            | No         |
+| [Developers](#developers-no-ai-required)                                                                     | Coders            | Branch, code, PR to `staging`           | Yes        |
+| [Good first issues](https://github.com/uplbtools/room-tba/issues?q=is%3Aopen+label%3A%22good+first+issue%22) | New devs          | Smaller coding tasks                    | Yes        |
+| [Maintainers / AI agents](#maintainers-and-agents)                                                           | Core team, Cursor | See [AGENTS.md](AGENTS.md)              | Yes        |
+
+**Community:** [Discord](https://discord.uplbtools.me) · [Messenger](https://messenger.uplbtools.me) · [UPLB Tools](https://uplbtools.me)
+
+---
+
+## Report wrong data
+
+Use this when a schedule, pin, direction, or building name is wrong.
+
+1. **In the app:** open the room or building → **Suggest an edit** (if you have contributor access).
+2. **On GitHub:** [New data correction issue](https://github.com/uplbtools/room-tba/issues/new?template=data_correction.yml).
+3. **Chat:** Discord or Messenger (link above) if GitHub is awkward.
+
+Include:
+
+- Room or building name (e.g. PSLH 1, PhySci)
+- Term, if it is schedule-related
+- What is wrong and what it should be
+- How you verified (walked there, SAIS, org page, photo)
+
+**You do not need to open a pull request.** Someone else will ship the fix and reply on the issue.
+
+---
+
+## Campus QA
+
+Use this when you can test the live or staging app on a real device.
+
+1. [New campus QA issue](https://github.com/uplbtools/room-tba/issues/new?template=campus_qa.yml)
+2. Label `qa` is applied automatically.
+
+Helpful checks: search a room you know, open schedules for the current term, try offline mode after loading once, check layout at narrow phone width.
+
+**No PR required** — describe what you saw; developers fix bugs from your report.
+
+---
+
+## Developers (no AI required)
+
+You can contribute code without using Cursor, agents, or [AGENTS.md](AGENTS.md).
+
+### Setup
+
+1. Install [Bun](https://bun.sh) 1.3+
+2. Clone the repo, copy [`.env.example`](.env.example) to `.env`
+3. Set `DATABASE_URL` (Supabase Postgres; session pooler recommended for local dev)
+4. Optional: `ADMIN_PASSWORD` for editor login locally
+
+```sh
+bun install
+bun dev
+```
+
+Open http://localhost:4321. More setup help: [docs/developer-guide.md](docs/developer-guide.md).
+
+### Workflow
+
+1. Find or file an issue ([coding task template](https://github.com/uplbtools/room-tba/issues/new?template=coding_task.yml) or [good first issue](https://github.com/uplbtools/room-tba/issues?q=is%3Aopen+label%3A%22good+first+issue%22)).
+2. Branch off **`staging`** (not `main`).
+3. Make your change.
+4. Before opening a PR:
+   - `bun test src`
+   - `bun run lint` (or `bunx prettier --check` on files you touched)
+   - `bun run build` for substantive changes (needs `DATABASE_URL`)
+5. Open a PR to **`staging`**. Use the PR template checkboxes.
+6. Use [Conventional Commits](https://www.conventionalcommits.org/) in commit messages (`fix(map): …`, `feat(api): …`).
+
+**Production:** features merge to `staging` first. Release to production is a separate **`staging` → `main`** PR (maintainers).
+
+### Picking up a campus issue
+
+If someone filed a `data` or `qa` issue without code:
+
+1. Comment that you are working on it
+2. Implement the fix
+3. Open a PR to `staging` and link the issue (`Closes #NNN`)
+4. Thank the reporter in the issue when merged
+
+### Optional (map / editor PRs only)
+
+- [docs/editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md)
+- [docs/agentic-qa-process.md](docs/agentic-qa-process.md)
+
+---
+
+## Maintainers and agents
+
+[AGENTS.md](AGENTS.md) is for AI assistants and maintainers who ship quickly across many files. **Human developers do not need to read it.**
+
+Includes: branch rules, issue hygiene for detailed specs, Cursor workflow skill, map chrome guardrails.
+
+---
+
+## Volunteer triage
+
+Running Discord triage or weekly issue review? See [docs/volunteer-triage.md](docs/volunteer-triage.md).
+
+---
+
+## Code of conduct
+
+Be helpful to students. Do not commit secrets (`.env`, passwords). Campus data fixes should be verifiable when possible.

--- a/README.md
+++ b/README.md
@@ -160,18 +160,15 @@ PR checklist: [`docs/agentic-qa-process.md`](docs/agentic-qa-process.md)
 
 ## Contributing
 
-We merge through GitHub. Rough flow:
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** — pick your path:
 
-1. **Find or file an issue.** Implementation details live there; keep them updated ([`docs/issue-hygiene.md`](docs/issue-hygiene.md)).
-2. **Branch off `staging`**, hack, run `bun test src` + Prettier.
-3. **PR to `staging`.** The template asks for QA evidence; CI runs Prettier + tests.
-4. **Human pass** for map/editor UI at 320px if you touched chrome.
+- **Report wrong data** or **campus QA** — no repo clone, no PR required
+- **Write code** — branch off `staging`, PR to `staging` ([developer guide](docs/developer-guide.md))
+- **Maintainers / agents** — [AGENTS.md](AGENTS.md)
 
-Commit messages: [Conventional Commits](https://www.conventionalcommits.org/) (`feat(map): …`, `fix(api): …`). semantic-release uses them on `main`.
+[Good first issues](https://github.com/uplbtools/room-tba/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · **Data:** label `data` · **QA:** label `qa`
 
-**Good first issues:** [good first issue](https://github.com/uplbtools/room-tba/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · **Data fixes:** label `data` · **QA passes:** label `qa`
-
-No separate admin dashboard. If you can view it on the map, you should eventually edit it there.
+Implementers: [issue hygiene](docs/issue-hygiene.md) · [PR QA process](docs/agentic-qa-process.md)
 
 ---
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,65 @@
+# Developer guide
+
+For human developers contributing code. Start with [CONTRIBUTING.md](../CONTRIBUTING.md); this doc covers setup details and repo layout.
+
+## Local setup
+
+| Requirement      | Notes                                                           |
+| ---------------- | --------------------------------------------------------------- |
+| Bun 1.3+         | Package manager and test runner                                 |
+| `DATABASE_URL`   | Supabase Postgres; use the **session pooler** URL for local dev |
+| `ADMIN_PASSWORD` | Optional; enables in-app editor login locally                   |
+
+```sh
+cp .env.example .env
+# Edit .env — DATABASE_URL is required for pages that hit the DB
+
+bun install
+bun dev   # http://localhost:4321
+```
+
+Without `DATABASE_URL`, the dev server starts but SSR pages that query Postgres return 500. That is expected.
+
+Refreshing a stale `.env`: see [AGENTS.md § Cursor Cloud](../AGENTS.md#cursor-cloud-specific-instructions) or copy `DATABASE_URL` from Vercel / Supabase dashboard.
+
+## Commands
+
+| Command                   | Purpose                                 |
+| ------------------------- | --------------------------------------- |
+| `bun dev`                 | Dev server                              |
+| `bun test src`            | Unit tests (no DB required)             |
+| `bun run lint`            | Prettier + ESLint                       |
+| `bun run format`          | Prettier write                          |
+| `bun run build`           | Production build (needs `DATABASE_URL`) |
+| `bunx drizzle-kit studio` | Browse Postgres                         |
+
+PR CI runs Prettier check + `bun test src` only. Run full lint and build locally before merge on substantive changes.
+
+## Project layout
+
+```
+src/pages/       Astro routes and /api/*
+src/components/  Svelte UI (map, search, editor)
+src/lib/         Stores, services, PGlite sync
+drizzle/         Postgres schema + SQL migrations (apply before deploy)
+docs/            QA checklists and contributor docs
+public/          Static assets
+```
+
+Do **not** edit `drizzle-migrations/` (archived SQLite history).
+
+## Common gotchas
+
+- **PGlite vs Postgres:** browser offline cache (`src/lib/local/data/pgliteDB.ts`) is separate from server schema. Schema changes need Drizzle migration + PGlite alignment.
+- **PR base branch:** target **`staging`**, not `main`.
+- **Admin surface:** edit in the map app; `/admin` browser pages redirect into the app.
+- **Migrations:** if you add a `drizzle/*.sql` migration, apply it to Supabase before deploying code that depends on it.
+
+## Tests
+
+Unit tests live under `src/**/*.test.ts`. Run all: `bun test src`. Add tests when changing non-trivial lib or API behavior.
+
+## Getting help
+
+- [Discord](https://discord.uplbtools.me) or [Messenger](https://messenger.uplbtools.me)
+- Open a [coding task issue](https://github.com/uplbtools/room-tba/issues/new?template=coding_task.yml) or draft PR early for feedback

--- a/docs/issue-hygiene.md
+++ b/docs/issue-hygiene.md
@@ -1,8 +1,33 @@
 # GitHub Issue Hygiene
 
-Issues in this repo often contain **implementation specifics** — file paths, table names, API routes, acceptance checklists, and design decisions. When agents ship code quickly, those details go stale within days. Treat issues as living specs, not write-once tickets.
+Issues are living specs. **Not every issue needs file paths** — match the track to the audience.
 
 Use `gh issue view <n> --repo uplbtools/room-tba` before and after issue-scoped work.
+
+## Three tracks
+
+| Track           | Typical labels                          | Who writes the issue | Implementation pointers                                         |
+| --------------- | --------------------------------------- | -------------------- | --------------------------------------------------------------- |
+| **Reporter**    | `data`, `qa`                            | Campus volunteers    | Added **when someone picks it up** — not required from reporter |
+| **Developer**   | `good first issue`, `help wanted`       | Developers           | Dev fills in as they learn the codebase                         |
+| **Spec / epic** | `enhancement`, `parent issue`, `[TASK]` | Maintainers          | Full paths, AC, `Last verified`                                 |
+
+**Reporter issues:** problem + verification only. Do not ask reporters to cite `src/` or open PRs.
+
+**Developer issues:** plain acceptance criteria; optional area of app (map, API, etc.).
+
+**Spec issues:** implementation specifics (paths, migrations) — keep current when agents or maintainers ship quickly.
+
+### Picking up a campus issue
+
+When implementing a `data` or `qa` issue on behalf of a reporter:
+
+1. Comment that you are working on it
+2. Append **Implementation pointers** to the issue body if helpful
+3. Open PR to `staging`; `Closes #NNN`
+4. Thank the reporter when merged
+
+---
 
 ## When to update an issue
 
@@ -32,7 +57,9 @@ Do **not** delete historical context — strike through or move obsolete paragra
 - **Comments:** progress pings, PR links, questions, blockers needing human input.
 - **Body edits:** anything the next implementer must trust (paths, AC, commands, schema).
 
-## Agent session checklist (issue-linked work)
+## Agent session checklist (spec / epic issues)
+
+For `data` / `qa` issues, steps 2–4 are optional until converting to an implementation spec.
 
 1. `gh issue view N --json title,body,state,labels`
 2. Verify cited files/routes exist; update issue if not.

--- a/docs/volunteer-triage.md
+++ b/docs/volunteer-triage.md
@@ -1,0 +1,52 @@
+# Volunteer triage
+
+Lightweight process for non-coding volunteers and triage leads. You do **not** need [AGENTS.md](../AGENTS.md).
+
+## Weekly check (5–10 minutes)
+
+1. Open [open issues](https://github.com/uplbtools/room-tba/issues).
+2. Sort by **`data`** and **`qa`** labels — campus reports.
+3. For each new issue:
+   - Is the report clear enough to act on? If not, ask one clarifying question in a comment.
+   - Add **`help wanted`** if it needs a developer and no one is assigned.
+   - Link related duplicates.
+4. Skim **`good first issue`** — ping Discord if something is unclaimed for 2+ weeks.
+
+## Who does what
+
+```mermaid
+flowchart LR
+  Reporter[Campus reporter]
+  Triage[Volunteer triage]
+  Dev[Developer PR]
+  Agent[Maintainer or agent]
+  Staging[staging]
+  Reporter --> Triage
+  Triage --> Dev
+  Triage --> Agent
+  Dev --> Staging
+  Agent --> Staging
+```
+
+| Role               | Action                                                |
+| ------------------ | ----------------------------------------------------- |
+| Reporter           | Data / QA issue or in-app suggest — **no PR**         |
+| Triage             | Label, clarify, surface `help wanted`                 |
+| Developer          | Picks up issue, PR to `staging`, comments on issue    |
+| Maintainer / agent | Same; may implement data fixes on behalf of reporters |
+
+## Credit
+
+- Thank reporters in issue comments when a fix merges.
+- Contributor profiles (#310) will extend this later.
+
+## Templates
+
+| Template                                                         | Use                             |
+| ---------------------------------------------------------------- | ------------------------------- |
+| [Data correction](../.github/ISSUE_TEMPLATE/data_correction.yml) | Wrong schedule, pin, directions |
+| [Campus QA](../.github/ISSUE_TEMPLATE/campus_qa.yml)             | Manual testing on device        |
+
+Full contributor paths: [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+Epic: [#217](https://github.com/uplbtools/room-tba/issues/217).


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md** — paths for campus (no PR), developers (no AGENTS.md), maintainers/agents
- **Issue templates:** data correction, campus QA, coding task; updated config with Discord/Messenger links
- **docs/developer-guide.md** and **docs/volunteer-triage.md**
- **PR template** routing checkboxes (campus vs developer vs maintainer)
- **issue-hygiene.md** three tracks (reporter / developer / spec)
- **AGENTS.md** + README cross-links; staging→main PR rules

Refs #217

## Test plan

- [x] Prettier on changed markdown
- [ ] GitHub issue template picker shows new templates
- [ ] CONTRIBUTING.md renders on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and GitHub templates only; no application code, auth, or data paths change.
> 
> **Overview**
> Introduces a **multi-audience contributor model** so campus volunteers, human developers, and maintainers/agents each have a clear path without reading agent-only docs.
> 
> **CONTRIBUTING.md** is the new entry point: report wrong data and campus QA **without cloning or opening PRs**; developers branch to **`staging`** with a lightweight checklist; maintainers are pointed to **AGENTS.md**. **README** Contributing now links there instead of inlining the old dev-only flow.
> 
> **GitHub issue templates** add **Data correction** (`data`), **Campus QA** (`qa`), and **Coding task** (`help wanted`); **config** adds Discord, Messenger, and CONTRIBUTING contact links. **Bug report** gains optional entity context; **feature request** and **implementation task** copy clarifies who implements.
> 
> **PR template** starts with **Who are you?** (campus vs developer vs maintainer), splits a **Developer checklist** from maintainer **QA / issue hygiene** sections.
> 
> **AGENTS.md** and the **agent workflow skill** document **`staging` → `main`** release semantics (“PR to main” ≠ feature PR against `main`) and that **`data` / `qa` reporters don’t PR**—implementers ship and credit on the issue. **issue-hygiene.md** defines **reporter / developer / spec** tracks; **docs/developer-guide.md** and **docs/volunteer-triage.md** support dev setup and weekly triage (refs #217).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d442292998297e20764772e975484439b48a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->