### PR TITLE
feat(batch): 5 small tickets — pin validation, schedule theme, PWA install, changelog, offline

### DIFF
--- a/src/components/svelte/PWAInstallPrompt.svelte
+++ b/src/components/svelte/PWAInstallPrompt.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { toastStore } from "@lib/store.svelte";
+  import Download from "@lucide/svelte/icons/download";
+  import X from "@lucide/svelte/icons/x";
+
+  const INSTALL_DISMISS_KEY = "room-tba:install-dismissed";
+  const INSTALL_DISMISS_DAYS = 14;
+
+  let deferredPrompt = $state<
+    | (Event & {
+        prompt: () => Promise<void>;
+        userChoice: Promise<{ outcome: string }>;
+      })
+    | null
+  >(null);
+  let dismissed = $state(false);
+  let isInstalled = $state(false);
+
+  function readDismissed(): boolean {
+    try {
+      const raw = localStorage.getItem(INSTALL_DISMISS_KEY);
+      if (!raw) return false;
+      const ts = Number(raw);
+      if (!Number.isFinite(ts)) return false;
+      const elapsed = Date.now() - ts;
+      return elapsed < INSTALL_DISMISS_DAYS * 24 * 60 * 60 * 1000;
+    } catch {
+      return false;
+    }
+  }
+
+  function writeDismissed() {
+    try {
+      localStorage.setItem(INSTALL_DISMISS_KEY, String(Date.now()));
+    } catch {
+      // ignore
+    }
+  }
+
+  onMount(() => {
+    // iOS Safari standalone
+    const iosStandalone =
+      "standalone" in window.navigator &&
+      (window.navigator as unknown as { standalone: boolean }).standalone ===
+        true;
+    const displayStandalone = window.matchMedia(
+      "(display-mode: standalone)",
+    ).matches;
+    isInstalled = iosStandalone || displayStandalone;
+    dismissed = readDismissed();
+
+    const handler = (e: Event) => {
+      e.preventDefault();
+      deferredPrompt = e as BeforeInstallPromptEvent;
+    };
+    window.addEventListener("beforeinstallprompt", handler);
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  });
+
+  async function promptInstall() {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === "accepted") {
+      isInstalled = true;
+      toastStore.show(
+        "Room TBA installed — open it from your home screen.",
+        "success",
+      );
+    }
+    deferredPrompt = null;
+  }
+
+  function dismiss() {
+    dismissed = true;
+    writeDismissed();
+  }
+
+  const showPrompt = $derived(
+    !isInstalled && !dismissed && deferredPrompt !== null,
+  );
+</script>
+
+{#if showPrompt}
+  <div class="pwa-install-prompt" role="status">
+    <Download size={14} aria-hidden="true" />
+    <span class="pwa-install-label">Install Room TBA for offline maps</span>
+    <button class="pwa-install-action" type="button" onclick={promptInstall}>
+      Install
+    </button>
+    <button
+      class="pwa-install-dismiss"
+      type="button"
+      aria-label="Dismiss install prompt"
+      onclick={dismiss}
+    >
+      <X size={12} aria-hidden="true" />
+    </button>
+  </div>
+{/if}
+
+<style>
+  .pwa-install-prompt {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-height: 1.5rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.75rem;
+    border: 1px solid hsl(5, 34%, 82%);
+    background: hsl(0, 0%, 99%);
+    color: hsl(5, 53%, 32%);
+    font-size: 0.8125rem;
+    line-height: 1.15;
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: min(100%, 18rem);
+  }
+
+  .pwa-install-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .pwa-install-action {
+    flex-shrink: 0;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid hsl(5, 53%, 32%);
+    background: hsl(5, 53%, 32%);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .pwa-install-action:hover,
+  .pwa-install-action:focus-visible {
+    background: hsl(5, 53%, 28%);
+  }
+
+  .pwa-install-dismiss {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: hsl(0, 0%, 50%);
+    cursor: pointer;
+    border-radius: 0.25rem;
+  }
+
+  .pwa-install-dismiss:hover,
+  .pwa-install-dismiss:focus-visible {
+    color: hsl(5, 53%, 32%);
+    background: hsl(5, 20%, 96%);
+  }
+
+  @media (max-width: 48rem) {
+    .pwa-install-prompt {
+      max-width: none;
+      flex: 1 1 auto;
+    }
+  }
+</style>

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
+  import WifiOff from "@lucide/svelte/icons/wifi-off";
   import { onMount } from "svelte";
   import { registerSW } from "virtual:pwa-register";
   import { getAppData } from "@lib/context";
@@ -12,6 +13,7 @@
   } from "@lib/store.svelte";
   import OfflineMaps from "@ui/OfflineMaps.svelte";
   import SyncStatus from "@ui/SyncStatus.svelte";
+  import PWAInstallPrompt from "@ui/PWAInstallPrompt.svelte";
   import MapChromeSession from "@ui/map-chrome/MapChromeSession.svelte";
   import StatusBarDetails from "./status-bar/StatusBarDetails.svelte";
   import StatusBarDirectionsStat from "./status-bar/StatusBarDirectionsStat.svelte";
@@ -24,6 +26,7 @@
   const appData = getAppData();
   const { directionCount, totalRooms } = $derived(appData());
   let isOpen = $state(false);
+  let isOnline = $state(true);
 
   const showFullSync = $derived(isOpen);
   const detailsCompact = $derived(!isOpen);
@@ -55,6 +58,21 @@
   );
 
   onMount(() => {
+    isOnline = typeof navigator !== "undefined" ? navigator.onLine : true;
+    const onOnline = () => {
+      isOnline = true;
+      toastStore.show("Back online — campus data will sync.", "success");
+    };
+    const onOffline = () => {
+      isOnline = false;
+      toastStore.show(
+        "You’re offline. Map and cached data still work.",
+        "info",
+      );
+    };
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+
     const updateSW = registerSW({
       immediate: true,
       onNeedRefresh() {
@@ -67,6 +85,10 @@
     syncToastStore.setRefreshHandler(() => {
       void updateSW(true);
     });
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+    };
   });
 
   async function handleSignOut() {
@@ -119,6 +141,14 @@
       <div class="status-bar__primary">
         <SyncStatus inline compact={detailsCompact} expanded={showFullSync} />
         <OfflineMaps compact={detailsCompact} />
+        <PWAInstallPrompt />
+        {#if !isOnline}
+          <span class="status-bar__sep" aria-hidden="true">·</span>
+          <span class="offline-chip" title="Offline mode">
+            <WifiOff size={12} aria-hidden="true" />
+            Offline
+          </span>
+        {/if}
         {#if showSessionChip}
           <MapChromeSession
             roleLabel={sessionRoleLabel}
@@ -157,5 +187,19 @@
 <style>
   * {
     pointer-events: auto;
+  }
+
+  .offline-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.75rem;
+    border: 1px solid hsl(0, 0%, 82%);
+    background: hsl(0, 0%, 97%);
+    color: hsl(0, 0%, 38%);
+    font-size: 0.8125rem;
+    line-height: 1.15;
+    flex-shrink: 0;
   }
 </style>

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -212,6 +212,20 @@
 
   async function pickOnMap() {
     error = null;
+    // Require basic identity before dropping a pin so the map interaction has
+    // context and the user doesn't place a pin for an empty form (#283).
+    if (kind === "create_building" && !buildingName.trim()) {
+      error = "You must add all information before picking location on map";
+      return;
+    }
+    if (kind === "create_event" && !eventTitle.trim()) {
+      error = "You must add all information before picking location on map";
+      return;
+    }
+    if (kind === "create_dorm" && !dormName.trim()) {
+      error = "You must add all information before picking location on map";
+      return;
+    }
     dismissHost();
     try {
       await additionProposalStore.requestMapPin();

--- a/src/components/svelte/SyncStatus.svelte
+++ b/src/components/svelte/SyncStatus.svelte
@@ -5,8 +5,10 @@
     LoaderCircle,
     RefreshCw,
     X,
+    FileText,
   } from "@lucide/svelte";
   import { syncToastStore, appBootstrapStore } from "@lib/store.svelte";
+  import { APP_VERSION_LABEL } from "@constants/version";
 
   type Props = {
     /** When true, show compact collapsed label for mobile status bar. */
@@ -242,12 +244,27 @@
     {:else if syncToastStore.needRefresh}
       <Info size={16} aria-hidden="true" />
       <div class="sync-status-copy">
-        <span class="sync-status-label">{displayedLabel}</span>
+        <span class="sync-status-label">
+          {displayedLabel}
+          {#if APP_VERSION_LABEL}
+            <span class="version-label">· {APP_VERSION_LABEL}</span>
+          {/if}
+        </span>
         {#if showDetail && displayedDetail}
           <span class="sync-status-detail">{displayedDetail}</span>
         {/if}
       </div>
       {#if showReload}
+        <a
+          class="sync-action changelog-link"
+          href="/changelog"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="View full changelog"
+        >
+          <FileText size={12} aria-hidden="true" />
+          Changelog
+        </a>
         <button
           class="sync-action reload-button"
           type="button"
@@ -606,6 +623,31 @@
     100% {
       left: 100%;
     }
+  }
+
+  .version-label {
+    opacity: 0.7;
+    font-weight: 500;
+  }
+
+  .changelog-link {
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid hsl(5, 34%, 82%);
+    background: transparent;
+    color: hsl(5, 53%, 32%);
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .changelog-link:hover,
+  .changelog-link:focus-visible {
+    background: hsl(5, 20%, 96%);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/lib/schedule-renderer.ts
+++ b/src/lib/schedule-renderer.ts
@@ -21,11 +21,11 @@ export class ScheduleRenderer {
     days: ["M", "T", "W", "Th", "F", "S"],
     colors: {
       background: "#FFFFFF",
-      header: "#1a1a1a",
+      header: "hsl(5, 53%, 32%)",
       headerText: "#FFFFFF",
-      grid: "#dadada",
-      gridLight: "#dfdfdf",
-      timeColumn: "#333333",
+      grid: "hsl(5, 10%, 78%)",
+      gridLight: "hsl(5, 10%, 85%)",
+      timeColumn: "hsl(5, 53%, 28%)",
       timeText: "#FFFFFF",
     },
     fonts: {


### PR DESCRIPTION
Implements 5 size/S tickets as a single batch:

- **#283** fix(ui): validate required fields before allowing map pin pick
- **#240** fix(ui): theme schedule canvas to Room TBA design tokens
- **#213** feat(ui): PWA install prompt in status bar
- **#212** feat(ui): show version label + changelog link in update prompt
- **#101** feat(ui): offline indicator and online/offline toasts

Verification:
- prettier --check: pass
- bun test src: 71/71 pass
- No new ESLint regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI, localStorage dismiss, and form validation; no auth, API, or data-model changes.
> 
> **Overview**
> This batch improves **status bar** and **contributor** UX without changing core sync or map data flows.
> 
> **PWA & connectivity:** A new **`PWAInstallPrompt`** listens for `beforeinstallprompt`, hides when already installed or dismissed (14-day `localStorage`), and is wired into the collapsed status bar. **`StatusBar`** tracks `navigator.onLine`, shows an **Offline** chip, and fires success/info toasts on online/offline transitions.
> 
> **App updates:** When a refresh is needed, **`SyncStatus`** appends **`APP_VERSION_LABEL`** to the update label and adds a **Changelog** link to `/changelog` beside **Reload**.
> 
> **Contributions:** **`SuggestAdditionPanel`** blocks **Pick on map** until building name, event title, or dorm name is filled (per entity type), avoiding pins on empty forms.
> 
> **Schedule export:** **`schedule-renderer`** header, grid, and time-column colors switch from neutral grays to **Room TBA** `hsl(5, …)` design tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4295fa54598510f54b7fcb1c7fd18c33b7dc4685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->