### PR TITLE
fix(layout): side panel no longer covers status bar

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -256,6 +256,11 @@
     --motion-duration-shelf: 260ms;
     --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
     --motion-ease-in: cubic-bezier(0.4, 0, 1, 1);
+    /* Stacking context tokens so status bar > side panel > map. */
+    --z-map: 0;
+    --z-side-panel: 2;
+    --z-status-bar: 3;
+    --z-map-tools: 15;
 
     width: 100%;
     height: 100dvh;
@@ -286,7 +291,7 @@
 
   .bottom-chrome {
     position: relative;
-    z-index: 1;
+    z-index: var(--z-status-bar, 3);
     display: flex;
     flex-direction: row;
     align-items: stretch;
@@ -392,7 +397,7 @@
     position: absolute;
     top: calc(var(--map-ui-padding) + 2px);
     right: calc(var(--map-ui-padding) + 2px);
-    z-index: 15;
+    z-index: var(--z-map-tools, 15);
     display: flex;
     width: min(22.5rem, calc(100% - 1rem));
     flex-direction: column;

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -125,7 +125,7 @@
     bottom: 0;
     left: 0;
     width: var(--map-search-chrome-width, min(31rem, calc(100vw - 15rem)));
-    z-index: 2;
+    z-index: var(--z-side-panel, 2);
     pointer-events: none;
     transition: transform var(--motion-duration-panel) var(--motion-ease-out);
   }
@@ -217,7 +217,6 @@
 
     .drawer {
       position: fixed;
-      z-index: 12;
       top: var(--mobile-detail-sheet-top-inset);
       right: 0;
       bottom: calc(


### PR DESCRIPTION
## Summary
- Remove mobile drawer `z-index` override that escaped the UI stacking context
- Tokenize z-index layers on `.app-layout` so bottom chrome stays above the drawer

Fixes #339

## Test plan
- [ ] At 320px: open side panel → status bar text and actions remain readable/tappable
- [ ] Map tools / camera controls still above map as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only stacking-order changes with no auth, data, or API impact; main risk is visual layering regressions on narrow viewports.
> 
> **Overview**
> Fixes mobile stacking so the **bottom status bar stays above the side panel** when search results are open (#339).
> 
> **`Entry.svelte`** defines shared z-index tokens on `.app-layout` (`--z-map`, `--z-side-panel`, `--z-status-bar`, `--z-map-tools`) and wires **bottom chrome** and **top-right map tools** to those variables instead of hard-coded values.
> 
> **`MainControls.svelte`** uses `--z-side-panel` for the drawer and **drops the mobile-only `z-index: 12`** that had been lifting the sheet above the status bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874a66697deac69ac090fcc007dab61cea81b138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->