### PR TITLE
feat(contributor-progress): building and room completeness dashboard (#315)

### DIFF
--- a/src/components/svelte/status-bar/ContributorProgressPanel.svelte
+++ b/src/components/svelte/status-bar/ContributorProgressPanel.svelte
@@ -1,0 +1,421 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { getAppData } from "@lib/context";
+  import {
+    ROOM_FIELD_CATEGORIES,
+    ROOM_FIELD_LABELS,
+    fetchContributorProgress,
+    missingFieldLabel,
+    progressPercent,
+    type BuildingContributorProgress,
+    type CampusContributorProgress,
+    type MineContributorProgress,
+    type RoomFieldCategory,
+  } from "@lib/contributor-progress";
+  import { adminAuthStore } from "@lib/store.svelte";
+  import MapChromeGhostButton from "@ui/map-chrome/MapChromeGhostButton.svelte";
+
+  type ScopeTab = "campus" | "building" | "mine";
+
+  type Props = {
+    defaultBuildingId?: number | null;
+  };
+
+  const { defaultBuildingId = null }: Props = $props();
+
+  const appData = getAppData();
+  const buildings = $derived(appData().buildings ?? []);
+
+  let activeScope = $state<ScopeTab>("campus");
+  let selectedBuildingId = $state<number | null>(defaultBuildingId);
+  let campusData = $state<CampusContributorProgress | null>(null);
+  let buildingData = $state<BuildingContributorProgress | null>(null);
+  let mineData = $state<MineContributorProgress | null>(null);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+
+  const showMineTab = $derived(adminAuthStore.isLoggedIn);
+
+  $effect(() => {
+    if (selectedBuildingId == null && buildings.length > 0) {
+      selectedBuildingId = buildings[0]?.id ?? null;
+    }
+  });
+
+  onMount(() => {
+    void loadScope("campus");
+  });
+
+  async function loadScope(scope: ScopeTab) {
+    activeScope = scope;
+    loading = true;
+    error = null;
+
+    try {
+      if (scope === "campus") {
+        campusData = await fetchContributorProgress("campus");
+      } else if (scope === "building") {
+        if (selectedBuildingId == null) {
+          buildingData = null;
+          return;
+        }
+        buildingData = await fetchContributorProgress(
+          "building",
+          selectedBuildingId,
+        );
+      } else {
+        mineData = await fetchContributorProgress("mine");
+      }
+    } catch (loadError) {
+      error =
+        loadError instanceof Error
+          ? loadError.message
+          : "Could not load progress.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  function selectScope(scope: ScopeTab) {
+    void loadScope(scope);
+  }
+
+  function handleBuildingChange(event: Event) {
+    const value = Number((event.currentTarget as HTMLSelectElement).value);
+    selectedBuildingId = Number.isFinite(value) ? value : null;
+    if (activeScope === "building") {
+      void loadScope("building");
+    }
+  }
+
+  function fieldRows(
+    counts: Record<RoomFieldCategory, { filled: number; total: number }>,
+  ) {
+    return ROOM_FIELD_CATEGORIES.map((category) => ({
+      category,
+      label: ROOM_FIELD_LABELS[category],
+      filled: counts[category].filled,
+      total: counts[category].total,
+      percent: progressPercent(counts[category].filled, counts[category].total),
+    }));
+  }
+
+  function formatEntityType(entityType: string): string {
+    return entityType.charAt(0).toUpperCase() + entityType.slice(1);
+  }
+</script>
+
+<section class="contributor-progress" aria-label="Contributor progress">
+  <div
+    class="contributor-progress__tabs"
+    role="tablist"
+    aria-label="Progress scope"
+  >
+    <MapChromeGhostButton
+      variant={activeScope === "campus" ? "accent" : "muted"}
+      onclick={() => selectScope("campus")}
+    >
+      Campus
+    </MapChromeGhostButton>
+    <MapChromeGhostButton
+      variant={activeScope === "building" ? "accent" : "muted"}
+      onclick={() => selectScope("building")}
+    >
+      Building
+    </MapChromeGhostButton>
+    {#if showMineTab}
+      <MapChromeGhostButton
+        variant={activeScope === "mine" ? "accent" : "muted"}
+        onclick={() => selectScope("mine")}
+      >
+        My work
+      </MapChromeGhostButton>
+    {/if}
+  </div>
+
+  {#if activeScope === "building"}
+    <label class="contributor-progress__building-picker">
+      <span class="contributor-progress__label">Building</span>
+      <select
+        class="contributor-progress__select"
+        value={selectedBuildingId ?? ""}
+        onchange={handleBuildingChange}
+      >
+        {#each buildings as building (building.id)}
+          <option value={building.id}>{building.buildingName}</option>
+        {/each}
+      </select>
+    </label>
+  {/if}
+
+  {#if loading}
+    <p class="contributor-progress__status">Loading progress…</p>
+  {:else if error}
+    <p class="contributor-progress__status contributor-progress__status--error">
+      {error}
+    </p>
+  {:else if activeScope === "campus" && campusData}
+    {#if campusData.termLabel}
+      <p class="contributor-progress__meta">
+        Schedule counts use {campusData.termLabel}.
+      </p>
+    {/if}
+
+    <div class="contributor-progress__group" aria-label="Room completeness">
+      <h3 class="contributor-progress__heading">Rooms</h3>
+      {#each fieldRows(campusData.rooms) as row (row.category)}
+        <div
+          class="contributor-progress__field"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={row.total}
+          aria-valuenow={row.filled}
+          aria-label="{row.label}: {row.filled} of {row.total}"
+        >
+          <div class="contributor-progress__field-head">
+            <span>{row.label}</span>
+            <span>{row.filled}/{row.total}</span>
+          </div>
+          <div class="map-chrome-progress">
+            <div
+              class="map-chrome-progress__value"
+              style:width={`${row.percent}%`}
+            ></div>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <div class="contributor-progress__group" aria-label="Building completeness">
+      <h3 class="contributor-progress__heading">Buildings</h3>
+      {#each [{ label: "Map pins", count: campusData.buildings.pins }, { label: "Directions", count: campusData.buildings.directions }] as row (row.label)}
+        {@const percent = progressPercent(row.count.filled, row.count.total)}
+        <div
+          class="contributor-progress__field"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={row.count.total}
+          aria-valuenow={row.count.filled}
+          aria-label="{row.label}: {row.count.filled} of {row.count.total}"
+        >
+          <div class="contributor-progress__field-head">
+            <span>{row.label}</span>
+            <span>{row.count.filled}/{row.count.total}</span>
+          </div>
+          <div class="map-chrome-progress">
+            <div
+              class="map-chrome-progress__value"
+              style:width={`${percent}%`}
+            ></div>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    {#if campusData.topBuildings.length > 0}
+      <div class="contributor-progress__group" aria-label="Buildings with gaps">
+        <h3 class="contributor-progress__heading">Buildings needing work</h3>
+        <ul class="contributor-progress__list">
+          {#each campusData.topBuildings as building (building.buildingId)}
+            <li>
+              <span class="contributor-progress__list-title"
+                >{building.buildingName}</span
+              >
+              <span class="contributor-progress__list-meta">
+                {building.directions.filled}/{building.roomTotal} directions ·
+                {building.schedule.filled}/{building.roomTotal} schedules ·
+                {building.position.filled}/{building.roomTotal} pins
+              </span>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+  {:else if activeScope === "building" && buildingData}
+    {#if buildingData.termLabel}
+      <p class="contributor-progress__meta">
+        {buildingData.buildingName} · schedule counts use {buildingData.termLabel}.
+      </p>
+    {:else}
+      <p class="contributor-progress__meta">{buildingData.buildingName}</p>
+    {/if}
+
+    {#each fieldRows(buildingData.rooms) as row (row.category)}
+      <div
+        class="contributor-progress__field"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={row.total}
+        aria-valuenow={row.filled}
+        aria-label="{row.label}: {row.filled} of {row.total}"
+      >
+        <div class="contributor-progress__field-head">
+          <span>{row.label}</span>
+          <span>{row.filled}/{row.total}</span>
+        </div>
+        <div class="map-chrome-progress">
+          <div
+            class="map-chrome-progress__value"
+            style:width={`${row.percent}%`}
+          ></div>
+        </div>
+      </div>
+    {/each}
+
+    {#if buildingData.roomRows.length === 0}
+      <p class="contributor-progress__status">No rooms in this building yet.</p>
+    {:else}
+      <ul class="contributor-progress__checklist" aria-label="Room checklist">
+        {#each buildingData.roomRows as room (room.id)}
+          <li class="contributor-progress__checklist-item">
+            <span class="contributor-progress__room-code">{room.code}</span>
+            {#if room.missingFields.length === 0}
+              <span class="contributor-progress__complete">Complete</span>
+            {:else}
+              <ul class="contributor-progress__gaps">
+                {#each room.missingFields as category (category)}
+                  <li>{missingFieldLabel(room.code, category)}</li>
+                {/each}
+              </ul>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  {:else if activeScope === "mine" && mineData}
+    <p class="contributor-progress__meta">
+      {mineData.totalEdits} edits recorded for {mineData.editedBy}.
+    </p>
+    {#if mineData.totalEdits === 0}
+      <p class="contributor-progress__status">
+        No published edits in history yet.
+      </p>
+    {:else}
+      <ul class="contributor-progress__list">
+        {#each Object.entries(mineData.byEntityType).sort( ([a], [b]) => a.localeCompare(b) ) as [entityType, count] (entityType)}
+          <li>
+            <span class="contributor-progress__list-title"
+              >{formatEntityType(entityType)}</span
+            >
+            <span class="contributor-progress__list-meta">{count} edits</span>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .contributor-progress {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+
+  .contributor-progress__tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .contributor-progress__building-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .contributor-progress__label,
+  .contributor-progress__meta,
+  .contributor-progress__status {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: hsl(0, 0%, 38%);
+  }
+
+  .contributor-progress__status--error {
+    color: hsl(0, 45%, 40%);
+  }
+
+  .contributor-progress__select {
+    width: 100%;
+    max-width: 100%;
+    font: inherit;
+    font-size: 0.8125rem;
+    padding: 0.25rem 0.375rem;
+    border: 1px solid hsl(0, 0%, 82%);
+    border-radius: 0.375rem;
+    background: hsl(0, 0%, 100%);
+  }
+
+  .contributor-progress__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .contributor-progress__heading {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: hsl(0, 0%, 28%);
+  }
+
+  .contributor-progress__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .contributor-progress__field-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 32%);
+  }
+
+  .contributor-progress__list,
+  .contributor-progress__checklist,
+  .contributor-progress__gaps {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .contributor-progress__list li,
+  .contributor-progress__checklist-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    padding: 0.375rem 0;
+    border-top: 1px solid hsl(0, 0%, 90%);
+    min-width: 0;
+  }
+
+  .contributor-progress__list-title,
+  .contributor-progress__room-code {
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: hsl(0, 0%, 22%);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .contributor-progress__list-meta,
+  .contributor-progress__gaps li,
+  .contributor-progress__complete {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: hsl(0, 0%, 40%);
+  }
+
+  .contributor-progress__complete {
+    color: hsl(130, 25%, 32%);
+  }
+</style>

--- a/src/components/svelte/status-bar/StatusBarDetails.svelte
+++ b/src/components/svelte/status-bar/StatusBarDetails.svelte
@@ -6,6 +6,8 @@
   import { slideDismiss, slideReveal } from "@lib/motion";
   import StatusBarDirectionsStat from "./StatusBarDirectionsStat.svelte";
   import StatusBarLinkGroups from "./StatusBarLinkGroups.svelte";
+  import ContributorProgressPanel from "./ContributorProgressPanel.svelte";
+  import MapChromeGhostButton from "@ui/map-chrome/MapChromeGhostButton.svelte";
   import type { StatusBarNavGroup } from "@constants/status-bar-links";
 
   type Props = {
@@ -27,6 +29,8 @@
     showEditorLogin,
     onAction,
   }: Props = $props();
+
+  let showProgressPanel = $state(false);
 
   const catalogUpdatedLabel = formatCatalogUpdatedDate();
   const navGroups = $derived<StatusBarNavGroup[]>(
@@ -51,6 +55,21 @@
         {progressPercent}
         variant="expanded"
       />
+      <div class="status-bar__progress-actions">
+        <MapChromeGhostButton
+          variant="muted"
+          aria-expanded={showProgressPanel}
+          aria-controls="contributor-progress-panel"
+          onclick={() => (showProgressPanel = !showProgressPanel)}
+        >
+          {showProgressPanel ? "Hide progress" : "Progress by building"}
+        </MapChromeGhostButton>
+      </div>
+      {#if showProgressPanel}
+        <div id="contributor-progress-panel">
+          <ContributorProgressPanel />
+        </div>
+      {/if}
     </section>
   {/if}
 

--- a/src/components/svelte/status-bar/status-bar.css
+++ b/src/components/svelte/status-bar/status-bar.css
@@ -138,6 +138,10 @@
   color: hsl(0, 0%, 22%);
 }
 
+.status-bar__progress-actions {
+  margin-top: 0.25rem;
+}
+
 .status-bar__directions-collapsed {
   flex: 0 1 auto;
   min-width: 0;

--- a/src/lib/contributor-progress.test.ts
+++ b/src/lib/contributor-progress.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "bun:test";
+import {
+  aggregateHistoryByEntityType,
+  buildRoomProgressRow,
+  buildRoomProgressRows,
+  computeBuildingBreakdown,
+  hasBuildingPin,
+  isNonEmptyText,
+  missingFieldLabel,
+  progressPercent,
+  summarizeFieldCounts,
+  topBuildingsByGap,
+} from "./contributor-progress";
+
+describe("contributor-progress", () => {
+  it("treats whitespace-only directions as missing", () => {
+    expect(isNonEmptyText("  ")).toBe(false);
+    expect(isNonEmptyText("Turn left at the lobby")).toBe(true);
+  });
+
+  it("builds room completeness from directions, schedule, and position", () => {
+    const row = buildRoomProgressRow({
+      id: 1,
+      code: "PSLH 4",
+      buildingId: 9,
+      directions: "Near the stairs",
+      classCount: 2,
+      hasPosition: false,
+    });
+
+    expect(row.fields).toEqual({
+      directions: true,
+      schedule: true,
+      position: false,
+    });
+    expect(row.missingFields).toEqual(["position"]);
+    expect(missingFieldLabel("PSLH 4", "position")).toBe(
+      "PSLH 4 — floor plan pin missing",
+    );
+  });
+
+  it("summarizes campus room field counts", () => {
+    const rows = buildRoomProgressRows([
+      {
+        id: 1,
+        code: "A",
+        buildingId: 1,
+        directions: "x",
+        classCount: 1,
+        hasPosition: true,
+      },
+      {
+        id: 2,
+        code: "B",
+        buildingId: 1,
+        directions: null,
+        classCount: 0,
+        hasPosition: false,
+      },
+    ]);
+
+    expect(summarizeFieldCounts(rows)).toEqual({
+      directions: { filled: 1, total: 2 },
+      schedule: { filled: 1, total: 2 },
+      position: { filled: 1, total: 2 },
+    });
+    expect(progressPercent(1, 2)).toBe(50);
+  });
+
+  it("ranks buildings with the largest gaps first", () => {
+    const rows = buildRoomProgressRows([
+      {
+        id: 1,
+        code: "A1",
+        buildingId: 1,
+        directions: "x",
+        classCount: 1,
+        hasPosition: true,
+      },
+      {
+        id: 2,
+        code: "A2",
+        buildingId: 1,
+        directions: "x",
+        classCount: 1,
+        hasPosition: true,
+      },
+      {
+        id: 3,
+        code: "B1",
+        buildingId: 2,
+        directions: null,
+        classCount: 0,
+        hasPosition: false,
+      },
+      {
+        id: 4,
+        code: "B2",
+        buildingId: 2,
+        directions: null,
+        classCount: 0,
+        hasPosition: false,
+      },
+    ]);
+
+    const names = new Map([
+      [1, "Alpha Hall"],
+      [2, "Beta Hall"],
+    ]);
+    const breakdown = computeBuildingBreakdown(rows, names);
+    expect(breakdown[0]?.buildingName).toBe("Beta Hall");
+    expect(breakdown[0]?.gapScore).toBeGreaterThan(breakdown[1]?.gapScore ?? 0);
+    expect(topBuildingsByGap(breakdown, 1)).toHaveLength(1);
+  });
+
+  it("aggregates editor history counts by entity type", () => {
+    expect(
+      aggregateHistoryByEntityType([
+        { entityType: "room", count: 7 },
+        { entityType: "building", count: 2 },
+      ]),
+    ).toEqual({
+      totalEdits: 9,
+      byEntityType: {
+        room: 7,
+        building: 2,
+      },
+    });
+  });
+
+  it("detects building pins from finite coordinates", () => {
+    expect(hasBuildingPin(14.65, 121.07)).toBe(true);
+    expect(hasBuildingPin(null, 121)).toBe(false);
+  });
+});

--- a/src/lib/contributor-progress.ts
+++ b/src/lib/contributor-progress.ts
@@ -1,0 +1,261 @@
+import { fetchJsonWithRetry } from "@lib/local/data/fetch-json";
+
+export const ROOM_FIELD_CATEGORIES = [
+  "directions",
+  "schedule",
+  "position",
+] as const;
+
+export type RoomFieldCategory = (typeof ROOM_FIELD_CATEGORIES)[number];
+
+export const ROOM_FIELD_LABELS: Record<RoomFieldCategory, string> = {
+  directions: "Directions",
+  schedule: "Schedule",
+  position: "Floor plan pin",
+};
+
+export type ProgressCount = {
+  filled: number;
+  total: number;
+};
+
+export type RoomProgressInput = {
+  id: number;
+  code: string;
+  buildingId: number | null;
+  directions: string | null;
+  classCount: number;
+  hasPosition: boolean;
+};
+
+export type RoomProgressRow = {
+  id: number;
+  code: string;
+  buildingId: number | null;
+  fields: Record<RoomFieldCategory, boolean>;
+  missingFields: RoomFieldCategory[];
+};
+
+export type BuildingProgressBreakdown = {
+  buildingId: number;
+  buildingName: string;
+  roomTotal: number;
+  directions: ProgressCount;
+  schedule: ProgressCount;
+  position: ProgressCount;
+  gapScore: number;
+};
+
+export type CampusContributorProgress = {
+  scope: "campus";
+  termId: number | null;
+  termLabel: string | null;
+  rooms: Record<RoomFieldCategory, ProgressCount>;
+  buildings: {
+    total: number;
+    pins: ProgressCount;
+    directions: ProgressCount;
+  };
+  topBuildings: BuildingProgressBreakdown[];
+};
+
+export type BuildingContributorProgress = {
+  scope: "building";
+  buildingId: number;
+  buildingName: string;
+  termId: number | null;
+  termLabel: string | null;
+  rooms: Record<RoomFieldCategory, ProgressCount>;
+  roomRows: RoomProgressRow[];
+};
+
+export type MineContributorProgress = {
+  scope: "mine";
+  editedBy: string;
+  totalEdits: number;
+  byEntityType: Record<string, number>;
+};
+
+export type ContributorProgressResponse =
+  | CampusContributorProgress
+  | BuildingContributorProgress
+  | MineContributorProgress;
+
+export const TOP_BUILDINGS_LIMIT = 10;
+
+export function isNonEmptyText(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function hasBuildingPin(
+  lat: number | null | undefined,
+  lon: number | null | undefined,
+): boolean {
+  return Number.isFinite(lat) && Number.isFinite(lon);
+}
+
+export function progressPercent(filled: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.floor((filled / total) * 100);
+}
+
+export function emptyProgressCount(total: number): ProgressCount {
+  return { filled: 0, total };
+}
+
+export function summarizeFieldCounts(
+  rows: RoomProgressRow[],
+): Record<RoomFieldCategory, ProgressCount> {
+  const total = rows.length;
+  const counts: Record<RoomFieldCategory, ProgressCount> = {
+    directions: emptyProgressCount(total),
+    schedule: emptyProgressCount(total),
+    position: emptyProgressCount(total),
+  };
+
+  for (const row of rows) {
+    for (const category of ROOM_FIELD_CATEGORIES) {
+      if (row.fields[category]) {
+        counts[category].filled += 1;
+      }
+    }
+  }
+
+  return counts;
+}
+
+export function buildRoomProgressRow(room: RoomProgressInput): RoomProgressRow {
+  const fields: Record<RoomFieldCategory, boolean> = {
+    directions: isNonEmptyText(room.directions),
+    schedule: room.classCount > 0,
+    position: room.hasPosition,
+  };
+  const missingFields = ROOM_FIELD_CATEGORIES.filter(
+    (category) => !fields[category],
+  );
+
+  return {
+    id: room.id,
+    code: room.code,
+    buildingId: room.buildingId,
+    fields,
+    missingFields,
+  };
+}
+
+export function buildRoomProgressRows(
+  rooms: RoomProgressInput[],
+): RoomProgressRow[] {
+  return rooms.map(buildRoomProgressRow);
+}
+
+export function buildingGapScore(
+  counts: Record<RoomFieldCategory, ProgressCount>,
+): number {
+  return ROOM_FIELD_CATEGORIES.reduce((score, category) => {
+    const { filled, total } = counts[category];
+    return score + Math.max(0, total - filled);
+  }, 0);
+}
+
+export function computeBuildingBreakdown(
+  rows: RoomProgressRow[],
+  buildingNames: Map<number, string>,
+): BuildingProgressBreakdown[] {
+  const grouped = new Map<number, RoomProgressRow[]>();
+
+  for (const row of rows) {
+    if (row.buildingId == null) continue;
+    const list = grouped.get(row.buildingId) ?? [];
+    list.push(row);
+    grouped.set(row.buildingId, list);
+  }
+
+  const breakdown: BuildingProgressBreakdown[] = [];
+
+  for (const [buildingId, buildingRows] of grouped) {
+    const counts = summarizeFieldCounts(buildingRows);
+    breakdown.push({
+      buildingId,
+      buildingName: buildingNames.get(buildingId) ?? `Building ${buildingId}`,
+      roomTotal: buildingRows.length,
+      directions: counts.directions,
+      schedule: counts.schedule,
+      position: counts.position,
+      gapScore: buildingGapScore(counts),
+    });
+  }
+
+  return breakdown.sort((a, b) => {
+    if (b.gapScore !== a.gapScore) return b.gapScore - a.gapScore;
+    return a.buildingName.localeCompare(b.buildingName);
+  });
+}
+
+export function topBuildingsByGap(
+  breakdown: BuildingProgressBreakdown[],
+  limit = TOP_BUILDINGS_LIMIT,
+): BuildingProgressBreakdown[] {
+  return breakdown.slice(0, limit);
+}
+
+export function aggregateHistoryByEntityType(
+  rows: Array<{ entityType: string; count: number }>,
+): { totalEdits: number; byEntityType: Record<string, number> } {
+  const byEntityType: Record<string, number> = {};
+  let totalEdits = 0;
+
+  for (const row of rows) {
+    byEntityType[row.entityType] = row.count;
+    totalEdits += row.count;
+  }
+
+  return { totalEdits, byEntityType };
+}
+
+export function missingFieldLabel(
+  roomCode: string,
+  category: RoomFieldCategory,
+): string {
+  return `${roomCode} — ${ROOM_FIELD_LABELS[category].toLowerCase()} missing`;
+}
+
+type ContributorProgressApiResponse = {
+  success: boolean;
+  data?: ContributorProgressResponse;
+  error?: string;
+};
+
+export async function fetchContributorProgress(
+  scope: "campus",
+): Promise<CampusContributorProgress>;
+export async function fetchContributorProgress(
+  scope: "building",
+  buildingId: number,
+): Promise<BuildingContributorProgress>;
+export async function fetchContributorProgress(
+  scope: "mine",
+): Promise<MineContributorProgress>;
+export async function fetchContributorProgress(
+  scope: "campus" | "building" | "mine",
+  buildingId?: number,
+): Promise<ContributorProgressResponse> {
+  const params = new URLSearchParams({ scope });
+  if (scope === "building") {
+    if (!Number.isFinite(buildingId)) {
+      throw new Error("Building scope requires a building id.");
+    }
+    params.set("buildingId", String(buildingId));
+  }
+
+  const payload = await fetchJsonWithRetry<ContributorProgressApiResponse>(
+    `/api/contributor-progress?${params.toString()}`,
+    { attempts: 3, timeoutMs: 20_000, baseDelayMs: 500, maxDelayMs: 4_000 },
+  );
+
+  if (!payload.success || !payload.data) {
+    throw new Error(payload.error ?? "Failed to load contributor progress.");
+  }
+
+  return payload.data;
+}

--- a/src/pages/api/contributor-progress.ts
+++ b/src/pages/api/contributor-progress.ts
@@ -1,0 +1,242 @@
+import type { APIRoute } from "astro";
+import { eq, sql } from "drizzle-orm";
+import {
+  buildingsTable,
+  classesTable,
+  editorHistoryTable,
+  roomPositionsTable,
+  roomsTable,
+} from "@drizzle/schema";
+import { sessionEditedBy } from "@lib/admin/auth";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import {
+  aggregateHistoryByEntityType,
+  buildRoomProgressRows,
+  computeBuildingBreakdown,
+  hasBuildingPin,
+  isNonEmptyText,
+  summarizeFieldCounts,
+  topBuildingsByGap,
+  type BuildingContributorProgress,
+  type CampusContributorProgress,
+  type MineContributorProgress,
+  type RoomProgressInput,
+} from "@lib/contributor-progress";
+import { db } from "@lib/db";
+import { getDefaultTerm } from "@lib/services/term-service";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ url, cookies }) => {
+  const scope = url.searchParams.get("scope") ?? "campus";
+  const buildingIdRaw = url.searchParams.get("buildingId");
+
+  if (scope === "mine") {
+    const auth = editorSessionOrUnauthorized(cookies);
+    if (auth instanceof Response) return auth;
+    return json(await fetchMineProgress(sessionEditedBy(auth.session)));
+  }
+
+  if (scope === "building") {
+    const buildingId = Number(buildingIdRaw);
+    if (!Number.isFinite(buildingId)) {
+      return json({ success: false, error: "buildingId is required" }, 400);
+    }
+    const result = await fetchBuildingProgress(buildingId);
+    if (result instanceof Response) return result;
+    return json(result);
+  }
+
+  if (scope === "campus") {
+    return json(await fetchCampusProgress());
+  }
+
+  return json({ success: false, error: "Invalid scope" }, 400);
+};
+
+async function fetchCampusProgress(): Promise<{
+  success: true;
+  data: CampusContributorProgress;
+}> {
+  const term = await getDefaultTerm();
+  const { roomInputs, buildingNames, buildings } = await loadRoomInputs(
+    term?.id ?? null,
+  );
+  const roomRows = buildRoomProgressRows(roomInputs);
+  const roomCounts = summarizeFieldCounts(roomRows);
+  const breakdown = topBuildingsByGap(
+    computeBuildingBreakdown(roomRows, buildingNames),
+  );
+
+  const buildingTotal = buildings.length;
+  let pinFilled = 0;
+  let directionsFilled = 0;
+
+  for (const building of buildings) {
+    if (hasBuildingPin(building.lat, building.lon)) pinFilled += 1;
+    if (isNonEmptyText(building.directions)) directionsFilled += 1;
+  }
+
+  return {
+    success: true,
+    data: {
+      scope: "campus",
+      termId: term?.id ?? null,
+      termLabel: term?.label ?? null,
+      rooms: roomCounts,
+      buildings: {
+        total: buildingTotal,
+        pins: { filled: pinFilled, total: buildingTotal },
+        directions: { filled: directionsFilled, total: buildingTotal },
+      },
+      topBuildings: breakdown,
+    },
+  };
+}
+
+async function fetchBuildingProgress(
+  buildingId: number,
+): Promise<{ success: true; data: BuildingContributorProgress } | Response> {
+  const building = await db
+    .select({
+      id: buildingsTable.id,
+      buildingName: buildingsTable.buildingName,
+    })
+    .from(buildingsTable)
+    .where(eq(buildingsTable.id, buildingId))
+    .limit(1);
+
+  if (building.length === 0) {
+    return json({ success: false, error: "Building not found" }, 404);
+  }
+
+  const term = await getDefaultTerm();
+  const { roomInputs } = await loadRoomInputs(term?.id ?? null, buildingId);
+  const roomRows = buildRoomProgressRows(roomInputs).sort((a, b) =>
+    a.code.localeCompare(b.code),
+  );
+
+  return {
+    success: true,
+    data: {
+      scope: "building",
+      buildingId,
+      buildingName: building[0].buildingName,
+      termId: term?.id ?? null,
+      termLabel: term?.label ?? null,
+      rooms: summarizeFieldCounts(roomRows),
+      roomRows,
+    },
+  };
+}
+
+async function fetchMineProgress(editedBy: string): Promise<{
+  success: true;
+  data: MineContributorProgress;
+}> {
+  const rows = await db
+    .select({
+      entityType: editorHistoryTable.entityType,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(editorHistoryTable)
+    .where(eq(editorHistoryTable.editedBy, editedBy))
+    .groupBy(editorHistoryTable.entityType);
+
+  const { totalEdits, byEntityType } = aggregateHistoryByEntityType(rows);
+
+  return {
+    success: true,
+    data: {
+      scope: "mine",
+      editedBy,
+      totalEdits,
+      byEntityType,
+    },
+  };
+}
+
+async function loadRoomInputs(
+  termId: number | null,
+  buildingId?: number,
+): Promise<{
+  roomInputs: RoomProgressInput[];
+  buildingNames: Map<number, string>;
+  buildings: Array<{
+    id: number;
+    buildingName: string;
+    lat: number;
+    lon: number;
+    directions: string;
+  }>;
+}> {
+  const roomsQuery = db
+    .select({
+      id: roomsTable.id,
+      code: roomsTable.roomCode,
+      buildingId: roomsTable.buildingId,
+      directions: roomsTable.directions,
+    })
+    .from(roomsTable);
+
+  const rooms =
+    buildingId != null
+      ? await roomsQuery.where(eq(roomsTable.buildingId, buildingId))
+      : await roomsQuery;
+
+  const classCounts =
+    termId != null
+      ? await db
+          .select({
+            roomId: classesTable.roomId,
+            count: sql<number>`count(*)::int`,
+          })
+          .from(classesTable)
+          .where(eq(classesTable.termId, termId))
+          .groupBy(classesTable.roomId)
+      : [];
+
+  const classCountByRoom = new Map<number, number>();
+  for (const row of classCounts) {
+    if (row.roomId != null) {
+      classCountByRoom.set(row.roomId, row.count);
+    }
+  }
+
+  const positionRows = await db
+    .select({ roomId: roomPositionsTable.roomId })
+    .from(roomPositionsTable);
+  const positionedRoomIds = new Set(positionRows.map((row) => row.roomId));
+
+  const buildings = await db
+    .select({
+      id: buildingsTable.id,
+      buildingName: buildingsTable.buildingName,
+      lat: buildingsTable.lat,
+      lon: buildingsTable.lon,
+      directions: buildingsTable.directions,
+    })
+    .from(buildingsTable);
+
+  const buildingNames = new Map(
+    buildings.map((building) => [building.id, building.buildingName]),
+  );
+
+  const roomInputs: RoomProgressInput[] = rooms.map((room) => ({
+    id: room.id,
+    code: room.code,
+    buildingId: room.buildingId,
+    directions: room.directions,
+    classCount: classCountByRoom.get(room.id) ?? 0,
+    hasPosition: positionedRoomIds.has(room.id),
+  }));
+
+  return { roomInputs, buildingNames, buildings };
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/contributor-progress` with campus, building, and signed-in “mine” scopes
- Adds `ContributorProgressPanel` reachable from Status Bar details → “Progress by building”
- Pure aggregation helpers + 6 unit tests

## Test plan
- [x] `bun test src/lib/contributor-progress.test.ts`
- [ ] Status Bar → expand → Progress by building (Campus / Building / My work when signed in)
- [ ] Building scope shows room checklist with named gaps

Closes #315

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only reporting and UI; only the mine scope touches auth, using the existing editor session guard.
> 
> **Overview**
> Introduces **`GET /api/contributor-progress`** with **`campus`**, **`building`**, and **`mine`** scopes. Campus and building responses aggregate room completeness (directions, schedule for the default term, floor-plan pins), building map pins/directions, and a ranked “buildings needing work” list; **`mine`** returns editor-history counts per entity type and requires an editor session.
> 
> A new **`@lib/contributor-progress`** module holds the aggregation rules (e.g. whitespace-only directions count as missing, schedule from class counts, gap scoring) plus **`fetchContributorProgress`** for the client. **`ContributorProgressPanel`** exposes Campus / Building / My work tabs with progress bars and a per-room gap checklist; it is toggled from expanded status bar directions via **“Progress by building”**. Six unit tests cover the pure helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ee7b88784dda9ad677b9f64843f17a52614cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->