### PR TITLE
feat(schedule-route): import personal schedule and multi-stop routing (#329)

### DIFF
--- a/docs/schedule-import-formats.md
+++ b/docs/schedule-import-formats.md
@@ -1,0 +1,73 @@
+# Schedule import formats
+
+Personal schedule import accepts exports from [AMIS Schedule Extractor](https://github.com/Towphe/amis-schedule-extractor) or a simple CSV. Instructor names and other faculty PII are stripped on parse and never stored server-side.
+
+## JSON (preferred)
+
+Top-level array of class rows, or a paginated wrapper (`classes.data` / `data`).
+
+Required fields per row:
+
+| Field         | Aliases                   | Example                  |
+| ------------- | ------------------------- | ------------------------ |
+| `course_code` | `courseCode`, `course`    | `"CMSC 123"`             |
+| `section`     | `sec`                     | `"A"`                    |
+| `type`        | `class_type`, `classType` | `"LEC"`                  |
+| `schedule`    | —                         | `["MW 08:00AM-09:00AM"]` |
+
+Schedule slots use the same compact AMIS format parsed by `parseScheduleTime()` in `src/lib/schedule-renderer.ts` (e.g. `TTh 01:00PM-02:30PM`).
+
+Rows may include `class_dates` instead of `schedule`; these are normalized to the same string format.
+
+### Sample sanitized payload
+
+```json
+[
+  {
+    "course_code": "CMSC 123",
+    "section": "A",
+    "type": "LEC",
+    "schedule": ["MW 08:00AM-09:00AM"]
+  },
+  {
+    "course_code": "CMSC 123",
+    "section": "A",
+    "type": "LAB",
+    "schedule": ["T 01:00PM-04:00PM"]
+  }
+]
+```
+
+Do **not** commit exports containing `faculty`, `formatted_name`, `email`, or similar keys. The client parser strips those fields before matching.
+
+## CSV fallback
+
+Header row required. Column names (case-insensitive):
+
+- `course_code` (or `course`, `code`)
+- `section` (or `sec`)
+- `type` (or `class_type`)
+- `schedule` (optional; semicolon-separated slots)
+
+Example:
+
+```csv
+course_code,section,type,schedule
+CMSC 123,A,LEC,MW 08:00AM-09:00AM
+CMSC 123,A,LAB,T 01:00PM-04:00PM
+```
+
+## Matching and routing
+
+1. Rows match institutional `classes` for the active term (`course_code` + `section` + `type`).
+2. Room codes resolve to building coordinates via local PGlite cache or `/api/rooms`.
+3. Unresolved rows (no match, no room, thesis/special-problem types) appear in the UI but are skipped for routing.
+4. Imported data persists in `sessionStorage` only for the current browser tab session.
+
+## Related code
+
+- Parser: `src/lib/schedule-import/parse-import.ts`
+- Matcher: `src/lib/schedule-import/match-classes.ts`
+- Weekday ordering: `src/lib/schedule-import/day-stops.ts`
+- UI: Map tools flyout → Schedule → `ScheduleImportPanel.svelte`
+- Store: `scheduleRouteStore` in `src/lib/store.svelte.ts`

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -1478,7 +1478,22 @@
   $effect(() => {
     if (!directions) return;
 
-    if (locationStore.routeOrigin && locationStore.destination) {
+    const waypoints = locationStore.routeWaypoints;
+    if (waypoints && waypoints.length >= 2) {
+      directions.setWaypoints(waypoints);
+      const map = mapStore.mapInstance;
+      if (map) {
+        const bounds = new mapGl.LngLatBounds();
+        for (const point of waypoints) {
+          bounds.extend(point);
+        }
+        map.fitBounds(bounds, {
+          padding: { top: 80, bottom: 80, left: 80, right: 80 },
+          duration: 1200,
+          maxZoom: 18,
+        });
+      }
+    } else if (locationStore.routeOrigin && locationStore.destination) {
       directions.setWaypoints([
         locationStore.routeOrigin,
         locationStore.destination,

--- a/src/components/svelte/MapToolsFlyout.svelte
+++ b/src/components/svelte/MapToolsFlyout.svelte
@@ -9,6 +9,7 @@
   import MapLegend from "@ui/MapLegend.svelte";
   import TerrainControl from "@ui/TerrainControl.svelte";
   import JeepneyMenu from "@ui/JeepneyMenu.svelte";
+  import ScheduleImportPanel from "@ui/ScheduleImportPanel.svelte";
   import { trapFocus } from "@lib/focus-trap";
   import MapChromeFabTrigger from "@ui/map-chrome/MapChromeFabTrigger.svelte";
   import MapChromePanel from "@ui/map-chrome/MapChromePanel.svelte";
@@ -23,6 +24,7 @@
     { id: "legend", label: "Legend" },
     { id: "terrain", label: "Terrain" },
     { id: "jeepney", label: "Transit" },
+    { id: "schedule", label: "Schedule" },
   ];
 
   function toggleSection(id: MapToolsSection) {
@@ -97,6 +99,8 @@
                   <TerrainControl embedded />
                 {:else if section.id === "jeepney"}
                   <JeepneyMenu embedded />
+                {:else if section.id === "schedule"}
+                  <ScheduleImportPanel embedded />
                 {/if}
               </div>
             {/if}

--- a/src/components/svelte/ScheduleImportPanel.svelte
+++ b/src/components/svelte/ScheduleImportPanel.svelte
@@ -1,0 +1,326 @@
+<script lang="ts">
+  import { scheduleRouteStore, type Weekday } from "@lib/store.svelte";
+  import { onMount } from "svelte";
+  import { formatMinutes } from "@lib/schedule-import/day-stops";
+  import { WEEKDAY_LABELS, WEEKDAYS } from "@lib/schedule-import/types";
+
+  type Props = {
+    embedded?: boolean;
+  };
+
+  let { embedded = false }: Props = $props();
+
+  let pasteText = $state("");
+
+  const pastePlaceholder =
+    '[{"course_code":"CMSC 123","section":"A","type":"LEC","schedule":["MW 08:00AM-09:00AM"]}]';
+
+  onMount(() => {
+    scheduleRouteStore.init();
+  });
+
+  async function handleImport() {
+    const ok = await scheduleRouteStore.importText(pasteText);
+    if (ok) pasteText = "";
+  }
+
+  function selectWeekday(day: Weekday) {
+    scheduleRouteStore.selectWeekday(day);
+  }
+
+  function routeDay() {
+    scheduleRouteStore.routeDay();
+  }
+
+  function clearImport() {
+    scheduleRouteStore.clearImport();
+    pasteText = "";
+  }
+</script>
+
+<div
+  class="schedule-import-panel"
+  class:schedule-import-panel--embedded={embedded}
+>
+  <p class="schedule-import-panel__note">
+    Personal import stays in this browser tab only (session storage). Room TBA
+    matches your rows against institutional lecture and lab data for the active
+    term — not your enlistment account.
+  </p>
+  <p class="schedule-import-panel__scope">{scheduleRouteStore.scopeNote}</p>
+
+  <label class="schedule-import-panel__label" for="schedule-import-paste">
+    Paste JSON or CSV export
+  </label>
+  <textarea
+    id="schedule-import-paste"
+    class="schedule-import-panel__textarea"
+    bind:value={pasteText}
+    rows="4"
+    placeholder={pastePlaceholder}></textarea>
+
+  {#if scheduleRouteStore.importError}
+    <p class="schedule-import-panel__error" role="alert">
+      {scheduleRouteStore.importError}
+    </p>
+  {/if}
+
+  <div class="schedule-import-panel__actions">
+    <button
+      type="button"
+      class="schedule-import-panel__primary"
+      disabled={!pasteText.trim() || scheduleRouteStore.matching}
+      onclick={handleImport}
+    >
+      {scheduleRouteStore.matching ? "Matching…" : "Import schedule"}
+    </button>
+    {#if scheduleRouteStore.hasImport}
+      <button
+        type="button"
+        class="schedule-import-panel__secondary"
+        onclick={clearImport}
+      >
+        Clear
+      </button>
+    {/if}
+  </div>
+
+  {#if scheduleRouteStore.hasImport}
+    <div
+      class="schedule-import-panel__weekdays"
+      role="group"
+      aria-label="Weekday"
+    >
+      {#each WEEKDAYS as day (day)}
+        <button
+          type="button"
+          class="schedule-import-panel__weekday"
+          class:schedule-import-panel__weekday--active={scheduleRouteStore.selectedWeekday ===
+            day}
+          aria-pressed={scheduleRouteStore.selectedWeekday === day}
+          onclick={() => selectWeekday(day)}
+        >
+          {WEEKDAY_LABELS[day]}
+        </button>
+      {/each}
+    </div>
+
+    {#if scheduleRouteStore.matching}
+      <p class="schedule-import-panel__status">Matching classes…</p>
+    {:else}
+      <ul
+        class="schedule-import-panel__stops"
+        aria-label="Class stops for selected day"
+      >
+        {#each scheduleRouteStore.dayStops as stop, index (stop.courseCode + stop.type + stop.scheduleSlot)}
+          <li class="schedule-import-panel__stop">
+            <span class="schedule-import-panel__stop-time">
+              {formatMinutes(stop.startMinutes)}–{formatMinutes(
+                stop.endMinutes,
+              )}
+            </span>
+            <span class="schedule-import-panel__stop-title">
+              {stop.courseCode}
+              {stop.section} ({stop.type})
+            </span>
+            <span class="schedule-import-panel__stop-room">{stop.roomCode}</span
+            >
+            {#if stop.gapMinutesAfter !== null && index < scheduleRouteStore.dayStops.length - 1}
+              <span class="schedule-import-panel__gap">
+                {stop.gapMinutesAfter} min until next
+              </span>
+            {/if}
+          </li>
+        {:else}
+          <li class="schedule-import-panel__empty">
+            No routable classes this day.
+          </li>
+        {/each}
+      </ul>
+
+      {#if scheduleRouteStore.unresolved.length > 0}
+        <details class="schedule-import-panel__unresolved">
+          <summary>
+            Unresolved ({scheduleRouteStore.unresolved.length})
+          </summary>
+          <ul>
+            {#each scheduleRouteStore.unresolved as item (item.row.courseCode + item.row.section + item.row.type)}
+              <li>
+                {item.row.courseCode}
+                {item.row.section} ({item.row.type}) —
+                {item.unresolvedReason}
+              </li>
+            {/each}
+          </ul>
+        </details>
+      {/if}
+
+      <button
+        type="button"
+        class="schedule-import-panel__primary schedule-import-panel__route"
+        disabled={scheduleRouteStore.dayStops.length === 0}
+        onclick={routeDay}
+      >
+        Route this day
+      </button>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .schedule-import-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 0;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .schedule-import-panel__note,
+  .schedule-import-panel__scope {
+    margin: 0;
+    font-size: 0.75rem;
+    line-height: 1.35;
+    color: hsl(0, 0%, 35%);
+  }
+
+  .schedule-import-panel__label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: hsl(5, 53%, 22%);
+  }
+
+  .schedule-import-panel__textarea {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 5.5rem;
+    padding: 0.5rem 0.625rem;
+    border: 1px solid var(--map-chrome-border, hsl(0, 0%, 58%));
+    border-radius: 0.5rem;
+    font: inherit;
+    font-size: 0.8125rem;
+    resize: vertical;
+  }
+
+  .schedule-import-panel__error {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: hsl(0, 65%, 40%);
+  }
+
+  .schedule-import-panel__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+
+  .schedule-import-panel__primary,
+  .schedule-import-panel__secondary {
+    box-sizing: border-box;
+    border-radius: 0.625rem;
+    padding: 0.4375rem 0.75rem;
+    font: inherit;
+    font-size: 0.8125rem;
+    cursor: pointer;
+    max-width: 100%;
+  }
+
+  .schedule-import-panel__primary {
+    border: 1px solid hsl(5, 53%, 32%);
+    background: hsl(5, 53%, 32%);
+    color: #fff;
+  }
+
+  .schedule-import-panel__primary:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .schedule-import-panel__secondary {
+    border: 1px solid var(--map-chrome-border, hsl(0, 0%, 58%));
+    background: var(--map-chrome-surface, #fff);
+    color: hsl(5, 53%, 22%);
+  }
+
+  .schedule-import-panel__weekdays {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .schedule-import-panel__weekday {
+    flex: 1 1 auto;
+    min-width: 2.5rem;
+    padding: 0.3125rem 0.375rem;
+    border-radius: 999px;
+    border: 1px solid var(--map-chrome-border, hsl(0, 0%, 58%));
+    background: hsl(0, 0%, 98%);
+    font: inherit;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+
+  .schedule-import-panel__weekday--active {
+    border-color: hsl(5, 53%, 32%);
+    background: hsl(5, 53%, 96%);
+    color: hsl(5, 53%, 22%);
+  }
+
+  .schedule-import-panel__stops {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .schedule-import-panel__stop {
+    display: grid;
+    gap: 0.125rem;
+    padding: 0.4375rem 0.5rem;
+    border-radius: 0.5rem;
+    background: hsl(0, 0%, 98%);
+    font-size: 0.8125rem;
+    min-width: 0;
+  }
+
+  .schedule-import-panel__stop-time {
+    font-weight: 600;
+    color: hsl(5, 53%, 22%);
+  }
+
+  .schedule-import-panel__stop-title,
+  .schedule-import-panel__stop-room {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .schedule-import-panel__gap {
+    font-size: 0.75rem;
+    color: hsl(0, 0%, 40%);
+  }
+
+  .schedule-import-panel__empty,
+  .schedule-import-panel__status {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: hsl(0, 0%, 40%);
+  }
+
+  .schedule-import-panel__unresolved {
+    font-size: 0.75rem;
+    color: hsl(0, 0%, 35%);
+  }
+
+  .schedule-import-panel__unresolved ul {
+    margin: 0.375rem 0 0;
+    padding-left: 1rem;
+  }
+
+  .schedule-import-panel__route {
+    width: 100%;
+  }
+</style>

--- a/src/lib/schedule-import/day-stops.test.ts
+++ b/src/lib/schedule-import/day-stops.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatMinutes,
+  orderDayStops,
+  parseSlotMinutes,
+  scheduleSlotOnWeekday,
+  tokenizeScheduleDays,
+} from "./day-stops";
+import type { ScheduleMatchResult } from "./types";
+
+describe("tokenizeScheduleDays", () => {
+  it("splits T and Th correctly", () => {
+    expect(tokenizeScheduleDays("TTh")).toEqual(["T", "Th"]);
+    expect(tokenizeScheduleDays("MWF")).toEqual(["M", "W", "F"]);
+  });
+});
+
+describe("scheduleSlotOnWeekday", () => {
+  it("matches Tuesday but not Thursday for T slot", () => {
+    expect(scheduleSlotOnWeekday("T 10:00AM-11:00AM", "T")).toBe(true);
+    expect(scheduleSlotOnWeekday("T 10:00AM-11:00AM", "Th")).toBe(false);
+  });
+
+  it("matches Thursday for TTh slot", () => {
+    expect(scheduleSlotOnWeekday("TTh 01:00PM-02:30PM", "Th")).toBe(true);
+  });
+});
+
+describe("parseSlotMinutes", () => {
+  it("parses AM and PM boundaries", () => {
+    expect(parseSlotMinutes("MW 07:00AM-08:00AM")).toEqual({
+      startMinutes: 7 * 60,
+      endMinutes: 8 * 60,
+    });
+    expect(parseSlotMinutes("M 09:00AM-03:00PM")).toEqual({
+      startMinutes: 9 * 60,
+      endMinutes: 15 * 60,
+    });
+  });
+});
+
+describe("orderDayStops", () => {
+  const baseMatch = (
+    overrides: Partial<ScheduleMatchResult>,
+  ): ScheduleMatchResult => ({
+    row: {
+      courseCode: "CMSC 123",
+      section: "A",
+      type: "LEC",
+      schedule: ["MW 08:00AM-09:00AM"],
+    },
+    matchedClassId: 1,
+    roomCode: "ICS 314",
+    coords: [121.077, 14.135],
+    unresolvedReason: null,
+    ...overrides,
+  });
+
+  it("orders stops by start time and computes gaps", () => {
+    const matches: ScheduleMatchResult[] = [
+      baseMatch({
+        row: {
+          courseCode: "CMSC 170",
+          section: "B",
+          type: "LAB",
+          schedule: ["M 01:00PM-04:00PM"],
+        },
+        roomCode: "ICS 316",
+        coords: [121.078, 14.136],
+      }),
+      baseMatch({
+        row: {
+          courseCode: "CMSC 123",
+          section: "A",
+          type: "LEC",
+          schedule: ["M 08:00AM-09:00AM"],
+        },
+      }),
+    ];
+
+    const stops = orderDayStops(matches, "M");
+    expect(stops).toHaveLength(2);
+    expect(stops[0].courseCode).toBe("CMSC 123");
+    expect(stops[1].courseCode).toBe("CMSC 170");
+    expect(stops[0].gapMinutesAfter).toBe(4 * 60);
+  });
+
+  it("skips unresolved rows", () => {
+    const stops = orderDayStops(
+      [
+        baseMatch({
+          coords: null,
+          unresolvedReason: "No room",
+        }),
+      ],
+      "M",
+    );
+    expect(stops).toHaveLength(0);
+  });
+});
+
+describe("formatMinutes", () => {
+  it("formats noon and half hours", () => {
+    expect(formatMinutes(12 * 60)).toBe("12 PM");
+    expect(formatMinutes(13 * 60 + 30)).toBe("1:30 PM");
+  });
+});

--- a/src/lib/schedule-import/day-stops.ts
+++ b/src/lib/schedule-import/day-stops.ts
@@ -1,0 +1,122 @@
+import { parseScheduleTime } from "@lib/schedule-renderer";
+import type { ScheduleDayStop, ScheduleMatchResult, Weekday } from "./types";
+
+const SCHEDULE_TIME_RE =
+  /^([MTWThFSa]+)\s+(\d{1,2}):(\d{2})\s*(AM|PM)\s*-\s*(\d{1,2}):(\d{2})\s*(AM|PM)$/i;
+
+function to24Hour(hour: number, period: string): number {
+  const p = period.toUpperCase();
+  if (p === "PM" && hour !== 12) return hour + 12;
+  if (p === "AM" && hour === 12) return 0;
+  return hour;
+}
+
+export function parseSlotMinutes(
+  scheduleStr: string,
+): { startMinutes: number; endMinutes: number } | null {
+  const match = scheduleStr.match(SCHEDULE_TIME_RE);
+  if (!match) return null;
+
+  const startHour = to24Hour(parseInt(match[2], 10), match[4]);
+  const startMin = parseInt(match[3], 10);
+  const endHour = to24Hour(parseInt(match[5], 10), match[7]);
+  const endMin = parseInt(match[6], 10);
+
+  return {
+    startMinutes: startHour * 60 + startMin,
+    endMinutes: endHour * 60 + endMin,
+  };
+}
+
+/** Tokenize AMIS day string (handles T vs Th). */
+export function tokenizeScheduleDays(days: string): Weekday[] {
+  const tokens: Weekday[] = [];
+  let i = 0;
+  while (i < days.length) {
+    if (days.startsWith("Th", i)) {
+      tokens.push("Th");
+      i += 2;
+    } else if (days[i] === "T") {
+      tokens.push("T");
+      i += 1;
+    } else if (days[i] === "M") {
+      tokens.push("M");
+      i += 1;
+    } else if (days[i] === "W") {
+      tokens.push("W");
+      i += 1;
+    } else if (days[i] === "F") {
+      tokens.push("F");
+      i += 1;
+    } else if (days[i] === "S") {
+      tokens.push("S");
+      i += 1;
+    } else {
+      i += 1;
+    }
+  }
+  return tokens;
+}
+
+export function scheduleSlotOnWeekday(
+  scheduleStr: string,
+  weekday: Weekday,
+): boolean {
+  const parsed = parseScheduleTime(scheduleStr);
+  if (!parsed) return false;
+  return tokenizeScheduleDays(parsed.days).includes(weekday);
+}
+
+/** Build time-ordered routable stops for a weekday. Skips unresolved rows. */
+export function orderDayStops(
+  matches: ScheduleMatchResult[],
+  weekday: Weekday,
+): ScheduleDayStop[] {
+  const stops: ScheduleDayStop[] = [];
+
+  for (const match of matches) {
+    if (match.unresolvedReason || !match.coords) continue;
+
+    for (const slot of match.row.schedule) {
+      if (!scheduleSlotOnWeekday(slot, weekday)) continue;
+      const minutes = parseSlotMinutes(slot);
+      if (!minutes) continue;
+
+      stops.push({
+        courseCode: match.row.courseCode,
+        section: match.row.section,
+        type: match.row.type,
+        scheduleSlot: slot,
+        roomCode: match.roomCode,
+        coords: match.coords,
+        startMinutes: minutes.startMinutes,
+        endMinutes: minutes.endMinutes,
+        gapMinutesAfter: null,
+      });
+    }
+  }
+
+  stops.sort((a, b) => {
+    if (a.startMinutes !== b.startMinutes) {
+      return a.startMinutes - b.startMinutes;
+    }
+    return a.endMinutes - b.endMinutes;
+  });
+
+  for (let i = 0; i < stops.length - 1; i += 1) {
+    const gap = stops[i + 1].startMinutes - stops[i].endMinutes;
+    stops[i].gapMinutesAfter = gap >= 0 ? gap : null;
+  }
+
+  return stops;
+}
+
+export function formatMinutes(minutes: number): string {
+  const hour24 = Math.floor(minutes / 60);
+  const min = minutes % 60;
+  const period = hour24 >= 12 ? "PM" : "AM";
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  return min > 0
+    ? `${hour12}:${String(min).padStart(2, "0")} ${period}`
+    : `${hour12} ${period}`;
+}

--- a/src/lib/schedule-import/match-classes.test.ts
+++ b/src/lib/schedule-import/match-classes.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { matchImportedScheduleRows } from "./match-classes";
+import type { ClassMapValue } from "@lib/types";
+import type { ImportedScheduleRow } from "./types";
+
+const sampleClass: ClassMapValue = {
+  id: 1,
+  termId: 1252,
+  roomId: 10,
+  courseCode: "CMSC 123",
+  roomCode: "ICS 314",
+  section: "A",
+  type: "LEC",
+  schedule: ["MW 08:00AM-09:00AM"],
+  directions: null,
+  courseTitle: "Intro",
+};
+
+describe("matchImportedScheduleRows", () => {
+  const row: ImportedScheduleRow = {
+    courseCode: "CMSC 123",
+    section: "A",
+    type: "LEC",
+    schedule: ["MW 08:00AM-09:00AM"],
+  };
+
+  it("matches course section type to institutional class", () => {
+    const [result] = matchImportedScheduleRows([row], [sampleClass], () => [
+      121.077, 14.135,
+    ]);
+    expect(result.matchedClassId).toBe(1);
+    expect(result.roomCode).toBe("ICS 314");
+    expect(result.coords).toEqual([121.077, 14.135]);
+    expect(result.unresolvedReason).toBeNull();
+  });
+
+  it("marks missing sections unresolved", () => {
+    const [result] = matchImportedScheduleRows([row], [], () => null);
+    expect(result.unresolvedReason).toContain("No matching section");
+  });
+
+  it("skips thesis sections for routing", () => {
+    const [result] = matchImportedScheduleRows(
+      [{ ...row, type: "THE" }],
+      [sampleClass],
+      () => [121, 14],
+    );
+    expect(result.unresolvedReason).toContain("no fixed room");
+  });
+
+  it("flags rooms without coordinates", () => {
+    const [result] = matchImportedScheduleRows(
+      [row],
+      [sampleClass],
+      () => null,
+    );
+    expect(result.unresolvedReason).toContain("no map coordinates");
+  });
+});

--- a/src/lib/schedule-import/match-classes.ts
+++ b/src/lib/schedule-import/match-classes.ts
@@ -1,0 +1,101 @@
+import {
+  isRoomScheduledClassType,
+  NON_ROOM_CLASS_TYPES,
+} from "@lib/amis/room-scheduled-types";
+import type { ClassMapValue } from "@lib/types";
+import { matchKey } from "./parse-import";
+import type { ImportedScheduleRow, ScheduleMatchResult } from "./types";
+
+export type RoomCoordLookup = (
+  roomCode: string,
+) => [number, number] | null | undefined;
+
+function buildClassIndex(classes: ClassMapValue[]): Map<string, ClassMapValue> {
+  const index = new Map<string, ClassMapValue>();
+  for (const row of classes) {
+    if (!row.courseCode || !row.section || !row.type) continue;
+    const key = matchKey(
+      row.courseCode.trim().toUpperCase(),
+      row.section.trim().toUpperCase(),
+      row.type.trim().toUpperCase(),
+    );
+    if (!index.has(key)) index.set(key, row);
+  }
+  return index;
+}
+
+function resolveCoords(
+  roomCode: string | null | undefined,
+  lookup: RoomCoordLookup,
+): [number, number] | null {
+  if (!roomCode) return null;
+  const coords = lookup(roomCode);
+  if (!coords) return null;
+  return coords;
+}
+
+/** Match imported rows against institutional classes for the active term. */
+export function matchImportedScheduleRows(
+  rows: ImportedScheduleRow[],
+  classes: ClassMapValue[],
+  lookupRoomCoords: RoomCoordLookup,
+): ScheduleMatchResult[] {
+  const index = buildClassIndex(classes);
+
+  return rows.map((row) => {
+    if (!isRoomScheduledClassType(row.type)) {
+      const meta = NON_ROOM_CLASS_TYPES[row.type];
+      return {
+        row,
+        matchedClassId: null,
+        roomCode: null,
+        coords: null,
+        unresolvedReason:
+          meta?.description ??
+          `${row.type} sections usually have no fixed room in Room TBA.`,
+      };
+    }
+
+    const key = matchKey(row.courseCode, row.section, row.type);
+    const matched = index.get(key);
+    if (!matched) {
+      return {
+        row,
+        matchedClassId: null,
+        roomCode: null,
+        coords: null,
+        unresolvedReason: "No matching section in Room TBA for this term.",
+      };
+    }
+
+    const roomCode = matched.roomCode?.trim().toUpperCase() ?? null;
+    if (!roomCode) {
+      return {
+        row,
+        matchedClassId: matched.id,
+        roomCode: null,
+        coords: null,
+        unresolvedReason: "Matched section has no room assigned.",
+      };
+    }
+
+    const coords = resolveCoords(roomCode, lookupRoomCoords);
+    if (!coords) {
+      return {
+        row,
+        matchedClassId: matched.id,
+        roomCode,
+        coords: null,
+        unresolvedReason: `Room ${roomCode} has no map coordinates yet.`,
+      };
+    }
+
+    return {
+      row,
+      matchedClassId: matched.id,
+      roomCode,
+      coords,
+      unresolvedReason: null,
+    };
+  });
+}

--- a/src/lib/schedule-import/parse-import.test.ts
+++ b/src/lib/schedule-import/parse-import.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { matchKey, parseScheduleImport } from "./parse-import";
+
+describe("parseScheduleImport", () => {
+  it("parses AMIS Schedule Extractor JSON array", () => {
+    const result = parseScheduleImport(
+      JSON.stringify([
+        {
+          course_code: "CMSC 123",
+          section: "A",
+          type: "LEC",
+          schedule: ["MW 08:00AM-09:00AM"],
+        },
+      ]),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0]).toEqual({
+        courseCode: "CMSC 123",
+        section: "A",
+        type: "LEC",
+        schedule: ["MW 08:00AM-09:00AM"],
+      });
+    }
+  });
+
+  it("strips instructor fields from nested payloads", () => {
+    const result = parseScheduleImport(
+      JSON.stringify({
+        classes: {
+          data: [
+            {
+              course_code: "HK 12",
+              section: "AB",
+              type: "LEC",
+              schedule: ["MW 07:00AM-08:00AM"],
+              faculty: "SHOULD NOT APPEAR",
+            },
+          ],
+        },
+      }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects JSON without course rows", () => {
+    const result = parseScheduleImport(JSON.stringify([{ last_name: "DOE" }]));
+    expect(result.ok).toBe(false);
+  });
+
+  it("parses CSV with standard headers", () => {
+    const csv = [
+      "course_code,section,type,schedule",
+      "CMSC 170,B,LAB,M 01:00PM-04:00PM",
+    ].join("\n");
+    const result = parseScheduleImport(csv);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.rows[0].courseCode).toBe("CMSC 170");
+      expect(result.rows[0].schedule).toEqual(["M 01:00PM-04:00PM"]);
+    }
+  });
+});
+
+describe("matchKey", () => {
+  it("normalizes lookup keys", () => {
+    expect(matchKey("cmsc 123", "a", "lec")).toBe("CMSC 123::A::LEC");
+  });
+});

--- a/src/lib/schedule-import/parse-import.ts
+++ b/src/lib/schedule-import/parse-import.ts
@@ -1,0 +1,254 @@
+import { extractClassRows } from "@lib/amis/normalize-class";
+import type { ImportedScheduleRow, ParseImportResult } from "./types";
+
+const STRIP_KEYS = new Set([
+  "faculty",
+  "instructors",
+  "instructor",
+  "faculty_in_charge",
+  "user",
+  "first_name",
+  "middle_name",
+  "last_name",
+  "formatted_name",
+  "full_name",
+  "name_suffix",
+  "suffix",
+  "email",
+  "contact_email",
+  "phone",
+  "mobile",
+]);
+
+function asString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+function normalizeCourseCode(value: unknown): string | null {
+  const raw = asString(value);
+  return raw ? raw.replace(/\s+/g, " ").toUpperCase() : null;
+}
+
+function normalizeSection(value: unknown): string | null {
+  const raw = asString(value);
+  return raw ? raw.trim().toUpperCase() : null;
+}
+
+function normalizeType(value: unknown): string | null {
+  const raw = asString(value);
+  return raw ? raw.trim().toUpperCase() : null;
+}
+
+function scheduleFromField(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map(asString)
+      .filter((slot): slot is string => slot !== null && slot !== "TBA");
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === "TBA") return [];
+    return trimmed
+      .split(/[|;]/)
+      .map((slot) => slot.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function rowFromRecord(
+  record: Record<string, unknown>,
+): ImportedScheduleRow | null {
+  const courseCode =
+    normalizeCourseCode(record.course_code) ??
+    normalizeCourseCode(record.courseCode) ??
+    normalizeCourseCode(record.course);
+  const section =
+    normalizeSection(record.section) ?? normalizeSection(record.sec);
+  const type =
+    normalizeType(record.type) ??
+    normalizeType(record.class_type) ??
+    normalizeType(record.classType);
+
+  if (!courseCode || !section || !type) return null;
+
+  let schedule = scheduleFromField(record.schedule);
+  if (schedule.length === 0 && Array.isArray(record.class_dates)) {
+    schedule = record.class_dates
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") return null;
+        const row = entry as Record<string, unknown>;
+        const day = asString(row.date);
+        const start = asString(row.start_time)?.replace(/\s+/g, "");
+        const end = asString(row.end_time)?.replace(/\s+/g, "");
+        if (!day || !start || !end) return null;
+        return `${day} ${start}-${end}`;
+      })
+      .filter((slot): slot is string => slot !== null);
+  }
+
+  return {
+    courseCode,
+    section,
+    type,
+    schedule,
+  };
+}
+
+function stripPii(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripPii);
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      if (STRIP_KEYS.has(key)) continue;
+      out[key] = stripPii(nested);
+    }
+    return out;
+  }
+  return value;
+}
+
+function rowsFromJsonPayload(payload: unknown): ImportedScheduleRow[] {
+  const rawRows = extractClassRows(payload);
+  const normalized: ImportedScheduleRow[] = [];
+
+  for (const row of rawRows) {
+    const record = row as Record<string, unknown>;
+    const parsed = rowFromRecord(record);
+    if (parsed) normalized.push(parsed);
+  }
+
+  if (normalized.length === 0 && Array.isArray(payload)) {
+    for (const entry of payload) {
+      if (!entry || typeof entry !== "object") continue;
+      const parsed = rowFromRecord(entry as Record<string, unknown>);
+      if (parsed) normalized.push(parsed);
+    }
+  }
+
+  return normalized;
+}
+
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+    if (char === "," && !inQuotes) {
+      cells.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  cells.push(current.trim());
+  return cells;
+}
+
+function headerIndex(headers: string[], names: string[]): number {
+  const normalized = headers.map((h) =>
+    h.trim().toLowerCase().replace(/\s+/g, "_"),
+  );
+  for (const name of names) {
+    const idx = normalized.indexOf(name);
+    if (idx >= 0) return idx;
+  }
+  return -1;
+}
+
+function rowsFromCsv(text: string): ImportedScheduleRow[] {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length < 2) return [];
+
+  const headers = parseCsvLine(lines[0]);
+  const courseIdx = headerIndex(headers, ["course_code", "course", "code"]);
+  const sectionIdx = headerIndex(headers, ["section", "sec"]);
+  const typeIdx = headerIndex(headers, ["type", "class_type"]);
+  const scheduleIdx = headerIndex(headers, ["schedule", "schedules", "time"]);
+
+  if (courseIdx < 0 || sectionIdx < 0 || typeIdx < 0) return [];
+
+  const rows: ImportedScheduleRow[] = [];
+  for (const line of lines.slice(1)) {
+    const cells = parseCsvLine(line);
+    const record: Record<string, unknown> = {
+      course_code: cells[courseIdx],
+      section: cells[sectionIdx],
+      type: cells[typeIdx],
+    };
+    if (scheduleIdx >= 0) {
+      record.schedule = cells[scheduleIdx];
+    }
+    const parsed = rowFromRecord(record);
+    if (parsed) rows.push(parsed);
+  }
+  return rows;
+}
+
+/** Parse AMIS Schedule Extractor JSON or CSV export into normalized rows. */
+export function parseScheduleImport(text: string): ParseImportResult {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Paste a schedule export to import." };
+  }
+
+  if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+    try {
+      const payload = stripPii(JSON.parse(trimmed)) as unknown;
+      const rows = rowsFromJsonPayload(payload);
+      if (rows.length === 0) {
+        return {
+          ok: false,
+          error:
+            "No course rows found in JSON. Check course_code, section, and type fields.",
+        };
+      }
+      return { ok: true, rows };
+    } catch {
+      return { ok: false, error: "Invalid JSON. Check the export format." };
+    }
+  }
+
+  const csvRows = rowsFromCsv(trimmed);
+  if (csvRows.length === 0) {
+    return {
+      ok: false,
+      error:
+        "Unrecognized format. Paste JSON from AMIS Schedule Extractor or CSV with course_code, section, type, and schedule columns.",
+    };
+  }
+  return { ok: true, rows: csvRows };
+}
+
+export function matchKey(
+  courseCode: string,
+  section: string,
+  type: string,
+): string {
+  return `${courseCode.trim().toUpperCase()}::${section.trim().toUpperCase()}::${type.trim().toUpperCase()}`;
+}

--- a/src/lib/schedule-import/types.ts
+++ b/src/lib/schedule-import/types.ts
@@ -1,0 +1,43 @@
+export type Weekday = "M" | "T" | "W" | "Th" | "F" | "S";
+
+export const WEEKDAYS: Weekday[] = ["M", "T", "W", "Th", "F", "S"];
+
+export const WEEKDAY_LABELS: Record<Weekday, string> = {
+  M: "Mon",
+  T: "Tue",
+  W: "Wed",
+  Th: "Thu",
+  F: "Fri",
+  S: "Sat",
+};
+
+/** Normalized personal schedule row (no instructor PII). */
+export type ImportedScheduleRow = {
+  courseCode: string;
+  section: string;
+  type: string;
+  schedule: string[];
+};
+
+export type ScheduleMatchResult = {
+  row: ImportedScheduleRow;
+  matchedClassId: number | null;
+  roomCode: string | null;
+  coords: [number, number] | null;
+  unresolvedReason: string | null;
+};
+
+export type ScheduleDayStop = {
+  courseCode: string;
+  section: string;
+  type: string;
+  scheduleSlot: string;
+  roomCode: string | null;
+  coords: [number, number] | null;
+  startMinutes: number;
+  endMinutes: number;
+  gapMinutesAfter: number | null;
+};
+
+export type ParseImportResult =
+  { ok: true; rows: ImportedScheduleRow[] } | { ok: false; error: string };

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -24,6 +24,15 @@ import {
 } from "./local/offline-maps";
 import { clearProposeEventDraft } from "./contributor-drafts";
 import type { BuildingTypeFilter } from "@constants/building-types";
+import { orderDayStops, type Weekday } from "./schedule-import/day-stops";
+import { matchImportedScheduleRows } from "./schedule-import/match-classes";
+import { parseScheduleImport } from "./schedule-import/parse-import";
+import type {
+  ImportedScheduleRow,
+  ScheduleDayStop,
+  ScheduleMatchResult,
+} from "./schedule-import/types";
+import { ROOM_SCHEDULE_SCOPE_NOTE } from "./amis/room-scheduled-types";
 
 export type { BuildingTypeFilter };
 
@@ -317,6 +326,8 @@ class LocationStore {
   isTracking: boolean = $state(false);
   destination: [number, number] | null = $state(null);
   routeOrigin: [number, number] | null = $state(null);
+  /** Multi-stop foot route (schedule import or 2-point fallback). */
+  routeWaypoints: [number, number][] | null = $state(null);
   private watchId: number | null = null;
 
   private isWithinBounds(lng: number, lat: number) {
@@ -402,11 +413,25 @@ class LocationStore {
   setDestination = (coords: [number, number]) => {
     this.destination = coords;
     this.routeOrigin = this.coords;
+    this.routeWaypoints = null;
   };
 
   clearDestination = () => {
     this.destination = null;
     this.routeOrigin = null;
+    this.routeWaypoints = null;
+  };
+
+  setRouteWaypoints = (waypoints: [number, number][] | null) => {
+    this.routeWaypoints = waypoints;
+    if (waypoints && waypoints.length >= 2) {
+      this.destination = null;
+      this.routeOrigin = null;
+    }
+  };
+
+  clearRouteWaypoints = () => {
+    this.routeWaypoints = null;
   };
 }
 
@@ -459,7 +484,8 @@ class FloatingControlPanelStore {
   };
 }
 
-export type MapToolsSection = "view" | "legend" | "terrain" | "jeepney";
+export type MapToolsSection =
+  "view" | "legend" | "terrain" | "jeepney" | "schedule";
 
 class MapToolsStore {
   open = $state(false);
@@ -1611,9 +1637,212 @@ class RoomClassesStore {
   };
 }
 
+const SCHEDULE_IMPORT_SS_KEY = "room-tba:schedule-import";
+
+type ScheduleImportPersisted = {
+  importedRows: ImportedScheduleRow[];
+  selectedWeekday: Weekday;
+};
+
+class ScheduleRouteStore {
+  importedRows = $state<ImportedScheduleRow[]>([]);
+  matches = $state<ScheduleMatchResult[]>([]);
+  selectedWeekday = $state<Weekday>("M");
+  matching = $state(false);
+  importError: string | null = $state(null);
+  private _roomCoordCache = new Map<string, [number, number] | null>();
+  private _hydrated = false;
+
+  scopeNote = ROOM_SCHEDULE_SCOPE_NOTE;
+
+  dayStops = $derived(orderDayStops(this.matches, this.selectedWeekday));
+
+  unresolved = $derived(
+    this.matches.filter((match) => match.unresolvedReason !== null),
+  );
+
+  hasImport = $derived(this.importedRows.length > 0);
+
+  init = () => {
+    if (this._hydrated || typeof window === "undefined") return;
+    this._hydrated = true;
+    try {
+      const raw = sessionStorage.getItem(SCHEDULE_IMPORT_SS_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as ScheduleImportPersisted;
+      if (!Array.isArray(parsed.importedRows)) return;
+      this.importedRows = parsed.importedRows;
+      if (parsed.selectedWeekday) {
+        this.selectedWeekday = parsed.selectedWeekday;
+      }
+      void this.rematch();
+    } catch (e) {
+      console.error("Failed to hydrate schedule import:", e);
+    }
+  };
+
+  private persist = () => {
+    if (typeof window === "undefined") return;
+    if (this.importedRows.length === 0) {
+      sessionStorage.removeItem(SCHEDULE_IMPORT_SS_KEY);
+      return;
+    }
+    const payload: ScheduleImportPersisted = {
+      importedRows: this.importedRows,
+      selectedWeekday: this.selectedWeekday,
+    };
+    sessionStorage.setItem(SCHEDULE_IMPORT_SS_KEY, JSON.stringify(payload));
+  };
+
+  private async resolveRoomCoords(
+    roomCode: string,
+  ): Promise<[number, number] | null> {
+    const normalized = roomCode.trim().toUpperCase();
+    if (this._roomCoordCache.has(normalized)) {
+      return this._roomCoordCache.get(normalized) ?? null;
+    }
+
+    let coords: [number, number] | null = null;
+    try {
+      const localRoom = await getLocalRoomByCode(normalized);
+      const room = localRoom
+        ? localRoom
+        : (
+            await getJSONFetch<{ data: RoomData }>(
+              `/api/rooms?code=${encodeURIComponent(normalized)}`,
+            )
+          ).data;
+      const lat = room?.building?.lat;
+      const lon = room?.building?.lon;
+      if (lat != null && lon != null) {
+        coords = [lon, lat];
+      }
+    } catch (e) {
+      console.error(`Failed to resolve room ${normalized}:`, e);
+    }
+
+    this._roomCoordCache.set(normalized, coords);
+    return coords;
+  }
+
+  private async fetchClassesForTerm(
+    termId: number | null,
+  ): Promise<ClassMapValue[]> {
+    const params = new URLSearchParams();
+    if (termId != null) params.set("term_id", String(termId));
+    const query = params.toString();
+    return getJSONFetch<ClassMapValue[]>(
+      query ? `/api/classes?${query}` : "/api/classes",
+    );
+  }
+
+  rematch = async () => {
+    if (this.importedRows.length === 0) {
+      this.matches = [];
+      return;
+    }
+
+    this.matching = true;
+    this.importError = null;
+    try {
+      const classes = await this.fetchClassesForTerm(termStore.activeTermId);
+      const uniqueRooms = new Set<string>();
+      for (const row of classes) {
+        if (row.roomCode) uniqueRooms.add(row.roomCode.trim().toUpperCase());
+      }
+      await Promise.all(
+        [...uniqueRooms].map((code) => this.resolveRoomCoords(code)),
+      );
+
+      this.matches = matchImportedScheduleRows(
+        this.importedRows,
+        classes,
+        (roomCode) =>
+          this._roomCoordCache.get(roomCode.trim().toUpperCase()) ?? null,
+      );
+    } catch (e) {
+      console.error("Schedule match failed:", e);
+      this.importError = "Could not load classes for matching. Try again.";
+      this.matches = [];
+    } finally {
+      this.matching = false;
+    }
+  };
+
+  importText = async (text: string) => {
+    const parsed = parseScheduleImport(text);
+    if (!parsed.ok) {
+      this.importError = parsed.error;
+      return false;
+    }
+
+    this.importedRows = parsed.rows;
+    this.importError = null;
+    this._roomCoordCache.clear();
+    this.persist();
+    await this.rematch();
+    toastStore.show(
+      `Imported ${parsed.rows.length} schedule row${parsed.rows.length === 1 ? "" : "s"}.`,
+      "success",
+    );
+    return true;
+  };
+
+  selectWeekday = (weekday: Weekday) => {
+    this.selectedWeekday = weekday;
+    this.persist();
+  };
+
+  routeDay = (weekday: Weekday = this.selectedWeekday) => {
+    this.selectedWeekday = weekday;
+    this.persist();
+    const stops = orderDayStops(this.matches, weekday);
+    const stopCoords = stops
+      .map((stop) => stop.coords)
+      .filter((coords): coords is [number, number] => coords !== null);
+
+    if (stopCoords.length === 0) {
+      toastStore.show("No routable classes on this day.", "info");
+      return;
+    }
+
+    const waypoints: [number, number][] = [];
+    if (locationStore.coords) {
+      waypoints.push(locationStore.coords);
+    }
+    waypoints.push(...stopCoords);
+
+    if (waypoints.length < 2) {
+      toastStore.show(
+        "Need at least two stops. Enable location or add more classes.",
+        "error",
+      );
+      return;
+    }
+
+    locationStore.setRouteWaypoints(waypoints);
+    toastStore.show(
+      `Routing ${stops.length} class stop${stops.length === 1 ? "" : "s"}.`,
+      "success",
+    );
+  };
+
+  clearImport = () => {
+    this.importedRows = [];
+    this.matches = [];
+    this.importError = null;
+    this._roomCoordCache.clear();
+    locationStore.clearRouteWaypoints();
+    this.persist();
+  };
+}
+
+export type { Weekday, ScheduleDayStop, ScheduleMatchResult };
+
 export const queryStore = new QueryStore();
 export const termStore = new TermStore();
 export const roomClassesStore = new RoomClassesStore();
+export const scheduleRouteStore = new ScheduleRouteStore();
 export const offlineStore = new OfflineStore();
 export const modalStore = new ModalStore();
 export const toastStore = new ToastStore();


### PR DESCRIPTION
## Summary
- Map tools → Schedule: paste AMIS JSON/CSV, match to institutional classes for active term
- Weekday stop list + multi-stop foot routing via `routeWaypoints`
- Client-only sessionStorage; no instructor PII; 16 unit tests

## Test plan
- [x] `bun test src/lib/schedule-import`
- [ ] Map tools → Schedule → import sample → Route this day draws multi-stop path
- [ ] Unresolved rows listed; Clear resets import

Closes #329

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core map routing (`LocationStore`, directions effect) and client-side schedule data handling; PII stripping and session-only storage reduce exposure, but matching depends on `/api/classes` and room resolution correctness.
> 
> **Overview**
> Adds **personal schedule import** from Map tools → **Schedule**: users paste AMIS JSON or CSV, rows are parsed (with instructor PII stripped), matched to institutional classes for the active term, and kept only in **sessionStorage** for the tab.
> 
> New **`schedule-import`** pipeline covers parsing, class/room matching (including non-room types like thesis), and **weekday-ordered stops** with time gaps. **`scheduleRouteStore`** drives import, rematch, and **Route this day**, which builds multi-stop foot waypoints (optional GPS first) via **`locationStore.routeWaypoints`**.
> 
> **`Map.svelte`** now prefers multi-waypoint directions and **fitBounds** when waypoints are set; two-point origin/destination routing remains as fallback. Docs added in **`docs/schedule-import-formats.md`**; **16 unit tests** cover parse, match, and day-stops logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b83491f88087ebca55303bb5c158e252f4422a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->