### PR TITLE
fix(ux): Contributors opens Campus team tab

### DIFF
--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -76,7 +76,7 @@
 
   function handleNavAction(id: "contributors" | "editor-login") {
     if (id === "contributors") {
-      modalStore.openModal("landing");
+      modalStore.openModal("landing", { landingTab: "campus" });
       return;
     }
     adminAuthStore.openLogin();

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { modalStore } from "@lib/store.svelte";
   import { contributors, designers } from "@constants/contributors";
   import { UPLB_TOOLS_URL } from "@constants/community-links";
@@ -69,8 +68,10 @@
     modalStore.closeModal();
   }
 
-  onMount(() => {
-    void loadGithubContributors();
+  $effect(() => {
+    if (!modalStore.open || modalStore.type !== "landing") return;
+    activeTab = modalStore.landingTab ?? "welcome";
+    if (activeTab === "campus") void loadGithubContributors();
   });
 </script>
 

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -129,9 +129,12 @@ export const currentRoom = {
   },
 };
 
+export type LandingModalTab = "welcome" | "campus";
+
 interface ModalStoreState {
   open: boolean;
   type: (typeof modalOptions)[number] | null;
+  landingTab?: LandingModalTab;
 }
 
 export interface QueryStoreState {
@@ -166,10 +169,15 @@ class ModalStore {
 
   open = $derived(this._modalStore.open);
   type = $derived(this._modalStore.type);
+  landingTab = $derived(this._modalStore.landingTab);
 
-  openModal = (type: ModalStoreState["type"]) => {
+  openModal = (
+    type: ModalStoreState["type"],
+    options?: { landingTab?: LandingModalTab },
+  ) => {
     this._modalStore.open = true;
     this._modalStore.type = type;
+    this._modalStore.landingTab = options?.landingTab;
   };
 
   closeModal = () => {


### PR DESCRIPTION
## Summary
- Extend `modalStore.openModal` with optional `landingTab`
- Status bar Contributors action opens landing modal on **Campus team**
- First-visit auto-open still defaults to Welcome

Fixes #320

## Test plan
- [ ] Status bar Contributors → Campus team tab + GitHub list loads
- [ ] First visit / cleared `hideLandingModal` → Welcome tab

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX-only changes to modal state and landing tab selection; no auth, data, or API impact.
> 
> **Overview**
> The status bar **Contributors** action now opens the landing modal on the **Campus team** tab instead of always starting on Welcome.
> 
> `modalStore.openModal` accepts an optional `{ landingTab }` (`welcome` | `campus`), exposed via a derived `landingTab`. **LandingModal** syncs its active tab from the store when the landing modal opens (replacing mount-time GitHub loading), and loads GitHub contributors when that tab is campus. First-visit auto-open in **Entry** still calls `openModal("landing")` with no tab, so it defaults to Welcome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dae07dd0cb4e16bc365ca13e98a3513baf4f5c40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->