### PR TITLE
feat(ui): sync copy, action chips, LEC/LAB grouping (#338, #319, #301)

### DIFF
--- a/.cursor/rules/side-panel.mdc
+++ b/.cursor/rules/side-panel.mdc
@@ -18,7 +18,8 @@ Before adding UI to entity detail views in the MainControls drawer:
    - **Directions:** one merged block — directions text, contribute/suggest links, nav chips (Directions, Google Maps). No duplicate colored boxes or second nav row.
    - **Footer:** secondary links only (schedule, external refs) as subtle text links — not full-width buttons.
 3. Do **not** add new full-width button rows or colored highlight boxes without removing or consolidating existing ones.
-4. Match existing action chip patterns: `CopyLinkButton variant="chip"`, `EntityEditorToggle variant="toolbar"`, `MapChromeActionChip`, or `.map-chrome-action-chip` anchors.
-5. Side panel changes require checking **RoomResult + BuildingResult + DormResult** (minimum) for parity before merge.
-6. Keep browse mode compact — prefer collapsed `<details>` for long secondary content; editor fields use progressive disclosure.
-7. Update `docs/map-ui-mode-matrix.md` if drawer zones or collapse behavior change.
+4. Match existing action chip patterns: `CopyLinkButton variant="chip"`, `EntityEditorToggle variant="toolbar"`, `MapChromeActionChip`, `EntityEditorPinRow`, or `.map-chrome-action-chip` anchors.
+5. **Links navigate; buttons/chips act.** Use `<a href>` for navigation (legal, external community, back links). State-changing controls (edit mode, pin move, toggles) use `<button>` with chip/toolbar styling, not underlined inline text.
+6. Side panel changes require checking **RoomResult + BuildingResult + DormResult** (minimum) for parity before merge.
+7. Keep browse mode compact — prefer collapsed `<details>` for long secondary content; editor fields use progressive disclosure.
+8. Update `docs/map-ui-mode-matrix.md` if drawer zones or collapse behavior change.

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -508,7 +508,9 @@
   {#if buildingRooms}
     <ResultDisplay filteredRooms={buildingRooms} {classCounts} />
   {:else if building}
-    <p class="entity-loading-note">Loading rooms…</p>
+    <p class="entity-loading-note">
+      Loading rooms for {building.buildingName}…
+    </p>
   {/if}
 </div>
 

--- a/src/components/svelte/controls/CollegeResult.svelte
+++ b/src/components/svelte/controls/CollegeResult.svelte
@@ -290,8 +290,10 @@
   {/if}
   {#if collegeRooms}
     <ResultDisplay filteredRooms={collegeRooms} {classCounts} />
-  {:else}
-    Loading data...
+  {:else if college}
+    <p class="entity-loading-note">
+      Loading rooms for {college.collegeName}…
+    </p>
   {/if}
 </div>
 

--- a/src/components/svelte/controls/DivisionResult.svelte
+++ b/src/components/svelte/controls/DivisionResult.svelte
@@ -329,8 +329,10 @@
   {/if}
   {#if divisionRooms}
     <ResultDisplay filteredRooms={divisionRooms} {classCounts} />
-  {:else}
-    Loading data...
+  {:else if division}
+    <p class="entity-loading-note">
+      Loading rooms for {division.divisionName}…
+    </p>
   {/if}
 </div>
 

--- a/src/components/svelte/controls/DormEditorPanel.svelte
+++ b/src/components/svelte/controls/DormEditorPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { DormData } from "@lib/types";
   import EntityEditorPanel from "@ui/editor/EntityEditorPanel.svelte";
+  import EntityEditorPinRow from "@ui/editor/EntityEditorPinRow.svelte";
   import EntityEditorField from "@ui/editor/EntityEditorField.svelte";
   import EntityEditorCheckboxField from "@ui/editor/EntityEditorCheckboxField.svelte";
   import { entityEditorSavedMessage } from "@lib/editor/field-action-label";
@@ -340,30 +341,29 @@
       {#if mapEditStore.enabled}
         Map editing is on. Drag this dorm's pin on the map to move it.
       {:else}
-        To move this dorm's map pin,
-        <button
-          type="button"
-          class="inline-link-btn"
-          onclick={() => mapEditStore.enable()}
-        >
-          enable map editing
-        </button>
-        from the shield control, then drag its marker.
+        Move this dorm's map pin from the map after enabling edit mode.
       {/if}
     {:else if dorm.lat && dorm.lon}
       {#if mapProposalStore.allowsKey(`dorm:${dorm.id}`)}
         Pin move mode is on. Drag this dorm's marker on the map.
       {:else}
-        To suggest a map pin move,
-        <button
-          type="button"
-          class="inline-link-btn"
-          onclick={enablePinProposal}
-        >
-          enable pin move
-        </button>
-        , then drag its marker.
+        Suggest a map pin move, then drag its marker on the map.
       {/if}
     {/if}
   </p>
+  {#if canPublish && !mapEditStore.enabled}
+    <EntityEditorPinRow
+      label="Map pin"
+      pickLabel="Enable map edit"
+      {disabled}
+      onclick={() => mapEditStore.enable()}
+    />
+  {:else if !canPublish && dorm.lat && dorm.lon && !mapProposalStore.allowsKey(`dorm:${dorm.id}`)}
+    <EntityEditorPinRow
+      label="Map pin"
+      pickLabel="Enable pin move"
+      {disabled}
+      onclick={enablePinProposal}
+    />
+  {/if}
 </EntityEditorPanel>

--- a/src/components/svelte/controls/EventResult.svelte
+++ b/src/components/svelte/controls/EventResult.svelte
@@ -974,7 +974,7 @@
                   {:else if mapProposalStore.allowsKey(`event:${event.id}:location`)}
                     Pin move mode is on. Drag the event marker on the map.
                   {:else}
-                    <p>Suggest a map pin move, then drag the marker.</p>
+                    Suggest a map pin move, then drag the marker.
                     <EntityEditorPinRow
                       label="Event marker"
                       pickLabel="Enable pin move"

--- a/src/components/svelte/controls/EventResult.svelte
+++ b/src/components/svelte/controls/EventResult.svelte
@@ -10,6 +10,7 @@
   import EntityEditorPanel from "@ui/editor/EntityEditorPanel.svelte";
   import EntityEditorFormField from "@ui/editor/EntityEditorFormField.svelte";
   import EntityEditorCard from "@ui/editor/EntityEditorCard.svelte";
+  import EntityEditorPinRow from "@ui/editor/EntityEditorPinRow.svelte";
   import EntityEditorSubmitButton from "@ui/editor/EntityEditorSubmitButton.svelte";
   import ImageUpload from "@ui/editor/ImageUpload.svelte";
   import { fieldSaveActionLabel } from "@lib/editor/field-action-label";
@@ -973,15 +974,12 @@
                   {:else if mapProposalStore.allowsKey(`event:${event.id}:location`)}
                     Pin move mode is on. Drag the event marker on the map.
                   {:else}
-                    Suggest a map pin move with
-                    <button
-                      type="button"
-                      class="inline-link-btn"
+                    <p>Suggest a map pin move, then drag the marker.</p>
+                    <EntityEditorPinRow
+                      label="Event marker"
+                      pickLabel="Enable pin move"
                       onclick={enableEventPinProposal}
-                    >
-                      enable pin move
-                    </button>
-                    , then drag the marker.
+                    />
                   {/if}
                 </p>
               {:else}

--- a/src/components/svelte/editor/entity-editor.css
+++ b/src/components/svelte/editor/entity-editor.css
@@ -162,18 +162,6 @@
   line-height: 1.45;
 }
 
-.inline-link-btn {
-  border: none;
-  background: none;
-  color: #7b1113;
-  cursor: pointer;
-  font: inherit;
-  font-size: inherit;
-  font-weight: 700;
-  padding: 0;
-  text-decoration: underline;
-}
-
 .editor-message {
   margin: 0;
   font-size: 0.75rem;

--- a/src/components/svelte/room/Classes.svelte
+++ b/src/components/svelte/room/Classes.svelte
@@ -1,75 +1,183 @@
 <script lang="ts">
+  import { queryStore } from "@lib/store.svelte";
+  import { groupClassesByOffering } from "@lib/class-offering-groups";
   import type { ClassMapValue } from "@lib/types";
 
   interface Props {
     classes: ClassMapValue[];
+    currentRoomCode?: string | null;
   }
-  const { classes }: Props = $props();
+
+  const { classes, currentRoomCode = null }: Props = $props();
+
+  const groups = $derived(groupClassesByOffering(classes));
+
+  function openRoom(roomCode: string | null | undefined) {
+    if (!roomCode) return;
+    queryStore.updateQuery({
+      type: "result",
+      category: "room",
+      value: roomCode,
+    });
+    queryStore.inputValue = roomCode;
+  }
+
+  function formatSchedule(schedule: string[] | null): string {
+    if (!schedule?.length) return "Schedule TBA";
+    return schedule.join(" · ");
+  }
 </script>
 
 <div class="class-list">
-  {#each classes as { courseCode, courseTitle, section, type, schedule }}
-    <div class="class-item">
-      <div class="class-info">
-        <div class="class-code">{courseCode} ({type})</div>
-        <div class="class-title">{courseTitle}</div>
-        <div class="class-section">{section}</div>
-      </div>
-      <div class="class-schedule">
-        {#each schedule as sched}
-          <div>{sched}</div>
+  {#each groups as group (group.key)}
+    <section
+      class="class-offering"
+      class:class-offering--multi={group.sections.length > 1}
+      aria-label="{group.courseCode} section {group.section}"
+    >
+      <header class="class-offering__header">
+        <div class="class-offering__title">{group.courseCode}</div>
+        {#if group.courseTitle}
+          <div class="class-offering__subtitle">{group.courseTitle}</div>
+        {/if}
+        <div class="class-offering__section">Section {group.section}</div>
+      </header>
+
+      <div class="class-offering__sections">
+        {#each group.sections as sectionClass (sectionClass.id)}
+          {@const elsewhere =
+            currentRoomCode &&
+            sectionClass.roomCode &&
+            sectionClass.roomCode !== currentRoomCode}
+          <article class="class-section-row">
+            <div class="class-section-row__main">
+              <div class="class-section-row__type">
+                {sectionClass.type ?? "Class"}
+                {#if elsewhere && sectionClass.roomCode}
+                  <span class="class-section-row__room">
+                    in {sectionClass.roomCode}
+                  </span>
+                {/if}
+              </div>
+              <div class="class-section-row__schedule">
+                {formatSchedule(sectionClass.schedule)}
+              </div>
+            </div>
+            {#if elsewhere && sectionClass.roomCode}
+              <button
+                type="button"
+                class="class-section-row__open"
+                onclick={() => openRoom(sectionClass.roomCode)}
+              >
+                Open room
+              </button>
+            {/if}
+          </article>
         {/each}
       </div>
-    </div>
+    </section>
   {/each}
 </div>
 
 <style>
   .class-list {
     display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 8px;
+    flex-direction: column;
+    gap: 0.625rem;
     margin: 0.5rem 0;
   }
 
-  .class-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    padding: 10px 12px;
-    background: hsl(0, 0%, 95%);
-    border-radius: 3px;
-    font-size: 14px;
-    flex: 1 0 300px;
-    border: 1px solid transparent;
-    transition:
-      border 0.15s,
-      background-color 0.1s;
+  .class-offering {
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 0.5rem;
+    background: hsl(0, 0%, 98%);
+    overflow: hidden;
   }
-  .class-info {
+
+  .class-offering--multi {
+    border-color: hsl(5, 35%, 82%);
+    box-shadow: inset 3px 0 0 hsl(5, 53%, 42%);
+  }
+
+  .class-offering__header {
+    padding: 0.625rem 0.75rem 0.375rem;
+    border-bottom: 1px solid hsl(0, 0%, 92%);
+  }
+
+  .class-offering__title {
+    font-weight: 600;
+    font-size: 0.9375rem;
+    color: #111;
+  }
+
+  .class-offering__subtitle {
+    margin-top: 0.125rem;
+    color: #555;
+    font-size: 0.8125rem;
+    line-height: 1.35;
+  }
+
+  .class-offering__section {
+    margin-top: 0.25rem;
+    color: #777;
+    font-size: 0.75rem;
+  }
+
+  .class-offering__sections {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding: 0.5rem 0.75rem 0.625rem;
+  }
+
+  .class-section-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: 0.375rem;
+    background: white;
+    border: 1px solid hsl(0, 0%, 92%);
+  }
+
+  .class-section-row__main {
+    min-width: 0;
     flex: 1;
   }
 
-  .class-code {
+  .class-section-row__type {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #222;
+  }
+
+  .class-section-row__room {
+    margin-left: 0.25rem;
     font-weight: 500;
-  }
-
-  .class-title {
     color: #666;
-    font-size: 13px;
-    margin-top: 2px;
   }
 
-  .class-section {
-    color: #888;
-    font-size: 12px;
+  .class-section-row__schedule {
+    margin-top: 0.125rem;
+    font-size: 0.75rem;
+    color: #555;
+    line-height: 1.35;
   }
 
-  .class-schedule {
-    text-align: right;
-    font-size: 13px;
-    color: #444;
-    white-space: nowrap;
+  .class-section-row__open {
+    flex-shrink: 0;
+    border: 1px solid hsl(5, 53%, 82%);
+    border-radius: 999px;
+    background: white;
+    color: hsl(5, 53%, 32%);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    padding: 0.25rem 0.625rem;
+    cursor: pointer;
+  }
+
+  .class-section-row__open:hover {
+    background: hsl(5, 53%, 96%);
   }
 </style>

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -690,7 +690,10 @@
       {#if roomClassesStore.loading}
         <p class="entity-schedule__empty">Loading classes…</p>
       {:else if roomClassesStore.classes.length > 0}
-        <Classes classes={roomClassesStore.classes} />
+        <Classes
+          classes={roomClassesStore.classes}
+          currentRoomCode={currentRoom.value?.code ?? null}
+        />
       {:else}
         <p class="entity-schedule__empty">
           No classes listed for this room{activeTermLabel

--- a/src/components/svelte/room/ScheduleRender.svelte
+++ b/src/components/svelte/room/ScheduleRender.svelte
@@ -4,6 +4,7 @@
     parseScheduleTime,
     ScheduleRenderer,
   } from "@lib/schedule-renderer";
+  import { offeringGroupKey } from "@lib/class-offering-groups";
   import type { ClassMapValue } from "@lib/types";
 
   interface Props {
@@ -41,6 +42,10 @@
           courseCode: label,
           section: sectionClass.section,
           color,
+          groupKey: offeringGroupKey(
+            sectionClass.courseCode,
+            sectionClass.section,
+          ),
         });
       });
     });

--- a/src/constants/status-bar-links.ts
+++ b/src/constants/status-bar-links.ts
@@ -1,4 +1,9 @@
-import { LEGAL_LINKS, UPLB_TOOLS_URL } from "@constants/community-links";
+import {
+  LEGAL_LINKS,
+  UPLB_TOOLS_URL,
+  DISCORD_URL,
+  MESSENGER_URL,
+} from "@constants/community-links";
 
 /** Icon keys resolved in StatusBarLinkGroup — add new icons there when extending. */
 export type StatusBarIcon = "external" | "discord" | "messenger" | "version";
@@ -41,7 +46,7 @@ export const STATUS_BAR_COMMUNITY_GROUP: StatusBarNavGroup = {
       kind: "link",
       id: "discord",
       label: "Discord",
-      href: "/discord",
+      href: DISCORD_URL,
       external: true,
       icon: "discord",
     },
@@ -49,7 +54,7 @@ export const STATUS_BAR_COMMUNITY_GROUP: StatusBarNavGroup = {
       kind: "link",
       id: "messenger",
       label: "Messenger",
-      href: "/messenger",
+      href: MESSENGER_URL,
       external: true,
       icon: "messenger",
     },

--- a/src/lib/class-offering-groups.ts
+++ b/src/lib/class-offering-groups.ts
@@ -1,0 +1,73 @@
+import type { ClassMapValue } from "@lib/types";
+
+export type ClassOfferingGroup = {
+  key: string;
+  courseCode: string;
+  courseTitle: string | null;
+  section: string;
+  sections: ClassMapValue[];
+};
+
+const TYPE_ORDER: Record<string, number> = {
+  LEC: 0,
+  LAB: 1,
+  SEM: 2,
+};
+
+export function offeringGroupKey(
+  courseCode: string | null | undefined,
+  section: string | null | undefined,
+): string | null {
+  if (!courseCode || !section) return null;
+  return `${courseCode}::${section}`;
+}
+
+/** Group LEC/LAB/SEM rows that share course code + section (#301). */
+export function groupClassesByOffering(
+  classes: ClassMapValue[],
+): ClassOfferingGroup[] {
+  const groups = new Map<string, ClassOfferingGroup>();
+
+  for (const row of classes) {
+    const key = offeringGroupKey(row.courseCode, row.section);
+    if (!key) {
+      groups.set(`__solo__${row.id}`, {
+        key: `__solo__${row.id}`,
+        courseCode: row.courseCode ?? "Class",
+        courseTitle: row.courseTitle,
+        section: row.section ?? "",
+        sections: [row],
+      });
+      continue;
+    }
+
+    const existing = groups.get(key);
+    if (existing) {
+      existing.sections.push(row);
+      if (!existing.courseTitle && row.courseTitle) {
+        existing.courseTitle = row.courseTitle;
+      }
+    } else {
+      groups.set(key, {
+        key,
+        courseCode: row.courseCode!,
+        courseTitle: row.courseTitle,
+        section: row.section!,
+        sections: [row],
+      });
+    }
+  }
+
+  for (const group of groups.values()) {
+    group.sections.sort((a, b) => {
+      const ta = TYPE_ORDER[a.type ?? ""] ?? 9;
+      const tb = TYPE_ORDER[b.type ?? ""] ?? 9;
+      if (ta !== tb) return ta - tb;
+      return (a.roomCode ?? "").localeCompare(b.roomCode ?? "");
+    });
+  }
+
+  return [...groups.values()].sort((a, b) =>
+    a.courseCode.localeCompare(b.courseCode),
+  );
+}

--- a/src/lib/schedule-renderer.ts
+++ b/src/lib/schedule-renderer.ts
@@ -6,6 +6,7 @@ type Course = {
   courseCode: string;
   section: string;
   color: string;
+  groupKey?: string | null;
 };
 
 export class ScheduleRenderer {
@@ -174,6 +175,12 @@ export class ScheduleRenderer {
       ctx.beginPath();
       ctx.roundRect(x, y, width, height, 2);
       ctx.fill();
+
+      if (course.groupKey) {
+        ctx.strokeStyle = "rgba(123, 17, 19, 0.55)";
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
 
       ctx.fillStyle = "#FFFFFF";
       ctx.textAlign = "center";

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -270,7 +270,7 @@ export async function getClassesForRoom(
   termId?: number,
 ): Promise<ClassMapValue[]> {
   try {
-    const data = await db
+    const inRoom = await db
       .select({
         id: classesTable.id,
         termId: classesTable.termId,
@@ -291,7 +291,61 @@ export async function getClassesForRoom(
           termId != null ? eq(classesTable.termId, termId) : undefined,
         ),
       );
-    return data;
+
+    if (inRoom.length === 0) return inRoom;
+
+    const pairKeys = [
+      ...new Map(
+        inRoom
+          .filter((row) => row.courseCode && row.section)
+          .map((row) => [
+            `${row.courseCode}::${row.section}`,
+            { courseCode: row.courseCode!, section: row.section! },
+          ]),
+      ).values(),
+    ];
+
+    if (pairKeys.length === 0) return inRoom;
+
+    const offeringRows = await db
+      .select({
+        id: classesTable.id,
+        termId: classesTable.termId,
+        roomId: classesTable.roomId,
+        courseCode: classesTable.courseCode,
+        roomCode: roomsTable.roomCode,
+        section: classesTable.section,
+        type: classesTable.type,
+        schedule: classesTable.schedule,
+        directions: roomsTable.directions,
+        courseTitle: classesTable.courseTitle,
+      })
+      .from(classesTable)
+      .leftJoin(roomsTable, eq(roomsTable.id, classesTable.roomId))
+      .where(
+        and(
+          termId != null ? eq(classesTable.termId, termId) : undefined,
+          or(
+            ...pairKeys.map((pair) =>
+              and(
+                eq(classesTable.courseCode, pair.courseCode),
+                eq(classesTable.section, pair.section),
+              ),
+            ),
+          ),
+        ),
+      );
+
+    const byId = new Map<number, ClassMapValue>();
+    for (const row of [...inRoom, ...offeringRows]) {
+      byId.set(row.id, row);
+    }
+
+    return [...byId.values()].sort((a, b) => {
+      const code = (a.courseCode ?? "").localeCompare(b.courseCode ?? "");
+      if (code !== 0) return code;
+      return (a.section ?? "").localeCompare(b.section ?? "");
+    });
   } catch (e) {
     console.error("Error: ", e);
     throw new Error("Failed to fetch classes for room", { cause: e });

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -64,7 +64,7 @@ export type SyncTableKey =
 export type SyncActivity = "idle" | "checking" | "fetching" | "writing";
 
 const SYNC_TABLE_LABELS: Record<SyncTableKey, string> = {
-  buildings: "buildings",
+  buildings: "building list",
   colleges: "colleges",
   divisions: "divisions",
   dorms: "dorms",
@@ -443,11 +443,7 @@ class MainControlsStore {
 }
 
 export type FloatingControlPanel =
-  | "legend"
-  | "building-type"
-  | "terrain"
-  | "admin"
-  | "suggest-addition";
+  "legend" | "building-type" | "terrain" | "admin" | "suggest-addition";
 
 class FloatingControlPanelStore {
   openPanel: FloatingControlPanel | null = $state(null);
@@ -1032,12 +1028,7 @@ class JeepneyStore {
 }
 
 export type AppBootstrapPhase =
-  | "idle"
-  | "local"
-  | "remote"
-  | "sync"
-  | "ready"
-  | "error";
+  "idle" | "local" | "remote" | "sync" | "ready" | "error";
 
 class AppBootstrapStore {
   phase = $state<AppBootstrapPhase>("idle");
@@ -1208,7 +1199,7 @@ class SyncToastStore {
   stepDetail = $derived.by((): string | null => {
     if (this.syncError) return "Tap to retry";
     if (this.allSynced && !this.needRefresh) {
-      return "Room TBA can now work offline";
+      return "Campus directory cached; room lists load when you open a building";
     }
     if (this.needRefresh) return "Reload to get the latest updates.";
     if (this.activity === "checking") {


### PR DESCRIPTION
## Summary

Three `size/M` UX issues in one batch:

- **#338** — Distinguish global building-list sync from per-entity room loads: status bar says "building list", offline detail explains room lists load on open, and building/college/division panels show scoped "Loading rooms for {name}…" copy (lifecycle reload via existing `$effect` on entity id).
- **#319** — Replace `.inline-link-btn` action pattern with `EntityEditorPinRow` chips in dorm/event editor panels; document links-navigate / buttons-act in `side-panel.mdc`; status bar Discord/Messenger use canonical `DISCORD_URL` / `MESSENGER_URL` from `community-links.ts`.
- **#301** — Group LEC/LAB/SEM rows by course+section in `Classes.svelte`, fetch sibling offering rows in `getClassesForRoom`, and add shared group styling in timetable blocks via `groupKey` in `schedule-renderer.ts`.

## Test plan

- [ ] After bootstrap, status bar shows "Syncing building list" (not generic buildings); offline toast does not imply rooms are cached globally
- [ ] Open a building immediately after sync: scoped loading copy, rooms appear (no stuck state when switching buildings/colleges/divisions)
- [ ] Dorm/event editor: pin move and map edit actions render as chips, not underlined text; 320px tap targets OK
- [ ] Status bar Discord/Messenger open `https://discord.uplbtools.me` and `https://messenger.uplbtools.me`
- [ ] Room with split LEC/LAB: grouped card, sibling in other room shows "Open room"; timetable paired blocks share group stroke
- [ ] LEC-only or LAB-only offerings still render as single rows without empty placeholders

Refs #338, #319, #301

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `getClassesForRoom` widens DB reads with an OR over course+section pairs (more rows per room view); otherwise copy, link, and UI changes are low impact.
> 
> **Overview**
> Clarifies **global building-list sync** vs **per-entity room loads**: sync labels say “building list,” the offline toast explains room lists load when you open a building, and building/college/division panels show scoped **“Loading rooms for {name}…”** instead of generic loading text.
> 
> **Editor UX:** dorm and event pin/map actions move from underlined **`.inline-link-btn`** to **`EntityEditorPinRow`** chips; **`side-panel.mdc`** documents **links navigate / buttons act** and **`EntityEditorPinRow`**. Status bar Discord/Messenger now use **`DISCORD_URL`** / **`MESSENGER_URL`** from `community-links.ts` instead of `/discord` and `/messenger`.
> 
> **Room schedule (#301):** new **`groupClassesByOffering`** groups LEC/LAB/SEM by course+section; **`getClassesForRoom`** also fetches sibling offering rows campus-wide for those pairs. **`Classes.svelte`** renders grouped cards with **Open room** when a component meets elsewhere; the timetable canvas strokes blocks that share a **`groupKey`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2fa0cdfc1fa5bd26803f9eddf13b5e581a9e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->