### PR TITLE
fix(ui): restore browse modal chips, drawer layout, event action row (#339 #319)

### DIFF
--- a/src/components/svelte/CopyLinkButton.svelte
+++ b/src/components/svelte/CopyLinkButton.svelte
@@ -81,7 +81,7 @@
     onclick={handleCopy}
   >
     <span>{label}</span>
-    <Copy size={16} aria-hidden="true" />
+    <Copy size={14} aria-hidden="true" />
   </button>
   {#if feedback === "inline"}
     <span class="copy-link-status" role="status" aria-live="polite">
@@ -134,8 +134,16 @@
   }
 
   [data-variant="chip"] .copy-link-btn {
+    box-sizing: border-box;
     width: max-content;
-    padding: 0.375rem 0.75rem;
+    min-height: 1.75rem;
+    height: 1.75rem;
+    padding: 0 0.5rem;
+    border-radius: 0.75rem;
+    background: #fffafa;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1;
   }
 
   [data-variant="chip"] .copy-link-btn:hover:not(:disabled) {

--- a/src/components/svelte/controls/EventResult.svelte
+++ b/src/components/svelte/controls/EventResult.svelte
@@ -6,6 +6,7 @@
   import Route from "@lucide/svelte/icons/route";
   import X from "@lucide/svelte/icons/x";
   import CopyLinkButton from "@ui/CopyLinkButton.svelte";
+  import MapChromeActionChip from "@ui/map-chrome/MapChromeActionChip.svelte";
   import EntityEditorToggle from "@ui/editor/EntityEditorToggle.svelte";
   import EntityEditorPanel from "@ui/editor/EntityEditorPanel.svelte";
   import EntityEditorFormField from "@ui/editor/EntityEditorFormField.svelte";
@@ -648,10 +649,9 @@
           loading="lazy"
         />
       {/if}
-      <div class="event-actions">
+      <div class="entity-actions">
         {#if primaryLocation && primaryLocation.resolvedLon !== null && primaryLocation.resolvedLat !== null}
-          <button
-            class="primary-action"
+          <MapChromeActionChip
             onclick={() => {
               if (!primaryLocation) return;
               locationStore.requestLocation();
@@ -661,9 +661,9 @@
               ]);
             }}
           >
+            <CornerRightUp size={14} aria-hidden="true" />
             Get directions
-            <CornerRightUp size={18} />
-          </button>
+          </MapChromeActionChip>
         {/if}
         <CopyLinkButton
           url={shareUrl}
@@ -1046,6 +1046,7 @@
 </div>
 
 <style>
+  @import "./entity-detail.css";
   @import "../editor/entity-editor.css";
 
   .event-result {
@@ -1170,31 +1171,6 @@
     gap: 0.35rem;
     margin: 0;
     padding-left: 1rem;
-  }
-
-  .event-actions {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .primary-action {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.375rem;
-    width: max-content;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    font: inherit;
-    font-size: 0.875rem;
-    font-weight: 500;
-    line-height: 1.25;
-    padding: 0.375rem 0.75rem;
-    border: none;
-    background: #7b1113;
-    color: white;
   }
 
   .source-link {

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -140,6 +140,23 @@
     transform: translateX(-100%);
   }
 
+  /* Desktop: pin the open drawer to the viewport band between search and status bar. */
+  @media (min-width: 48.0625rem) {
+    .drawer:not(.is-collapsed) {
+      position: fixed;
+      top: calc(
+        var(--search-block-height, 3.25rem) + var(--map-ui-padding, 0.5rem)
+      );
+      bottom: calc(
+        var(--status-bar-block-height, 2.75rem) +
+          var(--map-ui-padding, 0.5rem) + 0.5rem +
+          env(safe-area-inset-bottom, 0px)
+      );
+      left: var(--map-ui-padding, 0.5rem);
+      height: auto;
+    }
+  }
+
   .drawer-card {
     pointer-events: auto;
     height: 100%;
@@ -227,7 +244,8 @@
       top: var(--mobile-detail-sheet-top-inset);
       right: 0;
       bottom: calc(
-        var(--status-bar-block-height) + env(safe-area-inset-bottom, 0px)
+        var(--status-bar-block-height, 2.75rem) +
+          env(safe-area-inset-bottom, 0px) + 0.25rem
       );
       left: 0;
       width: auto;

--- a/src/components/svelte/controls/entity-detail.css
+++ b/src/components/svelte/controls/entity-detail.css
@@ -135,6 +135,10 @@
 .entity-actions :global(.editor-toggle--toolbar),
 .entity-directions__nav :global(.map-chrome-action-chip) {
   box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
   min-height: 1.75rem;
   height: 1.75rem;
   padding: 0 0.5rem;
@@ -149,6 +153,13 @@
     background-color 0.16s,
     border-color 0.16s,
     box-shadow 0.16s;
+}
+
+.entity-actions :global(.copy-link-btn :global(svg)),
+.entity-actions :global(.map-chrome-action-chip :global(svg)) {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
 }
 
 .entity-actions :global(.map-chrome-action-chip:hover:not(:disabled)),

--- a/src/components/svelte/controls/entity-detail.css
+++ b/src/components/svelte/controls/entity-detail.css
@@ -107,11 +107,23 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  align-content: flex-start;
   gap: 0.375rem;
   /* Scroll containers (overflow-y: auto) clip outline rings; inset focus + padding avoids trim. */
   padding: 2px;
   margin: -2px;
   overflow: visible;
+}
+
+.entity-actions > :global(.copy-link-wrapper),
+.entity-actions > :global(.map-chrome-action-chip),
+.entity-actions > :global(.editor-toggle--toolbar) {
+  flex-shrink: 0;
+}
+
+.entity-actions > :global(.copy-link-wrapper) {
+  display: inline-flex;
+  align-items: center;
 }
 
 .entity-directions__nav {

--- a/src/components/svelte/modal/FilterModalContent.svelte
+++ b/src/components/svelte/modal/FilterModalContent.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
+  import X from "@lucide/svelte/icons/x";
   import { getAppData } from "@lib/context";
   import { modalStore, queryStore } from "@lib/store.svelte";
   import type { QueryStoreState } from "@lib/store.svelte";
 
+  type BrowseTab = "buildings" | "colleges" | "divisions";
+
   const appData = getAppData();
   const { buildings, colleges, divisions } = $derived(appData());
-  let type: "buildings" | "colleges" | "divisions" = $state("buildings");
+  let activeTab = $state<BrowseTab>("buildings");
+
+  const tabs: { id: BrowseTab; label: string }[] = [
+    { id: "buildings", label: "Buildings" },
+    { id: "colleges", label: "Colleges" },
+    { id: "divisions", label: "Divisions" },
+  ];
 
   function filterButtonClick(
     filter_type: Exclude<QueryStoreState["category"], "room" | null>,
@@ -19,81 +28,265 @@
       modalStore.closeModal();
     };
   }
+
+  function formatBuildingLabel(name: string) {
+    return name.replace(" Building", "");
+  }
+
+  function formatCollegeLabel(name: string) {
+    return name.replace("College of ", "");
+  }
+
+  function formatDivisionLabel(name: string) {
+    return name.replace(/(Department of |Institute of)/, "");
+  }
 </script>
 
-<div class="filters-wrap">
-  <div class="filter-controls">
+<div class="filter-modal">
+  <header class="filter-modal__header">
+    <h2 class="filter-modal__title" id="filter-modal-title">Browse campus</h2>
     <button
-      class:active={type === "buildings"}
-      onclick={() => (type = "buildings")}
-      id="building-button">Buildings</button
+      type="button"
+      class="filter-modal__close"
+      aria-label="Close browse dialog"
+      onclick={() => modalStore.closeModal()}
     >
-    <button
-      class:active={type === "colleges"}
-      onclick={() => (type = "colleges")}>Colleges</button
-    >
-    <button
-      class:active={type === "divisions"}
-      onclick={() => (type = "divisions")}>Divisions</button
-    >
+      <X size={20} aria-hidden="true" />
+    </button>
+  </header>
+
+  <div class="filter-modal__tabs" role="tablist" aria-label="Browse by type">
+    {#each tabs as tab (tab.id)}
+      <button
+        type="button"
+        role="tab"
+        id="filter-tab-{tab.id}"
+        class="filter-modal__tab"
+        class:filter-modal__tab--active={activeTab === tab.id}
+        aria-selected={activeTab === tab.id}
+        aria-controls="filter-panel-{tab.id}"
+        onclick={() => (activeTab = tab.id)}
+      >
+        {tab.label}
+      </button>
+    {/each}
   </div>
-  <div class="filters">
-    {#if type === "buildings"}
-      {#each buildings as { building_name }}
-        <button
-          class="filter-button"
-          onclick={filterButtonClick("building", building_name)}
-          >{building_name.replace(" Building", "")}</button
-        >
-      {/each}
-    {:else if type === "colleges"}
-      {#each colleges as { college_name }}
-        <button
-          class="filter-button"
-          onclick={filterButtonClick("college", college_name)}
-          >{college_name.replace("College of ", "")}</button
-        >
-      {/each}
-    {:else}
-      {#each divisions as { division_name }}
-        <button
-          class="filter-button"
-          onclick={filterButtonClick("division", division_name)}
-        >
-          {division_name.replace(/(Department\ of |Institute\ of)/, "")}
-        </button>
-      {/each}
-    {/if}
+
+  <div
+    class="filter-modal__scroll"
+    role="tabpanel"
+    id="filter-panel-{activeTab}"
+    aria-labelledby="filter-tab-{activeTab}"
+  >
+    <div class="filter-modal__grid">
+      {#if activeTab === "buildings"}
+        {#each buildings as { building_name } (building_name)}
+          <button
+            type="button"
+            class="filter-modal__chip"
+            onclick={filterButtonClick("building", building_name)}
+          >
+            <span class="filter-modal__chip-label"
+              >{formatBuildingLabel(building_name)}</span
+            >
+          </button>
+        {/each}
+      {:else if activeTab === "colleges"}
+        {#each colleges as { college_name } (college_name)}
+          <button
+            type="button"
+            class="filter-modal__chip"
+            onclick={filterButtonClick("college", college_name)}
+          >
+            <span class="filter-modal__chip-label"
+              >{formatCollegeLabel(college_name)}</span
+            >
+          </button>
+        {/each}
+      {:else}
+        {#each divisions as { division_name } (division_name)}
+          <button
+            type="button"
+            class="filter-modal__chip"
+            onclick={filterButtonClick("division", division_name)}
+          >
+            <span class="filter-modal__chip-label"
+              >{formatDivisionLabel(division_name)}</span
+            >
+          </button>
+        {/each}
+      {/if}
+    </div>
   </div>
 </div>
 
 <style>
-  .filters {
+  .filter-modal {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-height: 0;
+    max-height: min(78dvh, 36rem);
+    width: min(100%, 40rem);
+    padding: 0.75rem 0.875rem 0.875rem;
+    box-sizing: border-box;
+  }
+
+  .filter-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     gap: 0.5rem;
+    flex-shrink: 0;
   }
-  .filter-controls {
-    margin-bottom: 1rem;
-    button.active {
-      border-color: transparent;
-      background-color: hsl(5, 53%, 32%);
-      color: white;
-    }
+
+  .filter-modal__title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.25;
+    color: hsl(5, 53%, 22%);
   }
-  .filters-wrap {
+
+  .filter-modal__close {
+    all: unset;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    flex-shrink: 0;
+    border-radius: 0.5rem;
+    color: hsl(0, 0%, 18%);
+    cursor: pointer;
+  }
+
+  .filter-modal__close:hover,
+  .filter-modal__close:focus-visible {
+    background-color: hsl(0, 0%, 96%);
+  }
+
+  .filter-modal__close:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 1px;
+  }
+
+  .filter-modal__tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.375rem;
+    flex-shrink: 0;
+  }
+
+  .filter-modal__tab {
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.75rem;
+    padding: 0.5rem 0.375rem;
+    border: 1px solid hsl(0, 0%, 83%);
+    border-radius: 0.625rem;
+    background: white;
+    color: hsl(0, 0%, 28%);
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.2;
+    text-align: center;
+    cursor: pointer;
+    transition:
+      background-color 0.125s,
+      border-color 0.125s,
+      color 0.125s;
+  }
+
+  .filter-modal__tab--active {
+    border-color: hsl(5, 53%, 32%);
+    background-color: hsl(5, 53%, 32%);
+    color: white;
+  }
+
+  .filter-modal__tab:hover:not(.filter-modal__tab--active),
+  .filter-modal__tab:focus-visible:not(.filter-modal__tab--active) {
+    border-color: hsl(5, 53%, 32%);
+    color: hsl(5, 53%, 32%);
+  }
+
+  .filter-modal__tab:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 2px;
+  }
+
+  .filter-modal__scroll {
+    flex: 1 1 auto;
+    min-height: 0;
     overflow-y: auto;
-    button {
-      font-size: 0.875rem;
-      padding: 0.5rem 1rem;
-      border-radius: 0.25rem;
-      border: 1px solid hsl(0, 0%, 83%);
-      transition: all 0.125s;
-      &:hover:not(.active),
-      &:focus-visible:not(.active) {
-        border-color: hsl(5, 53%, 32%);
-        color: hsl(5, 53%, 32%);
-      }
+    overscroll-behavior: contain;
+    padding: 0.125rem 0.125rem 0.25rem;
+    margin: 0 -0.125rem;
+  }
+
+  .filter-modal__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
+    gap: 0.5rem;
+    align-items: stretch;
+  }
+
+  .filter-modal__chip {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.75rem;
+    width: 100%;
+    padding: 0.5rem 0.625rem;
+    border: 1px solid hsl(0, 0%, 83%);
+    border-radius: 0.625rem;
+    background: white;
+    color: hsl(0, 0%, 18%);
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1.25;
+    text-align: center;
+    cursor: pointer;
+    transition:
+      background-color 0.125s,
+      border-color 0.125s,
+      color 0.125s;
+  }
+
+  .filter-modal__chip-label {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    word-break: break-word;
+  }
+
+  .filter-modal__chip:hover,
+  .filter-modal__chip:focus-visible {
+    border-color: hsl(5, 53%, 32%);
+    background-color: hsl(5, 53%, 98%);
+    color: hsl(5, 53%, 22%);
+  }
+
+  .filter-modal__chip:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 2px;
+  }
+
+  @media screen and (max-width: 31.25rem) {
+    .filter-modal {
+      max-height: min(82dvh, none);
+      padding: 0.625rem 0.75rem 0.75rem;
+    }
+
+    .filter-modal__grid {
+      grid-template-columns: repeat(auto-fill, minmax(8.25rem, 1fr));
     }
   }
 </style>

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -55,7 +55,9 @@
       aria-modal="true"
       aria-labelledby={modalStore.type === "landing"
         ? "landing-modal-title"
-        : undefined}
+        : modalStore.type === "filter"
+          ? "filter-modal-title"
+          : undefined}
       aria-label={modalAriaLabel}
       in:fly={modalContentReveal(reducedMotion.current)}
       out:fly={modalContentDismiss(reducedMotion.current)}

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -6,7 +6,11 @@
     searchLocalRooms,
   } from "@lib/local/data/utils";
   import { buildEntitySuggestions } from "@lib/search-suggestions";
-  import { queryStore, buildingTypeFilter } from "@lib/store.svelte";
+  import {
+    queryStore,
+    buildingTypeFilter,
+    modalStore,
+  } from "@lib/store.svelte";
   import {
     buildingMatchesTypeFilter,
     dormMatchesTypeFilter,
@@ -134,6 +138,15 @@
 <div class="suggestions-container search-suggestions">
   <!-- class:force-visible={queryStore.inputValue === ""} -->
   {#if queryStore.inputValue === ""}
+    <div class="browse-campus-row">
+      <button
+        type="button"
+        class="browse-campus-btn"
+        onclick={() => modalStore.openModal("filter")}
+      >
+        Browse buildings & rooms
+      </button>
+    </div>
     {#if queryStore.recentSearches.length !== 0}
       <h2 class="suggestions-header">Recent searches</h2>
       {#each queryStore.recentSearches as { category, value, eventSlug }, id (id)}
@@ -207,6 +220,43 @@
     letter-spacing: 0.02em;
     text-transform: uppercase;
     color: hsl(0, 0%, 45%);
+  }
+
+  .browse-campus-row {
+    padding: 0 0.5rem 0.375rem;
+  }
+
+  .browse-campus-btn {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 2.75rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid hsl(5, 53%, 32%);
+    border-radius: 0.625rem;
+    background: hsl(5, 53%, 98%);
+    color: hsl(5, 53%, 28%);
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.25;
+    cursor: pointer;
+    transition:
+      background-color 0.125s,
+      border-color 0.125s;
+  }
+
+  .browse-campus-btn:hover,
+  .browse-campus-btn:focus-visible {
+    background: hsl(5, 53%, 94%);
+    border-color: hsl(5, 53%, 26%);
+  }
+
+  .browse-campus-btn:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 2px;
   }
 
   .alias-hint {


### PR DESCRIPTION
## Summary
Restores three UI fixes that were committed locally but never pushed before the batch PR merges:

- **Browse campus modal** — equal tab/chip grid, header/close, search suggestions entry (`471eac0`)
- **Side panel drawer** — desktop fixed inset above status bar (`d631fb9`, #339)
- **Event detail actions** — shared `entity-actions` chip row for Get directions / Copy link / Suggest changes (#319)

EventResult changes were applied selectively (not the full messy local commit that deleted unrelated files).

## Test plan
- [x] `bun test src` (109 pass)
- [ ] Search (empty) → Browse buildings & rooms → modal tabs/chips aligned
- [ ] Open building/event → drawer stops above status bar on desktop
- [ ] Event panel → three action chips same height/style

Refs #339, #319

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and layout-only changes to modals, drawer CSS, and action chip styling; no API, auth, or data logic changes.
> 
> **Overview**
> Restores three map UI fixes: **browse campus**, **side drawer layout**, and **event detail actions**.
> 
> The **Browse campus** flow is redesigned: empty search shows a **Browse buildings & rooms** button that opens the filter modal with a titled header, close control, equal-width **tabs**, and a scrollable **chip grid** (with label formatting helpers). `Modal` wires `aria-labelledby` to `filter-modal-title` for that dialog.
> 
> On **desktop**, the open details **drawer** uses `position: fixed` between the search block and the status bar (with CSS variable fallbacks). **Mobile** bottom inset for the drawer also picks up a default status-bar height and a small extra gap.
> 
> **Event** panels join other entity details: **Get directions** uses `MapChromeActionChip` in a shared `entity-actions` row (via `entity-detail.css`), with matching **Copy link** chip sizing and 14px icons. `CopyLinkButton`’s `chip` variant is tightened to the same 1.75rem height and typography.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b730c3c26c1f2b296b7fdc1e0273a9ea2721bba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->