### PR TITLE
feat(batch): 5 small tickets — refresh, class counts, transit exclusivity, stop panel, z-index fix

### DIFF
--- a/docs/map-ui-mode-matrix.md
+++ b/docs/map-ui-mode-matrix.md
@@ -13,6 +13,18 @@ Source of truth for which map chrome is visible in each mode.
 
 Implementation: `getMapChromeVisibility()` in `src/lib/map-chrome.ts`.
 
+## Browse overlay exclusivity (chip row)
+
+Only one browse overlay from the chip row is active at a time (except **All** pins, the neutral default):
+
+- **Transit on** → building/dorm pin filter resets to **All** (`jeepneyStore.enableLayer` sets `buildingTypeFilter` to `"all"`). Covers the search chip, Map tools → Transit, and the route sub-panel — every enable path funnels through `enableLayer`.
+- **Non-All pin filter selected** (Class / Admin / UP dorms / Other dorms) → transit layer + selected route/stop turn off (`BuildingTypeFilterBar.selectFilter` calls `jeepneyStore.disableLayer`).
+- **Events shelf** ↔ Transit exclusivity is unchanged (`openEventsShelf` disables transit; transit active closes the events shelf).
+- **All** is neutral: selecting it does not touch transit.
+- Edit/terrain exclusivity via `deactivateMapModesExcept` is unchanged.
+
+Term-chip exclusivity is intentionally not enforced here (deferred — needs a product call on whether opening the term picker should drop transit/pins).
+
 ## Layout zones (Entry.svelte)
 
 - **Top band:** search column (editor icon button when signed in), building pin filter chips (`BuildingTypeFilterBar.svelte`), **term selector chip** (`TermSelector.svelte`, class schedules), transit toggle chip (`TransitFilterChip.svelte`, count badge + route sub-panel when active), event banner, Map tools trigger; mobile chip row includes compact `MapDimensionToggle` (2D/3D only). Individual jeepney routes are picked in the transit sub-panel under the chip row or in Map tools → Transit (`JeepneyMenu.svelte` / `TransitRoutePanel.svelte`), not as top-level chips. On mobile (≤48rem), the editor icon opens a full-screen editor dashboard (`EditorScreen.svelte`) instead of an inline shelf under the chip row.

--- a/src/components/svelte/BuildingTypeFilterBar.svelte
+++ b/src/components/svelte/BuildingTypeFilterBar.svelte
@@ -9,7 +9,7 @@
     type BuildingTypeFilter,
   } from "@constants/building-types";
   import { getAppData } from "@lib/context";
-  import { buildingTypeFilter } from "@lib/store.svelte";
+  import { buildingTypeFilter, jeepneyStore } from "@lib/store.svelte";
   import "./map-chrome/map-chrome.css";
 
   const appData = getAppData();
@@ -34,6 +34,9 @@
   } as const;
 
   function selectFilter(value: BuildingTypeFilter) {
+    // Non-All pin filters are mutually exclusive with the transit layer:
+    // turn off jeepney routes/stops so filtered pins aren't obscured (#325).
+    if (value !== "all") jeepneyStore.disableLayer();
     buildingTypeFilter.set(value);
   }
 </script>

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -255,6 +255,11 @@
     --motion-duration-shelf: 260ms;
     --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
     --motion-ease-in: cubic-bezier(0.4, 0, 1, 1);
+    /* Stacking context tokens so status bar > side panel > map. */
+    --z-map: 0;
+    --z-side-panel: 2;
+    --z-status-bar: 3;
+    --z-map-tools: 15;
 
     width: 100%;
     height: 100dvh;
@@ -285,7 +290,7 @@
 
   .bottom-chrome {
     position: relative;
-    z-index: 1;
+    z-index: var(--z-status-bar, 3);
     display: flex;
     flex-direction: row;
     align-items: stretch;
@@ -391,7 +396,7 @@
     position: absolute;
     top: calc(var(--map-ui-padding) + 2px);
     right: calc(var(--map-ui-padding) + 2px);
-    z-index: 15;
+    z-index: var(--z-map-tools, 15);
     display: flex;
     width: min(22.5rem, calc(100% - 1rem));
     flex-direction: column;

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -88,7 +88,8 @@
   });
 
   const drawerExpanded = $derived(
-    queryStore.category !== null && !sidePanelStore.collapsed,
+    (queryStore.category !== null || jeepneyStore.selectedStopIndex !== null) &&
+      !sidePanelStore.collapsed,
   );
 
   let mapToolsStackEl = $state<HTMLDivElement | null>(null);
@@ -126,11 +127,7 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {
       if (modalStore.open) {
-        if (modalStore.type === "jeepney-stop") {
-          jeepneyStore.closeStop();
-        } else {
-          modalStore.closeModal();
-        }
+        modalStore.closeModal();
       } else if (adminAuthStore.loginOpen) {
         adminAuthStore.closeLogin();
       } else if (editorChromeStore.additionModalOpen) {
@@ -139,6 +136,8 @@
         editorChromeStore.closeShelf();
       } else if (mapToolsStore.open) {
         mapToolsStore.close();
+      } else if (jeepneyStore.selectedStopIndex !== null) {
+        jeepneyStore.closeStop();
       } else if (queryStore.inputValue !== "" || queryStore.type === "result") {
         queryStore.clearQuery();
         if (locationStore.destination) {

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -7,6 +7,7 @@
     locationStore,
     building3DStore,
     toastStore,
+    termStore,
   } from "@lib/store.svelte";
   import { getAppActions, getAppData } from "@lib/context";
   import CornerRightUp from "@lucide/svelte/icons/corner-right-up";
@@ -21,7 +22,10 @@
   import EntityEditorPinRow from "@ui/editor/EntityEditorPinRow.svelte";
   import { entityEditorSavedMessage } from "@lib/editor/field-action-label";
   import { tick } from "svelte";
-  import { getBuildingRooms } from "@lib/local/data/utils";
+  import {
+    getBuildingRooms,
+    fetchRoomClassCounts,
+  } from "@lib/local/data/utils";
   import {
     checkLocalBuildingRoom,
     syncBuildingRooms,
@@ -61,6 +65,7 @@
   );
 
   let buildingRooms = $state<RoomData[] | null>(null);
+  let classCounts = $state<Map<number, number> | null>(null);
 
   let editing = $state(false);
   let draftBuildingId = $state<number | null>(null);
@@ -103,6 +108,30 @@
       if (gen !== roomLoadGeneration) return;
       buildingRooms = rooms;
       await syncBuildingRooms(buildingChecker, id, rooms);
+    })();
+  });
+
+  // Class counts per room for the active term, batched in one request so the
+  // room list preview doesn't fire N+1 /api/classes calls (#342). Re-fetches
+  // when the building or the active term changes; null while loading/offline.
+  let classCountGeneration = 0;
+
+  $effect(() => {
+    const id = building?.id;
+    const termId = termStore.activeTermId;
+    if (id == null) {
+      classCounts = null;
+      return;
+    }
+    const gen = ++classCountGeneration;
+    void (async () => {
+      const counts = await fetchRoomClassCounts(
+        "building",
+        id,
+        termId ?? undefined,
+      );
+      if (gen !== classCountGeneration) return;
+      classCounts = counts;
     })();
   });
 
@@ -477,7 +506,7 @@
   {/if}
 
   {#if buildingRooms}
-    <ResultDisplay filteredRooms={buildingRooms} />
+    <ResultDisplay filteredRooms={buildingRooms} {classCounts} />
   {:else if building}
     <p class="entity-loading-note">Loading rooms…</p>
   {/if}

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -20,7 +20,7 @@
   import EntityEditorField from "@ui/editor/EntityEditorField.svelte";
   import EntityEditorPinRow from "@ui/editor/EntityEditorPinRow.svelte";
   import { entityEditorSavedMessage } from "@lib/editor/field-action-label";
-  import { onMount, tick } from "svelte";
+  import { tick } from "svelte";
   import { getBuildingRooms } from "@lib/local/data/utils";
   import {
     checkLocalBuildingRoom,
@@ -83,11 +83,27 @@
     buildingType: "Building type",
   };
 
-  onMount(async () => {
-    if (!building) return;
-    const buildingChecker = await checkLocalBuildingRoom(building.id);
-    buildingRooms = await getBuildingRooms(buildingChecker, building.id);
-    await syncBuildingRooms(buildingChecker, building.id, buildingRooms);
+  // Room list must reload when the selected building changes (search result,
+  // pin, breadcrumb). BuildingResult is not remounted on switch, so onMount
+  // would only fire once and leave a stale list. Key the load on building id
+  // and discard in-flight fetches from a previous selection (#340).
+  let roomLoadGeneration = 0;
+
+  $effect(() => {
+    const id = building?.id;
+    if (id == null) {
+      buildingRooms = null;
+      return;
+    }
+    const gen = ++roomLoadGeneration;
+    buildingRooms = null;
+    void (async () => {
+      const buildingChecker = await checkLocalBuildingRoom(id);
+      const rooms = await getBuildingRooms(buildingChecker, id);
+      if (gen !== roomLoadGeneration) return;
+      buildingRooms = rooms;
+      await syncBuildingRooms(buildingChecker, id, rooms);
+    })();
   });
 
   function applyAutoEditIntent() {

--- a/src/components/svelte/controls/CollegeResult.svelte
+++ b/src/components/svelte/controls/CollegeResult.svelte
@@ -19,7 +19,6 @@
     checkLocalCollegeRoom,
     syncCollegeRooms,
   } from "@lib/local/data/sync";
-  import { onMount } from "svelte";
 
   type CollegePatchResponse = {
     success?: boolean;
@@ -57,11 +56,26 @@
   let submitterNameDraft = $state("");
   const canPublish = $derived(adminAuthStore.canPublish);
 
-  onMount(async () => {
-    if (!college) return;
-    const collegeChecker = await checkLocalCollegeRoom(college.id);
-    collegeRooms = await getCollegeRooms(collegeChecker, college.id);
-    await syncCollegeRooms(collegeChecker, college.id, collegeRooms);
+  // Reload rooms when the selected college changes; CollegeResult is not
+  // remounted on switch, so key the load on college id and discard stale
+  // fetches from a previous selection (#340).
+  let roomLoadGeneration = 0;
+
+  $effect(() => {
+    const id = college?.id;
+    if (id == null) {
+      collegeRooms = null;
+      return;
+    }
+    const gen = ++roomLoadGeneration;
+    collegeRooms = null;
+    void (async () => {
+      const collegeChecker = await checkLocalCollegeRoom(id);
+      const rooms = await getCollegeRooms(collegeChecker, id);
+      if (gen !== roomLoadGeneration) return;
+      collegeRooms = rooms;
+      await syncCollegeRooms(collegeChecker, id, rooms);
+    })();
   });
 
   $effect(() => {

--- a/src/components/svelte/controls/CollegeResult.svelte
+++ b/src/components/svelte/controls/CollegeResult.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { adminAuthStore, queryStore, toastStore } from "@lib/store.svelte";
+  import {
+    adminAuthStore,
+    queryStore,
+    toastStore,
+    termStore,
+  } from "@lib/store.svelte";
   import { persistEntityChange } from "@lib/proposals/client";
   import { handlePersistEntityResult } from "@lib/editor/handle-persist-result";
   import {
@@ -8,7 +13,7 @@
     scheduleEntityContributorDraftSave,
   } from "@lib/contributor-drafts";
   import { getAppActions, getAppData } from "@lib/context";
-  import { getCollegeRooms } from "@lib/local/data/utils";
+  import { getCollegeRooms, fetchRoomClassCounts } from "@lib/local/data/utils";
   import type { CollegeData, RoomData } from "@lib/types";
   import ResultDisplay from "./ResultDisplay.svelte";
   import EntityEditorToggle from "@ui/editor/EntityEditorToggle.svelte";
@@ -46,6 +51,7 @@
   });
 
   let collegeRooms = $state<RoomData[] | null>(null);
+  let classCounts = $state<Map<number, number> | null>(null);
   let editing = $state(false);
   let draftCollegeId = $state<number | null>(null);
   let draftVersion = $state<number | null>(null);
@@ -75,6 +81,30 @@
       if (gen !== roomLoadGeneration) return;
       collegeRooms = rooms;
       await syncCollegeRooms(collegeChecker, id, rooms);
+    })();
+  });
+
+  // Class counts per room for the active term, batched in one request so the
+  // room list preview doesn't fire N+1 /api/classes calls (#342). Re-fetches
+  // when the college or the active term changes; null while loading/offline.
+  let classCountGeneration = 0;
+
+  $effect(() => {
+    const id = college?.id;
+    const termId = termStore.activeTermId;
+    if (id == null) {
+      classCounts = null;
+      return;
+    }
+    const gen = ++classCountGeneration;
+    void (async () => {
+      const counts = await fetchRoomClassCounts(
+        "college",
+        id,
+        termId ?? undefined,
+      );
+      if (gen !== classCountGeneration) return;
+      classCounts = counts;
     })();
   });
 
@@ -259,7 +289,7 @@
     </section>
   {/if}
   {#if collegeRooms}
-    <ResultDisplay filteredRooms={collegeRooms} />
+    <ResultDisplay filteredRooms={collegeRooms} {classCounts} />
   {:else}
     Loading data...
   {/if}

--- a/src/components/svelte/controls/DivisionResult.svelte
+++ b/src/components/svelte/controls/DivisionResult.svelte
@@ -19,7 +19,6 @@
     checkLocalDivisionRoom,
     syncDivisionRooms,
   } from "@lib/local/data/sync";
-  import { onMount } from "svelte";
 
   type DivisionPatchResponse = {
     success?: boolean;
@@ -56,11 +55,26 @@
   let submitterNameDraft = $state("");
   const canPublish = $derived(adminAuthStore.canPublish);
 
-  onMount(async () => {
-    if (!division) return;
-    const divisionChecker = await checkLocalDivisionRoom(division.id);
-    divisionRooms = await getDivisionRooms(divisionChecker, division.id);
-    await syncDivisionRooms(divisionChecker, division.id, divisionRooms);
+  // Reload rooms when the selected division changes; DivisionResult is not
+  // remounted on switch, so key the load on division id and discard stale
+  // fetches from a previous selection (#340).
+  let roomLoadGeneration = 0;
+
+  $effect(() => {
+    const id = division?.id;
+    if (id == null) {
+      divisionRooms = null;
+      return;
+    }
+    const gen = ++roomLoadGeneration;
+    divisionRooms = null;
+    void (async () => {
+      const divisionChecker = await checkLocalDivisionRoom(id);
+      const rooms = await getDivisionRooms(divisionChecker, id);
+      if (gen !== roomLoadGeneration) return;
+      divisionRooms = rooms;
+      await syncDivisionRooms(divisionChecker, id, rooms);
+    })();
   });
 
   $effect(() => {

--- a/src/components/svelte/controls/DivisionResult.svelte
+++ b/src/components/svelte/controls/DivisionResult.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { adminAuthStore, queryStore, toastStore } from "@lib/store.svelte";
+  import {
+    adminAuthStore,
+    queryStore,
+    toastStore,
+    termStore,
+  } from "@lib/store.svelte";
   import { persistEntityChange } from "@lib/proposals/client";
   import { handlePersistEntityResult } from "@lib/editor/handle-persist-result";
   import {
@@ -9,7 +14,10 @@
   } from "@lib/contributor-drafts";
   import { getAppActions, getAppData } from "@lib/context";
   import type { DivisionData, RoomData } from "@lib/types";
-  import { getDivisionRooms } from "@lib/local/data/utils";
+  import {
+    getDivisionRooms,
+    fetchRoomClassCounts,
+  } from "@lib/local/data/utils";
   import ResultDisplay from "./ResultDisplay.svelte";
   import EntityEditorToggle from "@ui/editor/EntityEditorToggle.svelte";
   import EntityEditorPanel from "@ui/editor/EntityEditorPanel.svelte";
@@ -44,6 +52,7 @@
   });
 
   let divisionRooms = $state<RoomData[] | null>(null);
+  let classCounts = $state<Map<number, number> | null>(null);
   let editing = $state(false);
   let draftDivisionId = $state<number | null>(null);
   let draftVersion = $state<number | null>(null);
@@ -74,6 +83,30 @@
       if (gen !== roomLoadGeneration) return;
       divisionRooms = rooms;
       await syncDivisionRooms(divisionChecker, id, rooms);
+    })();
+  });
+
+  // Class counts per room for the active term, batched in one request so the
+  // room list preview doesn't fire N+1 /api/classes calls (#342). Re-fetches
+  // when the division or the active term changes; null while loading/offline.
+  let classCountGeneration = 0;
+
+  $effect(() => {
+    const id = division?.id;
+    const termId = termStore.activeTermId;
+    if (id == null) {
+      classCounts = null;
+      return;
+    }
+    const gen = ++classCountGeneration;
+    void (async () => {
+      const counts = await fetchRoomClassCounts(
+        "division",
+        id,
+        termId ?? undefined,
+      );
+      if (gen !== classCountGeneration) return;
+      classCounts = counts;
     })();
   });
 
@@ -295,7 +328,7 @@
     </section>
   {/if}
   {#if divisionRooms}
-    <ResultDisplay filteredRooms={divisionRooms} />
+    <ResultDisplay filteredRooms={divisionRooms} {classCounts} />
   {:else}
     Loading data...
   {/if}

--- a/src/components/svelte/controls/JeepneyStopPanel.svelte
+++ b/src/components/svelte/controls/JeepneyStopPanel.svelte
@@ -2,6 +2,7 @@
   import Bus from "@lucide/svelte/icons/bus";
   import ExternalLink from "@lucide/svelte/icons/external-link";
   import MapPin from "@lucide/svelte/icons/map-pin";
+  import X from "@lucide/svelte/icons/x";
   import { JEEPNEY_ROUTES } from "@constants/jeepney-routes";
   import { jeepneyStore } from "@lib/store.svelte";
   import MapChromeActionChip from "@ui/map-chrome/MapChromeActionChip.svelte";
@@ -34,31 +35,44 @@
     if (stopIndex >= route.stops.length - 1) return;
     jeepneyStore.openStop(stopIndex + 1);
   }
+
+  function closeStop() {
+    jeepneyStore.closeStop();
+  }
 </script>
 
 {#if route && stop && stopIndex !== null}
-  <div class="jeepney-stop-modal">
-    <div class="jeepney-stop-modal__header">
+  <div class="jeepney-stop-panel">
+    <button
+      type="button"
+      class="jeepney-stop-panel__close"
+      aria-label="Close stop details"
+      onclick={closeStop}
+    >
+      <X size={18} aria-hidden="true" />
+    </button>
+
+    <div class="jeepney-stop-panel__header">
       <span
-        class="jeepney-stop-modal__route-badge"
+        class="jeepney-stop-panel__route-badge"
         style:background-color={route.color}
       >
         <Bus size={14} aria-hidden="true" />
         {route.name}
       </span>
-      <h2 class="jeepney-stop-modal__title">{stop.name}</h2>
-      <p class="jeepney-stop-modal__meta">
+      <h2 class="jeepney-stop-panel__title">{stop.name}</h2>
+      <p class="jeepney-stop-panel__meta">
         Stop {stopIndex + 1} of {route.stops.length}
       </p>
-      <p class="jeepney-stop-modal__description">{route.description}</p>
+      <p class="jeepney-stop-panel__description">{route.description}</p>
     </div>
 
-    <div class="jeepney-stop-modal__coords">
+    <div class="jeepney-stop-panel__coords">
       <MapPin size={14} aria-hidden="true" />
       <span>{stop.lat.toFixed(5)}, {stop.lon.toFixed(5)}</span>
     </div>
 
-    <div class="jeepney-stop-modal__actions">
+    <div class="jeepney-stop-panel__actions">
       <MapChromeActionChip disabled={stopIndex <= 0} onclick={openPreviousStop}>
         Previous stop
       </MapChromeActionChip>
@@ -70,7 +84,7 @@
       </MapChromeActionChip>
       {#if mapsUrl}
         <a
-          class="jeepney-stop-modal__maps-link map-chrome-action-chip"
+          class="jeepney-stop-panel__maps-link map-chrome-action-chip"
           href={mapsUrl}
           target="_blank"
           rel="noopener noreferrer"
@@ -84,23 +98,49 @@
 {/if}
 
 <style>
-  .jeepney-stop-modal {
+  .jeepney-stop-panel {
+    position: relative;
     display: flex;
     flex-direction: column;
-    gap: 0.875rem;
-    padding: 0.75rem 0.875rem 1rem;
-    min-width: min(100%, 22rem);
-    max-width: 28rem;
+    gap: 0.75rem;
+    padding: 0.25rem 0.125rem 0.5rem;
+    min-width: 0;
   }
 
-  .jeepney-stop-modal__header {
+  .jeepney-stop-panel__close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0.25rem;
+    border-radius: 0.375rem;
+    color: hsl(0, 0%, 30%);
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+  }
+  .jeepney-stop-panel__close:hover,
+  .jeepney-stop-panel__close:focus-visible {
+    background-color: hsl(0, 0%, 92%);
+  }
+  .jeepney-stop-panel__close:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 1px;
+  }
+
+  .jeepney-stop-panel__header {
     display: flex;
     flex-direction: column;
     gap: 0.375rem;
     min-width: 0;
+    padding-right: 1.75rem;
   }
 
-  .jeepney-stop-modal__route-badge {
+  .jeepney-stop-panel__route-badge {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
@@ -117,7 +157,7 @@
     text-overflow: ellipsis;
   }
 
-  .jeepney-stop-modal__title {
+  .jeepney-stop-panel__title {
     margin: 0;
     font-size: 1.125rem;
     font-weight: 700;
@@ -125,21 +165,21 @@
     color: #18181b;
   }
 
-  .jeepney-stop-modal__meta {
+  .jeepney-stop-panel__meta {
     margin: 0;
     font-size: 0.8125rem;
     font-weight: 600;
     color: hsl(0, 0%, 42%);
   }
 
-  .jeepney-stop-modal__description {
+  .jeepney-stop-panel__description {
     margin: 0;
     font-size: 0.8125rem;
     line-height: 1.45;
     color: hsl(0, 0%, 38%);
   }
 
-  .jeepney-stop-modal__coords {
+  .jeepney-stop-panel__coords {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
@@ -148,13 +188,13 @@
     color: hsl(0, 0%, 45%);
   }
 
-  .jeepney-stop-modal__actions {
+  .jeepney-stop-panel__actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.375rem;
   }
 
-  .jeepney-stop-modal__maps-link {
+  .jeepney-stop-panel__maps-link {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Search from "@ui/search/Search.svelte";
-  import { queryStore, sidePanelStore } from "@lib/store.svelte";
+  import { queryStore, sidePanelStore, jeepneyStore } from "@lib/store.svelte";
   import BuildingResult from "./BuildingResult.svelte";
   import CollegeResult from "./CollegeResult.svelte";
   import DivisionResult from "./DivisionResult.svelte";
@@ -9,6 +9,7 @@
   import EventResult from "./EventResult.svelte";
   import RoomResult from "@ui/room/RoomResult.svelte";
   import ClassQuery from "./ClassQuery.svelte";
+  import JeepneyStopPanel from "./JeepneyStopPanel.svelte";
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
   import ChevronUp from "@lucide/svelte/icons/chevron-up";
@@ -46,7 +47,7 @@
 <div class="side-panel-wrapper">
   <Search />
   <div class="side-panel-controls">
-    {#if queryStore.category !== null}
+    {#if queryStore.category !== null || jeepneyStore.selectedStopIndex !== null}
       <div class="drawer" class:is-collapsed={sidePanelStore.collapsed}>
         <button
           class="drawer-handle"
@@ -75,7 +76,9 @@
             class="side-panel-details"
             aria-hidden={sidePanelStore.collapsed}
           >
-            {#if queryStore.category === "building"}
+            {#if jeepneyStore.selectedStopIndex !== null}
+              <JeepneyStopPanel />
+            {:else if queryStore.category === "building"}
               <BuildingResult />
             {:else if queryStore.category === "college"}
               <CollegeResult />

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -128,7 +128,7 @@
     bottom: 0;
     left: 0;
     width: var(--map-search-chrome-width, min(31rem, calc(100vw - 15rem)));
-    z-index: 2;
+    z-index: var(--z-side-panel, 2);
     pointer-events: none;
     transition: transform var(--motion-duration-panel) var(--motion-ease-out);
   }
@@ -220,7 +220,6 @@
 
     .drawer {
       position: fixed;
-      z-index: 12;
       top: var(--mobile-detail-sheet-top-inset);
       right: 0;
       bottom: calc(

--- a/src/components/svelte/controls/ResultDisplay.svelte
+++ b/src/components/svelte/controls/ResultDisplay.svelte
@@ -7,8 +7,9 @@
 
   interface Props {
     filteredRooms: RoomData[];
+    classCounts?: Map<number, number> | null;
   }
-  const { filteredRooms }: Props = $props();
+  const { filteredRooms, classCounts }: Props = $props();
 
   const paginatedRooms = $derived(
     filteredRooms.slice(
@@ -25,7 +26,11 @@
   <h3 class="rooms-subtitle">Rooms in the building</h3>
   <div class="room-list">
     {#each paginatedRooms as room (room.id)}
-      <RoomDisplay {room} searchInput="" />
+      <RoomDisplay
+        {room}
+        searchInput=""
+        classCount={classCounts?.get(room.id)}
+      />
     {/each}
 
     {#if filteredRooms.length === 0}

--- a/src/components/svelte/controls/RoomDisplay.svelte
+++ b/src/components/svelte/controls/RoomDisplay.svelte
@@ -5,15 +5,25 @@
   type Props = {
     room: RoomData;
     searchInput: string;
+    classCount?: number | null;
   };
 
-  const { room, searchInput }: Props = $props();
+  const { room, searchInput, classCount }: Props = $props();
   const pattern = $derived(new RegExp(`(${searchInput.trim()})`, "gi"));
   function highlightSearch(original: string, pattern: RegExp): string {
     return searchInput.length < 2
       ? original
       : original.replaceAll(pattern, (substr) => `<mark>${substr}</mark>`);
   }
+
+  // Class count is undefined while the batched count request is in flight (or
+  // offline), so the chip stays empty rather than flashing a wrong "0". A
+  // loaded 0 renders explicitly as "0 classes" (#342).
+  const classCountLabel = $derived(
+    typeof classCount === "number"
+      ? `${classCount} class${classCount !== 1 ? "es" : ""}`
+      : null,
+  );
 
   function openRoomData() {
     queryStore.updateQuery({
@@ -45,7 +55,7 @@
     </div>
     <h3 class="room-code">{@html highlightSearch(room.code, pattern)}</h3>
     <div class="class-count">
-      <!-- {classes.length} class{classes.length !== 1 ? "es" : ""} -->
+      {#if classCountLabel}{classCountLabel}{/if}
     </div>
   </div>
 </button>

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { jeepneyStore, modalStore } from "@lib/store.svelte";
+  import { modalStore } from "@lib/store.svelte";
   import { fade, fly } from "svelte/transition";
   import {
     modalContentDismiss,
@@ -11,7 +11,6 @@
   import LandingModal from "./LandingModal.svelte";
   import ScheduleModal from "./ScheduleModal.svelte";
   import FilterModalContent from "./FilterModalContent.svelte";
-  import JeepneyStopModal from "./JeepneyStopModal.svelte";
   import X from "@lucide/svelte/icons/x";
 
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
@@ -22,15 +21,10 @@
     if (modalStore.type === "landing") return undefined;
     if (modalStore.type === "schedule-expand") return "Room schedule";
     if (modalStore.type === "filter") return "Filter campus";
-    if (modalStore.type === "jeepney-stop") return "Jeepney stop details";
     return "Dialog";
   });
 
   function closeDialog() {
-    if (modalStore.type === "jeepney-stop") {
-      jeepneyStore.closeStop();
-      return;
-    }
     modalStore.closeModal();
   }
 
@@ -80,16 +74,6 @@
         <ScheduleModal />
       {:else if modalStore.type === "filter"}
         <FilterModalContent />
-      {:else if modalStore.type === "jeepney-stop"}
-        <button
-          type="button"
-          class="modal-content__close-icon"
-          aria-label="Close jeepney stop details"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </button>
-        <JeepneyStopModal />
       {/if}
     </div>
   </div>

--- a/src/constants/modal-states.ts
+++ b/src/constants/modal-states.ts
@@ -1,8 +1,3 @@
 // src/constants/modal-states.ts
 
-export const modalOptions = [
-  "landing",
-  "schedule-expand",
-  "filter",
-  "jeepney-stop",
-] as const;
+export const modalOptions = ["landing", "schedule-expand", "filter"] as const;

--- a/src/lib/local/data/utils.ts
+++ b/src/lib/local/data/utils.ts
@@ -440,6 +440,32 @@ export const getDivisionRooms = getEntityRooms(
   getLocalDivisionRooms,
 );
 
+/** Per-room class counts for an entity's room list, scoped to the active term.
+ * One batched /api/rooms/class-counts request replaces N+1 /api/classes calls
+ * per visible row (#342). Returns null on offline/server error so the UI can
+ * distinguish "not loaded yet" from a real "0 classes". */
+export async function fetchRoomClassCounts(
+  entityName: "building" | "college" | "division",
+  id: number,
+  termId?: number,
+): Promise<Map<number, number> | null> {
+  const params = new URLSearchParams({ [`${entityName}_id`]: String(id) });
+  if (termId != null) params.set("term_id", String(termId));
+  try {
+    const response = await fetch(
+      `/api/rooms/class-counts?${params.toString()}`,
+    );
+    if (!response.ok) return null;
+    const payload = (await response.json()) as {
+      data?: { roomId: number; count: number }[];
+    };
+    if (!Array.isArray(payload?.data)) return null;
+    return new Map(payload.data.map((row) => [row.roomId, row.count]));
+  } catch {
+    return null;
+  }
+}
+
 export async function getRoomsData(): Promise<
   Pick<DBData, "directionCount" | "totalRooms">
 > {

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -298,6 +298,45 @@ export async function getClassesForRoom(
   }
 }
 
+/** Per-room class counts for one building/college/division, optionally scoped
+ * to a term. Returns a Map of roomId -> count; rooms with no classes for the
+ * scope are included with count 0 (LEFT JOIN + GROUP BY). One grouped query
+ * feeds the room list preview so we avoid N+1 /api/classes calls per row
+ * (#342). */
+export async function getRoomClassCounts(
+  entityName: "building" | "college" | "division",
+  id: number,
+  termId?: number,
+): Promise<Map<number, number>> {
+  try {
+    const column =
+      entityName === "building"
+        ? roomsTable.buildingId
+        : entityName === "college"
+          ? roomsTable.collegeId
+          : roomsTable.divisionId;
+    const data = await db
+      .select({
+        roomId: roomsTable.id,
+        count: sql<number>`count(${classesTable.id})::int`,
+      })
+      .from(roomsTable)
+      .leftJoin(
+        classesTable,
+        and(
+          eq(classesTable.roomId, roomsTable.id),
+          termId != null ? eq(classesTable.termId, termId) : undefined,
+        ),
+      )
+      .where(eq(column, id))
+      .groupBy(roomsTable.id);
+    return new Map(data.map((row) => [row.roomId, row.count]));
+  } catch (e) {
+    console.error("Error: ", e);
+    throw new Error("Failed to fetch room class counts", { cause: e });
+  }
+}
+
 export type AliasMatch = {
   alias: string;
   targetType: string;

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -435,7 +435,11 @@ class MainControlsStore {
 }
 
 export type FloatingControlPanel =
-  "legend" | "building-type" | "terrain" | "admin" | "suggest-addition";
+  | "legend"
+  | "building-type"
+  | "terrain"
+  | "admin"
+  | "suggest-addition";
 
 class FloatingControlPanelStore {
   openPanel: FloatingControlPanel | null = $state(null);
@@ -969,6 +973,10 @@ class JeepneyStore {
     this.layerActive = true;
     mapToolsStore.close();
     deactivateMapModesExcept("routes");
+    // Transit is mutually exclusive with building/dorm pin filters: reset to
+    // All so filtered pins don't overlap jeepney routes/stops (#325). This
+    // covers every enable path (search chip, map tools flyout, route picker).
+    buildingTypeFilter.set("all");
   };
 
   disableLayer = () => {
@@ -1006,20 +1014,22 @@ class JeepneyStore {
     if (this.selectedRouteId === null) return;
     this.selectedStopIndex = index;
     this.hoveredStopIndex = index;
-    modalStore.openModal("jeepney-stop");
+    sidePanelStore.expand();
   };
 
   closeStop = () => {
     this.selectedStopIndex = null;
     this.hoveredStopIndex = null;
-    if (modalStore.open && modalStore.type === "jeepney-stop") {
-      modalStore.closeModal();
-    }
   };
 }
 
 export type AppBootstrapPhase =
-  "idle" | "local" | "remote" | "sync" | "ready" | "error";
+  | "idle"
+  | "local"
+  | "remote"
+  | "sync"
+  | "ready"
+  | "error";
 
 class AppBootstrapStore {
   phase = $state<AppBootstrapPhase>("idle");

--- a/src/pages/api/rooms/class-counts.ts
+++ b/src/pages/api/rooms/class-counts.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro";
+import { getRoomClassCounts } from "@lib/services/map-data-service";
+
+export const prerender = false;
+
+export const GET = (async ({ url }) => {
+  const buildingId = url.searchParams.get("building_id");
+  const collegeId = url.searchParams.get("college_id");
+  const divisionId = url.searchParams.get("division_id");
+  const termIdRaw = url.searchParams.get("term_id");
+  const termId =
+    termIdRaw !== null && termIdRaw !== "" ? Number(termIdRaw) : undefined;
+
+  let entityName: "building" | "college" | "division";
+  let id: number;
+  if (buildingId !== null) {
+    entityName = "building";
+    id = Number(buildingId);
+  } else if (collegeId !== null) {
+    entityName = "college";
+    id = Number(collegeId);
+  } else if (divisionId !== null) {
+    entityName = "division";
+    id = Number(divisionId);
+  } else {
+    return new Response(
+      JSON.stringify({ error: "Missing entity filter", success: false }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  if (!Number.isFinite(id)) {
+    return new Response(
+      JSON.stringify({ error: "Invalid entity id", success: false }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  try {
+    const counts = await getRoomClassCounts(
+      entityName,
+      id,
+      Number.isFinite(termId) ? termId : undefined,
+    );
+    const data = Array.from(counts.entries()).map(([roomId, count]) => ({
+      roomId,
+      count,
+    }));
+    return new Response(JSON.stringify({ data, success: true }, null, 2), {
+      headers: [
+        ["Access-Control-Allow-Origin", "*"],
+        ["Content-Type", "application/json"],
+      ],
+    });
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch class counts", success: false }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+}) satisfies APIRoute;


### PR DESCRIPTION
## Summary

Batch implementation of 5 unassigned `size/S` tickets.

### Commits

| Ticket | Commit | Description |
|--------|--------|-------------|
| #340 | `1854b12` | Reload rooms when entity selection changes (`$effect` keyed on id + generation counter) |
| #342 | `ffbfa7d` | Term-scoped class count preview per room row (batch API + UI) |
| #325 | (in `3a09bff`) | Transit ↔ pin-filter exclusivity (`enableLayer` resets filter to `"all"`; `selectFilter` disables transit) |
| #324 | `3a09bff` | Jeepney stop opens in side panel instead of modal; close button clears stop state |
| #339 | `aac9423` | Fix side panel overlapping status bar (remove mobile drawer `z-index: 12`, tokenize stack) |

### QA

- `bun test src`: 71/71 passing.
- `prettier --check` clean on all edited files.
- ESLint: no new errors introduced (pre-existing `.svelte.ts` parser quirk on `store.svelte.ts` line 26 is present on `staging`).
- Build: not verified end-to-end due to missing `DATABASE_URL` in local `.env` (DB routes expected to fail prerender; not a code regression).

### Files changed

- `src/components/svelte/controls/BuildingResult.svelte`
- `src/components/svelte/controls/CollegeResult.svelte`
- `src/components/svelte/controls/DivisionResult.svelte`
- `src/components/svelte/controls/ResultDisplay.svelte`
- `src/components/svelte/controls/RoomDisplay.svelte`
- `src/components/svelte/controls/JeepneyStopPanel.svelte` ← new
- `src/components/svelte/controls/MainControls.svelte`
- `src/components/svelte/BuildingTypeFilterBar.svelte`
- `src/components/svelte/Entry.svelte`
- `src/components/svelte/modal/Modal.svelte`
- `src/constants/modal-states.ts`
- `src/lib/store.svelte.ts`
- `src/lib/local/data/utils.ts`
- `src/lib/services/map-data-service.ts`
- `src/pages/api/rooms/class-counts.ts` ← new
- `docs/map-ui-mode-matrix.md`

Refs #340 #342 #325 #324 #339

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new read-only API and changes jeepney/side-panel and filter store interactions across map chrome; scope is UX and data loading, not auth or writes.
> 
> **Overview**
> This batch tightens browse-mode map chrome: **transit vs pin filters**, **room list data**, **jeepney stop UX**, **layout stacking**, and **term-scoped class previews**.
> 
> **Transit ↔ building pin filters** are now mutually exclusive: enabling transit resets the pin filter to **All**, and choosing any non-All pin filter disables the jeepney layer. The map UI mode matrix doc describes this chip-row behavior.
> 
> **Building/college/division detail** room lists reload when the selected entity changes (`$effect` + generation counters instead of one-time `onMount`), fixing stale rooms when switching results in the same panel.
> 
> **Room rows** show per-room class counts for the **active term** via a new batched **`GET /api/rooms/class-counts`** path (`getRoomClassCounts` grouped query). Counts refresh when entity or term changes; the label stays blank while loading and shows **0 classes** only after a successful load.
> 
> **Jeepney stops** open in the **side panel** (`JeepneyStopPanel`) with expand-on-open and Escape/close handling; the **`jeepney-stop` modal** type is removed from `Modal` and modal options.
> 
> **Mobile layout**: drawer stacking uses CSS tokens (`--z-side-panel`, `--z-status-bar`) and drops the mobile drawer’s hard `z-index: 12` so the bottom status bar is not covered; drawer expansion also accounts for an open jeepney stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac942318c62029a35754ccadb32fc3ed5d7a49c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->