### PR TITLE
release: staging → main (batch fixes + stop-panel query fix)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,9 +23,17 @@ export default defineConfig({
         globPatterns: [
           "**/*.{js,css,ico,png,svg,webmanifest,json,jpg}",
           "index.html",
+          "privacy/index.html",
+          "terms/index.html",
+          "changelog/index.html",
         ],
         navigateFallback: "/",
-        navigateFallbackDenylist: [/^\/api\//],
+        navigateFallbackDenylist: [
+          /^\/api\//,
+          /^\/privacy(\/|$)/,
+          /^\/terms(\/|$)/,
+          /^\/changelog(\/|$)/,
+        ],
         swDest: `dist/client/sw.js`,
         // Cache third-party map resources at runtime so the campus map works
         // offline once visited (or after an explicit "download offline maps").

--- a/docs/map-ui-mode-matrix.md
+++ b/docs/map-ui-mode-matrix.md
@@ -13,6 +13,18 @@ Source of truth for which map chrome is visible in each mode.
 
 Implementation: `getMapChromeVisibility()` in `src/lib/map-chrome.ts`.
 
+## Browse overlay exclusivity (chip row)
+
+Only one browse overlay from the chip row is active at a time (except **All** pins, the neutral default):
+
+- **Transit on** → building/dorm pin filter resets to **All** (`jeepneyStore.enableLayer` sets `buildingTypeFilter` to `"all"`). Covers the search chip, Map tools → Transit, and the route sub-panel — every enable path funnels through `enableLayer`.
+- **Non-All pin filter selected** (Class / Admin / UP dorms / Other dorms) → transit layer + selected route/stop turn off (`BuildingTypeFilterBar.selectFilter` calls `jeepneyStore.disableLayer`).
+- **Events shelf** ↔ Transit exclusivity is unchanged (`openEventsShelf` disables transit; transit active closes the events shelf).
+- **All** is neutral: selecting it does not touch transit.
+- Edit/terrain exclusivity via `deactivateMapModesExcept` is unchanged.
+
+Term-chip exclusivity is intentionally not enforced here (deferred — needs a product call on whether opening the term picker should drop transit/pins).
+
 ## Layout zones (Entry.svelte)
 
 - **Top band:** search column (editor icon button when signed in), building pin filter chips (`BuildingTypeFilterBar.svelte`), **term selector chip** (`TermSelector.svelte`, class schedules), transit toggle chip (`TransitFilterChip.svelte`, count badge + route sub-panel when active), event banner, Map tools trigger; mobile chip row includes compact `MapDimensionToggle` (2D/3D only). Individual jeepney routes are picked in the transit sub-panel under the chip row or in Map tools → Transit (`JeepneyMenu.svelte` / `TransitRoutePanel.svelte`), not as top-level chips. On mobile (≤48rem), the editor icon opens a full-screen editor dashboard (`EditorScreen.svelte`) instead of an inline shelf under the chip row.

--- a/src/components/svelte/BuildingTypeFilterBar.svelte
+++ b/src/components/svelte/BuildingTypeFilterBar.svelte
@@ -9,7 +9,7 @@
     type BuildingTypeFilter,
   } from "@constants/building-types";
   import { getAppData } from "@lib/context";
-  import { buildingTypeFilter } from "@lib/store.svelte";
+  import { buildingTypeFilter, jeepneyStore } from "@lib/store.svelte";
   import "./map-chrome/map-chrome.css";
 
   const appData = getAppData();
@@ -34,6 +34,9 @@
   } as const;
 
   function selectFilter(value: BuildingTypeFilter) {
+    // Non-All pin filters are mutually exclusive with the transit layer:
+    // turn off jeepney routes/stops so filtered pins aren't obscured (#325).
+    if (value !== "all") jeepneyStore.disableLayer();
     buildingTypeFilter.set(value);
   }
 </script>

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -88,7 +88,8 @@
   });
 
   const drawerExpanded = $derived(
-    queryStore.category !== null && !sidePanelStore.collapsed,
+    (queryStore.category !== null || jeepneyStore.selectedStopIndex !== null) &&
+      !sidePanelStore.collapsed,
   );
 
   let mapToolsStackEl = $state<HTMLDivElement | null>(null);
@@ -126,11 +127,7 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {
       if (modalStore.open) {
-        if (modalStore.type === "jeepney-stop") {
-          jeepneyStore.closeStop();
-        } else {
-          modalStore.closeModal();
-        }
+        modalStore.closeModal();
       } else if (adminAuthStore.loginOpen) {
         adminAuthStore.closeLogin();
       } else if (editorChromeStore.additionModalOpen) {
@@ -139,6 +136,8 @@
         editorChromeStore.closeShelf();
       } else if (mapToolsStore.open) {
         mapToolsStore.close();
+      } else if (jeepneyStore.selectedStopIndex !== null) {
+        jeepneyStore.closeStop();
       } else if (queryStore.inputValue !== "" || queryStore.type === "result") {
         queryStore.clearQuery();
         if (locationStore.destination) {
@@ -256,6 +255,11 @@
     --motion-duration-shelf: 260ms;
     --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
     --motion-ease-in: cubic-bezier(0.4, 0, 1, 1);
+    /* Stacking context tokens so status bar > side panel > map. */
+    --z-map: 0;
+    --z-side-panel: 2;
+    --z-status-bar: 3;
+    --z-map-tools: 15;
 
     width: 100%;
     height: 100dvh;
@@ -286,7 +290,7 @@
 
   .bottom-chrome {
     position: relative;
-    z-index: 1;
+    z-index: var(--z-status-bar, 3);
     display: flex;
     flex-direction: row;
     align-items: stretch;
@@ -392,7 +396,7 @@
     position: absolute;
     top: calc(var(--map-ui-padding) + 2px);
     right: calc(var(--map-ui-padding) + 2px);
-    z-index: 15;
+    z-index: var(--z-map-tools, 15);
     display: flex;
     width: min(22.5rem, calc(100% - 1rem));
     flex-direction: column;

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -76,7 +76,7 @@
 
   function handleNavAction(id: "contributors" | "editor-login") {
     if (id === "contributors") {
-      modalStore.openModal("landing");
+      modalStore.openModal("landing", { landingTab: "campus" });
       return;
     }
     adminAuthStore.openLogin();

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -7,6 +7,7 @@
     locationStore,
     building3DStore,
     toastStore,
+    termStore,
   } from "@lib/store.svelte";
   import { getAppActions, getAppData } from "@lib/context";
   import CornerRightUp from "@lucide/svelte/icons/corner-right-up";
@@ -20,8 +21,11 @@
   import EntityEditorField from "@ui/editor/EntityEditorField.svelte";
   import EntityEditorPinRow from "@ui/editor/EntityEditorPinRow.svelte";
   import { entityEditorSavedMessage } from "@lib/editor/field-action-label";
-  import { onMount, tick } from "svelte";
-  import { getBuildingRooms } from "@lib/local/data/utils";
+  import { tick } from "svelte";
+  import {
+    getBuildingRooms,
+    fetchRoomClassCounts,
+  } from "@lib/local/data/utils";
   import {
     checkLocalBuildingRoom,
     syncBuildingRooms,
@@ -61,6 +65,7 @@
   );
 
   let buildingRooms = $state<RoomData[] | null>(null);
+  let classCounts = $state<Map<number, number> | null>(null);
 
   let editing = $state(false);
   let draftBuildingId = $state<number | null>(null);
@@ -83,11 +88,51 @@
     buildingType: "Building type",
   };
 
-  onMount(async () => {
-    if (!building) return;
-    const buildingChecker = await checkLocalBuildingRoom(building.id);
-    buildingRooms = await getBuildingRooms(buildingChecker, building.id);
-    await syncBuildingRooms(buildingChecker, building.id, buildingRooms);
+  // Room list must reload when the selected building changes (search result,
+  // pin, breadcrumb). BuildingResult is not remounted on switch, so onMount
+  // would only fire once and leave a stale list. Key the load on building id
+  // and discard in-flight fetches from a previous selection (#340).
+  let roomLoadGeneration = 0;
+
+  $effect(() => {
+    const id = building?.id;
+    if (id == null) {
+      buildingRooms = null;
+      return;
+    }
+    const gen = ++roomLoadGeneration;
+    buildingRooms = null;
+    void (async () => {
+      const buildingChecker = await checkLocalBuildingRoom(id);
+      const rooms = await getBuildingRooms(buildingChecker, id);
+      if (gen !== roomLoadGeneration) return;
+      buildingRooms = rooms;
+      await syncBuildingRooms(buildingChecker, id, rooms);
+    })();
+  });
+
+  // Class counts per room for the active term, batched in one request so the
+  // room list preview doesn't fire N+1 /api/classes calls (#342). Re-fetches
+  // when the building or the active term changes; null while loading/offline.
+  let classCountGeneration = 0;
+
+  $effect(() => {
+    const id = building?.id;
+    const termId = termStore.activeTermId;
+    if (id == null) {
+      classCounts = null;
+      return;
+    }
+    const gen = ++classCountGeneration;
+    void (async () => {
+      const counts = await fetchRoomClassCounts(
+        "building",
+        id,
+        termId ?? undefined,
+      );
+      if (gen !== classCountGeneration) return;
+      classCounts = counts;
+    })();
   });
 
   function applyAutoEditIntent() {
@@ -461,7 +506,7 @@
   {/if}
 
   {#if buildingRooms}
-    <ResultDisplay filteredRooms={buildingRooms} />
+    <ResultDisplay filteredRooms={buildingRooms} {classCounts} />
   {:else if building}
     <p class="entity-loading-note">Loading rooms…</p>
   {/if}

--- a/src/components/svelte/controls/CollegeResult.svelte
+++ b/src/components/svelte/controls/CollegeResult.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { adminAuthStore, queryStore, toastStore } from "@lib/store.svelte";
+  import {
+    adminAuthStore,
+    queryStore,
+    toastStore,
+    termStore,
+  } from "@lib/store.svelte";
   import { persistEntityChange } from "@lib/proposals/client";
   import { handlePersistEntityResult } from "@lib/editor/handle-persist-result";
   import {
@@ -8,7 +13,7 @@
     scheduleEntityContributorDraftSave,
   } from "@lib/contributor-drafts";
   import { getAppActions, getAppData } from "@lib/context";
-  import { getCollegeRooms } from "@lib/local/data/utils";
+  import { getCollegeRooms, fetchRoomClassCounts } from "@lib/local/data/utils";
   import type { CollegeData, RoomData } from "@lib/types";
   import ResultDisplay from "./ResultDisplay.svelte";
   import EntityEditorToggle from "@ui/editor/EntityEditorToggle.svelte";
@@ -19,7 +24,6 @@
     checkLocalCollegeRoom,
     syncCollegeRooms,
   } from "@lib/local/data/sync";
-  import { onMount } from "svelte";
 
   type CollegePatchResponse = {
     success?: boolean;
@@ -47,6 +51,7 @@
   });
 
   let collegeRooms = $state<RoomData[] | null>(null);
+  let classCounts = $state<Map<number, number> | null>(null);
   let editing = $state(false);
   let draftCollegeId = $state<number | null>(null);
   let draftVersion = $state<number | null>(null);
@@ -57,11 +62,50 @@
   let submitterNameDraft = $state("");
   const canPublish = $derived(adminAuthStore.canPublish);
 
-  onMount(async () => {
-    if (!college) return;
-    const collegeChecker = await checkLocalCollegeRoom(college.id);
-    collegeRooms = await getCollegeRooms(collegeChecker, college.id);
-    await syncCollegeRooms(collegeChecker, college.id, collegeRooms);
+  // Reload rooms when the selected college changes; CollegeResult is not
+  // remounted on switch, so key the load on college id and discard stale
+  // fetches from a previous selection (#340).
+  let roomLoadGeneration = 0;
+
+  $effect(() => {
+    const id = college?.id;
+    if (id == null) {
+      collegeRooms = null;
+      return;
+    }
+    const gen = ++roomLoadGeneration;
+    collegeRooms = null;
+    void (async () => {
+      const collegeChecker = await checkLocalCollegeRoom(id);
+      const rooms = await getCollegeRooms(collegeChecker, id);
+      if (gen !== roomLoadGeneration) return;
+      collegeRooms = rooms;
+      await syncCollegeRooms(collegeChecker, id, rooms);
+    })();
+  });
+
+  // Class counts per room for the active term, batched in one request so the
+  // room list preview doesn't fire N+1 /api/classes calls (#342). Re-fetches
+  // when the college or the active term changes; null while loading/offline.
+  let classCountGeneration = 0;
+
+  $effect(() => {
+    const id = college?.id;
+    const termId = termStore.activeTermId;
+    if (id == null) {
+      classCounts = null;
+      return;
+    }
+    const gen = ++classCountGeneration;
+    void (async () => {
+      const counts = await fetchRoomClassCounts(
+        "college",
+        id,
+        termId ?? undefined,
+      );
+      if (gen !== classCountGeneration) return;
+      classCounts = counts;
+    })();
   });
 
   $effect(() => {
@@ -245,7 +289,7 @@
     </section>
   {/if}
   {#if collegeRooms}
-    <ResultDisplay filteredRooms={collegeRooms} />
+    <ResultDisplay filteredRooms={collegeRooms} {classCounts} />
   {:else}
     Loading data...
   {/if}

--- a/src/components/svelte/controls/DivisionResult.svelte
+++ b/src/components/svelte/controls/DivisionResult.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { adminAuthStore, queryStore, toastStore } from "@lib/store.svelte";
+  import {
+    adminAuthStore,
+    queryStore,
+    toastStore,
+    termStore,
+  } from "@lib/store.svelte";
   import { persistEntityChange } from "@lib/proposals/client";
   import { handlePersistEntityResult } from "@lib/editor/handle-persist-result";
   import {
@@ -9,7 +14,10 @@
   } from "@lib/contributor-drafts";
   import { getAppActions, getAppData } from "@lib/context";
   import type { DivisionData, RoomData } from "@lib/types";
-  import { getDivisionRooms } from "@lib/local/data/utils";
+  import {
+    getDivisionRooms,
+    fetchRoomClassCounts,
+  } from "@lib/local/data/utils";
   import ResultDisplay from "./ResultDisplay.svelte";
   import EntityEditorToggle from "@ui/editor/EntityEditorToggle.svelte";
   import EntityEditorPanel from "@ui/editor/EntityEditorPanel.svelte";
@@ -19,7 +27,6 @@
     checkLocalDivisionRoom,
     syncDivisionRooms,
   } from "@lib/local/data/sync";
-  import { onMount } from "svelte";
 
   type DivisionPatchResponse = {
     success?: boolean;
@@ -45,6 +52,7 @@
   });
 
   let divisionRooms = $state<RoomData[] | null>(null);
+  let classCounts = $state<Map<number, number> | null>(null);
   let editing = $state(false);
   let draftDivisionId = $state<number | null>(null);
   let draftVersion = $state<number | null>(null);
@@ -56,11 +64,50 @@
   let submitterNameDraft = $state("");
   const canPublish = $derived(adminAuthStore.canPublish);
 
-  onMount(async () => {
-    if (!division) return;
-    const divisionChecker = await checkLocalDivisionRoom(division.id);
-    divisionRooms = await getDivisionRooms(divisionChecker, division.id);
-    await syncDivisionRooms(divisionChecker, division.id, divisionRooms);
+  // Reload rooms when the selected division changes; DivisionResult is not
+  // remounted on switch, so key the load on division id and discard stale
+  // fetches from a previous selection (#340).
+  let roomLoadGeneration = 0;
+
+  $effect(() => {
+    const id = division?.id;
+    if (id == null) {
+      divisionRooms = null;
+      return;
+    }
+    const gen = ++roomLoadGeneration;
+    divisionRooms = null;
+    void (async () => {
+      const divisionChecker = await checkLocalDivisionRoom(id);
+      const rooms = await getDivisionRooms(divisionChecker, id);
+      if (gen !== roomLoadGeneration) return;
+      divisionRooms = rooms;
+      await syncDivisionRooms(divisionChecker, id, rooms);
+    })();
+  });
+
+  // Class counts per room for the active term, batched in one request so the
+  // room list preview doesn't fire N+1 /api/classes calls (#342). Re-fetches
+  // when the division or the active term changes; null while loading/offline.
+  let classCountGeneration = 0;
+
+  $effect(() => {
+    const id = division?.id;
+    const termId = termStore.activeTermId;
+    if (id == null) {
+      classCounts = null;
+      return;
+    }
+    const gen = ++classCountGeneration;
+    void (async () => {
+      const counts = await fetchRoomClassCounts(
+        "division",
+        id,
+        termId ?? undefined,
+      );
+      if (gen !== classCountGeneration) return;
+      classCounts = counts;
+    })();
   });
 
   $effect(() => {
@@ -281,7 +328,7 @@
     </section>
   {/if}
   {#if divisionRooms}
-    <ResultDisplay filteredRooms={divisionRooms} />
+    <ResultDisplay filteredRooms={divisionRooms} {classCounts} />
   {:else}
     Loading data...
   {/if}

--- a/src/components/svelte/controls/JeepneyStopPanel.svelte
+++ b/src/components/svelte/controls/JeepneyStopPanel.svelte
@@ -2,6 +2,7 @@
   import Bus from "@lucide/svelte/icons/bus";
   import ExternalLink from "@lucide/svelte/icons/external-link";
   import MapPin from "@lucide/svelte/icons/map-pin";
+  import X from "@lucide/svelte/icons/x";
   import { JEEPNEY_ROUTES } from "@constants/jeepney-routes";
   import { jeepneyStore } from "@lib/store.svelte";
   import MapChromeActionChip from "@ui/map-chrome/MapChromeActionChip.svelte";
@@ -34,31 +35,44 @@
     if (stopIndex >= route.stops.length - 1) return;
     jeepneyStore.openStop(stopIndex + 1);
   }
+
+  function closeStop() {
+    jeepneyStore.closeStop();
+  }
 </script>
 
 {#if route && stop && stopIndex !== null}
-  <div class="jeepney-stop-modal">
-    <div class="jeepney-stop-modal__header">
+  <div class="jeepney-stop-panel">
+    <button
+      type="button"
+      class="jeepney-stop-panel__close"
+      aria-label="Close stop details"
+      onclick={closeStop}
+    >
+      <X size={18} aria-hidden="true" />
+    </button>
+
+    <div class="jeepney-stop-panel__header">
       <span
-        class="jeepney-stop-modal__route-badge"
+        class="jeepney-stop-panel__route-badge"
         style:background-color={route.color}
       >
         <Bus size={14} aria-hidden="true" />
         {route.name}
       </span>
-      <h2 class="jeepney-stop-modal__title">{stop.name}</h2>
-      <p class="jeepney-stop-modal__meta">
+      <h2 class="jeepney-stop-panel__title">{stop.name}</h2>
+      <p class="jeepney-stop-panel__meta">
         Stop {stopIndex + 1} of {route.stops.length}
       </p>
-      <p class="jeepney-stop-modal__description">{route.description}</p>
+      <p class="jeepney-stop-panel__description">{route.description}</p>
     </div>
 
-    <div class="jeepney-stop-modal__coords">
+    <div class="jeepney-stop-panel__coords">
       <MapPin size={14} aria-hidden="true" />
       <span>{stop.lat.toFixed(5)}, {stop.lon.toFixed(5)}</span>
     </div>
 
-    <div class="jeepney-stop-modal__actions">
+    <div class="jeepney-stop-panel__actions">
       <MapChromeActionChip disabled={stopIndex <= 0} onclick={openPreviousStop}>
         Previous stop
       </MapChromeActionChip>
@@ -70,7 +84,7 @@
       </MapChromeActionChip>
       {#if mapsUrl}
         <a
-          class="jeepney-stop-modal__maps-link map-chrome-action-chip"
+          class="jeepney-stop-panel__maps-link map-chrome-action-chip"
           href={mapsUrl}
           target="_blank"
           rel="noopener noreferrer"
@@ -84,23 +98,49 @@
 {/if}
 
 <style>
-  .jeepney-stop-modal {
+  .jeepney-stop-panel {
+    position: relative;
     display: flex;
     flex-direction: column;
-    gap: 0.875rem;
-    padding: 0.75rem 0.875rem 1rem;
-    min-width: min(100%, 22rem);
-    max-width: 28rem;
+    gap: 0.75rem;
+    padding: 0.25rem 0.125rem 0.5rem;
+    min-width: 0;
   }
 
-  .jeepney-stop-modal__header {
+  .jeepney-stop-panel__close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0.25rem;
+    border-radius: 0.375rem;
+    color: hsl(0, 0%, 30%);
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+  }
+  .jeepney-stop-panel__close:hover,
+  .jeepney-stop-panel__close:focus-visible {
+    background-color: hsl(0, 0%, 92%);
+  }
+  .jeepney-stop-panel__close:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 1px;
+  }
+
+  .jeepney-stop-panel__header {
     display: flex;
     flex-direction: column;
     gap: 0.375rem;
     min-width: 0;
+    padding-right: 1.75rem;
   }
 
-  .jeepney-stop-modal__route-badge {
+  .jeepney-stop-panel__route-badge {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
@@ -117,7 +157,7 @@
     text-overflow: ellipsis;
   }
 
-  .jeepney-stop-modal__title {
+  .jeepney-stop-panel__title {
     margin: 0;
     font-size: 1.125rem;
     font-weight: 700;
@@ -125,21 +165,21 @@
     color: #18181b;
   }
 
-  .jeepney-stop-modal__meta {
+  .jeepney-stop-panel__meta {
     margin: 0;
     font-size: 0.8125rem;
     font-weight: 600;
     color: hsl(0, 0%, 42%);
   }
 
-  .jeepney-stop-modal__description {
+  .jeepney-stop-panel__description {
     margin: 0;
     font-size: 0.8125rem;
     line-height: 1.45;
     color: hsl(0, 0%, 38%);
   }
 
-  .jeepney-stop-modal__coords {
+  .jeepney-stop-panel__coords {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
@@ -148,13 +188,13 @@
     color: hsl(0, 0%, 45%);
   }
 
-  .jeepney-stop-modal__actions {
+  .jeepney-stop-panel__actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.375rem;
   }
 
-  .jeepney-stop-modal__maps-link {
+  .jeepney-stop-panel__maps-link {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Search from "@ui/search/Search.svelte";
-  import { queryStore, sidePanelStore } from "@lib/store.svelte";
+  import { queryStore, sidePanelStore, jeepneyStore } from "@lib/store.svelte";
   import BuildingResult from "./BuildingResult.svelte";
   import CollegeResult from "./CollegeResult.svelte";
   import DivisionResult from "./DivisionResult.svelte";
@@ -9,6 +9,7 @@
   import EventResult from "./EventResult.svelte";
   import RoomResult from "@ui/room/RoomResult.svelte";
   import ClassQuery from "./ClassQuery.svelte";
+  import JeepneyStopPanel from "./JeepneyStopPanel.svelte";
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
   import ChevronUp from "@lucide/svelte/icons/chevron-up";
@@ -46,7 +47,7 @@
 <div class="side-panel-wrapper">
   <Search />
   <div class="side-panel-controls">
-    {#if queryStore.category !== null}
+    {#if queryStore.category !== null || jeepneyStore.selectedStopIndex !== null}
       <div class="drawer" class:is-collapsed={sidePanelStore.collapsed}>
         <button
           class="drawer-handle"
@@ -75,7 +76,9 @@
             class="side-panel-details"
             aria-hidden={sidePanelStore.collapsed}
           >
-            {#if queryStore.category === "building"}
+            {#if jeepneyStore.selectedStopIndex !== null}
+              <JeepneyStopPanel />
+            {:else if queryStore.category === "building"}
               <BuildingResult />
             {:else if queryStore.category === "college"}
               <CollegeResult />
@@ -125,7 +128,7 @@
     bottom: 0;
     left: 0;
     width: var(--map-search-chrome-width, min(31rem, calc(100vw - 15rem)));
-    z-index: 2;
+    z-index: var(--z-side-panel, 2);
     pointer-events: none;
     transition: transform var(--motion-duration-panel) var(--motion-ease-out);
   }
@@ -217,7 +220,6 @@
 
     .drawer {
       position: fixed;
-      z-index: 12;
       top: var(--mobile-detail-sheet-top-inset);
       right: 0;
       bottom: calc(

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -36,6 +36,7 @@
     if (identity === lastPanelIdentity) return;
 
     sidePanelStore.expand();
+    jeepneyStore.closeStop();
     lastPanelIdentity = identity;
   });
 

--- a/src/components/svelte/controls/ResultDisplay.svelte
+++ b/src/components/svelte/controls/ResultDisplay.svelte
@@ -7,8 +7,9 @@
 
   interface Props {
     filteredRooms: RoomData[];
+    classCounts?: Map<number, number> | null;
   }
-  const { filteredRooms }: Props = $props();
+  const { filteredRooms, classCounts }: Props = $props();
 
   const paginatedRooms = $derived(
     filteredRooms.slice(
@@ -25,7 +26,11 @@
   <h3 class="rooms-subtitle">Rooms in the building</h3>
   <div class="room-list">
     {#each paginatedRooms as room (room.id)}
-      <RoomDisplay {room} searchInput="" />
+      <RoomDisplay
+        {room}
+        searchInput=""
+        classCount={classCounts?.get(room.id)}
+      />
     {/each}
 
     {#if filteredRooms.length === 0}

--- a/src/components/svelte/controls/RoomDisplay.svelte
+++ b/src/components/svelte/controls/RoomDisplay.svelte
@@ -5,15 +5,25 @@
   type Props = {
     room: RoomData;
     searchInput: string;
+    classCount?: number | null;
   };
 
-  const { room, searchInput }: Props = $props();
+  const { room, searchInput, classCount }: Props = $props();
   const pattern = $derived(new RegExp(`(${searchInput.trim()})`, "gi"));
   function highlightSearch(original: string, pattern: RegExp): string {
     return searchInput.length < 2
       ? original
       : original.replaceAll(pattern, (substr) => `<mark>${substr}</mark>`);
   }
+
+  // Class count is undefined while the batched count request is in flight (or
+  // offline), so the chip stays empty rather than flashing a wrong "0". A
+  // loaded 0 renders explicitly as "0 classes" (#342).
+  const classCountLabel = $derived(
+    typeof classCount === "number"
+      ? `${classCount} class${classCount !== 1 ? "es" : ""}`
+      : null,
+  );
 
   function openRoomData() {
     queryStore.updateQuery({
@@ -45,7 +55,7 @@
     </div>
     <h3 class="room-code">{@html highlightSearch(room.code, pattern)}</h3>
     <div class="class-count">
-      <!-- {classes.length} class{classes.length !== 1 ? "es" : ""} -->
+      {#if classCountLabel}{classCountLabel}{/if}
     </div>
   </div>
 </button>

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { modalStore } from "@lib/store.svelte";
   import { contributors, designers } from "@constants/contributors";
   import { UPLB_TOOLS_URL } from "@constants/community-links";
@@ -69,8 +68,10 @@
     modalStore.closeModal();
   }
 
-  onMount(() => {
-    void loadGithubContributors();
+  $effect(() => {
+    if (!modalStore.open || modalStore.type !== "landing") return;
+    activeTab = modalStore.landingTab ?? "welcome";
+    if (activeTab === "campus") void loadGithubContributors();
   });
 </script>
 

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { jeepneyStore, modalStore } from "@lib/store.svelte";
+  import { modalStore } from "@lib/store.svelte";
   import { fade, fly } from "svelte/transition";
   import {
     modalContentDismiss,
@@ -11,7 +11,6 @@
   import LandingModal from "./LandingModal.svelte";
   import ScheduleModal from "./ScheduleModal.svelte";
   import FilterModalContent from "./FilterModalContent.svelte";
-  import JeepneyStopModal from "./JeepneyStopModal.svelte";
   import X from "@lucide/svelte/icons/x";
 
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
@@ -22,15 +21,10 @@
     if (modalStore.type === "landing") return undefined;
     if (modalStore.type === "schedule-expand") return "Room schedule";
     if (modalStore.type === "filter") return "Filter campus";
-    if (modalStore.type === "jeepney-stop") return "Jeepney stop details";
     return "Dialog";
   });
 
   function closeDialog() {
-    if (modalStore.type === "jeepney-stop") {
-      jeepneyStore.closeStop();
-      return;
-    }
     modalStore.closeModal();
   }
 
@@ -80,16 +74,6 @@
         <ScheduleModal />
       {:else if modalStore.type === "filter"}
         <FilterModalContent />
-      {:else if modalStore.type === "jeepney-stop"}
-        <button
-          type="button"
-          class="modal-content__close-icon"
-          aria-label="Close jeepney stop details"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </button>
-        <JeepneyStopModal />
       {/if}
     </div>
   </div>

--- a/src/components/svelte/room/ScheduleRender.svelte
+++ b/src/components/svelte/room/ScheduleRender.svelte
@@ -11,14 +11,17 @@
     classes: ClassMapValue[];
   }
   const { roomCode, classes }: Props = $props();
-  const canvasId = $derived(`schedule-${roomCode}`);
-  const renderer = $derived(
-    new ScheduleRenderer(canvasId, {
+
+  let canvasEl = $state<HTMLCanvasElement | undefined>();
+
+  $effect(() => {
+    if (!canvasEl) return;
+
+    const renderer = new ScheduleRenderer(canvasEl, {
       width: 1000,
       height: 600,
-    }),
-  );
-  $effect(() => {
+    });
+
     classes.forEach((sectionClass) => {
       const schedule: string[] = sectionClass.schedule ?? [];
       if (schedule.length === 0) return;
@@ -44,7 +47,8 @@
   });
 </script>
 
-<canvas id={canvasId}></canvas>
+<canvas bind:this={canvasEl} aria-label={`Class schedule for ${roomCode}`}
+></canvas>
 
 <style>
   canvas {

--- a/src/components/svelte/search/Suggestion.svelte
+++ b/src/components/svelte/search/Suggestion.svelte
@@ -31,6 +31,12 @@
     });
     queryStore.inputValue = value;
   }
+
+  function handleRemoveRecent(event: MouseEvent) {
+    event.stopPropagation();
+    if (typeof id === "undefined") return;
+    queryStore.removeRecentSearch(id);
+  }
 </script>
 
 {#snippet icon(type: typeof category)}
@@ -53,35 +59,69 @@
   </span>
 {/snippet}
 
-<button class="suggestion" onclick={handleSuggestionClick}>
-  {@render icon(category)}
-  <div class="text">{value}</div>
+<div class="suggestion-row">
+  <button type="button" class="suggestion" onclick={handleSuggestionClick}>
+    {@render icon(category)}
+    <div class="text">{value}</div>
+    {#if typeof id === "undefined"}
+      <ArrowUpRight size={20} class="icon trailing" />
+    {/if}
+  </button>
   {#if typeof id !== "undefined"}
-    <X
-      size={20}
-      style="margin-left:auto"
-      onclick={(e) => {
-        e.stopImmediatePropagation();
-        queryStore.removeRecentSearch(id);
-      }}
-    ></X>
-  {:else}
-    <ArrowUpRight size={20} style="margin-left:auto" class="icon" />
+    <button
+      type="button"
+      class="suggestion-remove"
+      aria-label={`Remove ${value} from recent searches`}
+      onclick={handleRemoveRecent}
+    >
+      <X size={18} aria-hidden="true" />
+    </button>
   {/if}
-</button>
+</div>
 
 <style>
+  .suggestion-row {
+    display: flex;
+    align-items: stretch;
+    gap: 0.125rem;
+    border-radius: 0.5rem;
+  }
+
+  .suggestion-row:hover .suggestion,
+  .suggestion-row:focus-within .suggestion {
+    background-color: hsl(0, 0%, 95%);
+  }
+
   .suggestion {
     all: unset;
+    box-sizing: border-box;
+    flex: 1;
+    min-width: 0;
     padding: 0.4375rem 0.5rem;
     display: flex;
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
     border-radius: 0.5rem;
-    &:hover {
-      background-color: hsl(0, 0%, 95%);
-    }
+  }
+
+  .suggestion-remove {
+    all: unset;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 2rem;
+    cursor: pointer;
+    border-radius: 0.5rem;
+    color: #52525b;
+  }
+
+  .suggestion-remove:hover,
+  .suggestion-remove:focus-visible {
+    background-color: hsl(0, 0%, 90%);
+    color: #18181b;
   }
 
   :global(.icon) {
@@ -92,13 +132,18 @@
     flex-shrink: 0;
   }
 
+  :global(.icon.trailing) {
+    margin-left: auto;
+  }
+
   .text {
     font-size: 0.875rem;
-    color: #18181b; /* zinc-900 */
+    color: #18181b;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
   @media (max-width: 425px) {
     .suggestion {
       padding: 0.4375rem 0.375rem;

--- a/src/constants/modal-states.ts
+++ b/src/constants/modal-states.ts
@@ -1,8 +1,3 @@
 // src/constants/modal-states.ts
 
-export const modalOptions = [
-  "landing",
-  "schedule-expand",
-  "filter",
-  "jeepney-stop",
-] as const;
+export const modalOptions = ["landing", "schedule-expand", "filter"] as const;

--- a/src/lib/local/data/utils.ts
+++ b/src/lib/local/data/utils.ts
@@ -440,6 +440,32 @@ export const getDivisionRooms = getEntityRooms(
   getLocalDivisionRooms,
 );
 
+/** Per-room class counts for an entity's room list, scoped to the active term.
+ * One batched /api/rooms/class-counts request replaces N+1 /api/classes calls
+ * per visible row (#342). Returns null on offline/server error so the UI can
+ * distinguish "not loaded yet" from a real "0 classes". */
+export async function fetchRoomClassCounts(
+  entityName: "building" | "college" | "division",
+  id: number,
+  termId?: number,
+): Promise<Map<number, number> | null> {
+  const params = new URLSearchParams({ [`${entityName}_id`]: String(id) });
+  if (termId != null) params.set("term_id", String(termId));
+  try {
+    const response = await fetch(
+      `/api/rooms/class-counts?${params.toString()}`,
+    );
+    if (!response.ok) return null;
+    const payload = (await response.json()) as {
+      data?: { roomId: number; count: number }[];
+    };
+    if (!Array.isArray(payload?.data)) return null;
+    return new Map(payload.data.map((row) => [row.roomId, row.count]));
+  } catch {
+    return null;
+  }
+}
+
 export async function getRoomsData(): Promise<
   Pick<DBData, "directionCount" | "totalRooms">
 > {

--- a/src/lib/schedule-renderer.ts
+++ b/src/lib/schedule-renderer.ts
@@ -39,10 +39,14 @@ export class ScheduleRenderer {
   cellWidth: number = 0;
   cellHeight: number = 0;
 
-  constructor(canvasId: string, config = {}) {
-    this.canvas = document.getElementById(canvasId) as HTMLCanvasElement;
-    if (!this.canvas) {
-      throw new Error(`Canvas with id "${canvasId}" not found`);
+  constructor(canvas: string | HTMLCanvasElement, config = {}) {
+    if (typeof canvas === "string") {
+      this.canvas = document.getElementById(canvas) as HTMLCanvasElement;
+      if (!this.canvas) {
+        throw new Error(`Canvas with id "${canvas}" not found`);
+      }
+    } else {
+      this.canvas = canvas;
     }
     this.ctx = this.canvas.getContext("2d") as CanvasRenderingContext2D;
 

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -298,6 +298,45 @@ export async function getClassesForRoom(
   }
 }
 
+/** Per-room class counts for one building/college/division, optionally scoped
+ * to a term. Returns a Map of roomId -> count; rooms with no classes for the
+ * scope are included with count 0 (LEFT JOIN + GROUP BY). One grouped query
+ * feeds the room list preview so we avoid N+1 /api/classes calls per row
+ * (#342). */
+export async function getRoomClassCounts(
+  entityName: "building" | "college" | "division",
+  id: number,
+  termId?: number,
+): Promise<Map<number, number>> {
+  try {
+    const column =
+      entityName === "building"
+        ? roomsTable.buildingId
+        : entityName === "college"
+          ? roomsTable.collegeId
+          : roomsTable.divisionId;
+    const data = await db
+      .select({
+        roomId: roomsTable.id,
+        count: sql<number>`count(${classesTable.id})::int`,
+      })
+      .from(roomsTable)
+      .leftJoin(
+        classesTable,
+        and(
+          eq(classesTable.roomId, roomsTable.id),
+          termId != null ? eq(classesTable.termId, termId) : undefined,
+        ),
+      )
+      .where(eq(column, id))
+      .groupBy(roomsTable.id);
+    return new Map(data.map((row) => [row.roomId, row.count]));
+  } catch (e) {
+    console.error("Error: ", e);
+    throw new Error("Failed to fetch room class counts", { cause: e });
+  }
+}
+
 export type AliasMatch = {
   alias: string;
   targetType: string;

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -435,7 +435,11 @@ class MainControlsStore {
 }
 
 export type FloatingControlPanel =
-  "legend" | "building-type" | "terrain" | "admin" | "suggest-addition";
+  | "legend"
+  | "building-type"
+  | "terrain"
+  | "admin"
+  | "suggest-addition";
 
 class FloatingControlPanelStore {
   openPanel: FloatingControlPanel | null = $state(null);
@@ -969,6 +973,10 @@ class JeepneyStore {
     this.layerActive = true;
     mapToolsStore.close();
     deactivateMapModesExcept("routes");
+    // Transit is mutually exclusive with building/dorm pin filters: reset to
+    // All so filtered pins don't overlap jeepney routes/stops (#325). This
+    // covers every enable path (search chip, map tools flyout, route picker).
+    buildingTypeFilter.set("all");
   };
 
   disableLayer = () => {
@@ -1006,20 +1014,22 @@ class JeepneyStore {
     if (this.selectedRouteId === null) return;
     this.selectedStopIndex = index;
     this.hoveredStopIndex = index;
-    modalStore.openModal("jeepney-stop");
+    sidePanelStore.expand();
   };
 
   closeStop = () => {
     this.selectedStopIndex = null;
     this.hoveredStopIndex = null;
-    if (modalStore.open && modalStore.type === "jeepney-stop") {
-      modalStore.closeModal();
-    }
   };
 }
 
 export type AppBootstrapPhase =
-  "idle" | "local" | "remote" | "sync" | "ready" | "error";
+  | "idle"
+  | "local"
+  | "remote"
+  | "sync"
+  | "ready"
+  | "error";
 
 class AppBootstrapStore {
   phase = $state<AppBootstrapPhase>("idle");

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -129,9 +129,12 @@ export const currentRoom = {
   },
 };
 
+export type LandingModalTab = "welcome" | "campus";
+
 interface ModalStoreState {
   open: boolean;
   type: (typeof modalOptions)[number] | null;
+  landingTab?: LandingModalTab;
 }
 
 export interface QueryStoreState {
@@ -166,10 +169,15 @@ class ModalStore {
 
   open = $derived(this._modalStore.open);
   type = $derived(this._modalStore.type);
+  landingTab = $derived(this._modalStore.landingTab);
 
-  openModal = (type: ModalStoreState["type"]) => {
+  openModal = (
+    type: ModalStoreState["type"],
+    options?: { landingTab?: LandingModalTab },
+  ) => {
     this._modalStore.open = true;
     this._modalStore.type = type;
+    this._modalStore.landingTab = options?.landingTab;
   };
 
   closeModal = () => {

--- a/src/pages/api/rooms/class-counts.ts
+++ b/src/pages/api/rooms/class-counts.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro";
+import { getRoomClassCounts } from "@lib/services/map-data-service";
+
+export const prerender = false;
+
+export const GET = (async ({ url }) => {
+  const buildingId = url.searchParams.get("building_id");
+  const collegeId = url.searchParams.get("college_id");
+  const divisionId = url.searchParams.get("division_id");
+  const termIdRaw = url.searchParams.get("term_id");
+  const termId =
+    termIdRaw !== null && termIdRaw !== "" ? Number(termIdRaw) : undefined;
+
+  let entityName: "building" | "college" | "division";
+  let id: number;
+  if (buildingId !== null) {
+    entityName = "building";
+    id = Number(buildingId);
+  } else if (collegeId !== null) {
+    entityName = "college";
+    id = Number(collegeId);
+  } else if (divisionId !== null) {
+    entityName = "division";
+    id = Number(divisionId);
+  } else {
+    return new Response(
+      JSON.stringify({ error: "Missing entity filter", success: false }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  if (!Number.isFinite(id)) {
+    return new Response(
+      JSON.stringify({ error: "Invalid entity id", success: false }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  try {
+    const counts = await getRoomClassCounts(
+      entityName,
+      id,
+      Number.isFinite(termId) ? termId : undefined,
+    );
+    const data = Array.from(counts.entries()).map(([roomId, count]) => ({
+      roomId,
+      count,
+    }));
+    return new Response(JSON.stringify({ data, success: true }, null, 2), {
+      headers: [
+        ["Access-Control-Allow-Origin", "*"],
+        ["Content-Type", "application/json"],
+      ],
+    });
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch class counts", success: false }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+}) satisfies APIRoute;


### PR DESCRIPTION
## Release

Merges the `staging` integration branch into `main` for production.

### Included changes

- PR #344: 5 small tickets (room list refresh, class counts, transit exclusivity, jeepney stop panel, z-index fix)
- Direct push to staging: fix for stop panel hiding new query results

### QA
- `bun test src`: 71/71 passing
- Prettier clean on all changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core map browse UX (side panel, transit, search) and adds a read-only API backed by grouped DB queries; changes are localized but user-facing across mobile and desktop.
> 
> **Overview**
> This release bundles map chrome, side-panel, and data-loading fixes ahead of **staging → main**.
> 
> **Jeepney stops** move out of the modal stack into the **side panel** (`JeepneyStopPanel` in `MainControls`). Selecting a stop expands the drawer; **Escape** and a panel close control dismiss it. When the user opens a **new search result**, the panel identity effect **closes the stop** so entity details replace stop UI (fixes stop panel blocking new queries). Drawer visibility also treats an open stop like an active category.
> 
> **Transit vs pin filters** are mutually exclusive: enabling transit resets pins to **All**; choosing Class/Admin/dorm filters **disables** the jeepney layer. Behavior is documented in `docs/map-ui-mode-matrix.md`.
> 
> **Building/college/division** room lists reload on entity switch via **`$effect` + generation guards** instead of one-shot `onMount`, avoiding stale rooms (#340). **Per-room class counts** for the active term come from a new **`GET /api/rooms/class-counts`** batch endpoint and show in the room list without N+1 `/api/classes` calls (#342).
> 
> Smaller touches: shared **z-index** tokens on map chrome; PWA precache/denylist for **privacy/terms/changelog**; landing modal **`landingTab`** (e.g. Contributors → Campus team); schedule canvas **`bind:this`**; recent-search **remove** as its own button in `Suggestion.svelte`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff86769d771ada9ece6d6913c87562f24df333a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->