### PR TITLE
fix(schedule): bind canvas element ref

### DIFF
--- a/src/components/svelte/room/ScheduleRender.svelte
+++ b/src/components/svelte/room/ScheduleRender.svelte
@@ -11,14 +11,17 @@
     classes: ClassMapValue[];
   }
   const { roomCode, classes }: Props = $props();
-  const canvasId = $derived(`schedule-${roomCode}`);
-  const renderer = $derived(
-    new ScheduleRenderer(canvasId, {
+
+  let canvasEl = $state<HTMLCanvasElement | undefined>();
+
+  $effect(() => {
+    if (!canvasEl) return;
+
+    const renderer = new ScheduleRenderer(canvasEl, {
       width: 1000,
       height: 600,
-    }),
-  );
-  $effect(() => {
+    });
+
     classes.forEach((sectionClass) => {
       const schedule: string[] = sectionClass.schedule ?? [];
       if (schedule.length === 0) return;
@@ -44,7 +47,8 @@
   });
 </script>
 
-<canvas id={canvasId}></canvas>
+<canvas bind:this={canvasEl} aria-label={`Class schedule for ${roomCode}`}
+></canvas>
 
 <style>
   canvas {

--- a/src/lib/schedule-renderer.ts
+++ b/src/lib/schedule-renderer.ts
@@ -39,10 +39,14 @@ export class ScheduleRenderer {
   cellWidth: number = 0;
   cellHeight: number = 0;
 
-  constructor(canvasId: string, config = {}) {
-    this.canvas = document.getElementById(canvasId) as HTMLCanvasElement;
-    if (!this.canvas) {
-      throw new Error(`Canvas with id "${canvasId}" not found`);
+  constructor(canvas: string | HTMLCanvasElement, config = {}) {
+    if (typeof canvas === "string") {
+      this.canvas = document.getElementById(canvas) as HTMLCanvasElement;
+      if (!this.canvas) {
+        throw new Error(`Canvas with id "${canvas}" not found`);
+      }
+    } else {
+      this.canvas = canvas;
     }
     this.ctx = this.canvas.getContext("2d") as CanvasRenderingContext2D;
 


### PR DESCRIPTION
## Summary
- `ScheduleRenderer` accepts `string | HTMLCanvasElement`
- `ScheduleRender.svelte` uses `bind:this` and renders inside `$effect` when the canvas is mounted

Fixes #330

## Test plan
- [ ] Open a room with classes → schedule grid renders without console errors
- [ ] Change term chip → schedule updates
- [x] `bun test src/lib/schedule-renderer.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI rendering fix with backward-compatible constructor overload; no auth, data, or API changes.
> 
> **Overview**
> Fixes room schedule grids failing when the canvas was not in the DOM yet by wiring the canvas through a **mounted element ref** instead of a derived DOM id lookup.
> 
> **`ScheduleRender.svelte`** now uses `bind:this` on the canvas and only constructs **`ScheduleRenderer`** inside `$effect` after `canvasEl` exists, then populates courses from `classes`. The canvas also gets an **`aria-label`** for accessibility.
> 
> **`ScheduleRenderer`** still supports a string canvas id for existing callers, but can also take an **`HTMLCanvasElement`** directly so Svelte can pass the bound node without `getElementById`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 873871910ad2b27243414c072b17e1dd221adb76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->