### PR TITLE
feat(opt): seamless bootstrap, offline toasts, latency health, perf spot-check

### DIFF
--- a/scripts/performance-spot-check.sh
+++ b/scripts/performance-spot-check.sh
@@ -39,4 +39,30 @@ find public -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \) | whi
   fi
 done
 
+# Check total JS payload
+echo "\n--- Total JS payload ---"
+total_js=$(find dist/client -name "*.js" | xargs wc -c | tail -1 | awk '{print $1}')
+total_js_kb=$((total_js / 1024))
+echo "  Total JS: ${total_js_kb}KB"
+if [ "$total_js_kb" -gt 2000 ]; then
+  echo "  WARNING: total JS exceeds 2MB"
+fi
+
+# Check for uncompressed assets
+echo "\n--- Compression check ---"
+find dist/client -name "*.js" -o -name "*.css" | head -5 | while read -r f; do
+  gz=$(gzip -9 -c "$f" | wc -c)
+  orig=$(wc -c < "$f")
+  ratio=$((100 * gz / orig))
+  echo "  $(basename "$f"): ${ratio}% of original after gzip"
+done
+
+# Check API health if server is running
+echo "\n--- API health ---"
+if curl -sf http://localhost:4321/api/health > /dev/null 2>&1; then
+  echo "  /api/health reachable"
+else
+  echo "  SKIP: dev server not running (run 'bun dev' first to check latency)"
+fi
+
 echo "\n=== Done ==="

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -10,6 +10,7 @@
     queryStore,
     syncToastStore,
     appBootstrapStore,
+    toastStore,
   } from "@lib/store.svelte";
   import type {
     BuildingData,
@@ -298,11 +299,19 @@
   onMount(() => {
     applyData(EMPTY_DB_DATA);
     loaded = true;
-    dismissStaticLoadingShell();
-    appBootstrapStore.complete();
     appBootstrapStore.setRetryHandler(() => {
       void refreshFromNetwork(false);
     });
+
+    const onOffline = () => {
+      toastStore.show("You are offline. Campus data may be stale.", "info");
+    };
+    const onOnline = () => {
+      toastStore.show("Back online. Syncing latest data...", "success");
+      void refreshFromNetwork(appBootstrapStore.hasCachedData);
+    };
+    window.addEventListener("offline", onOffline);
+    window.addEventListener("online", onOnline);
 
     void (async () => {
       try {
@@ -319,11 +328,16 @@
         appBootstrapStore.setHasCachedData(hasCache);
         if (hasCache) {
           applyData(cached);
+          dismissStaticLoadingShell();
         }
 
         await refreshFromNetwork(hasCache);
+        if (!hasCache) {
+          dismissStaticLoadingShell();
+        }
       } catch (error) {
         console.error("Bootstrap failed", error);
+        dismissStaticLoadingShell();
         if (appBootstrapStore.hasCachedData) {
           appBootstrapStore.complete();
         } else {
@@ -336,6 +350,11 @@
         }
       }
     })();
+
+    return () => {
+      window.removeEventListener("offline", onOffline);
+      window.removeEventListener("online", onOnline);
+    };
   });
 
   setAppData(() => appData);

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -14,6 +14,7 @@
     sidePanelStore,
     floatingControlPanelStore,
     jeepneyStore,
+    appBootstrapStore,
   } from "@lib/store.svelte";
   import Modal from "@ui/modal/Modal.svelte";
   import MainControls from "@ui/controls/MainControls.svelte";
@@ -46,7 +47,6 @@
     localStorage.setItem("recent-search", JSON.stringify(queryHistory));
   };
   onMount(() => {
-    const hideLanding = localStorage.getItem("hideLandingModal");
     const recentSearchesLS = localStorage.getItem("recent-search");
     try {
       const parsedSearches: unknown[] = JSON.parse(recentSearchesLS ?? "[]");
@@ -78,8 +78,15 @@
       floatingControlPanelStore.openPanel = "suggest-addition";
       window.history.replaceState({}, "", window.location.pathname);
     }
+  });
 
-    if (!suppressLandingModal && hideLanding !== "true") {
+  $effect(() => {
+    if (
+      appBootstrapStore.phase === "ready" &&
+      !suppressLandingModal &&
+      localStorage.getItem("hideLandingModal") !== "true" &&
+      !modalStore.open
+    ) {
       modalStore.openModal("landing");
     }
   });
@@ -128,6 +135,8 @@
     if (e.key === "Escape") {
       if (modalStore.open) {
         modalStore.closeModal();
+      } else if (building3DStore.buildingName) {
+        building3DStore.close();
       } else if (adminAuthStore.loginOpen) {
         adminAuthStore.closeLogin();
       } else if (editorChromeStore.additionModalOpen) {
@@ -255,13 +264,12 @@
     --motion-duration-shelf: 260ms;
     --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
     --motion-ease-in: cubic-bezier(0.4, 0, 1, 1);
-    /* Stacking contract — highest first, only one primary overlay at a time.
-       map(0) < ui-layer(10) < map-tools(15) < chrome-popover(17) < modal(100)
-       < login-modal(200) < toast(1000) < term-selector(1200).
-       When a modal opens, Escape or backdrop-click closes lower layers first.
-       (#302) */
+    /* Stacking contract — highest first; blocking overlays dismiss ephemeral chrome.
+       map(0) < side-panel(2) < search-elevated(12) < map-tools(15) < chrome-popover(17)
+       < modal(100) < login-modal(200) < toast(1000). (#302) */
     --z-map: 0;
     --z-side-panel: 2;
+    --z-search-elevated: 12;
     --z-status-bar: 3;
     --z-map-tools: 15;
     --z-chrome-popover: 17;

--- a/src/lib/__tests__/latency-tracker.test.ts
+++ b/src/lib/__tests__/latency-tracker.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "bun:test";
+import {
+  recordLatency,
+  getLatencyStats,
+  clearLatencySamples,
+} from "@lib/latency-tracker";
+
+describe("latency tracker", () => {
+  it("records and reports p50/p95/p99", () => {
+    clearLatencySamples();
+    for (let i = 1; i <= 100; i++) {
+      recordLatency("/api/test", i * 10);
+    }
+    const stats = getLatencyStats(10);
+    expect(stats.totalRequests).toBe(100);
+    expect(stats.overall?.p50).toBe(500);
+    expect(stats.overall?.p95).toBe(950);
+    expect(stats.overall?.p99).toBe(990);
+    const routeStats = stats.routes["/api/test"];
+    expect(routeStats).toBeDefined();
+    expect(routeStats!.count).toBe(100);
+  });
+
+  it("filters old samples", () => {
+    clearLatencySamples();
+    recordLatency("/api/old", 100);
+    const stats = getLatencyStats(-1);
+    expect(stats.totalRequests).toBe(0);
+  });
+});

--- a/src/lib/latency-tracker.ts
+++ b/src/lib/latency-tracker.ts
@@ -1,0 +1,68 @@
+type LatencySample = {
+  pathname: string;
+  duration: number;
+  timestamp: number;
+};
+
+const MAX_SAMPLES = 500;
+let samples: LatencySample[] = [];
+
+export function recordLatency(pathname: string, duration: number) {
+  samples.push({ pathname, duration, timestamp: Date.now() });
+  if (samples.length > MAX_SAMPLES) samples = samples.slice(-MAX_SAMPLES);
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+export function getLatencyStats(cutoffMinutes = 10) {
+  const cutoff = Date.now() - cutoffMinutes * 60_000;
+  const recent = samples.filter((s) => s.timestamp >= cutoff);
+
+  const byRoute = new Map<string, number[]>();
+  for (const s of recent) {
+    const arr = byRoute.get(s.pathname);
+    if (arr) {
+      arr.push(s.duration);
+    } else {
+      byRoute.set(s.pathname, [s.duration]);
+    }
+  }
+
+  const routes: Record<
+    string,
+    { count: number; p50: number; p95: number; p99: number }
+  > = {};
+
+  for (const [pathname, durations] of byRoute) {
+    const sorted = durations.slice().sort((a, b) => a - b);
+    routes[pathname] = {
+      count: sorted.length,
+      p50: percentile(sorted, 50),
+      p95: percentile(sorted, 95),
+      p99: percentile(sorted, 99),
+    };
+  }
+
+  const all = recent.map((s) => s.duration).sort((a, b) => a - b);
+
+  return {
+    totalRequests: all.length,
+    windowMinutes: cutoffMinutes,
+    overall: all.length
+      ? {
+          p50: percentile(all, 50),
+          p95: percentile(all, 95),
+          p99: percentile(all, 99),
+        }
+      : null,
+    routes,
+  };
+}
+
+export function clearLatencySamples() {
+  samples = [];
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,7 @@ import {
   applySupabaseCacheHeaders,
   refreshSupabaseSession,
 } from "./lib/supabase/session";
+import { recordLatency } from "./lib/latency-tracker";
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url;
@@ -37,6 +38,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   const response = await next();
   const duration = Math.round(performance.now() - start);
+  recordLatency(pathname, duration);
 
   // Add Server-Timing header for API routes so Vercel logs and browsers
   // can surface slow endpoints during QA (#313).

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from "astro";
+import { getLatencyStats } from "@lib/latency-tracker";
+
+export const prerender = false;
+
+export const GET: APIRoute = async () => {
+  const stats = getLatencyStats(10);
+
+  return new Response(
+    JSON.stringify(
+      {
+        status: "ok",
+        timestamp: new Date().toISOString(),
+        latency: stats,
+      },
+      null,
+      2,
+    ),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+};


### PR DESCRIPTION
Implements 4 optimization tickets.

Tickets: #336 #101 #313 #263

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UX and dev/QA tooling; `/api/health` exposes timing aggregates only (no auth) and uses in-process memory, which is acceptable for ops but not sensitive data.
> 
> **Overview**
> Improves **startup and connectivity UX** and adds **lightweight server observability** for QA.
> 
> **Bootstrap & offline:** The static loading shell stays until cached campus data is applied or the first network bootstrap finishes (including failure paths), instead of dismissing immediately on mount. **Offline/online** listeners show info/success toasts and trigger a refresh when connectivity returns.
> 
> **Landing & chrome:** The landing modal opens only after `appBootstrapStore` reaches **ready**, and only when no other modal is open. **Escape** now closes the 3D building viewer before lower-priority chrome. Z-index notes add `--z-search-elevated`.
> 
> **Latency & health:** Middleware records per-path handler duration in an in-memory tracker (capped samples, rolling window). New **`GET /api/health`** returns `status` plus aggregate and per-route **p50/p95/p99**; existing API routes still get **Server-Timing** and slow-request warnings.
> 
> **Perf script:** `performance-spot-check.sh` now warns on total JS over 2MB, samples gzip ratios for JS/CSS, and optionally curls `/api/health` when the dev server is up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fcb46986609d9ef3c1db3273381a7c419b4bfc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->