### PR TITLE
docs(copy): de-emdashify and tighten audience-facing text

### DIFF
--- a/.cursor/skills/room-tba-agent-workflow/SKILL.md
+++ b/.cursor/skills/room-tba-agent-workflow/SKILL.md
@@ -21,7 +21,7 @@ Policy (commits, verification tiers, architecture, product rules) lives in [AGEN
 
 Follow [AGENTS.md § Verify before done](../../AGENTS.md#verify-before-done) for the canonical checklist. Session tips:
 
-- During iterative edits, prefer targeted lint/tests on changed files — not full repo lint every edit.
+- During iterative edits, prefer targeted lint/tests on changed files; not full repo lint every edit.
 - Do not run `bun run build` after every small edit.
 - Run `bun run build` once before the final commit or PR, unless the user asks to skip it.
 - If a full build already passed after the final code changes, do not repeat it before committing unless new substantive changes were made.
@@ -31,7 +31,7 @@ Follow [AGENTS.md § Verify before done](../../AGENTS.md#verify-before-done) for
 
 Commit policy, Conventional Commits format, and GPG signing: [AGENTS.md § Commits](../../AGENTS.md#commits).
 
-- Do not end a session with uncommitted completed work unless the user explicitly deferred commit or a hook/blocker prevented it — report the blocker.
+- Do not end a session with uncommitted completed work unless the user explicitly deferred commit or a hook/blocker prevented it; report the blocker.
 - Before opening a PR, summarize the **full branch diff**, not just the latest commit.
 - In final summaries, call out what changed, what was verified, and any blockers or residual risk.
 

--- a/.github/ISSUE_TEMPLATE/campus_qa.yml
+++ b/.github/ISSUE_TEMPLATE/campus_qa.yml
@@ -1,5 +1,5 @@
 name: Campus QA
-description: Manual testing on a phone or laptop — layout, search, schedules, offline
+description: Manual testing on a phone or laptop (layout, search, schedules, offline)
 title: "[QA] "
 labels:
   - qa

--- a/.github/ISSUE_TEMPLATE/coding_task.yml
+++ b/.github/ISSUE_TEMPLATE/coding_task.yml
@@ -1,5 +1,5 @@
 name: Coding task
-description: Bug fix or feature for developers — no file paths required upfront
+description: Bug fix or feature for developers; no file paths required upfront
 title: "[CODE] "
 labels:
   - help wanted
@@ -41,7 +41,7 @@ body:
     id: acceptance
     attributes:
       label: Acceptance criteria
-      description: Plain checklist — what must be true when this is done?
+      description: Plain checklist of what must be true when this is done
       value: |
         - [ ]
         - [ ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,7 +8,7 @@ contact_links:
     about: Message the team
   - name: Contributing guide
     url: https://github.com/uplbtools/room-tba/blob/staging/CONTRIBUTING.md
-    about: Pick your path — report data, QA, or code
+    about: Pick your path (report data, QA, or code)
   - name: Room TBA repo
     url: https://github.com/uplbtools/room-tba
     about: Open issues and pull requests on GitHub

--- a/.github/ISSUE_TEMPLATE/data_correction.yml
+++ b/.github/ISSUE_TEMPLATE/data_correction.yml
@@ -34,7 +34,7 @@ body:
     id: term
     attributes:
       label: Term (if schedule-related)
-      description: e.g. 2nd Sem AY 2025-2026 — leave blank if not applicable
+      description: e.g. 2nd Sem AY 2025-2026; leave blank if not applicable
   - type: textarea
     id: wrong
     attributes:

--- a/.github/ISSUE_TEMPLATE/implementation_task.md
+++ b/.github/ISSUE_TEMPLATE/implementation_task.md
@@ -1,6 +1,6 @@
 ---
 name: Implementation task
-about: Detailed spec with file pointers — for epics, maintainers, or experienced devs
+about: Detailed spec with file pointers for epics, maintainers, or experienced devs
 title: "[TASK] "
 labels: enhancement
 assignees: ""

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 ## Who are you?
 
-- [ ] **Campus / data / QA only** — no code in this PR? Comment on the issue instead; skip the rest of this template.
-- [ ] **Developer** — code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
-- [ ] **Maintainer / agent** — full QA below + issue hygiene for linked specs.
+- [ ] **Campus / data / QA only:** no code in this PR? Comment on the issue and skip the rest.
+- [ ] **Developer:** code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
+- [ ] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.
 
 ## Summary
 
@@ -23,7 +23,7 @@ Automated:
 - [ ] Prettier passed: `bunx prettier --check .` (PR CI)
 - [ ] Unit tests passed: `bun test src` (PR CI)
 - [ ] Full lint passed (local): `bun run lint`
-- [ ] Build passed (local): `bun run build` — requires `DATABASE_URL`; not run in PR CI
+- [ ] Build passed (local): `bun run build` (needs `DATABASE_URL`; not run in PR CI)
 
 If auth, routing, or schema changed:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Doc map
 
-Read the right doc for the task — do not rely on this file alone for detailed checklists.
+Read the right doc for the task; do not rely on this file alone for detailed checklists.
 
 | When                                             | Read                                                                                                                    |
 | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
@@ -29,11 +29,11 @@ Read the right doc for the task — do not rely on this file alone for detailed 
 - **One pass is often enough.** Prefer a focused implementation plus verification over long planning loops or repeated “want me to…?” prompts.
 - **Preserve the dirty tree.** Do not revert unrelated user changes unless explicitly asked.
 - **Keep scope tight.** Avoid opportunistic refactors outside the request.
-- **Keep GitHub issues current** when work is tied to `#NNN` — issues hold implementation specifics that drift fast. See [docs/issue-hygiene.md](docs/issue-hygiene.md).
-- **Infer intent over typos.** User messages are often rushed — read for what they mean, not only literal wording. Common patterns:
+- **Keep GitHub issues current** when work is tied to `#NNN`; issues hold implementation specifics that drift fast. See [docs/issue-hygiene.md](docs/issue-hygiene.md).
+- **Infer intent over typos.** User messages are often rushed; read for what they mean, not only literal wording. Common patterns:
   - **"PR to main" / "merge to prod" / "ship it"** → promote **`staging` → `main`** (release PR), not a feature branch opened against `main`. See [Branches and pull requests](#branches-and-pull-requests).
   - **"PR to staging"** → feature branch → `staging` (default for new work).
-  - Minor typos (`pr`, `stagign`, `mrege`, doubled letters) — do not ask for clarification when context makes the goal obvious.
+  - Minor typos (`pr`, `stagign`, `mrege`, doubled letters); do not ask for clarification when context makes the goal obvious.
 - **`data` / `qa` issues:** reporters do not open PRs. Implement on their behalf; credit in issue comments.
 
 ## Branches and pull requests
@@ -42,20 +42,20 @@ Default flow: **feature branch → `staging` → `main`**.
 
 | User says (approx.)               | Do this                                                | Do **not** do this                                     |
 | --------------------------------- | ------------------------------------------------------ | ------------------------------------------------------ |
-| Open a PR / PR to staging         | `gh pr create --base staging --head <feature-branch>`  | —                                                      |
+| Open a PR / PR to staging         | `gh pr create --base staging --head <feature-branch>`  | ;                                                      |
 | PR to main / merge to prod / ship | Open (or merge) **`staging` → `main`** release PR only | `--base main --head <feature-branch>` for routine work |
 | Merge the feature PR              | Squash/merge into **`staging`** first                  | Skip `staging` and land features directly on `main`    |
 
 - **`main`** is production; semantic-release runs there.
-- **`staging`** is integration — feature PRs land here first unless the user explicitly asks for a hotfix straight to `main`.
+- **`staging`** is integration; feature PRs land here first unless the user explicitly asks for a hotfix straight to `main`.
 - When the user says **"PR to main"**, they usually mean **get it to production**, not "set the GitHub PR base branch to `main`."
 
 ## GitHub issues
 
 Issues are living specs (paths, schema, acceptance criteria). When coding quickly, update them in the same session as the code:
 
-- **Before starting:** `gh issue view N` — verify cited files/APIs still exist; fix stale body text first.
-- **While implementing:** if the approach changes, edit the issue — don't leave wrong paths for the next agent.
+- **Before starting:** `gh issue view N`; verify cited files/APIs still exist; fix stale body text first.
+- **While implementing:** if the approach changes, edit the issue; don't leave wrong paths for the next agent.
 - **With the PR:** comment on the issue with the PR link; check off completed AC; set `Last verified against staging: YYYY-MM-DD` and `Status:` at the top.
 - **After merge:** close if done, or trim the body and file follow-ups. Move obsolete text under `## Superseded`, don't delete history.
 
@@ -77,7 +77,7 @@ Do not run full build after every small edit. See the workflow skill for session
 
 ## Security automation (GitHub)
 
-Production readiness is backed by repo automation — do not disable without replacing:
+Production readiness is backed by repo automation; do not disable without replacing:
 
 | Tool                  | Config                                                                               | What it does                                     |
 | --------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ |
@@ -91,8 +91,8 @@ Enable **Dependabot security updates** and **secret scanning** in GitHub repo Se
 ## Commits
 
 - **When you finish a scoped task, commit it** unless the user says not to. Do not leave completed work uncommitted across turns.
-- **Use [Conventional Commits](https://www.conventionalcommits.org/)** — required for semantic-release on `main`. Format: `type(scope): imperative summary` (e.g. `feat(map-chrome): add transit route panel`, `fix(security): validate image URLs`). Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`. Scope is optional but preferred when the change is localized.
-- **One logical unit per commit** — atomic, reviewable, GPG-signed: `git commit -S -m "$(cat <<'EOF' … EOF)"`.
+- **Use [Conventional Commits](https://www.conventionalcommits.org/)**; required for semantic-release on `main`. Format: `type(scope): imperative summary` (e.g. `feat(map-chrome): add transit route panel`, `fix(security): validate image URLs`). Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`. Scope is optional but preferred when the change is localized.
+- **One logical unit per commit**; atomic, reviewable, GPG-signed: `git commit -S -m "$(cat <<'EOF' … EOF)"`.
 - Stage only files that belong together; write a message that states _why_, not a file list.
 - Do not push unless asked. Do not amend or force-push unless the user’s git rules allow it.
 
@@ -100,7 +100,7 @@ Enable **Dependabot security updates** and **secret scanning** in GitHub repo Se
 
 - **App:** Astro 7 SSR + Svelte 5 islands, Vercel adapter, Bun.
 - **Server data:** Supabase Postgres via Drizzle ([`src/lib/db.ts`](src/lib/db.ts), [`drizzle/schema.ts`](drizzle/schema.ts), migrations in `drizzle/`).
-- **Client offline cache:** PGlite in IndexedDB ([`src/lib/local/data/pgliteDB.ts`](src/lib/local/data/pgliteDB.ts)) — schema is maintained separately and **can drift** from Drizzle; update both when changing tables.
+- **Client offline cache:** PGlite in IndexedDB ([`src/lib/local/data/pgliteDB.ts`](src/lib/local/data/pgliteDB.ts)); schema is maintained separately and **can drift** from Drizzle; update both when changing tables.
 - **Client state:** [`src/lib/store.svelte.ts`](src/lib/store.svelte.ts) (monolithic store module; import via `@lib/store.svelte`).
 - **Auth:** HMAC cookie `admin_session` + bcrypt `admin_users` gates `/api/admin/*`. Supabase Auth ([`src/lib/supabase/*`](src/lib/supabase/)) is additive in middleware; intended long-term consolidation target.
 - **Do not edit:** `drizzle-migrations/` (archived SQLite history). Do not add browser `/admin` pages as the editor surface.
@@ -110,7 +110,7 @@ Enable **Dependabot security updates** and **secret scanning** in GitHub repo Se
 - Prefer editing in the main app over building a separate admin dashboard.
 - The editor login should use the in-app popup. `/admin` browser pages should redirect into the main app login flow.
 - Keep the read and edit experiences colocated: if a user can view an entity in the app, an editor should eventually edit it there.
-- Editor capabilities (map pin editing, proposals, optimistic concurrency, version history, undo/redo) live in the main map app — extend in place.
+- Editor capabilities (map pin editing, proposals, optimistic concurrency, version history, undo/redo) live in the main map app; extend in place.
 
 ## Editor UX rules
 
@@ -124,7 +124,7 @@ Enable **Dependabot security updates** and **secret scanning** in GitHub repo Se
 
 ## UI guardrails
 
-Map and side-panel layout rules are detailed in glob-scoped Cursor rules — read them before editing matched files.
+Map and side-panel layout rules are detailed in glob-scoped Cursor rules; read them before editing matched files.
 
 - **Map chrome:** Entry zones only; one Map tools flyout; verify 320px + 768px. See [map-layout.mdc](.cursor/rules/map-layout.mdc) and [map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md).
 - **Side panel:** Header → body → directions → footer; parity across Room/Building/Dorm results. See [side-panel.mdc](.cursor/rules/side-panel.mdc).
@@ -141,7 +141,7 @@ Map and side-panel layout rules are detailed in glob-scoped Cursor rules — rea
 
 - Supabase Postgres is the runtime source of truth via `DATABASE_URL` (not `NEON_CONNECTION_STRING`). Code, Drizzle, seeds, and the Astro env schema all use `DATABASE_URL`. On Vercel, name the env var `DATABASE_URL`.
 - Supabase JS (`@supabase/supabase-js` + `@supabase/ssr`) is additive: `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_PUBLISHABLE_KEY` power Auth/client features via `src/lib/supabase/*`. Keep using Drizzle + `DATABASE_URL` for existing Postgres queries unless a feature explicitly needs the JS client.
-- Drizzle schema changes need a matching SQL migration in `drizzle/`. Apply pending migrations to Supabase before deploying code that depends on them — skipped migrations cause runtime query failures (e.g. missing `0007_add_event_image_url.sql` leaves out `events.image_url` and breaks event loading).
+- Drizzle schema changes need a matching SQL migration in `drizzle/`. Apply pending migrations to Supabase before deploying code that depends on them; skipped migrations cause runtime query failures (e.g. missing `0007_add_event_image_url.sql` leaves out `events.image_url` and breaks event loading).
 - **PGlite drift:** offline tables in `pgliteDB.ts` must stay aligned with server schema and with [`src/lib/local/data/sync.ts`](src/lib/local/data/sync.ts) consumers.
 - Admin API routes live under `/api/admin/*` and must keep auth checks.
 - Keep PATCH routes field-level and partial so unrelated edits do not clobber each other.
@@ -150,17 +150,17 @@ Map and side-panel layout rules are detailed in glob-scoped Cursor rules — rea
 
 - After substantive changes: lint, relevant unit tests, and `bun run build` (local).
 - For editor changes: [docs/editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md).
-- For PR QA: [docs/agentic-qa-process.md](docs/agentic-qa-process.md) — separate automated evidence from browser-only checks.
+- For PR QA: [docs/agentic-qa-process.md](docs/agentic-qa-process.md); separate automated evidence from browser-only checks.
 - Avoid mutating production-like server data unless intentional and reversible. Restore accidental test mutations immediately.
 
 ## Cursor Cloud specific instructions
 
 - Package manager is **Bun** (installed at `~/.bun/bin`). The startup update script runs `bun install --frozen-lockfile`. Use Bun, not npm, even though a npm lockfile may also be present.
-- **A reachable Postgres is required — no local DB fallback.** Runtime DB is **Supabase** (`*.supabase.co`); `src/lib/db.ts` connects via `DATABASE_URL` (see `astro:env/server` in `astro.config.mjs`). Local `.env` must point at Supabase, not a stale Neon URL. `ADMIN_PASSWORD` is needed for admin/editor features. Apply migrations in `drizzle/` before first run.
-- **Refreshing local `.env`:** Production/preview `DATABASE_URL` lives in Vercel env vars. When `.env` is empty or stale: `vercel env pull .env.vercel --environment=development --yes` (requires Vercel CLI linked to `stimmie/saan-ang-room` — room-tba.stimmie.dev — not a separate empty `room-tba` project; see `.vercel/project.json`), merge `DATABASE_URL` into `.env`, keep local `ADMIN_PASSWORD` if already set. `vercel env pull` often returns empty `""` for encrypted vars like `DATABASE_URL` — copy from Vercel UI (Settings → Environment Variables) or Supabase dashboard instead. Use the Supabase **session pooler** URL (`*.pooler.supabase.com`) for local dev. Or provide `DATABASE_URL` via Cursor Secrets.
+- **A reachable Postgres is required; no local DB fallback.** Runtime DB is **Supabase** (`*.supabase.co`); `src/lib/db.ts` connects via `DATABASE_URL` (see `astro:env/server` in `astro.config.mjs`). Local `.env` must point at Supabase, not a stale Neon URL. `ADMIN_PASSWORD` is needed for admin/editor features. Apply migrations in `drizzle/` before first run.
+- **Refreshing local `.env`:** Production/preview `DATABASE_URL` lives in Vercel env vars. When `.env` is empty or stale: `vercel env pull .env.vercel --environment=development --yes` (requires Vercel CLI linked to `stimmie/saan-ang-room`; room-tba.stimmie.dev; not a separate empty `room-tba` project; see `.vercel/project.json`), merge `DATABASE_URL` into `.env`, keep local `ADMIN_PASSWORD` if already set. `vercel env pull` often returns empty `""` for encrypted vars like `DATABASE_URL`; copy from Vercel UI (Settings → Environment Variables) or Supabase dashboard instead. Use the Supabase **session pooler** URL (`*.pooler.supabase.com`) for local dev. Or provide `DATABASE_URL` via Cursor Secrets.
 - **`bun dev` without `DATABASE_URL`:** Server starts but SSR returns HTTP 500 (`EnvInvalidVariables: DATABASE_URL is missing`). Set a valid Supabase connection string in `.env` and restart.
 - **Optional R2:** Image upload (`/api/admin/upload`) needs `R2_*` vars (see `.env.example`, `wrangler.jsonc`). App runs without them; upload UI shows a not-configured message.
-- This is **Astro 7 SSR** (Vercel adapter). API routes under `src/pages/api/*` are server-rendered (`prerender = false`), and SSG entity pages (e.g. `/room/[slug]`) query the DB at build time — so `bun run build` fails without a working `DATABASE_URL`.
+- This is **Astro 7 SSR** (Vercel adapter). API routes under `src/pages/api/*` are server-rendered (`prerender = false`), and SSG entity pages (e.g. `/room/[slug]`) query the DB at build time; so `bun run build` fails without a working `DATABASE_URL`.
 - `@electric-sql/pglite` (`idb://site-data`) is a **browser-side cache only**, not a server/dev database fallback.
 - **PWA:** Workbox precaches `dist/client`; large client bundles affect offline install. See `astro.config.mjs` PWA config before adding heavy dependencies.
 - Standard scripts: `bun dev` (`http://localhost:4321/`), `bun run build`, `bun preview`, `bun run lint`, `bun run format`, `bun test src`. PR CI runs Prettier check + unit tests; run full lint and build locally before merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Use this when you can test the live or staging app on a real device.
 
 Helpful checks: search a room you know, open schedules for the current term, try offline mode after loading once, check layout at narrow phone width.
 
-**No PR required** — describe what you saw; developers fix bugs from your report.
+**No PR required.** Describe what you saw. A developer will fix it from your report.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Room TBA
 
-**Saan sa UPLB ang \___?** · Finally, a straight answer.
+**Saan sa UPLB ang \___?**
 
 [![Live app](https://img.shields.io/badge/open-room--tba.uplbtools.me-maroon?style=for-the-badge)](https://room-tba.uplbtools.me)
 [![MIT](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)](LICENSE)
@@ -27,17 +27,17 @@ No account needed to browse. Editors and contributors fix data in the same app (
 
 ---
 
-## What you can do (student mode)
+## What you can do
 
-| You want to…                         | Room TBA does…                                                                  |
-| ------------------------------------ | ------------------------------------------------------------------------------- |
-| Find **PSLH 1** or **PhySci**        | Search + alias matching (`PhySci`, `HUM`, building nicknames)                   |
-| See **who's in that room this sem**  | Term-aware class schedules + timetable view                                     |
-| Figure out **where the building is** | MapLibre campus map, pins, directions, Google Maps handoff                      |
-| Survive **dead zones**               | PWA + offline cache (PGlite in the browser; map tiles after you've loaded them) |
-| Check **events & org stuff**         | Campus events on the map with locations and routes                              |
-| Ride the **jeep** without guessing   | Jeepney route overlays                                                          |
-| Get **un-lost in 3D**                | Optional building view / terrain toward Makiling (online tiles)                 |
+| Goal                          | How                                        |
+| ----------------------------- | ------------------------------------------ |
+| Find **PSLH 1** or **PhySci** | Search + aliases (`PhySci`, `HUM`, …)      |
+| Room schedule this sem        | Term filter + timetable                    |
+| Building location             | Map, pins, directions, Google Maps         |
+| Offline / bad signal          | PWA + local cache; tiles if already loaded |
+| Campus events                 | Events on map with routes                  |
+| Jeepney routes                | Route overlays                             |
+| 3D view                       | Buildings + Makiling terrain (online)      |
 
 <details>
 <summary><strong>Editor / contributor mode</strong> (password from the team)</summary>
@@ -83,18 +83,17 @@ flowchart LR
 
 ---
 
-## Stack (for the curious)
+## Stack
 
-| Layer     | Choice                                                                              | Why it's here                                                 |
-| --------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| App shell | [Astro 7](https://astro.build) + [Svelte 5](https://svelte.dev)                     | SEO pages for every room/building **and** a snappy map island |
-| Runtime   | [Bun](https://bun.sh)                                                               | Dev speed, tests, installs                                    |
-| Database  | [Supabase](https://supabase.com) Postgres + [Drizzle ORM](https://orm.drizzle.team) | Relational data, migrations in `drizzle/`                     |
-| Offline   | [PGlite](https://pglite.dev) (`idb://site-data`)                                    | SQL in the browser, not a hand-rolled JSON cache              |
-| Maps      | [MapLibre GL](https://maplibre.org) + OSM/MapTiler                                  | Open tiles, no vendor lock-in on basemaps                     |
-| Images    | Cloudflare R2 (optional)                                                            | Event uploads via `/api/admin/upload`                         |
-| Host      | [Vercel](https://vercel.com)                                                        | SSR + API routes                                              |
-| CI        | Prettier, unit tests, CodeQL, Dependabot                                            | See [AGENTS.md](AGENTS.md)                                    |
+- [Astro 7](https://astro.build) + [Svelte 5](https://svelte.dev)
+- [Bun](https://bun.sh)
+- [Supabase](https://supabase.com) Postgres + [Drizzle](https://orm.drizzle.team) (`drizzle/`)
+- [PGlite](https://pglite.dev) in the browser for offline data
+- [MapLibre GL](https://maplibre.org), OSM / MapTiler tiles
+- [Vercel](https://vercel.com) for SSR and API routes
+- Cloudflare R2 for event uploads (optional)
+
+Contributor notes: [AGENTS.md](AGENTS.md)
 
 ---
 
@@ -160,11 +159,11 @@ PR checklist: [`docs/agentic-qa-process.md`](docs/agentic-qa-process.md)
 
 ## Contributing
 
-See **[CONTRIBUTING.md](CONTRIBUTING.md)** — pick your path:
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for how to help:
 
-- **Report wrong data** or **campus QA** — no repo clone, no PR required
-- **Write code** — branch off `staging`, PR to `staging` ([developer guide](docs/developer-guide.md))
-- **Maintainers / agents** — [AGENTS.md](AGENTS.md)
+- **Report wrong data** or **campus QA:** no clone, no PR
+- **Write code:** branch off `staging`, PR to `staging` ([developer guide](docs/developer-guide.md))
+- **Maintainers / agents:** [AGENTS.md](AGENTS.md)
 
 [Good first issues](https://github.com/uplbtools/room-tba/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · **Data:** label `data` · **QA:** label `qa`
 
@@ -207,6 +206,6 @@ Org: [uplbtools](https://github.com/uplbtools) · Campus tool, not an official U
 
 <div align="center">
 
-**[room-tba.uplbtools.me](https://room-tba.uplbtools.me)** · for people who've asked "Saan ba ang ___?" at least once this week
+**[room-tba.uplbtools.me](https://room-tba.uplbtools.me)**
 
 </div>

--- a/docs/agentic-qa-process.md
+++ b/docs/agentic-qa-process.md
@@ -19,7 +19,7 @@ One agent can play multiple roles, but the report must separate automated eviden
 - Local `.env` with `DATABASE_URL` and `ADMIN_PASSWORD`.
 - Current test checklist: `docs/editor-foundation-test-plan.md`.
 - A running local dev server on the expected port, usually `http://localhost:4321`.
-- Linked GitHub issue number(s), if any — re-read with `gh issue view N` before coding; see [issue-hygiene.md](issue-hygiene.md).
+- Linked GitHub issue number(s), if any; re-read with `gh issue view N` before coding; see [issue-hygiene.md](issue-hygiene.md).
 
 ## GitHub issue sync (PR prep)
 
@@ -43,7 +43,7 @@ Run only what applies to the PR scope:
 | Editor / admin API      | yes  | yes               | yes           | auth + one PATCH                      |
 | Drizzle migration       | yes  | yes               | yes           | confirm migration applied on Supabase |
 
-PR CI (GitHub Actions) runs **Prettier check + unit tests** — no `DATABASE_URL` required. Run full `bun run lint` (ESLint + Prettier) and `bun run build` locally before merge when the change is substantive.
+PR CI (GitHub Actions) runs **Prettier check + unit tests**; no `DATABASE_URL` required. Run full `bun run lint` (ESLint + Prettier) and `bun run build` locally before merge when the change is substantive.
 
 ## Automated Checks
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -12,7 +12,7 @@ For human developers contributing code. Start with [CONTRIBUTING.md](../CONTRIBU
 
 ```sh
 cp .env.example .env
-# Edit .env — DATABASE_URL is required for pages that hit the DB
+# Edit .env: DATABASE_URL is required for pages that hit the DB
 
 bun install
 bun dev   # http://localhost:4321

--- a/docs/editor-foundation-test-plan.md
+++ b/docs/editor-foundation-test-plan.md
@@ -35,7 +35,7 @@ Use this checklist before merging the in-app editor foundation PR.
 - On a low-bandwidth or data-saver connection, terrain copy warns that hosted elevation tiles are online-only.
 - Terrain controls live inside the Map tools flyout (collapsed by default) and do not cover the side panel, editor dock, or attribution.
 - Jeepney route chips live in the search filter row alongside building type filters; selecting a route highlights the chip and draws the route on the map.
-- Sync progress appears in the status bar only — no floating sync card on the map face.
+- Sync progress appears in the status bar only; no floating sync card on the map face.
 - PWA reload prompt appears as an action in the status bar.
 
 ## Building Type Filter
@@ -86,7 +86,7 @@ See also `docs/map-ui-mode-matrix.md` for chrome visibility by mode. Verify at *
 - Search bar can collapse to a compact tab; expanding restores query, selection, and side-panel state without moving the map.
 - Mobile edit dock (Undo / Redo) sits above the status bar with 44px touch targets; no keyboard-hint copy.
 - Touch-dragging a pin repositions the pin without excessive accidental map panning.
-- Only selected/active/saving pins show the Move affordance — not every pin at once.
+- Only selected/active/saving pins show the Move affordance; not every pin at once.
 - Failed save and rollback feedback remains readable on a narrow viewport.
 - Zero events: campus events shelf/tab and “Browse campus events” remain reachable.
 

--- a/docs/issue-hygiene.md
+++ b/docs/issue-hygiene.md
@@ -1,22 +1,22 @@
 # GitHub Issue Hygiene
 
-Issues are living specs. **Not every issue needs file paths** — match the track to the audience.
+Issues are living specs. **Not every issue needs file paths**: match the track to the audience.
 
 Use `gh issue view <n> --repo uplbtools/room-tba` before and after issue-scoped work.
 
 ## Three tracks
 
-| Track           | Typical labels                          | Who writes the issue | Implementation pointers                                         |
-| --------------- | --------------------------------------- | -------------------- | --------------------------------------------------------------- |
-| **Reporter**    | `data`, `qa`                            | Campus volunteers    | Added **when someone picks it up** — not required from reporter |
-| **Developer**   | `good first issue`, `help wanted`       | Developers           | Dev fills in as they learn the codebase                         |
-| **Spec / epic** | `enhancement`, `parent issue`, `[TASK]` | Maintainers          | Full paths, AC, `Last verified`                                 |
+| Track           | Typical labels                          | Who writes the issue | Implementation pointers                                        |
+| --------------- | --------------------------------------- | -------------------- | -------------------------------------------------------------- |
+| **Reporter**    | `data`, `qa`                            | Campus volunteers    | Added **when someone picks it up**: not required from reporter |
+| **Developer**   | `good first issue`, `help wanted`       | Developers           | Dev fills in as they learn the codebase                        |
+| **Spec / epic** | `enhancement`, `parent issue`, `[TASK]` | Maintainers          | Full paths, AC, `Last verified`                                |
 
 **Reporter issues:** problem + verification only. Do not ask reporters to cite `src/` or open PRs.
 
 **Developer issues:** plain acceptance criteria; optional area of app (map, API, etc.).
 
-**Spec issues:** implementation specifics (paths, migrations) — keep current when agents or maintainers ship quickly.
+**Spec issues:** implementation specifics (paths, migrations): keep current when agents or maintainers ship quickly.
 
 ### Picking up a campus issue
 
@@ -34,7 +34,7 @@ When implementing a `data` or `qa` issue on behalf of a reporter:
 | Moment                      | Action                                                                                                                                                       |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Starting work** on `#NNN` | Re-read the issue; grep the codebase for paths/APIs cited in the body. If anything moved or shipped already, edit the issue first (or note what's obsolete). |
-| **Mid-implementation**      | If you change the agreed approach (different script name, schema shape, UI surface), update the issue body — don't only reflect it in code.                  |
+| **Mid-implementation**      | If you change the agreed approach (different script name, schema shape, UI surface), update the issue body: don't only reflect it in code.                   |
 | **Opening a PR**            | Comment on `#NNN` with the PR link and a one-line status. Use `Closes #NNN` / `Refs #NNN` in the PR body when appropriate.                                   |
 | **Before merge**            | Check off completed acceptance criteria in the issue. Update file paths, env vars, and commands to match what actually merged.                               |
 | **After merge**             | Close the issue if scope is fully delivered. Otherwise trim done items, add a **Remaining** section, and file spin-off issues for deferred work.             |
@@ -44,13 +44,13 @@ When implementing a `data` or `qa` issue on behalf of a reporter:
 
 Priority order when editing an issue body:
 
-1. **Acceptance criteria** — checkboxes reflect reality (`[x]` done, `[ ]` still open).
-2. **Implementation pointers** — paths (`src/...`, `drizzle/...`), CLI commands, env vars, table/column names.
-3. **Status header** — short line at the top: `Status: in progress | blocked | partially shipped | done`.
-4. **Last verified** — `Last verified against staging: YYYY-MM-DD (@commit or PR #)` so the next agent knows whether to re-audit.
-5. **Related links** — PRs, parent/child issues, docs that replaced the spec.
+1. **Acceptance criteria**: checkboxes reflect reality (`[x]` done, `[ ]` still open).
+2. **Implementation pointers**: paths (`src/...`, `drizzle/...`), CLI commands, env vars, table/column names.
+3. **Status header**: short line at the top: `Status: in progress | blocked | partially shipped | done`.
+4. **Last verified**: `Last verified against staging: YYYY-MM-DD (@commit or PR #)` so the next agent knows whether to re-audit.
+5. **Related links**: PRs, parent/child issues, docs that replaced the spec.
 
-Do **not** delete historical context — strike through or move obsolete paragraphs under `## Superseded` instead of erasing decisions.
+Do **not** delete historical context: strike through or move obsolete paragraphs under `## Superseded` instead of erasing decisions.
 
 ## Issue comment vs body edit
 
@@ -71,11 +71,11 @@ For `data` / `qa` issues, steps 2–4 are optional until converting to an implem
 
 - Issue says `src/seed-classes.ts` + `info.db` but runtime is Supabase + `scripts/import-….ts`.
 - Issue references `#203` as "current PR" but multi-user auth already merged.
-- Checklist items duplicated in a parent issue and sub-issues — parent should point to children, not repeat stale AC.
+- Checklist items duplicated in a parent issue and sub-issues: parent should point to children, not repeat stale AC.
 - Open design questions that were decided in code but never marked resolved in the issue.
 
 ## Non-goals
 
 - Rewriting every open issue in one pass.
-- Long narrative changelogs in issue bodies — link to PR/`CHANGELOG.md` instead.
+- Long narrative changelogs in issue bodies: link to PR/`CHANGELOG.md` instead.
 - Closing issues without verifying AC because "we probably done that."

--- a/docs/map-ui-mode-matrix.md
+++ b/docs/map-ui-mode-matrix.md
@@ -17,7 +17,7 @@ Implementation: `getMapChromeVisibility()` in `src/lib/map-chrome.ts`.
 
 - **Top band:** search column (editor icon button when signed in), building pin filter chips (`BuildingTypeFilterBar.svelte`), transit toggle chip (`TransitFilterChip.svelte`, count badge + route sub-panel when active), event banner, Map tools trigger; mobile chip row includes compact `MapDimensionToggle` (2D/3D only). Individual jeepney routes are picked in the transit sub-panel under the chip row or in Map tools → Transit (`JeepneyMenu.svelte` / `TransitRoutePanel.svelte`), not as top-level chips. On mobile (≤48rem), the editor icon opens a full-screen editor dashboard (`EditorScreen.svelte`) instead of an inline shelf under the chip row.
 - **Map face:** map canvas, desktop unified camera column (`camera-controls-card`: vertical 2D/3D + rotate/tilt/north)
-- **Bottom band:** unified bottom chrome tray (`.bottom-chrome` in `Entry.svelte`) — attribution leading, status center, location/propose actions trailing; one shared surface
+- **Bottom band:** unified bottom chrome tray (`.bottom-chrome` in `Entry.svelte`); attribution leading, status center, location/propose actions trailing; one shared surface
 - **Ephemeral:** toast, modals, mobile editor screen (`EditorScreen.svelte` when `editorChromeStore.shelfOpen`)
 
 MapLibre attribution is disabled on the map canvas (`attributionControl={false}`). Required basemap credits live in `MapAttribution` on the bottom band so they stay visible above the mobile detail sheet.
@@ -53,7 +53,7 @@ Do not add duplicate action rows or colored highlight boxes. See `.cursor/rules/
 
 ## Verification viewports
 
-320px, 768px, desktop — browse, edit mode, map tools open, sync active.
+320px, 768px, desktop; browse, edit mode, map tools open, sync active.
 
 ## Motion
 
@@ -61,4 +61,4 @@ Functional transitions only (no decorative loops). Shared tokens on `.app-layout
 
 ## Basemap palette
 
-Campus map tiles use `public/liberty-customized.json` (OSM Liberty / MapTiler vector tiles). Eye-strain tuning lives in `src/constants/map-basemap-palette.ts` and is applied at runtime via `applyBasemapPalette()` in `Map.svelte` (also mirrored in the JSON for offline downloads). Adjust grass, water, building extrusions, and road fills there — not map chrome tokens on `.app-layout`. A full dark or muted theme would need a separate style variant and user setting.
+Campus map tiles use `public/liberty-customized.json` (OSM Liberty / MapTiler vector tiles). Eye-strain tuning lives in `src/constants/map-basemap-palette.ts` and is applied at runtime via `applyBasemapPalette()` in `Map.svelte` (also mirrored in the JSON for offline downloads). Adjust grass, water, building extrusions, and road fills there; not map chrome tokens on `.app-layout`. A full dark or muted theme would need a separate style variant and user setting.

--- a/docs/volunteer-triage.md
+++ b/docs/volunteer-triage.md
@@ -5,12 +5,12 @@ Lightweight process for non-coding volunteers and triage leads. You do **not** n
 ## Weekly check (5–10 minutes)
 
 1. Open [open issues](https://github.com/uplbtools/room-tba/issues).
-2. Sort by **`data`** and **`qa`** labels — campus reports.
+2. Sort by **`data`** and **`qa`** labels: campus reports.
 3. For each new issue:
    - Is the report clear enough to act on? If not, ask one clarifying question in a comment.
    - Add **`help wanted`** if it needs a developer and no one is assigned.
    - Link related duplicates.
-4. Skim **`good first issue`** — ping Discord if something is unclaimed for 2+ weeks.
+4. Skim **`good first issue`**: ping Discord if something is unclaimed for 2+ weeks.
 
 ## Who does what
 
@@ -30,7 +30,7 @@ flowchart LR
 
 | Role               | Action                                                |
 | ------------------ | ----------------------------------------------------- |
-| Reporter           | Data / QA issue or in-app suggest — **no PR**         |
+| Reporter           | Data / QA issue or in-app suggest: **no PR**          |
 | Triage             | Label, clarify, surface `help wanted`                 |
 | Developer          | Picks up issue, PR to `staging`, comments on issue    |
 | Maintainer / agent | Same; may implement data fixes on behalf of reporters |

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -270,7 +270,7 @@
         );
       } else if (hasUsableData) {
         syncToastStore.setSyncError(
-          "Could not sync campus data — tap to retry",
+          "Could not sync campus data. Tap to retry.",
           () => {
             void refreshFromNetwork(hasCachedDataAtStart);
           },

--- a/src/components/svelte/SubmitterNameField.svelte
+++ b/src/components/svelte/SubmitterNameField.svelte
@@ -75,7 +75,7 @@
       aria-live="polite"
     >
       {value.length}/{MAX_SUBMITTER_NAME_LENGTH}
-      · at least {MIN_SUBMITTER_NAME_LENGTH} characters — so editors can follow up
+      · at least {MIN_SUBMITTER_NAME_LENGTH} characters so editors can follow up
     </p>
   {/if}
 </div>

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -363,7 +363,7 @@
         error = result.error ?? "Could not submit proposal.";
         return;
       }
-      toastStore.show("Thanks — we'll review your suggestion soon.", "success");
+      toastStore.show("Thanks. We'll review your suggestion soon.", "success");
       clearSuggestAdditionDraft();
       resetFields();
       dismissHost();
@@ -383,8 +383,8 @@
       Add a missing building, room, dorm, college, or division. Buildings and
       dorms need a map pin before you create them.
     {:else}
-      Spot something missing on the map? Tell us what to add — editors review
-      every suggestion before it goes live.
+      Spot something missing on the map? Describe it below. Editors review every
+      suggestion before it goes live.
     {/if}
   </p>
 
@@ -433,7 +433,7 @@
       <EntityEditorFormField
         label="How do you find it?"
         inputId="addition-building-directions"
-        hint="Floor, nearby landmarks — anything that helps someone get there."
+        hint="Floor, nearby landmarks, or anything that helps someone get there."
       >
         {#snippet control()}
           <textarea
@@ -532,7 +532,7 @@
       <EntityEditorFormField
         label="Who can live here?"
         inputId="addition-dorm-gender"
-        hint="Coed, women only, men only — whatever applies."
+        hint="Coed, women only, men only, or whatever applies."
       >
         {#snippet control()}
           <input
@@ -561,7 +561,7 @@
       <EntityEditorFormField
         label="How do you get there?"
         inputId="addition-room-directions"
-        hint="Optional — stairs, wing, or landmarks help."
+        hint="Optional: stairs, wing, or landmarks."
       >
         {#snippet control()}
           <textarea

--- a/src/components/svelte/TermSelector.svelte
+++ b/src/components/svelte/TermSelector.svelte
@@ -35,11 +35,11 @@
       {:else}
         <a
           class="term-selector__empty"
-          href="/contribute"
+          href="https://github.com/uplbtools/room-tba/issues/new?template=data_correction.yml"
           target="_blank"
           rel="noopener noreferrer"
         >
-          No schedules yet — report
+          No schedules yet. Report data
         </a>
       {/if}
     {/if}

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -368,7 +368,7 @@
             {#if canPublish}
               <EntityEditorPinRow
                 label={mapEditStore.enabled
-                  ? "Map pin — drag marker on map"
+                  ? "Map pin: drag marker on map"
                   : "Map pin"}
                 pickLabel={mapEditStore.enabled ? "Active" : "Enable map edit"}
                 disabled={mapEditStore.enabled || savingField !== null}
@@ -377,7 +377,7 @@
             {:else}
               <EntityEditorPinRow
                 label={pinProposalActive
-                  ? "Pin move — drag marker on map"
+                  ? "Pin move: drag marker on map"
                   : "Map pin"}
                 pickLabel={pinProposalActive ? "Active" : "Suggest move"}
                 disabled={pinProposalActive || savingField !== null}

--- a/src/components/svelte/controls/DormEditorPanel.svelte
+++ b/src/components/svelte/controls/DormEditorPanel.svelte
@@ -338,7 +338,7 @@
   <p class="editor-note">
     {#if canPublish}
       {#if mapEditStore.enabled}
-        Map editing is on — drag this dorm's pin on the map to move it.
+        Map editing is on. Drag this dorm's pin on the map to move it.
       {:else}
         To move this dorm's map pin,
         <button
@@ -352,7 +352,7 @@
       {/if}
     {:else if dorm.lat && dorm.lon}
       {#if mapProposalStore.allowsKey(`dorm:${dorm.id}`)}
-        Pin move mode is on — drag this dorm's marker on the map.
+        Pin move mode is on. Drag this dorm's marker on the map.
       {:else}
         To suggest a map pin move,
         <button

--- a/src/components/svelte/controls/EventResult.svelte
+++ b/src/components/svelte/controls/EventResult.svelte
@@ -971,7 +971,7 @@
                     Drag the event marker on the map to move it. This edits the
                     primary location only.
                   {:else if mapProposalStore.allowsKey(`event:${event.id}:location`)}
-                    Pin move mode is on — drag the event marker on the map.
+                    Pin move mode is on. Drag the event marker on the map.
                   {:else}
                     Suggest a map pin move with
                     <button

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -127,7 +127,7 @@
       >
         <GithubContributorsSection
           title="Developers"
-          note="Pulled live from the Room TBA GitHub repo, sorted by commit count."
+          note="From GitHub commit history on the Room TBA repo."
           contributors={githubContributors}
           loading={githubLoading}
           loaded={githubLoaded}
@@ -147,8 +147,8 @@
         <section class="community-block">
           <h3>Join the community</h3>
           <p class="section-note">
-            Help keep campus data accurate — suggest edits in the map, chat with
-            volunteers, or say hi on our channels.
+            Suggest fixes in the map, or chat on Discord or Messenger if you
+            want to help verify data.
           </p>
           <ul class="community-links">
             <li>
@@ -181,8 +181,7 @@
         <section class="people-block">
           <h3>Design</h3>
           <p class="section-note">
-            Visual and UX design. These credits are manual, not from GitHub
-            commits.
+            Visual and UX design (manual credits, not from GitHub commits).
           </p>
           <PeopleAvatarGrid
             people={designerPeople}
@@ -193,8 +192,8 @@
         <section class="people-block">
           <h3>Campus editors &amp; contributors</h3>
           <p class="section-note">
-            Students who help keep map data and events accurate on the ground.
-            These credits are manual, not from GitHub commits.
+            Students who verify rooms and events on campus (manual credits, not
+            from GitHub commits).
           </p>
           <PeopleAvatarGrid
             people={campusContributorPeople}

--- a/src/components/svelte/modal/ScheduleModal.svelte
+++ b/src/components/svelte/modal/ScheduleModal.svelte
@@ -9,7 +9,7 @@
 
 <div class="schedule-modal">
   <div class="schedule-modal__header">
-    <h2>{room ? `Schedule — ${room.code}` : "Schedule"}</h2>
+    <h2>{room ? `Schedule: ${room.code}` : "Schedule"}</h2>
     {#if termLabel}
       <span class="schedule-modal__term">{termLabel}</span>
     {/if}

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -41,35 +41,35 @@ import { UPLB_TOOLS_URL } from "@constants/community-links";
         <h3>Browsing the map (no account)</h3>
         <ul>
           <li>
-            <strong>Usage analytics</strong> — We use Vercel Analytics on the public
+            <strong>Usage analytics.</strong> We use Vercel Analytics on the public
             site to understand traffic patterns (page views, referrers). We do not
             intentionally collect your name or student number through analytics.
           </li>
           <li>
-            <strong>Device storage</strong> — The app caches campus data in your browser
+            <strong>Device storage.</strong> The app caches campus data in your browser
             (PGlite / IndexedDB) and may store preferences such as recent searches,
             term selection, and “don’t show again” for the welcome modal.
           </li>
           <li>
-            <strong>Location (optional)</strong> — If you enable location on your
-            device, the map may use your coordinates locally to show where you are.
-            We do not persist your live GPS track on our servers.
+            <strong>Location (optional).</strong> If you enable location on your device,
+            the map may use your coordinates locally to show where you are. We do
+            not persist your live GPS track on our servers.
           </li>
         </ul>
 
         <h3>Contributors and editors (signed in)</h3>
         <ul>
           <li>
-            <strong>Account identifiers</strong> — Editor/contributor accounts store
+            <strong>Account identifiers.</strong> Editor/contributor accounts store
             a username, hashed password, role, and optional display name.
           </li>
           <li>
-            <strong>Edit proposals and published changes</strong> — Suggestions and
+            <strong>Edit proposals and published changes.</strong> Suggestions and
             approved edits record who submitted or approved them (`edited_by` and
             related audit fields).
           </li>
           <li>
-            <strong>Session cookies</strong> — Signed-in sessions use httpOnly cookies
+            <strong>Session cookies.</strong> Signed-in sessions use httpOnly cookies
             scoped to this site.
           </li>
         </ul>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -31,7 +31,7 @@ import { UPLB_TOOLS_URL } from "@constants/community-links";
         <h2>The service</h2>
         <p>
           Room TBA helps UPLB students find rooms, buildings, schedules, and
-          campus events on a map. We provide the site <strong>as is</strong> — free
+          campus events on a map. We provide the site <strong>as is.</strong> free
           of charge, without guaranteed uptime, accuracy, or completeness.
         </p>
       </section>
@@ -50,10 +50,9 @@ import { UPLB_TOOLS_URL } from "@constants/community-links";
         <h2>Data accuracy</h2>
         <p>
           Schedules and locations are crowd-maintained and imported from sources
-          such as AMIS exports. They can be wrong, stale, or missing —
-          especially during change of matriculation. Always verify critical
-          information with your instructor, department, or official university
-          channels.
+          such as AMIS exports. They can be wrong, stale, or missing. especially
+          during change of matriculation. Always verify critical information
+          with your instructor, department, or official university channels.
         </p>
       </section>
 
@@ -61,19 +60,19 @@ import { UPLB_TOOLS_URL } from "@constants/community-links";
         <h2>Contributing and editing</h2>
         <ul>
           <li>
-            <strong>In-app contributions</strong> — Use “Suggest an edit” or contributor
+            <strong>In-app contributions.</strong> Use “Suggest an edit” or contributor
             tools inside the map. Do not submit false or malicious data.
           </li>
           <li>
-            <strong>Review</strong> — Volunteer editors may approve, reject, or request
+            <strong>Review.</strong> Volunteer editors may approve, reject, or request
             changes to proposals before they go live.
           </li>
           <li>
-            <strong>Editor accounts</strong> — Accounts are issued at maintainer discretion.
+            <strong>Editor accounts.</strong> Accounts are issued at maintainer discretion.
             Misuse may result in deactivation without notice.
           </li>
           <li>
-            <strong>License to published edits</strong> — By submitting approved content
+            <strong>License to published edits.</strong> By submitting approved content
             you grant UPLB Tools a license to display and distribute that campus data
             as part of the open project (see repository MIT license for code).
           </li>
@@ -108,7 +107,7 @@ import { UPLB_TOOLS_URL } from "@constants/community-links";
         <p>
           To the fullest extent permitted by law, UPLB Tools volunteers and
           contributors are not liable for any indirect, incidental, or
-          consequential damages arising from your use of Room TBA — including
+          consequential damages arising from your use of Room TBA, including
           missed classes, wrong rooms, or lost data.
         </p>
       </section>


### PR DESCRIPTION
## Summary

Copy pass for three audiences (campus, developers, agents):

- **README:** drop tagline fluff, Goal/How feature table, plain stack bullets
- **CONTRIBUTING / PR template / issue templates:** fewer em dashes, clearer routing
- **Legal pages:** list labels use periods instead of em dashes
- **In-app:** landing modal, suggest panel, term selector empty state, editor pin hints, sync toast
- **Docs:** issue-hygiene, volunteer triage, AGENTS (punctuation only)

## Test plan

- [x] Prettier on changed files
- [ ] README and CONTRIBUTING read cleanly on GitHub
- [ ] Legal pages render (privacy, terms)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only changes with no logic or auth impact; verify `terms.astro` and the `AGENTS.md` PR table cell for accidental copy breaks before merge.
> 
> **Overview**
> **Copy and punctuation pass** across README, CONTRIBUTING, GitHub issue/PR templates, agent docs, and contributor-facing markdown: em dashes and long parentheticals are replaced with semicolons, colons, or shorter sentences; README is trimmed (tagline, Goal/How table, plain stack list).
> 
> **In-app and legal:** Suggest/addition flows, editor pin hints, sync toast, schedule modal titles, landing modal community copy, and privacy/terms list labels use periods instead of em dashes. **`TermSelector`** empty-term link now opens the **data correction** GitHub issue template instead of `/contribute`.
> 
> **Watch for regressions:** `AGENTS.md` branch table “Do not” cell for staging PRs reads **`;`** (likely accidental). **`terms.astro`** “as is.** free” reads like a broken sentence after punctuation edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9375092d02e4bb66420e298ae67991c3725a96a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->