### PR TITLE
Release: CRS term IDs, AMIS import hardening, and schedule UX

### DIFF
--- a/.cursor/skills/room-tba-agent-workflow/SKILL.md
+++ b/.cursor/skills/room-tba-agent-workflow/SKILL.md
@@ -50,5 +50,5 @@ Commit policy, Conventional Commits format, and GPG signing: [AGENTS.md § Commi
 3. For map/side-panel changes, confirm applicable Cursor rules were followed.
 4. **Issue sync:** for each linked `#NNN`, update AC/paths/status per [docs/issue-hygiene.md](../../docs/issue-hygiene.md); comment with the PR URL.
 5. Push with `-u origin HEAD` only when the user asked to push/open a PR.
-6. **Base branch:** feature work → `staging`. "PR to main" / prod ship → `staging` → `main` release only ([AGENTS.md § Branches and pull requests](../../AGENTS.md#branches-and-pull-requests)).
+6. **Base branch:** feature work → `staging`. "PR to main" / prod ship → `staging` → `main` release only ([AGENTS.md § Branches and pull requests](../../AGENTS.md#branches-and-pull-requests)). Direct push to `staging` when the user asks — see [§ Worktrees and multiple agents](../../AGENTS.md#worktrees-and-multiple-agents).
 7. **`data` / `qa` issues:** reporter does not PR; implement and link the PR on the issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Read the right doc for the task; do not rely on this file alone for detailed che
 | Human volunteers, developers (default)           | [CONTRIBUTING.md](CONTRIBUTING.md)                                                                                      |
 | Developer setup detail                           | [docs/developer-guide.md](docs/developer-guide.md)                                                                      |
 | Starting a coding session, commit, or PR         | [.cursor/skills/room-tba-agent-workflow/SKILL.md](.cursor/skills/room-tba-agent-workflow/SKILL.md)                      |
-| Worktrees, multiple agents, push to `staging`      | [AGENTS.md § Worktrees and multiple agents](#worktrees-and-multiple-agents)                                             |
+| Worktrees, multiple agents, push to `staging`    | [AGENTS.md § Worktrees and multiple agents](#worktrees-and-multiple-agents)                                             |
 | Map chrome, Entry zones, flyouts, 320/768 layout | [.cursor/rules/map-layout.mdc](.cursor/rules/map-layout.mdc) + [docs/map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md) |
 | Side panel / entity detail views                 | [.cursor/rules/side-panel.mdc](.cursor/rules/side-panel.mdc)                                                            |
 | Drizzle, API routes, migrations, PGlite          | [.cursor/rules/data-and-migrations.mdc](.cursor/rules/data-and-migrations.mdc)                                          |
@@ -83,14 +83,14 @@ git status --short --branch
 
 Multiple Cursor agents (or human + agent) on the **same path and branch** cause lost work, surprise merges, and “it built locally but Vercel failed” confusion.
 
-| Do | Don't |
-| --- | --- |
-| **One active agent per worktree path** | Two agents editing `/home/…/room-tba` on `staging` at once |
-| `git fetch` + `git status` before editing | Assume the tree matches remote |
-| `git pull --rebase origin staging` before push when others may be active | Force-push `staging` or `main` |
-| Commit only your scoped changes; preserve unrelated dirty files | Revert or `git checkout --` user WIP |
-| Open a **separate worktree + branch** for parallel long tasks | Long-lived stashes as a substitute for branches |
-| `git stash drop` / `git stash clear` only when the user asks | Bulk-drop stashes to “clean up” without checking |
+| Do                                                                       | Don't                                                      |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| **One active agent per worktree path**                                   | Two agents editing `/home/…/room-tba` on `staging` at once |
+| `git fetch` + `git status` before editing                                | Assume the tree matches remote                             |
+| `git pull --rebase origin staging` before push when others may be active | Force-push `staging` or `main`                             |
+| Commit only your scoped changes; preserve unrelated dirty files          | Revert or `git checkout --` user WIP                       |
+| Open a **separate worktree + branch** for parallel long tasks            | Long-lived stashes as a substitute for branches            |
+| `git stash drop` / `git stash clear` only when the user asks             | Bulk-drop stashes to “clean up” without checking           |
 
 ### Optional: extra worktrees
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Read the right doc for the task; do not rely on this file alone for detailed che
 | Human volunteers, developers (default)           | [CONTRIBUTING.md](CONTRIBUTING.md)                                                                                      |
 | Developer setup detail                           | [docs/developer-guide.md](docs/developer-guide.md)                                                                      |
 | Starting a coding session, commit, or PR         | [.cursor/skills/room-tba-agent-workflow/SKILL.md](.cursor/skills/room-tba-agent-workflow/SKILL.md)                      |
+| Worktrees, multiple agents, push to `staging`      | [AGENTS.md § Worktrees and multiple agents](#worktrees-and-multiple-agents)                                             |
 | Map chrome, Entry zones, flyouts, 320/768 layout | [.cursor/rules/map-layout.mdc](.cursor/rules/map-layout.mdc) + [docs/map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md) |
 | Side panel / entity detail views                 | [.cursor/rules/side-panel.mdc](.cursor/rules/side-panel.mdc)                                                            |
 | Drizzle, API routes, migrations, PGlite          | [.cursor/rules/data-and-migrations.mdc](.cursor/rules/data-and-migrations.mdc)                                          |
@@ -33,6 +34,7 @@ Read the right doc for the task; do not rely on this file alone for detailed che
 - **Infer intent over typos.** User messages are often rushed; read for what they mean, not only literal wording. Common patterns:
   - **"PR to main" / "merge to prod" / "ship it"** → promote **`staging` → `main`** (release PR), not a feature branch opened against `main`. See [Branches and pull requests](#branches-and-pull-requests).
   - **"PR to staging"** → feature branch → `staging` (default for new work).
+  - **"Push staging" / "ship to staging"** → commit on `staging` and `git push origin staging` ([§ Push to staging directly](#push-to-staging-directly)).
   - Minor typos (`pr`, `stagign`, `mrege`, doubled letters); do not ask for clarification when context makes the goal obvious.
 - **`data` / `qa` issues:** reporters do not open PRs. Implement on their behalf; credit in issue comments.
 
@@ -49,6 +51,71 @@ Default flow: **feature branch → `staging` → `main`**.
 - **`main`** is production; semantic-release runs there.
 - **`staging`** is integration; feature PRs land here first unless the user explicitly asks for a hotfix straight to `main`.
 - When the user says **"PR to main"**, they usually mean **get it to production**, not "set the GitHub PR base branch to `main`."
+
+### Push to `staging` directly
+
+For scoped fixes and solo/maintainer sessions, **committing on `staging` and pushing is fine** — you do not need a feature branch for every change.
+
+```sh
+git checkout staging
+git pull --rebase origin staging
+# … edit, verify, commit …
+git push origin staging
+```
+
+- Push to **`staging`** when the user asks to land work on integration, ship to staging, or says push (and context is not a release to prod).
+- **Do not push to `main`** except via the **`staging` → `main`** release PR (or an explicit hotfix the user requested).
+- After pushing `staging`, Vercel builds the staging preview (`staging.room-tba.uplbtools.me`). Preview env must have **`DATABASE_URL`** (same Supabase as production) or the build fails at prerender.
+
+Feature branches remain appropriate for large or review-heavy work: `feat/…` → PR to `staging` → merge → delete branch.
+
+## Worktrees and multiple agents
+
+**Default:** one repo checkout, one worktree, on **`staging`**. Run at session start:
+
+```sh
+git worktree list
+git fetch origin staging main
+git status --short --branch
+```
+
+### How not to collide with other agents
+
+Multiple Cursor agents (or human + agent) on the **same path and branch** cause lost work, surprise merges, and “it built locally but Vercel failed” confusion.
+
+| Do | Don't |
+| --- | --- |
+| **One active agent per worktree path** | Two agents editing `/home/…/room-tba` on `staging` at once |
+| `git fetch` + `git status` before editing | Assume the tree matches remote |
+| `git pull --rebase origin staging` before push when others may be active | Force-push `staging` or `main` |
+| Commit only your scoped changes; preserve unrelated dirty files | Revert or `git checkout --` user WIP |
+| Open a **separate worktree + branch** for parallel long tasks | Long-lived stashes as a substitute for branches |
+| `git stash drop` / `git stash clear` only when the user asks | Bulk-drop stashes to “clean up” without checking |
+
+### Optional: extra worktrees
+
+Use when you need a second branch checked out without disturbing `staging`:
+
+```sh
+# new branch in a sibling directory
+git worktree add ../room-tba-feat feat/my-thing
+cd ../room-tba-feat
+# … work, commit, push, open PR to staging …
+git worktree remove ../room-tba-feat   # after branch is merged and pushed
+```
+
+- Each worktree has its **own** working tree and `.env` (copy or symlink if needed); `node_modules` are per checkout unless shared.
+- List/remove: `git worktree list`, `git worktree remove <path>`.
+- **Never** edit the same file from two worktrees simultaneously without committing/pushing between pulls.
+
+### Session handoff checklist
+
+Before ending a turn with code changes:
+
+1. `git status` — clean or only intentional WIP left for the user.
+2. Commits on the correct branch (`staging` or feature branch).
+3. Push only if the user asked (or AGENTS default commit policy applies).
+4. If you applied DB migrations, note “run on Supabase before deploy” in the PR or issue.
 
 ## GitHub issues
 
@@ -94,7 +161,7 @@ Enable **Dependabot security updates** and **secret scanning** in GitHub repo Se
 - **Use [Conventional Commits](https://www.conventionalcommits.org/)**; required for semantic-release on `main`. Format: `type(scope): imperative summary` (e.g. `feat(map-chrome): add transit route panel`, `fix(security): validate image URLs`). Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`. Scope is optional but preferred when the change is localized.
 - **One logical unit per commit**; atomic, reviewable, GPG-signed: `git commit -S -m "$(cat <<'EOF' … EOF)"`.
 - Stage only files that belong together; write a message that states _why_, not a file list.
-- Do not push unless asked. Do not amend or force-push unless the user’s git rules allow it.
+- Do not push unless asked. **Exception:** user explicitly wants work on integration (`push staging`, `ship to staging`) — push `origin staging` after commit. Do not amend or force-push unless the user’s git rules allow it.
 
 ## Architecture (short)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,8 +139,36 @@ Map and side-panel layout rules are detailed in glob-scoped Cursor rules; read t
 
 ## AMIS class imports
 
+### CRS term IDs (source of truth)
+
+CRS/AMIS `term_id` values are **chronological within the academic year** — the number is not a semantic label:
+
+| CRS id   | Period       | Typical dates (AY 2025–2026) |
+| -------- | ------------ | ---------------------------- |
+| **1251** | 1st semester | Aug–Dec                      |
+| **1252** | 2nd semester | Jan–May                      |
+| **1253** | Midyear      | Jun–Jul                      |
+
+- **`terms.id` must equal the CRS id** you pass to `--term-id` / AMIS fetch. Fix labels and calendar dates in the `terms` row; **never move class rows between ids** to “fix” a naming mix-up.
+- Import commands: 2nd sem `--term-id 1252 --fetch`; midyear `--term-id 1253 --fetch`.
+- **Do not re-apply** [`drizzle/0012_reassign_second_sem_classes.sql`](drizzle/0012_reassign_second_sem_classes.sql) — it assumed 1252 was mislabeled 2nd sem data. That was wrong. Term metadata is corrected in [`0013_fix_crs_term_labels.sql`](drizzle/0013_fix_crs_term_labels.sql). Migrations `0009`/`0010` had the same backwards assumption; do not copy their label/date mapping into new code.
+
+### Pitfalls (read before triaging “wrong term” bugs)
+
+1. **Do not infer term type from row count.** A term with 3k+ rows is not automatically “2nd sem”; a term with ~200 rows is not automatically “broken.” Check **schedule patterns** in `classes.schedule`:
+   - **Midyear (1253):** intensive daily blocks — `MTWTHFS`, `MTWTHF`, `TTHS`, Saturday-heavy slots.
+   - **2nd sem (1252):** regular semester — mostly `TTH`, `MWF`, single-day weekly slots.
+2. **Do not conflate CRS id with English name.** Early agents assumed “1252 sounds like midyear slot” — wrong. Always trust the chronological table above and what AMIS returns for that numeric id.
+3. **Thousands fetched, hundreds imported is normal.** AMIS returns every section type; Room TBA imports only **LEC/LAB with a matched room** (see below). A 12k fetch → ~3k import for 2nd sem is expected; a 6k fetch → ~120 for midyear can be expected too.
+4. **Two different “skipped row” buckets** — do not treat them as the same bug:
+   - **By design:** THE (thesis), SPR (special problem), PRA (practicum), DSR (dissertation), IND, etc. usually have **no `facility_id`** in AMIS. Skipped on purpose; users are told on the room panel. See `src/lib/amis/room-scheduled-types.ts`.
+   - **Data gap (#300):** LEC/LAB rows **with** a facility string that does not match `rooms.room_code` (aliases, typos, `PSLH-A` vs `PSLH A`). Needs alias work, not term-id surgery.
+5. **Validate before “re-import to fix term”.** Query sample schedules per `term_id`, confirm `/api/terms` labels match CRS table, then re-import the **correct CRS id** with `--replace`. Do not run 0012-style mass `UPDATE term_id`.
+
+### Workflow
+
 - **Fetch once, reuse cache:** `bun run import:amis-classes -- --term-id <id> --fetch` saves sanitized rows to `data/amis-*-<id>.json` (gitignored). Re-import with the same command **without** `--fetch` — no AMIS hammering.
-- **Short-lived tokens:** `AMIS_BEARER_TOKEN` from a logged-in AMIS session expires in about an hour. Copy a fresh token right before `--fetch`; do not rely on a token saved in `.env` from yesterday. Cached JSON imports do not need a token.
+- **Short-lived tokens:** `AMIS_BEARER_TOKEN` from a logged-in AMIS session expires in about an hour. Copy a fresh token right before `--fetch`; do not rely on a token saved in `.env` from yesterday. Cached JSON imports do not need a token. Never commit tokens or paste them into issues or chat logs.
 - **Never store or commit instructor names.** AMIS responses embed faculty/user PII. `sanitizeAmisRow()` strips it before any JSON is written. Do not commit `data/amis-*.json`, raw AMIS dumps, or DB exports that include `faculty`, `first_name`, `formatted_name`, etc.
 - The app DB stores only course code, section, type, title, schedule slots, room, and term — never instructor fields.
 - If unsanitized exports exist locally, run `bun run import:amis-classes -- --scrub-exports`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _Schedules, buildings, jeepney routes, and "where is PSLH 1?" on one campus map.
 
 No account needed to browse. Editors and contributors fix data in the same app (login popup on the map, not a separate admin site).
 
-> **Data note:** Room and class listings are updated each term by volunteers. The default view targets **2nd Semester AY 2025–2026**. Wrong schedule? [Open an issue](https://github.com/uplbtools/room-tba/issues/new/choose). That is how the dataset gets better.
+> **Data note:** Room and class listings are updated each term by volunteers. The active term follows the academic calendar (midyear Jun–Jul, 2nd sem Jan–May, etc.). Schedules show **lecture and lab** sections with assigned rooms — thesis, special problem, dissertation, and similar sections usually are not tied to a room in AMIS. Wrong schedule? [Open an issue](https://github.com/uplbtools/room-tba/issues/new/choose).
 
 ---
 

--- a/drizzle/0013_fix_crs_term_labels.sql
+++ b/drizzle/0013_fix_crs_term_labels.sql
@@ -1,0 +1,21 @@
+-- CRS/AMIS term_id values are chronological within the AY (1251 1st, 1252 2nd, 1253 midyear).
+-- Supersedes wrong labels/dates from 0009/0010 and the class move in 0012 (do not re-run 0012).
+UPDATE "terms"
+SET
+  "label" = 'AY 2025-2026 2nd Semester',
+  "semester" = '2',
+  "starts_on" = '2026-01-19',
+  "ends_on" = '2026-05-31',
+  "sort_order" = 20,
+  "is_default" = false
+WHERE "id" = 1252;
+--> statement-breakpoint
+UPDATE "terms"
+SET
+  "label" = 'AY 2025-2026 Midyear',
+  "semester" = 'midyear',
+  "starts_on" = '2026-06-08',
+  "ends_on" = '2026-07-26',
+  "sort_order" = 30,
+  "is_default" = true
+WHERE "id" = 1253;

--- a/scripts/import-amis-classes.ts
+++ b/scripts/import-amis-classes.ts
@@ -2,7 +2,7 @@
  * Import AMIS class schedules into Supabase for a given CRS term_id.
  *
  * Workflow (fetch once, reuse local cache):
- *   AMIS_BEARER_TOKEN=… AMIS_SESSION_ID=… bun run import:amis-classes -- --term-id 1252 --fetch
+ *   AMIS_BEARER_TOKEN=… AMIS_SESSION_ID=… bun run import:amis-classes -- --term-id 1253 --fetch
  *   DATABASE_URL=… bun run import:amis-classes -- --term-id 1252
  *
  * AMIS bearer tokens expire in about an hour — paste a fresh token for --fetch only.
@@ -13,7 +13,8 @@
  *   --dry-run          Parse + map only; no DB writes
  *   --no-replace       Do not delete existing rows for the term before insert
  *
- * Midyear = 1252, 2nd sem = 1253, 1st sem = 1251.
+ * CRS term_id is chronological within the AY: 1251 = 1st sem, 1252 = 2nd sem, 1253 = midyear.
+ * Only LEC and LAB rows with a resolvable room are imported (thesis, special problem, etc. usually have no room in AMIS).
  * Local exports live at data/amis-*-{termId}.json (gitignored).
  * AMIS responses include instructor names — never commit raw exports or store names.
  */
@@ -42,6 +43,7 @@ import {
   amisExportContainsInstructorPii,
   sanitizeAmisRows,
 } from "@lib/amis/sanitize-row";
+import { isRoomScheduledClassType } from "@lib/amis/room-scheduled-types";
 import { randomUUID } from "node:crypto";
 
 config({ path: ".env" });
@@ -56,7 +58,7 @@ type CliOptions = {
 };
 
 function parseArgs(argv: string[]): CliOptions {
-  let termId = 1252;
+  let termId = 1253;
   let dryRun = false;
   let replace = true;
   let fetch = false;
@@ -125,7 +127,7 @@ function loadSanitizedExport(path: string, expectedTermId: number) {
 }
 
 async function refreshSyncKey(
-  db: ReturnType<typeof drizzle>,
+  db: Pick<ReturnType<typeof drizzle>, "update">,
   tableName: string,
 ) {
   await db
@@ -232,9 +234,16 @@ async function main() {
     }
 
     const unmatched = new Map<string, number>();
+    const skippedByType = new Map<string, number>();
     const inserts: (typeof classesTable.$inferInsert)[] = [];
 
     for (const row of normalized) {
+      if (!isRoomScheduledClassType(row.type)) {
+        const key = row.type?.trim().toUpperCase() || "(no type)";
+        skippedByType.set(key, (skippedByType.get(key) ?? 0) + 1);
+        continue;
+      }
+
       const facility = row.facilityCode?.trim();
       if (!facility) {
         unmatched.set(
@@ -261,22 +270,46 @@ async function main() {
     }
 
     if (options.replace) {
-      await db
-        .delete(classesTable)
-        .where(eq(classesTable.termId, options.termId));
-      console.log(`Cleared existing term_id=${options.termId} rows.`);
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(classesTable)
+          .where(eq(classesTable.termId, options.termId));
+
+        const batchSize = 500;
+        for (let i = 0; i < inserts.length; i += batchSize) {
+          await tx.insert(classesTable).values(inserts.slice(i, i + batchSize));
+        }
+
+        await refreshSyncKey(tx, "classes");
+      });
+      console.log(
+        `Cleared and re-imported term_id=${options.termId} (${inserts.length} rows, transactional).`,
+      );
+    } else {
+      const batchSize = 500;
+      for (let i = 0; i < inserts.length; i += batchSize) {
+        await db.insert(classesTable).values(inserts.slice(i, i + batchSize));
+      }
+      await refreshSyncKey(db, "classes");
+      console.log(
+        `Imported ${inserts.length} classes for term_id=${options.termId}.`,
+      );
     }
 
-    const batchSize = 500;
-    for (let i = 0; i < inserts.length; i += batchSize) {
-      await db.insert(classesTable).values(inserts.slice(i, i + batchSize));
+    if (skippedByType.size > 0) {
+      const totalSkipped = [...skippedByType.values()].reduce(
+        (a, b) => a + b,
+        0,
+      );
+      console.warn(
+        `Skipped ${totalSkipped} rows that are not room-scheduled LEC/LAB (thesis, special problem, dissertation, etc. usually have no room in AMIS):`,
+      );
+      for (const [type, count] of [...skippedByType.entries()].sort(
+        (a, b) => b[1] - a[1],
+      )) {
+        console.warn(`  ${count}× ${type}`);
+      }
     }
-
-    await refreshSyncKey(db, "classes");
-
-    console.log(
-      `Imported ${inserts.length} classes for term_id=${options.termId}.`,
-    );
     if (unmatched.size > 0) {
       console.warn(
         `Skipped ${[...unmatched.values()].reduce((a, b) => a + b, 0)} rows with unmatched facilities:`,

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -32,19 +32,13 @@
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import CopyLinkButton from "@ui/CopyLinkButton.svelte";
   import { getRoomShareUrl } from "@lib/share-links";
+  import { ROOM_SCHEDULE_SCOPE_NOTE } from "@lib/amis/room-scheduled-types";
   import type { RoomData } from "@lib/types";
   import { tick } from "svelte";
   import Classes from "./Classes.svelte";
 
   type RoomEditableField =
     "roomCode" | "directions" | "buildingId" | "collegeId" | "divisionId";
-
-  type RoomPatchResponse = {
-    success?: boolean;
-    room?: RoomData;
-    latest?: RoomData | null;
-    error?: string;
-  };
 
   const appData = getAppData();
   const app = $derived(appData());
@@ -211,7 +205,7 @@
     mergePrompt = null;
 
     try {
-      const { version, ...patch } = body;
+      const { version: _version, ...patch } = body;
       const result = await persistEntityChange({
         entityType: "room",
         entityId: room.id,
@@ -248,7 +242,7 @@
       if (outcome.proposal) {
         activeProposalId = outcome.proposal.id;
         proposalStatus = outcome.proposal.status;
-        clearEntityContributorDraft("room", current.id);
+        clearEntityContributorDraft("room", room.id);
         toastStore.show(
           `Suggestion for ${room.code} submitted for review.`,
           "success",
@@ -692,6 +686,7 @@
       {#if activeTermLabel}
         <p class="entity-schedule__term">{activeTermLabel}</p>
       {/if}
+      <p class="entity-schedule__scope">{ROOM_SCHEDULE_SCOPE_NOTE}</p>
       {#if roomClassesStore.loading}
         <p class="entity-schedule__empty">Loading classes…</p>
       {:else if roomClassesStore.classes.length > 0}
@@ -792,6 +787,13 @@
     font-size: 0.75rem;
     font-weight: 600;
     color: hsl(5, 53%, 32%);
+  }
+
+  .entity-schedule__scope {
+    margin: 0;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    color: hsl(0, 0%, 45%);
   }
 
   .entity-schedule__empty {

--- a/src/lib/amis/export-path.ts
+++ b/src/lib/amis/export-path.ts
@@ -4,9 +4,9 @@ export function defaultAmisExportPath(termId: number): string {
     termId === 1251
       ? "1st-sem"
       : termId === 1252
-        ? "midyear"
+        ? "2nd-sem"
         : termId === 1253
-          ? "2nd-sem"
+          ? "midyear"
           : `term-${termId}`;
   return `data/amis-${label}-${termId}.json`;
 }

--- a/src/lib/amis/fetch-classes.ts
+++ b/src/lib/amis/fetch-classes.ts
@@ -3,7 +3,7 @@ import type { AmisClassRow, AmisFetchOptions } from "./types";
 
 const AMIS_CLASSES_URL = "https://api-amis.uplb.edu.ph/api/students/classes";
 
-/** AMIS-friendly batch size (verified against midyear term 1252). */
+/** AMIS-friendly batch size (verified against CRS term imports). */
 export const AMIS_DEFAULT_PAGE_SIZE = 10_000;
 
 /** Pause between page requests so imports do not hammer AMIS. */

--- a/src/lib/amis/room-scheduled-types.test.ts
+++ b/src/lib/amis/room-scheduled-types.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isRoomScheduledClassType,
+  ROOM_SCHEDULE_SCOPE_NOTE,
+} from "./room-scheduled-types";
+
+describe("room-scheduled-types", () => {
+  it("treats LEC and LAB as room-scheduled", () => {
+    expect(isRoomScheduledClassType("LEC")).toBe(true);
+    expect(isRoomScheduledClassType("lab")).toBe(true);
+  });
+
+  it("excludes thesis and special-problem types", () => {
+    expect(isRoomScheduledClassType("THE")).toBe(false);
+    expect(isRoomScheduledClassType("SPR")).toBe(false);
+    expect(isRoomScheduledClassType("DSR")).toBe(false);
+    expect(isRoomScheduledClassType("PRA")).toBe(false);
+  });
+
+  it("documents scope for users", () => {
+    expect(ROOM_SCHEDULE_SCOPE_NOTE).toContain("Thesis");
+    expect(ROOM_SCHEDULE_SCOPE_NOTE).toContain("special problem");
+  });
+});

--- a/src/lib/amis/room-scheduled-types.ts
+++ b/src/lib/amis/room-scheduled-types.ts
@@ -1,0 +1,38 @@
+/** AMIS class types that normally meet in a campus room (import + room schedules). */
+export const ROOM_SCHEDULED_CLASS_TYPES = new Set(["LEC", "LAB"]);
+
+/** AMIS types we skip on import — usually no room assignment in AMIS. */
+export const NON_ROOM_CLASS_TYPES: Readonly<
+  Record<string, { label: string; description: string }>
+> = {
+  THE: {
+    label: "Thesis",
+    description: "Thesis sections usually have no fixed room in AMIS.",
+  },
+  SPR: {
+    label: "Special problem",
+    description: "Special-problem sections usually have no fixed room in AMIS.",
+  },
+  PRA: {
+    label: "Practicum",
+    description:
+      "Practicum sections may meet off-campus or without a room code.",
+  },
+  DSR: {
+    label: "Dissertation",
+    description: "Dissertation sections usually have no fixed room in AMIS.",
+  },
+  IND: {
+    label: "Independent study",
+    description: "Independent study usually has no fixed room in AMIS.",
+  },
+};
+
+/** Short copy for the room schedule panel in the app. */
+export const ROOM_SCHEDULE_SCOPE_NOTE =
+  "Schedules list lecture and lab sections with assigned rooms. Thesis, special problem, dissertation, and similar sections usually are not tied to a room in AMIS, so they do not appear here.";
+
+export function isRoomScheduledClassType(type: string | null | undefined) {
+  if (!type) return false;
+  return ROOM_SCHEDULED_CLASS_TYPES.has(type.trim().toUpperCase());
+}

--- a/src/lib/amis/sanitize-row.test.ts
+++ b/src/lib/amis/sanitize-row.test.ts
@@ -61,6 +61,11 @@ describe("amisExportContainsInstructorPii", () => {
     ).toBe(true);
     expect(
       amisExportContainsInstructorPii({
+        classes: [{ course_code: "CMSC 123", last_name: "DOE" }],
+      }),
+    ).toBe(true);
+    expect(
+      amisExportContainsInstructorPii({
         classes: [{ course_code: "CMSC 123" }],
       }),
     ).toBe(false);

--- a/src/lib/amis/sanitize-row.ts
+++ b/src/lib/amis/sanitize-row.ts
@@ -46,12 +46,22 @@ export function sanitizeAmisRows(rows: AmisClassRow[]): AmisClassRow[] {
   return rows.map(sanitizeAmisRow);
 }
 
-/** True when JSON still embeds instructor name fields (unsafe to commit). */
+/** True when JSON still embeds instructor PII keys (unsafe to commit). */
 export function amisExportContainsInstructorPii(payload: unknown): boolean {
-  const text = JSON.stringify(payload).toLowerCase();
-  return (
-    text.includes('"formatted_name"') ||
-    text.includes('"first_name"') ||
-    text.includes('"faculty":')
-  );
+  return objectContainsStripKey(payload, STRIP_KEYS);
+}
+
+function objectContainsStripKey(value: unknown, keys: Set<string>): boolean {
+  if (Array.isArray(value)) {
+    return value.some((entry) => objectContainsStripKey(entry, keys));
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [key, nested] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      if (keys.has(key)) return true;
+      if (objectContainsStripKey(nested, keys)) return true;
+    }
+  }
+  return false;
 }

--- a/src/lib/term-calendar.test.ts
+++ b/src/lib/term-calendar.test.ts
@@ -9,14 +9,16 @@ import type { Term } from "./types";
 
 function term(id: number, overrides: Partial<Term> = {}): Term {
   const window = TERM_CALENDAR_WINDOWS[id];
+  const semester =
+    id === 1253 ? "midyear" : id === 1252 ? "2" : String(id - 1250);
   return {
     id,
     label: `Term ${id}`,
     schoolYear: "2025-2026",
-    semester: id === 1252 ? "midyear" : String(id - 1250),
+    semester,
     startsOn: window?.startsOn ?? null,
     endsOn: window?.endsOn ?? null,
-    isDefault: id === 1252,
+    isDefault: id === 1253,
     isActive: true,
     sortOrder: id,
     version: 1,
@@ -27,7 +29,7 @@ function term(id: number, overrides: Partial<Term> = {}): Term {
 
 describe("term-calendar", () => {
   it("detects midyear from Manila calendar date", () => {
-    const midyear = term(1252);
+    const midyear = term(1253);
     expect(
       isDateWithinTerm(midyear, new Date("2026-06-29T12:00:00+08:00")),
     ).toBe(true);
@@ -40,14 +42,14 @@ describe("term-calendar", () => {
     const terms = [term(1251), term(1252), term(1253)];
     expect(
       resolveActiveTermByDate(terms, new Date("2026-06-29T08:00:00+08:00"))?.id,
-    ).toBe(1252);
+    ).toBe(1253);
     expect(
       resolveActiveTermByDate(terms, new Date("2026-03-15T08:00:00+08:00"))?.id,
-    ).toBe(1253);
+    ).toBe(1252);
   });
 
   it("handles postgres timestamp strings in UTC", () => {
-    const midyear = term(1252, {
+    const midyear = term(1253, {
       startsOn: "2026-06-07T16:00:00.000Z",
       endsOn: "2026-07-25T16:00:00.000Z",
     });
@@ -58,8 +60,8 @@ describe("term-calendar", () => {
 
   it("ignores stale local picks for undated terms during midyear", () => {
     const terms = [
-      { ...term(1253), classCount: 4351 },
-      { ...term(1252), classCount: 0 },
+      { ...term(1252), classCount: 4351 },
+      { ...term(1253), classCount: 200 },
       { ...term(1251), classCount: 0 },
     ];
     const midyearDay = new Date("2026-06-29T08:00:00+08:00");
@@ -75,8 +77,8 @@ describe("term-calendar", () => {
 
   it("keeps a usable stored term during the same instructional window", () => {
     const terms = [
-      { ...term(1253), classCount: 4351 },
-      { ...term(1252), classCount: 0 },
+      { ...term(1252), classCount: 4351 },
+      { ...term(1253), classCount: 200 },
       { ...term(1251), classCount: 0 },
     ];
     const midyearDay = new Date("2026-06-29T08:00:00+08:00");

--- a/src/lib/term-calendar.ts
+++ b/src/lib/term-calendar.ts
@@ -5,10 +5,10 @@ export const TERM_CALENDAR_WINDOWS: Record<
   number,
   { startsOn: string; endsOn: string }
 > = {
-  // CRS 1252 — midyear (Jun–Jul; schedules imported separately)
-  1252: { startsOn: "2026-06-08", endsOn: "2026-07-26" },
-  // CRS 1253 — UP second semester (Jan–May; production class rows live here)
-  1253: { startsOn: "2026-01-19", endsOn: "2026-05-31" },
+  // CRS 1252 — 2nd semester (Jan–May)
+  1252: { startsOn: "2026-01-19", endsOn: "2026-05-31" },
+  // CRS 1253 — midyear (Jun–Jul)
+  1253: { startsOn: "2026-06-08", endsOn: "2026-07-26" },
 };
 
 function toManilaDateKey(date: Date) {

--- a/src/pages/api/admin/auth.ts
+++ b/src/pages/api/admin/auth.ts
@@ -8,11 +8,19 @@ import {
 } from "@lib/admin/auth";
 import { getEditorSession } from "@lib/admin/require-editor";
 import {
+  checkRateLimit,
+  clientIp,
+  rateLimitResponse,
+} from "@lib/api/rate-limit";
+import {
   authenticateAdminUser,
   authenticateLegacyAdminPassword,
 } from "@lib/services/admin-user-service";
 
 export const prerender = false;
+
+const LOGIN_IP_LIMIT = { max: 12, windowMs: 15 * 60 * 1000 };
+const LOGIN_USER_LIMIT = { max: 8, windowMs: 15 * 60 * 1000 };
 
 export const GET: APIRoute = async ({ cookies }) => {
   const session = getEditorSession(cookies);
@@ -34,11 +42,32 @@ export const GET: APIRoute = async ({ cookies }) => {
 };
 
 export const POST: APIRoute = async ({ request }) => {
+  const ip = clientIp(request);
+  const ipRate = checkRateLimit(
+    `admin-login:ip:${ip}`,
+    LOGIN_IP_LIMIT.max,
+    LOGIN_IP_LIMIT.windowMs,
+  );
+  if (!ipRate.allowed) {
+    return rateLimitResponse(ipRate.resetAt);
+  }
+
   const formData = await request.formData();
   const usernameRaw = formData.get("username");
   const passwordRaw = formData.get("password");
   const username = typeof usernameRaw === "string" ? usernameRaw.trim() : "";
   const password = typeof passwordRaw === "string" ? passwordRaw : "";
+
+  if (username) {
+    const userRate = checkRateLimit(
+      `admin-login:user:${username.toLowerCase()}`,
+      LOGIN_USER_LIMIT.max,
+      LOGIN_USER_LIMIT.windowMs,
+    );
+    if (!userRate.allowed) {
+      return rateLimitResponse(userRate.resetAt);
+    }
+  }
 
   if (!password) {
     return json({ error: "Password is required" }, 400);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const structuredData = jsonLd(
   canonicalPath="/"
   structuredData={structuredData}
 >
-  <AppRoot client:only />
+  <AppRoot client:only="svelte" />
 </Layout>
 
 <style>


### PR DESCRIPTION
## Summary

- **Fix CRS/AMIS term mapping** — chronological order is `1251` 1st sem, `1252` 2nd sem, `1253` midyear (was backwards in labels/calendar). Migration `0013_fix_crs_term_labels.sql` corrects `terms` metadata; do not re-apply `0012`.
- **AMIS import hardening** — LEC/LAB + matched room only; transactional replace per term; expanded PII export detection; skip logging by section type (THE/SPR/PRA/DSR intentionally excluded).
- **UX + docs** — room schedule panel explains thesis/special-problem sections usually have no room; README calendar-driven term note; AGENTS.md pitfalls for future agents.
- **Review fixes** — RoomResult contributor draft bug (`room.id`); admin login rate limit; `client:only="svelte"` on index.

## Production data (already applied on Supabase)

- Migration `0013` applied; class re-imports run:
  - **1252** 2nd sem: ~3,354 LEC/LAB rows
  - **1253** midyear: ~120 LEC/LAB rows
- Apply `0013` on any env that missed it before deploy (idempotent).

## QA Summary

Automated:

- [x] Prettier passed: `bunx prettier --check .`
- [x] Unit tests passed: `bun test src` (71 tests)
- [x] README drift passed: `bun run check:readme`
- [ ] Full ESLint (local): not run — PR CI runs Prettier + tests only
- [ ] Build (local): not run this session

Manual browser:

- [ ] Term chip shows Midyear (1253) in Jun–Jul; switch to 2nd sem (1252) and confirm schedules change
- [ ] Room panel shows schedule scope note (thesis/special problem excluded)
- [ ] Contributor room edit → submit suggestion clears draft without error

Known gaps:

- Facility alias gaps remain ([#300](https://github.com/uplbtools/room-tba/issues/300))
- `roomClassesStore` still network-only (offline classes follow-up)

Issues updated:

- [x] Comment on [#286](https://github.com/uplbtools/room-tba/issues/286) (CRS ids + import scope)
- [x] Comment on [#300](https://github.com/uplbtools/room-tba/issues/300) (skip buckets clarified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wrong term metadata and class data affect all schedule views; migration 0013 must be applied before deploy. AMIS replace deletes per-term class rows transactionally—operational risk if run against wrong `term_id`.
> 
> **Overview**
> **CRS / term calendar fix:** The PR realigns AMIS `term_id` with chronological AY order (`1251` 1st, `1252` 2nd sem, `1253` midyear) in `term-calendar`, export paths, import defaults, and tests. Migration **`0013_fix_crs_term_labels.sql`** updates `terms` labels, dates, and default (midyear on **1253**); docs warn against re-running **`0012`**.
> 
> **AMIS import:** Imports now keep only **LEC/LAB** with a matched room via `room-scheduled-types`; non-room types are skipped with typed logging. **Replace** runs delete + batch insert + sync key refresh in a **single transaction**. PII export checks walk the JSON tree for strip keys (not string matching). README and **AGENTS.md** document pitfalls, worktrees, and direct push to `staging`.
> 
> **UX / security:** Room panel shows **`ROOM_SCHEDULE_SCOPE_NOTE`** under the term label. **Admin login** is rate-limited by IP and username. **RoomResult** clears contributor drafts with **`room.id`** after proposals. **`index.astro`** uses **`client:only="svelte"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd493edbe73aac211e319fbd51d064de269863f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->