### PR TITLE
fix(pwa): load legal pages outside fallback

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,9 +23,17 @@ export default defineConfig({
         globPatterns: [
           "**/*.{js,css,ico,png,svg,webmanifest,json,jpg}",
           "index.html",
+          "privacy/index.html",
+          "terms/index.html",
+          "changelog/index.html",
         ],
         navigateFallback: "/",
-        navigateFallbackDenylist: [/^\/api\//],
+        navigateFallbackDenylist: [
+          /^\/api\//,
+          /^\/privacy(\/|$)/,
+          /^\/terms(\/|$)/,
+          /^\/changelog(\/|$)/,
+        ],
         swDest: `dist/client/sw.js`,
         // Cache third-party map resources at runtime so the campus map works
         // offline once visited (or after an explicit "download offline maps").


### PR DESCRIPTION
## Summary

- Precache privacy, terms, and changelog page HTML in the service worker
- Exclude those static pages from the root app-shell navigation fallback
- Keep the existing `/api/*` fallback denylist unchanged

Fixes #321.

## Verification

- `bun test src`
- `bun scripts/check-readme-drift.ts`
- `.\node_modules\.bin\prettier.exe --check astro.config.mjs`
- `.\node_modules\.bin\eslint.exe astro.config.mjs`
- `git diff --check`

Notes:
- `bun run build` reaches prerendering, then fails because `DATABASE_URL` is not set locally.
- `bun run lint` fails in this Windows checkout before ESLint because Prettier reports existing CRLF formatting across hundreds of files; the changed `astro.config.mjs` passes targeted Prettier and ESLint checks.
