### PR TITLE
release: staging → main (ops/docs batch #356)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,18 +3,15 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/github",
     [
-      "@semantic-release/changelog",
+      "@semantic-release/git",
       {
-        "changelogFile": "CHANGELOG.md"
+        "assets": ["CHANGELOG.md", "package.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
       }
-    ],
-    [
-      "@semantic-release/npm",
-      {
-        "npmPublish": false
-      }
-    ],
-    "@semantic-release/github"
+    ]
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,37 @@ CRS/AMIS `term_id` values are **chronological within the academic year** — the
 - Admin API routes live under `/api/admin/*` and must keep auth checks.
 - Keep PATCH routes field-level and partial so unrelated edits do not clobber each other.
 
+## Vercel CLI and environment ops
+
+The project deploys on Vercel. Use the CLI for env management and preview control.
+
+```sh
+# Link (once)
+vercel link
+
+# Pull env vars for local dev
+vercel env pull .env.vercel --environment=development --yes
+# Merge DATABASE_URL into .env; keep local ADMIN_PASSWORD if set.
+
+# Add / update an env var
+vercel env add DATABASE_URL production
+vercel env add DATABASE_URL preview
+
+# List vars
+vercel env ls
+
+# Validate required vars before deploy
+./scripts/check-vercel-env.sh
+
+# Guard: prevent production deploys from staging branch
+./scripts/check-production-branch.sh
+```
+
+- **Vercel project:** `stimmie/saan-ang-room` (linked in `.vercel/project.json`).
+- **Preview builds** (`staging` branch) must have `DATABASE_URL` set or prerender fails.
+- **Production builds** must come from `main`; the `check-production-branch.sh` script enforces this.
+- `vercel env pull` sometimes returns `""` for encrypted vars; copy `DATABASE_URL` from the Vercel UI or Supabase dashboard if empty.
+
 ## README sync (no drift)
 
 `README.md` is the human onboarding contract — not decoration. **Never merge stack, env, workflow, or contributor-facing behavior changes without updating README in the same PR.** Do not file a follow-up “docs PR” unless the user explicitly asked to split.

--- a/docs/publications-strategy.md
+++ b/docs/publications-strategy.md
@@ -1,0 +1,34 @@
+# Publications strategy for Room TBA
+
+## Goal
+Increase product awareness among UPLB students, faculty, and campus organizations.
+
+## Channels
+
+### 1. Social media
+- **Facebook:** UPLB student groups, college pages, dorm communities
+- **Twitter/X:** UPLB-related hashtags (#UPLB, #LosBanos, #IskoLife)
+- **Instagram:** Campus photography + map features, Stories with QR code
+
+### 2. Campus outreach
+- Posters with QR code at key locations: library, DL Umali Hall, cafeterias
+- Flyers during enrollment week and org fairs
+- Class announcements via student councils
+
+### 3. Academic integration
+- Present to CS/IT classes as a capstone/community project example
+- Collaborate with the UPLB Web Team or UPLB CRS for official integration
+
+### 4. Content
+- Blog posts: "How we mapped every UPLB classroom"
+- User guides: "Finding your classroom in 30 seconds"
+- Behind-the-scenes: data collection process, contributor stories
+
+## Metrics
+- Monthly active users (MAU)
+- Organic search impressions (Google Search Console)
+- Social media engagement (shares, QR scans)
+- Contributor proposals submitted
+
+## Owner
+Marketing/outreach is volunteer-driven. Coordinate via GitHub issues labeled `growth`.

--- a/scripts/check-production-branch.sh
+++ b/scripts/check-production-branch.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Fail if attempting a production deploy from a non-main branch.
+set -euo pipefail
+
+CURRENT_BRANCH="${VERCEL_GIT_COMMIT_REF:-$(git branch --show-current 2>/dev/null || echo "unknown")}"
+
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "ERROR: Production builds must deploy from the main branch."
+  echo "Current branch: $CURRENT_BRANCH"
+  echo "Merge to main first, then redeploy."
+  exit 1
+fi
+
+echo "Production branch check passed ($CURRENT_BRANCH)."

--- a/scripts/check-vercel-env.sh
+++ b/scripts/check-vercel-env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Validate that required Vercel environment variables are set.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+REQUIRED=(
+  "DATABASE_URL"
+  "SUPABASE_URL"
+  "SUPABASE_ANON_KEY"
+)
+
+MISSING=0
+for var in "${REQUIRED[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "MISSING: $var"
+    MISSING=1
+  fi
+done
+
+if [[ "$MISSING" -eq 1 ]]; then
+  echo ""
+  echo "Some required Vercel env vars are not set."
+  echo "Set them with: vercel env add <name> [production|preview|development]"
+  exit 1
+fi
+
+echo "Vercel environment check passed."

--- a/scripts/resubmit-sitemap.sh
+++ b/scripts/resubmit-sitemap.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Resubmit sitemap to Google Search Console after a release.
+# Requires GSC_SITEMAP_URL env var (e.g. https://room-tba.uplbtools.me/sitemap-index.xml).
+set -euo pipefail
+
+if [[ -z "${GSC_SITEMAP_URL:-}" ]]; then
+  echo "GSC_SITEMAP_URL is not set. Skipping sitemap resubmission."
+  exit 0
+fi
+
+echo "Resubmitting sitemap to Google Search Console: $GSC_SITEMAP_URL"
+
+# Ping Google with the sitemap URL
+curl -sS "https://www.google.com/ping?sitemap=$GSC_SITEMAP_URL" || true
+
+echo "Sitemap resubmission complete."

--- a/src/components/svelte/PWAInstallPrompt.svelte
+++ b/src/components/svelte/PWAInstallPrompt.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { toastStore } from "@lib/store.svelte";
+  import Download from "@lucide/svelte/icons/download";
+  import X from "@lucide/svelte/icons/x";
+
+  const INSTALL_DISMISS_KEY = "room-tba:install-dismissed";
+  const INSTALL_DISMISS_DAYS = 14;
+
+  let deferredPrompt = $state<
+    | (Event & {
+        prompt: () => Promise<void>;
+        userChoice: Promise<{ outcome: string }>;
+      })
+    | null
+  >(null);
+  let dismissed = $state(false);
+  let isInstalled = $state(false);
+
+  function readDismissed(): boolean {
+    try {
+      const raw = localStorage.getItem(INSTALL_DISMISS_KEY);
+      if (!raw) return false;
+      const ts = Number(raw);
+      if (!Number.isFinite(ts)) return false;
+      const elapsed = Date.now() - ts;
+      return elapsed < INSTALL_DISMISS_DAYS * 24 * 60 * 60 * 1000;
+    } catch {
+      return false;
+    }
+  }
+
+  function writeDismissed() {
+    try {
+      localStorage.setItem(INSTALL_DISMISS_KEY, String(Date.now()));
+    } catch {
+      // ignore
+    }
+  }
+
+  onMount(() => {
+    // iOS Safari standalone
+    const iosStandalone =
+      "standalone" in window.navigator &&
+      (window.navigator as unknown as { standalone: boolean }).standalone ===
+        true;
+    const displayStandalone = window.matchMedia(
+      "(display-mode: standalone)",
+    ).matches;
+    isInstalled = iosStandalone || displayStandalone;
+    dismissed = readDismissed();
+
+    const handler = (e: Event) => {
+      e.preventDefault();
+      deferredPrompt = e as BeforeInstallPromptEvent;
+    };
+    window.addEventListener("beforeinstallprompt", handler);
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  });
+
+  async function promptInstall() {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === "accepted") {
+      isInstalled = true;
+      toastStore.show(
+        "Room TBA installed — open it from your home screen.",
+        "success",
+      );
+    }
+    deferredPrompt = null;
+  }
+
+  function dismiss() {
+    dismissed = true;
+    writeDismissed();
+  }
+
+  const showPrompt = $derived(
+    !isInstalled && !dismissed && deferredPrompt !== null,
+  );
+</script>
+
+{#if showPrompt}
+  <div class="pwa-install-prompt" role="status">
+    <Download size={14} aria-hidden="true" />
+    <span class="pwa-install-label">Install Room TBA for offline maps</span>
+    <button class="pwa-install-action" type="button" onclick={promptInstall}>
+      Install
+    </button>
+    <button
+      class="pwa-install-dismiss"
+      type="button"
+      aria-label="Dismiss install prompt"
+      onclick={dismiss}
+    >
+      <X size={12} aria-hidden="true" />
+    </button>
+  </div>
+{/if}
+
+<style>
+  .pwa-install-prompt {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-height: 1.5rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.75rem;
+    border: 1px solid hsl(5, 34%, 82%);
+    background: hsl(0, 0%, 99%);
+    color: hsl(5, 53%, 32%);
+    font-size: 0.8125rem;
+    line-height: 1.15;
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: min(100%, 18rem);
+  }
+
+  .pwa-install-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .pwa-install-action {
+    flex-shrink: 0;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid hsl(5, 53%, 32%);
+    background: hsl(5, 53%, 32%);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .pwa-install-action:hover,
+  .pwa-install-action:focus-visible {
+    background: hsl(5, 53%, 28%);
+  }
+
+  .pwa-install-dismiss {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: hsl(0, 0%, 50%);
+    cursor: pointer;
+    border-radius: 0.25rem;
+  }
+
+  .pwa-install-dismiss:hover,
+  .pwa-install-dismiss:focus-visible {
+    color: hsl(5, 53%, 32%);
+    background: hsl(5, 20%, 96%);
+  }
+
+  @media (max-width: 48rem) {
+    .pwa-install-prompt {
+      max-width: none;
+      flex: 1 1 auto;
+    }
+  }
+</style>

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
+  import WifiOff from "@lucide/svelte/icons/wifi-off";
   import { onMount } from "svelte";
   import { registerSW } from "virtual:pwa-register";
   import { getAppData } from "@lib/context";
@@ -12,6 +13,7 @@
   } from "@lib/store.svelte";
   import OfflineMaps from "@ui/OfflineMaps.svelte";
   import SyncStatus from "@ui/SyncStatus.svelte";
+  import PWAInstallPrompt from "@ui/PWAInstallPrompt.svelte";
   import MapChromeSession from "@ui/map-chrome/MapChromeSession.svelte";
   import StatusBarDetails from "./status-bar/StatusBarDetails.svelte";
   import StatusBarDirectionsStat from "./status-bar/StatusBarDirectionsStat.svelte";
@@ -24,6 +26,7 @@
   const appData = getAppData();
   const { directionCount, totalRooms } = $derived(appData());
   let isOpen = $state(false);
+  let isOnline = $state(true);
 
   const showFullSync = $derived(isOpen);
   const detailsCompact = $derived(!isOpen);
@@ -55,6 +58,21 @@
   );
 
   onMount(() => {
+    isOnline = typeof navigator !== "undefined" ? navigator.onLine : true;
+    const onOnline = () => {
+      isOnline = true;
+      toastStore.show("Back online — campus data will sync.", "success");
+    };
+    const onOffline = () => {
+      isOnline = false;
+      toastStore.show(
+        "You’re offline. Map and cached data still work.",
+        "info",
+      );
+    };
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+
     const updateSW = registerSW({
       immediate: true,
       onNeedRefresh() {
@@ -67,6 +85,10 @@
     syncToastStore.setRefreshHandler(() => {
       void updateSW(true);
     });
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+    };
   });
 
   async function handleSignOut() {
@@ -119,6 +141,14 @@
       <div class="status-bar__primary">
         <SyncStatus inline compact={detailsCompact} expanded={showFullSync} />
         <OfflineMaps compact={detailsCompact} />
+        <PWAInstallPrompt />
+        {#if !isOnline}
+          <span class="status-bar__sep" aria-hidden="true">·</span>
+          <span class="offline-chip" title="Offline mode">
+            <WifiOff size={12} aria-hidden="true" />
+            Offline
+          </span>
+        {/if}
         {#if showSessionChip}
           <MapChromeSession
             roleLabel={sessionRoleLabel}
@@ -157,5 +187,19 @@
 <style>
   * {
     pointer-events: auto;
+  }
+
+  .offline-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.75rem;
+    border: 1px solid hsl(0, 0%, 82%);
+    background: hsl(0, 0%, 97%);
+    color: hsl(0, 0%, 38%);
+    font-size: 0.8125rem;
+    line-height: 1.15;
+    flex-shrink: 0;
   }
 </style>

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -212,6 +212,20 @@
 
   async function pickOnMap() {
     error = null;
+    // Require basic identity before dropping a pin so the map interaction has
+    // context and the user doesn't place a pin for an empty form (#283).
+    if (kind === "create_building" && !buildingName.trim()) {
+      error = "You must add all information before picking location on map";
+      return;
+    }
+    if (kind === "create_event" && !eventTitle.trim()) {
+      error = "You must add all information before picking location on map";
+      return;
+    }
+    if (kind === "create_dorm" && !dormName.trim()) {
+      error = "You must add all information before picking location on map";
+      return;
+    }
     dismissHost();
     try {
       await additionProposalStore.requestMapPin();

--- a/src/components/svelte/SyncStatus.svelte
+++ b/src/components/svelte/SyncStatus.svelte
@@ -5,8 +5,10 @@
     LoaderCircle,
     RefreshCw,
     X,
+    FileText,
   } from "@lucide/svelte";
   import { syncToastStore, appBootstrapStore } from "@lib/store.svelte";
+  import { APP_VERSION_LABEL } from "@constants/version";
 
   type Props = {
     /** When true, show compact collapsed label for mobile status bar. */
@@ -242,12 +244,27 @@
     {:else if syncToastStore.needRefresh}
       <Info size={16} aria-hidden="true" />
       <div class="sync-status-copy">
-        <span class="sync-status-label">{displayedLabel}</span>
+        <span class="sync-status-label">
+          {displayedLabel}
+          {#if APP_VERSION_LABEL}
+            <span class="version-label">· {APP_VERSION_LABEL}</span>
+          {/if}
+        </span>
         {#if showDetail && displayedDetail}
           <span class="sync-status-detail">{displayedDetail}</span>
         {/if}
       </div>
       {#if showReload}
+        <a
+          class="sync-action changelog-link"
+          href="/changelog"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="View full changelog"
+        >
+          <FileText size={12} aria-hidden="true" />
+          Changelog
+        </a>
         <button
           class="sync-action reload-button"
           type="button"
@@ -606,6 +623,31 @@
     100% {
       left: 100%;
     }
+  }
+
+  .version-label {
+    opacity: 0.7;
+    font-weight: 500;
+  }
+
+  .changelog-link {
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid hsl(5, 34%, 82%);
+    background: transparent;
+    color: hsl(5, 53%, 32%);
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .changelog-link:hover,
+  .changelog-link:focus-visible {
+    background: hsl(5, 20%, 96%);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/lib/schedule-renderer.ts
+++ b/src/lib/schedule-renderer.ts
@@ -22,11 +22,11 @@ export class ScheduleRenderer {
     days: ["M", "T", "W", "Th", "F", "S"],
     colors: {
       background: "#FFFFFF",
-      header: "#1a1a1a",
+      header: "hsl(5, 53%, 32%)",
       headerText: "#FFFFFF",
-      grid: "#dadada",
-      gridLight: "#dfdfdf",
-      timeColumn: "#333333",
+      grid: "hsl(5, 10%, 78%)",
+      gridLight: "hsl(5, 10%, 85%)",
+      timeColumn: "hsl(5, 53%, 28%)",
       timeText: "#FFFFFF",
     },
     fonts: {


### PR DESCRIPTION
Promotes the ops/docs batch from staging to main.

- #334 production deploy guardrails
- #333 Vercel env validation
- #332 Vercel CLI docs
- #149 semantic-release + GSC sitemap
- #39 publications strategy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Semantic-release and npm plugin changes can alter what gets published or committed on `main` releases; otherwise changes are mostly docs, shell guards, and client-side UX.
> 
> **Overview**
> **Release and deploy ops:** `.releaserc.json` now runs `@semantic-release/git` to commit `CHANGELOG.md` and `package.json` with a `[skip ci]` release message (replacing the prior changelog-only plugin config and dropping the explicit `npmPublish: false` on the npm plugin). New shell scripts validate required Vercel env vars, block production builds off `main`, and optionally ping Google after releases when `GSC_SITEMAP_URL` is set. **AGENTS.md** documents Vercel CLI env workflows; **docs/publications-strategy.md** outlines UPLB outreach channels.
> 
> **In-app UX:** A new **PWA install** chip in the collapsed status bar uses `beforeinstallprompt` with a 14-day dismiss. **Online/offline** listeners show toasts and an **Offline** chip when disconnected. When a service-worker update is available, **SyncStatus** shows the app version and a **Changelog** link beside reload. **SuggestAdditionPanel** blocks “pick on map” until building name, event title, or dorm name is filled (#283). **Schedule canvas** headers/grid colors shift to the app’s maroon HSL palette.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 757931d380a84cdfdfbd4a1b5651e2e7f303633d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->