### PR TITLE
fix(search): recent search delete button

### DIFF
--- a/src/components/svelte/search/Suggestion.svelte
+++ b/src/components/svelte/search/Suggestion.svelte
@@ -31,6 +31,12 @@
     });
     queryStore.inputValue = value;
   }
+
+  function handleRemoveRecent(event: MouseEvent) {
+    event.stopPropagation();
+    if (typeof id === "undefined") return;
+    queryStore.removeRecentSearch(id);
+  }
 </script>
 
 {#snippet icon(type: typeof category)}
@@ -53,35 +59,69 @@
   </span>
 {/snippet}
 
-<button class="suggestion" onclick={handleSuggestionClick}>
-  {@render icon(category)}
-  <div class="text">{value}</div>
+<div class="suggestion-row">
+  <button type="button" class="suggestion" onclick={handleSuggestionClick}>
+    {@render icon(category)}
+    <div class="text">{value}</div>
+    {#if typeof id === "undefined"}
+      <ArrowUpRight size={20} class="icon trailing" />
+    {/if}
+  </button>
   {#if typeof id !== "undefined"}
-    <X
-      size={20}
-      style="margin-left:auto"
-      onclick={(e) => {
-        e.stopImmediatePropagation();
-        queryStore.removeRecentSearch(id);
-      }}
-    ></X>
-  {:else}
-    <ArrowUpRight size={20} style="margin-left:auto" class="icon" />
+    <button
+      type="button"
+      class="suggestion-remove"
+      aria-label={`Remove ${value} from recent searches`}
+      onclick={handleRemoveRecent}
+    >
+      <X size={18} aria-hidden="true" />
+    </button>
   {/if}
-</button>
+</div>
 
 <style>
+  .suggestion-row {
+    display: flex;
+    align-items: stretch;
+    gap: 0.125rem;
+    border-radius: 0.5rem;
+  }
+
+  .suggestion-row:hover .suggestion,
+  .suggestion-row:focus-within .suggestion {
+    background-color: hsl(0, 0%, 95%);
+  }
+
   .suggestion {
     all: unset;
+    box-sizing: border-box;
+    flex: 1;
+    min-width: 0;
     padding: 0.4375rem 0.5rem;
     display: flex;
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
     border-radius: 0.5rem;
-    &:hover {
-      background-color: hsl(0, 0%, 95%);
-    }
+  }
+
+  .suggestion-remove {
+    all: unset;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 2rem;
+    cursor: pointer;
+    border-radius: 0.5rem;
+    color: #52525b;
+  }
+
+  .suggestion-remove:hover,
+  .suggestion-remove:focus-visible {
+    background-color: hsl(0, 0%, 90%);
+    color: #18181b;
   }
 
   :global(.icon) {
@@ -92,13 +132,18 @@
     flex-shrink: 0;
   }
 
+  :global(.icon.trailing) {
+    margin-left: auto;
+  }
+
   .text {
     font-size: 0.875rem;
-    color: #18181b; /* zinc-900 */
+    color: #18181b;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
   @media (max-width: 425px) {
     .suggestion {
       padding: 0.4375rem 0.375rem;


### PR DESCRIPTION
## Summary
- Replace nested X icon inside the suggestion row with a sibling remove button
- Keeps valid HTML (no button-in-button) and stops delete clicks from opening the result

Fixes #326

## Test plan
- [ ] Open search with empty input → recent searches visible
- [ ] Click X on one item → it disappears without navigating
- [ ] Reload → item stays removed (`localStorage` `recent-search`)
- [ ] Click row body → still opens result

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Search suggestion UI and click handling only; no changes to auth, data APIs, or `removeRecentSearch` store logic beyond wiring.
> 
> **Overview**
> Recent-search rows in `Suggestion.svelte` are no longer a single button with an **X** inside. Each row is a **flex** wrapper: the main **button** still runs the search, and a **sibling** remove **button** calls `removeRecentSearch` via `handleRemoveRecent` with `stopPropagation` so delete does not open the result.
> 
> Non-recent suggestions still show the trailing **ArrowUpRight** inside the main button. Hover/focus styling moves to the row (`.suggestion-row:hover` / `:focus-within`) so the main area still highlights when the remove control is focused. The remove control gets an **`aria-label`** and dedicated hover styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28454da4b209c8b4a2d55c60b6f0c1c52b36d764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->