### PR TITLE
feat(ui): overlay stacking, PWA guards, changelog overview (#302, #321-323, #212)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Unit tests
         run: bun test src
+
+      - name: PWA legal route guardrails
+        run: bun run check:pwa-legal

--- a/docs/map-ui-mode-matrix.md
+++ b/docs/map-ui-mode-matrix.md
@@ -23,7 +23,27 @@ Only one browse overlay from the chip row is active at a time (except **All** pi
 - **All** is neutral: selecting it does not touch transit.
 - Edit/terrain exclusivity via `deactivateMapModesExcept` is unchanged.
 
-Term-chip exclusivity is intentionally not enforced here (deferred — needs a product call on whether opening the term picker should drop transit/pins).
+Term-chip exclusivity: opening the term picker closes the map tools flyout (and vice versa) so top-band popovers do not stack on mobile.
+
+## Overlay stacking (`.app-layout` tokens)
+
+Lowest to highest:
+
+| Layer                     | Token / value            | Surfaces                                       |
+| ------------------------- | ------------------------ | ---------------------------------------------- |
+| Map canvas                | `--z-map: 0`             | MapLibre canvas                                |
+| Side panel                | `--z-side-panel: 2`      | MainControls drawer                            |
+| Bottom chrome             | `--z-status-bar: 3`      | Status bar tray                                |
+| UI shell                  | `10` (`.ui-layer`)       | Search, side panel host                        |
+| Drawer-lift FABs          | `14`                     | Location button when sheet open                |
+| Map tools (mobile)        | `--z-map-tools: 16`      | Map tools flyout stack                         |
+| Chrome popovers           | `--z-chrome-popover: 17` | Term picker, offline maps (portaled to `body`) |
+| Edit dock / editor screen | `18`                     | Map edit toolbar                               |
+| Browse modals             | `--z-modal: 100`         | Landing, schedule expand                       |
+| Login / editor addition   | `--z-login-modal: 200`   | Admin login (closes browse modals on open)     |
+| Toast                     | `--z-toast: 1000`        | App-layout sibling (above edit dock)           |
+
+Portaled popovers use `use:portal` so they are not trapped in the bottom-chrome stacking context. Editor login closes browse modals before opening.
 
 ## Layout zones (Entry.svelte)
 

--- a/docs/publications-strategy.md
+++ b/docs/publications-strategy.md
@@ -1,34 +1,41 @@
 # Publications strategy for Room TBA
 
 ## Goal
+
 Increase product awareness among UPLB students, faculty, and campus organizations.
 
 ## Channels
 
 ### 1. Social media
+
 - **Facebook:** UPLB student groups, college pages, dorm communities
 - **Twitter/X:** UPLB-related hashtags (#UPLB, #LosBanos, #IskoLife)
 - **Instagram:** Campus photography + map features, Stories with QR code
 
 ### 2. Campus outreach
+
 - Posters with QR code at key locations: library, DL Umali Hall, cafeterias
 - Flyers during enrollment week and org fairs
 - Class announcements via student councils
 
 ### 3. Academic integration
+
 - Present to CS/IT classes as a capstone/community project example
 - Collaborate with the UPLB Web Team or UPLB CRS for official integration
 
 ### 4. Content
+
 - Blog posts: "How we mapped every UPLB classroom"
 - User guides: "Finding your classroom in 30 seconds"
 - Behind-the-scenes: data collection process, contributor stories
 
 ## Metrics
+
 - Monthly active users (MAU)
 - Organic search impressions (Google Search Console)
 - Social media engagement (shares, QR scans)
 - Contributor proposals submitted
 
 ## Owner
+
 Marketing/outreach is volunteer-driven. Coordinate via GitHub issues labeled `growth`.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format": "prettier --write .",
     "test": "bun test src",
     "check:readme": "bun run scripts/check-readme-drift.ts",
+    "check:pwa-legal": "bun run scripts/check-pwa-legal-routes.ts",
     "seed:events": "bun src/seed-events.ts",
     "seed:aliases": "bun run scripts/seed-aliases.ts",
     "import:amis-classes": "bun run scripts/import-amis-classes.ts",

--- a/scripts/check-pwa-legal-routes.ts
+++ b/scripts/check-pwa-legal-routes.ts
@@ -1,0 +1,50 @@
+/**
+ * Guardrail: legal/static pages must stay precached and denylisted from
+ * Workbox navigateFallback (fixes #321, #322, #323).
+ *
+ * Run: bun run check:pwa-legal
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const configPath = resolve(import.meta.dir, "../astro.config.mjs");
+const source = readFileSync(configPath, "utf8");
+
+const requiredPrecache = [
+  "privacy/index.html",
+  "terms/index.html",
+  "changelog/index.html",
+];
+
+const requiredDenylist = [
+  String.raw`/^\/privacy(\/|$)/`,
+  String.raw`/^\/terms(\/|$)/`,
+  String.raw`/^\/changelog(\/|$)/`,
+];
+
+let failed = false;
+
+for (const pattern of requiredPrecache) {
+  if (!source.includes(`"${pattern}"`)) {
+    console.error(`Missing globPatterns precache entry: ${pattern}`);
+    failed = true;
+  }
+}
+
+for (const pattern of requiredDenylist) {
+  if (!source.includes(pattern)) {
+    console.error(`Missing navigateFallbackDenylist entry: ${pattern}`);
+    failed = true;
+  }
+}
+
+if (!source.includes('navigateFallback: "/"')) {
+  console.error('Expected navigateFallback: "/" for offline app shell');
+  failed = true;
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log("PWA legal route guardrails OK");

--- a/src/components/svelte/AdminLoginModal.svelte
+++ b/src/components/svelte/AdminLoginModal.svelte
@@ -125,7 +125,7 @@
     position: fixed;
     inset: 0;
     background-color: rgba(8, 12, 22, 0.55);
-    z-index: 200;
+    z-index: var(--z-login-modal, 200);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -190,14 +190,14 @@
         </div>
       </div>
     </div>
-    {#if toastStore.message}
-      <Toast
-        message={toastStore.message}
-        type={toastStore.type}
-        onclose={() => toastStore.clear()}
-      />
-    {/if}
   </div>
+  {#if toastStore.message}
+    <Toast
+      message={toastStore.message}
+      type={toastStore.type}
+      onclose={() => toastStore.clear()}
+    />
+  {/if}
   <Modal />
   {#if building3DStore.buildingName}
     <Building3DViewer name={building3DStore.buildingName} />
@@ -260,6 +260,10 @@
     --z-side-panel: 2;
     --z-status-bar: 3;
     --z-map-tools: 15;
+    --z-chrome-popover: 17;
+    --z-modal: 100;
+    --z-login-modal: 200;
+    --z-toast: 1000;
 
     width: 100%;
     height: 100dvh;

--- a/src/components/svelte/OfflineMaps.svelte
+++ b/src/components/svelte/OfflineMaps.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import DownloadCloud from "@lucide/svelte/icons/download-cloud";
-  import { offlineStore } from "@lib/store.svelte";
+  import { mapToolsStore, offlineStore } from "@lib/store.svelte";
   import { rafThrottle } from "@lib/layout-css-vars";
   import { trapFocus } from "@lib/focus-trap";
+  import { portal } from "@lib/portal";
   import "./map-chrome/map-chrome.css";
 
   type Props = {
@@ -44,6 +45,9 @@
   });
 
   function toggleOpen() {
+    if (!open) {
+      mapToolsStore.close();
+    }
     open = !open;
     if (open) {
       queueMicrotask(updatePopoverPosition);
@@ -108,6 +112,7 @@
       role="dialog"
       aria-modal="true"
       aria-label="Offline maps"
+      use:portal
     >
       {#if offlineStore.status === "downloading"}
         <p class="map-chrome-popover-line">
@@ -206,7 +211,7 @@
 
   .offline-popover {
     position: fixed;
-    z-index: 25;
+    z-index: var(--z-chrome-popover, 17);
     border-radius: 0.75rem;
   }
 

--- a/src/components/svelte/SyncStatus.svelte
+++ b/src/components/svelte/SyncStatus.svelte
@@ -9,6 +9,8 @@
   } from "@lucide/svelte";
   import { syncToastStore, appBootstrapStore } from "@lib/store.svelte";
   import { APP_VERSION_LABEL } from "@constants/version";
+  import { parseChangelogHighlights } from "@lib/changelog-highlights";
+  import changelogRaw from "../../../CHANGELOG.md?raw";
 
   type Props = {
     /** When true, show compact collapsed label for mobile status bar. */
@@ -89,6 +91,15 @@
   );
   const showIndeterminate = $derived(
     syncToastStore.isSyncing && !syncToastStore.hasCountableProgress,
+  );
+
+  const updateHighlights = $derived(parseChangelogHighlights(changelogRaw));
+  const showUpdateHighlights = $derived(
+    syncToastStore.needRefresh &&
+      showDetail &&
+      !compact &&
+      updateHighlights !== null &&
+      updateHighlights.items.length > 0,
   );
 
   const statusLabel = $derived.by(() => {
@@ -252,6 +263,19 @@
         </span>
         {#if showDetail && displayedDetail}
           <span class="sync-status-detail">{displayedDetail}</span>
+        {/if}
+        {#if showUpdateHighlights && updateHighlights}
+          <ul class="sync-update-highlights" aria-label="What's new">
+            {#each updateHighlights.items as item (item)}
+              <li>{item}</li>
+            {/each}
+          </ul>
+          {#if updateHighlights.totalCount > updateHighlights.items.length}
+            <p class="sync-update-more">
+              + {updateHighlights.totalCount - updateHighlights.items.length} more
+              in changelog
+            </p>
+          {/if}
         {/if}
       </div>
       {#if showReload}
@@ -514,6 +538,27 @@
     line-height: 1.1;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .sync-update-highlights {
+    margin: 0.25rem 0 0;
+    padding-left: 1rem;
+    color: hsl(0, 0%, 28%);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    line-height: 1.35;
+    list-style: disc;
+  }
+
+  .sync-update-highlights li + li {
+    margin-top: 0.125rem;
+  }
+
+  .sync-update-more {
+    margin: 0.125rem 0 0;
+    color: hsl(0, 0%, 45%);
+    font-size: 0.6875rem;
+    font-weight: 500;
   }
 
   .sync-action.reload-button {

--- a/src/components/svelte/TermSelector.svelte
+++ b/src/components/svelte/TermSelector.svelte
@@ -6,7 +6,7 @@
   import { formatTermDateRange } from "@lib/term-calendar";
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
-  import { termStore } from "@lib/store.svelte";
+  import { mapToolsStore, termStore } from "@lib/store.svelte";
   import type { TermWithCount } from "@lib/types";
   import "./map-chrome/map-chrome.css";
 
@@ -56,6 +56,9 @@
   });
 
   function toggleOpen() {
+    if (!open) {
+      mapToolsStore.close();
+    }
     open = !open;
     if (open) queueMicrotask(updatePanelPosition);
   }
@@ -72,6 +75,10 @@
   $effect(() => {
     if (!open || !panelEl) return;
     return trapFocus(panelEl, { onEscape: closePanel });
+  });
+
+  $effect(() => {
+    if (mapToolsStore.open) closePanel();
   });
 
   function handleDocumentPointerDown(event: PointerEvent) {
@@ -304,7 +311,7 @@
 
   .term-picker-panel {
     position: fixed;
-    z-index: 1200;
+    z-index: var(--z-chrome-popover, 17);
     box-sizing: border-box;
     display: flex;
     flex-direction: column;

--- a/src/components/svelte/Toast.svelte
+++ b/src/components/svelte/Toast.svelte
@@ -109,7 +109,7 @@
     );
     left: 50%;
     transform: translateX(-50%);
-    z-index: 1000;
+    z-index: var(--z-toast, 1000);
     display: flex;
     align-items: center;
     gap: 0.75rem;

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -97,7 +97,7 @@
     padding: 0.75rem;
     width: 100%;
     height: 100dvh;
-    z-index: 100;
+    z-index: var(--z-modal, 100);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -226,7 +226,13 @@
         ariaExpanded={mapToolsStore.open}
         ariaControls="map-tools-panel"
         title="Map menu"
-        onclick={() => mapToolsStore.toggle()}
+        onclick={() => {
+          if (!mapToolsStore.open) {
+            searchFocused = false;
+            searchElement?.blur();
+          }
+          mapToolsStore.toggle();
+        }}
       >
         <Menu size={20} aria-hidden="true" />
       </MapChromeToggleButton>

--- a/src/lib/changelog-highlights.test.ts
+++ b/src/lib/changelog-highlights.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { parseChangelogHighlights } from "./changelog-highlights";
+
+describe("parseChangelogHighlights", () => {
+  test("returns top bullets for the latest version", () => {
+    const md = `# [1.9.0](https://example.com)
+
+### Features
+
+* **feat:** campus events on the map
+* **fix:** mobile search chrome
+
+# [1.8.0](https://example.com)
+
+* older entry
+`;
+
+    const result = parseChangelogHighlights(md, { maxItems: 2 });
+    expect(result?.version).toBe("1.9.0");
+    expect(result?.items).toEqual([
+      "feat: campus events on the map",
+      "fix: mobile search chrome",
+    ]);
+    expect(result?.totalCount).toBe(2);
+  });
+
+  test("returns null when no bullets exist", () => {
+    expect(parseChangelogHighlights("# [1.0.0](https://example.com)\n")).toBeNull();
+  });
+});

--- a/src/lib/changelog-highlights.test.ts
+++ b/src/lib/changelog-highlights.test.ts
@@ -25,6 +25,8 @@ describe("parseChangelogHighlights", () => {
   });
 
   test("returns null when no bullets exist", () => {
-    expect(parseChangelogHighlights("# [1.0.0](https://example.com)\n")).toBeNull();
+    expect(
+      parseChangelogHighlights("# [1.0.0](https://example.com)\n"),
+    ).toBeNull();
   });
 });

--- a/src/lib/changelog-highlights.ts
+++ b/src/lib/changelog-highlights.ts
@@ -1,0 +1,50 @@
+export type ChangelogHighlight = {
+  version: string;
+  items: string[];
+  totalCount: number;
+};
+
+const VERSION_HEADING = /^# \[([^\]]+)\]/;
+
+/** Human-readable bullets for the update prompt (#212). */
+export function parseChangelogHighlights(
+  markdown: string,
+  options?: { maxItems?: number },
+): ChangelogHighlight | null {
+  const maxItems = options?.maxItems ?? 5;
+  const lines = markdown.split(/\r?\n/);
+  let version: string | null = null;
+  const bullets: string[] = [];
+
+  for (const line of lines) {
+    const versionMatch = line.match(VERSION_HEADING);
+    if (versionMatch) {
+      if (version !== null) break;
+      version = versionMatch[1] ?? null;
+      continue;
+    }
+    if (version === null) continue;
+
+    const bulletMatch = line.match(/^\* (.+)$/);
+    if (bulletMatch?.[1]) {
+      bullets.push(sanitizeBullet(bulletMatch[1]));
+    }
+  }
+
+  if (!version || bullets.length === 0) return null;
+
+  return {
+    version,
+    items: bullets.slice(0, maxItems),
+    totalCount: bullets.length,
+  };
+}
+
+function sanitizeBullet(raw: string): string {
+  return raw
+    .replace(/\(\[[^\]]+\]\([^)]+\)\)/g, "")
+    .replace(/\[[^\]]+\]\([^)]+\)/g, "")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -940,6 +940,7 @@ class AdminAuthStore {
   };
 
   openLogin = () => {
+    modalStore.closeModal();
     this.loginOpen = true;
   };
 


### PR DESCRIPTION
## Summary

Five-issue batch:

- **#302** — Overlay stacking contract in `map-ui-mode-matrix.md`; z-index tokens on `.app-layout`; toast moved outside `.ui-layer`; editor login closes browse modals; term/offline popovers portaled with shared `--z-chrome-popover`; map tools ↔ term picker mutual exclusion; search blurs when opening map tools on mobile
- **#321, #322, #323** — CI guardrail `check:pwa-legal` verifies Workbox precache + denylist for privacy/terms/changelog (config already shipped; prevents regression)
- **#212** — Update prompt shows compact changelog highlights from `CHANGELOG.md` when a reload is available

## Test plan

- [x] `bun test src` (73 pass)
- [x] `bun run check:pwa-legal`
- [ ] Manual: expand status bar with update ready → see bullet highlights + Reload/Changelog
- [ ] Manual: open term picker + map tools on mobile → only one popover at a time
- [ ] Manual: editor sign-in while landing modal open → modal closes, login wins
- [ ] Manual: save error toast visible above edit dock on mobile

Refs #302, #321, #322, #323, #212

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PWA offline routing guardrails and broad z-index/portal behavior across mobile chrome; mis-stacking or a broken denylist could affect legal pages offline or popover focus.
> 
> **Overview**
> Standardizes **map overlay stacking** with shared `--z-*` tokens on `.app-layout`, moves **toasts** outside `.ui-layer` so they sit above the edit dock, and documents the contract in `map-ui-mode-matrix.md`. **Term picker** and **offline maps** popovers use `use:portal` and `--z-chrome-popover`; **map tools** and the term picker are mutually exclusive; mobile **map menu** blurs search when opening tools; **editor login** closes browse modals first (`modalStore.closeModal()`).
> 
> Adds CI **`check:pwa-legal`** to assert Workbox precache entries and `navigateFallbackDenylist` for privacy/terms/changelog (regression guard for #321–#323).
> 
> When a service-worker **update is ready**, the expanded sync status shows compact **“What’s new”** bullets parsed from `CHANGELOG.md` via new `parseChangelogHighlights` (with unit tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b8d31731f84a3254f4328e8df8437f3a881a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->