### PR TITLE
docs(amis): bearer tokens expire in about an hour

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ R2_SECRET_ACCESS_KEY=
 R2_BUCKET_NAME=
 R2_PUBLIC_URL=
 
-# AMIS import (scripts/import-amis-classes.ts) — copy from AMIS enrollment URL after login.
-# Never commit real tokens. Rotate if exposed.
-# Fetch once with --fetch; later imports read data/amis-*-{termId}.json (gitignored).
+# AMIS import (scripts/import-amis-classes.ts) — copy bearer token from browser DevTools after AMIS login.
+# Tokens expire in about an hour; paste fresh when running --fetch. Never commit real tokens.
+# Fetch once with --fetch (while token is valid); later imports read data/amis-*-{termId}.json (gitignored).
 AMIS_BEARER_TOKEN=
 AMIS_SESSION_ID=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ Map and side-panel layout rules are detailed in glob-scoped Cursor rules; read t
 ## AMIS class imports
 
 - **Fetch once, reuse cache:** `bun run import:amis-classes -- --term-id <id> --fetch` saves sanitized rows to `data/amis-*-<id>.json` (gitignored). Re-import with the same command **without** `--fetch` — no AMIS hammering.
+- **Short-lived tokens:** `AMIS_BEARER_TOKEN` from a logged-in AMIS session expires in about an hour. Copy a fresh token right before `--fetch`; do not rely on a token saved in `.env` from yesterday. Cached JSON imports do not need a token.
 - **Never store or commit instructor names.** AMIS responses embed faculty/user PII. `sanitizeAmisRow()` strips it before any JSON is written. Do not commit `data/amis-*.json`, raw AMIS dumps, or DB exports that include `faculty`, `first_name`, `formatted_name`, etc.
 - The app DB stores only course code, section, type, title, schedule slots, room, and term — never instructor fields.
 - If unsanitized exports exist locally, run `bun run import:amis-classes -- --scrub-exports`.

--- a/scripts/import-amis-classes.ts
+++ b/scripts/import-amis-classes.ts
@@ -5,6 +5,7 @@
  *   AMIS_BEARER_TOKEN=… AMIS_SESSION_ID=… bun run import:amis-classes -- --term-id 1252 --fetch
  *   DATABASE_URL=… bun run import:amis-classes -- --term-id 1252
  *
+ * AMIS bearer tokens expire in about an hour — paste a fresh token for --fetch only.
  * Flags:
  *   --fetch            Fetch from AMIS, strip instructor PII, save JSON, then import
  *   --from-json path   Import from saved JSON only (no AMIS call)


### PR DESCRIPTION
## Summary

Documents that AMIS `AMIS_BEARER_TOKEN` values expire in ~1 hour. `--fetch` needs a fresh token; cached `data/amis-*.json` imports do not.

## Test plan

- [x] `bun run check:readme`
- [x] Docs-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and agent-guide updates only; no application code or import logic changed.
> 
> **Overview**
> **Docs-only:** clarifies that AMIS `AMIS_BEARER_TOKEN` values are short-lived (~1 hour) and that only `--fetch` needs a fresh token from browser DevTools; cached `data/amis-*-{termId}.json` re-imports do not.
> 
> Updates **`.env.example`** comments (DevTools sourcing, expiry, fetch-vs-cache workflow), adds a **Short-lived tokens** bullet under **AMIS class imports** in **`AGENTS.md`**, and a matching line in the **`import-amis-classes.ts`** file header. No runtime, API, or import-script behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3bc84cfab6ae8f6dd9fa1ff06fc39159d6f702b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->