### PR TITLE
release: staging → main (10 small tickets — #94 #213 #246 #240 #241 #128 #268 #269 #270 #237)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Supabase Postgres connection string (Settings → Database → Connection string).
 # Required for local dev, Vercel Production, and all Vercel Preview builds (prerender).
+# Legacy data/info.db (bun:sqlite) is for old seed scripts only — not used at runtime.
 DATABASE_URL=
 ADMIN_PASSWORD=
 # Preferred signing secret for admin_session cookies (falls back to ADMIN_PASSWORD if unset).

--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ Open **http://localhost:4321**. Without `DATABASE_URL`, the dev server starts bu
 | `bun run format`             | Prettier write                                                                               |
 | `bunx drizzle-kit studio`    | Browse/edit Postgres visually                                                                |
 | `bun run seed:aliases`       | Seed building aliases from `public/room_info.json`                                           |
+| `bun run import:amis-classes` | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`)                                   |
 | `bun run import:final-exams` | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`) |
 
-Legacy **`data/info.db`** SQLite is only for old seed/export scripts. Production does not use it.
+Legacy **`data/info.db`** SQLite is only for old seed/export scripts (`bun:sqlite`, not runtime). Production uses Supabase Postgres via `DATABASE_URL`. Archived SQLite migrations live in `drizzle-migrations/` — do not edit; active schema is `drizzle/`.
 
 Optional env vars (R2 uploads, Supabase Auth client): see [`.env.example`](.env.example).
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,6 @@
         "@vitejs/plugin-basic-ssl": "^2.3.0",
         "astro": "^7.0.3",
         "bcrypt": "^6.0.0",
-        "better-sqlite3": "^12.11.1",
         "dotenv": "^17.4.2",
         "drizzle-orm": "^0.45.2",
         "es-toolkit": "^1.49.0",
@@ -1005,7 +1004,7 @@
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
-    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
@@ -1939,7 +1938,7 @@
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
@@ -2709,8 +2708,6 @@
 
     "read-package-up/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
     "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "safe-push-apply/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
@@ -2729,8 +2726,6 @@
 
     "signale/figures": ["figures@2.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA=="],
 
-    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
     "stringify-object/is-obj": ["is-obj@1.0.1", "", {}, "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg=="],
 
     "svelte/aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
@@ -2741,7 +2736,7 @@
 
     "svelte-eslint-parser/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
-    "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -2752,6 +2747,8 @@
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "tsx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "tunnel-agent/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 

--- a/data/seed.ts
+++ b/data/seed.ts
@@ -1,3 +1,4 @@
+// Legacy SQLite seed only — runtime data is Supabase Postgres (DATABASE_URL).
 // src/seed.ts
 
 import Database from "bun:sqlite";

--- a/docs/amis-com-refresh-runbook.md
+++ b/docs/amis-com-refresh-runbook.md
@@ -1,0 +1,64 @@
+# AMIS class refresh during COM
+
+Use this when AMIS publishes an updated class export during **change of matriculation (COM)**.
+
+## Prerequisites
+
+- `DATABASE_URL` in `.env` (Supabase Postgres)
+- Sanitized export at `data/amis-*-{termId}.json`, or a fresh fetch:
+
+```sh
+AMIS_BEARER_TOKEN=… AMIS_SESSION_ID=… \
+  bun run import:amis-classes -- --term-id 1252 --fetch
+```
+
+Bearer tokens expire in about an hour. Fetch once, then reuse the saved JSON for repeat imports.
+
+## Refresh a term (default upsert)
+
+```sh
+DATABASE_URL=… bun run import:amis-classes -- --term-id 1252
+```
+
+This **upserts** by natural key (`term_id` + course + section + type):
+
+- New sections are inserted
+- Changed schedules/rooms/titles are updated
+- Unchanged rows are left alone
+- Stale sections **remain** unless you pass `--replace-term`
+
+The script prints a categorized report (room matches, TBA/missing, unmatched facilities, DB diff).
+
+## Remove stale sections after COM
+
+When AMIS drops sections entirely, pass:
+
+```sh
+DATABASE_URL=… bun run import:amis-classes -- --term-id 1252 --replace-term
+```
+
+Rows for that term that are no longer in the export are deleted after upsert.
+
+## Dry run
+
+```sh
+bun run import:amis-classes -- --term-id 1252 --dry-run
+```
+
+## Verify in the app
+
+1. Import bumps the `classes` sync key — browsers refetch on next online visit (no redeploy).
+2. Open the map, pick the term in the status bar, search a course that changed.
+3. Confirm room and schedule match the latest export.
+
+## Cadence
+
+During active COM (midyear Jun–Jul, sem start Jan/May), refresh **weekly** or whenever editors report AMIS posted a new dump.
+
+## Facility aliases
+
+Unmatched AMIS facility strings can be mapped via `aliases` rows with `target_type = room`. See [amis-facility-aliases.md](./amis-facility-aliases.md).
+
+## TBA sections
+
+Rows with no `facility_id` are **not imported** (no map pin). They appear in the import report under “Missing facility”. Product policy: list-only / no pin until a room is known — see issue #300.

--- a/docs/amis-facility-aliases.md
+++ b/docs/amis-facility-aliases.md
@@ -1,0 +1,30 @@
+# AMIS facility aliases
+
+AMIS `facility_id` strings often differ from `rooms.room_code` (hyphens, spacing, abbreviations). The import script resolves rooms in two passes:
+
+1. **Direct match** — normalized facility string equals a room code
+2. **Alias match** — normalized string matches an `aliases` row with `target_type = room`
+
+## Add an alias (editor / admin)
+
+Use the admin aliases API or insert via Drizzle:
+
+- `alias`: human-readable AMIS string (e.g. `PS B-203`)
+- `normalized_alias`: same normalization as import (`normalizeFacilityKey`)
+- `target_type`: `room`
+- `target_id`: `rooms.id` for the canonical room
+
+Re-run the import for the term; the report shows **alias-matched** counts separately from direct matches.
+
+## Import report categories
+
+| Category | Meaning |
+| --- | --- |
+| Direct room match | Facility string matched `rooms.room_code` |
+| Via alias | Matched through `aliases` (`target_type = room`) |
+| Missing facility | AMIS row has no facility (TBA) — **skipped**, not pinned |
+| Unmatched facility | Non-empty string with no room or alias — fix alias or room data |
+
+## TBA policy
+
+Sections with no facility after COM are **omitted from the map** today. They remain visible in the import report so editors can add aliases or wait for AMIS updates. We do not assign a synthetic default room id.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@vitejs/plugin-basic-ssl": "^2.3.0",
     "astro": "^7.0.3",
     "bcrypt": "^6.0.0",
-    "better-sqlite3": "^12.11.1",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "es-toolkit": "^1.49.0",

--- a/scripts/import-amis-classes.ts
+++ b/scripts/import-amis-classes.ts
@@ -11,7 +11,11 @@
  *   --from-json path   Import from saved JSON only (no AMIS call)
  *   --scrub-exports    Re-sanitize all data/amis-*.json in place (no AMIS / DB)
  *   --dry-run          Parse + map only; no DB writes
- *   --no-replace       Do not delete existing rows for the term before insert
+ *   --replace-term     Remove term rows not present in the new export (COM stale sections)
+ *   --no-replace       Legacy alias; upsert without stale removal (default)
+ *
+ * Default import upserts by natural key (term + course + section + type).
+ * See docs/amis-com-refresh-runbook.md for COM refresh workflow.
  *
  * CRS term_id is chronological within the AY: 1251 = 1st sem, 1252 = 2nd sem, 1253 = midyear.
  * Only LEC and LAB rows with a resolvable room are imported (thesis, special problem, etc. usually have no room in AMIS).
@@ -31,19 +35,27 @@ import { dirname } from "node:path";
 import pg from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { eq } from "drizzle-orm";
-import { classesTable, roomsTable, updateTable } from "@drizzle/schema";
+import {
+  aliasesTable,
+  classesTable,
+  roomsTable,
+  updateTable,
+} from "@drizzle/schema";
 import { fetchAmisClasses } from "@lib/amis/fetch-classes";
 import { defaultAmisExportPath } from "@lib/amis/export-path";
-import { extractClassRows } from "@lib/amis/normalize-class";
 import {
-  normalizeAmisClass,
-  normalizeFacilityKey,
-} from "@lib/amis/normalize-class";
+  buildRoomLookup,
+  classNaturalKey,
+  formatImportReport,
+  resolveImportRows,
+  summarizeImportChanges,
+} from "@lib/amis/import-classes";
+import { extractClassRows } from "@lib/amis/normalize-class";
+import { normalizeAmisClass } from "@lib/amis/normalize-class";
 import {
   amisExportContainsInstructorPii,
   sanitizeAmisRows,
 } from "@lib/amis/sanitize-row";
-import { isRoomScheduledClassType } from "@lib/amis/room-scheduled-types";
 import { randomUUID } from "node:crypto";
 
 config({ path: ".env" });
@@ -51,7 +63,7 @@ config({ path: ".env" });
 type CliOptions = {
   termId: number;
   dryRun: boolean;
-  replace: boolean;
+  replaceTerm: boolean;
   fetch: boolean;
   fromJson: string | null;
   scrubExports: boolean;
@@ -60,7 +72,7 @@ type CliOptions = {
 function parseArgs(argv: string[]): CliOptions {
   let termId = 1253;
   let dryRun = false;
-  let replace = true;
+  let replaceTerm = false;
   let fetch = false;
   let fromJson: string | null = null;
   let scrubExports = false;
@@ -71,8 +83,10 @@ function parseArgs(argv: string[]): CliOptions {
       termId = Number(argv[++i]);
     } else if (arg === "--dry-run") {
       dryRun = true;
+    } else if (arg === "--replace-term" || arg === "--replace") {
+      replaceTerm = true;
     } else if (arg === "--no-replace") {
-      replace = false;
+      replaceTerm = false;
     } else if (arg === "--fetch") {
       fetch = true;
     } else if (arg === "--from-json") {
@@ -86,7 +100,7 @@ function parseArgs(argv: string[]): CliOptions {
     throw new Error("Invalid --term-id");
   }
 
-  return { termId, dryRun, replace, fetch, fromJson, scrubExports };
+  return { termId, dryRun, replaceTerm, fetch, fromJson, scrubExports };
 }
 
 function saveSanitizedExport(
@@ -225,101 +239,101 @@ async function main() {
   const db = drizzle(pool);
 
   try {
-    const rooms = await db
-      .select({ id: roomsTable.id, code: roomsTable.roomCode })
-      .from(roomsTable);
-    const roomIdByKey = new Map<string, number>();
-    for (const room of rooms) {
-      roomIdByKey.set(normalizeFacilityKey(room.code), room.id);
-    }
+    const [rooms, roomAliases, existingClasses] = await Promise.all([
+      db.select({ id: roomsTable.id, code: roomsTable.roomCode }).from(roomsTable),
+      db
+        .select({
+          alias: aliasesTable.alias,
+          targetId: aliasesTable.targetId,
+        })
+        .from(aliasesTable)
+        .where(eq(aliasesTable.targetType, "room")),
+      db
+        .select({
+          id: classesTable.id,
+          courseCode: classesTable.courseCode,
+          section: classesTable.section,
+          type: classesTable.type,
+          courseTitle: classesTable.courseTitle,
+          schedule: classesTable.schedule,
+          roomId: classesTable.roomId,
+          termId: classesTable.termId,
+        })
+        .from(classesTable)
+        .where(eq(classesTable.termId, options.termId)),
+    ]);
 
-    const unmatched = new Map<string, number>();
-    const skippedByType = new Map<string, number>();
-    const inserts: (typeof classesTable.$inferInsert)[] = [];
+    const roomLookup = buildRoomLookup(rooms, roomAliases);
 
-    for (const row of normalized) {
-      if (!isRoomScheduledClassType(row.type)) {
-        const key = row.type?.trim().toUpperCase() || "(no type)";
-        skippedByType.set(key, (skippedByType.get(key) ?? 0) + 1);
-        continue;
-      }
+    const { rows: incomingRows, stats, unmatched } = resolveImportRows(
+      normalized,
+      roomLookup,
+    );
 
-      const facility = row.facilityCode?.trim();
-      if (!facility) {
-        unmatched.set(
-          "(missing facility)",
-          (unmatched.get("(missing facility)") ?? 0) + 1,
-        );
-        continue;
-      }
-      const roomId = roomIdByKey.get(normalizeFacilityKey(facility));
-      if (roomId == null) {
-        unmatched.set(facility, (unmatched.get(facility) ?? 0) + 1);
-        continue;
-      }
-
-      inserts.push({
-        courseCode: row.courseCode,
-        section: row.section,
-        type: row.type,
-        courseTitle: row.courseTitle,
-        schedule: row.schedule,
-        roomId,
-        termId: row.termId,
-      });
-    }
-
-    if (options.replace) {
-      await db.transaction(async (tx) => {
-        await tx
-          .delete(classesTable)
-          .where(eq(classesTable.termId, options.termId));
-
-        const batchSize = 500;
-        for (let i = 0; i < inserts.length; i += batchSize) {
-          await tx.insert(classesTable).values(inserts.slice(i, i + batchSize));
-        }
-
-        await refreshSyncKey(tx, "classes");
-      });
-      console.log(
-        `Cleared and re-imported term_id=${options.termId} (${inserts.length} rows, transactional).`,
+    const existingByKey = new Map<
+      string,
+      (typeof existingClasses)[number]
+    >();
+    for (const row of existingClasses) {
+      if (row.termId == null) continue;
+      existingByKey.set(
+        classNaturalKey({
+          termId: row.termId,
+          courseCode: row.courseCode ?? "",
+          section: row.section,
+          type: row.type,
+        }),
+        row,
       );
-    } else {
+    }
+
+    const { summary, inserts, updates, removeIds } = summarizeImportChanges({
+      replaceTerm: options.replaceTerm,
+      existingKeys: new Set(existingByKey.keys()),
+      existingByKey,
+      incomingRows,
+    });
+
+    await db.transaction(async (tx) => {
+      if (removeIds.length > 0) {
+        for (const id of removeIds) {
+          await tx.delete(classesTable).where(eq(classesTable.id, id));
+        }
+      }
+
+      for (const { id, row } of updates) {
+        await tx
+          .update(classesTable)
+          .set({
+            courseCode: row.courseCode,
+            section: row.section,
+            type: row.type,
+            courseTitle: row.courseTitle,
+            schedule: row.schedule,
+            roomId: row.roomId,
+            termId: row.termId,
+          })
+          .where(eq(classesTable.id, id));
+      }
+
       const batchSize = 500;
       for (let i = 0; i < inserts.length; i += batchSize) {
-        await db.insert(classesTable).values(inserts.slice(i, i + batchSize));
+        await tx.insert(classesTable).values(inserts.slice(i, i + batchSize));
       }
-      await refreshSyncKey(db, "classes");
-      console.log(
-        `Imported ${inserts.length} classes for term_id=${options.termId}.`,
-      );
-    }
 
-    if (skippedByType.size > 0) {
-      const totalSkipped = [...skippedByType.values()].reduce(
-        (a, b) => a + b,
-        0,
-      );
-      console.warn(
-        `Skipped ${totalSkipped} rows that are not room-scheduled LEC/LAB (thesis, special problem, dissertation, etc. usually have no room in AMIS):`,
-      );
-      for (const [type, count] of [...skippedByType.entries()].sort(
-        (a, b) => b[1] - a[1],
-      )) {
-        console.warn(`  ${count}× ${type}`);
-      }
-    }
-    if (unmatched.size > 0) {
-      console.warn(
-        `Skipped ${[...unmatched.values()].reduce((a, b) => a + b, 0)} rows with unmatched facilities:`,
-      );
-      for (const [facility, count] of [...unmatched.entries()].sort(
-        (a, b) => b[1] - a[1],
-      )) {
-        console.warn(`  ${count}× ${facility}`);
-      }
-    }
+      await refreshSyncKey(tx, "classes");
+    });
+
+    console.log(
+      formatImportReport({
+        termId: options.termId,
+        rawCount: rawRows.length,
+        normalizedCount: normalized.length,
+        stats,
+        summary,
+        unmatched,
+      }),
+    );
   } finally {
     await pool.end();
   }

--- a/scripts/performance-spot-check.sh
+++ b/scripts/performance-spot-check.sh
@@ -39,4 +39,30 @@ find public -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \) | whi
   fi
 done
 
+# Check total JS payload
+echo "\n--- Total JS payload ---"
+total_js=$(find dist/client -name "*.js" | xargs wc -c | tail -1 | awk '{print $1}')
+total_js_kb=$((total_js / 1024))
+echo "  Total JS: ${total_js_kb}KB"
+if [ "$total_js_kb" -gt 2000 ]; then
+  echo "  WARNING: total JS exceeds 2MB"
+fi
+
+# Check for uncompressed assets
+echo "\n--- Compression check ---"
+find dist/client -name "*.js" -o -name "*.css" | head -5 | while read -r f; do
+  gz=$(gzip -9 -c "$f" | wc -c)
+  orig=$(wc -c < "$f")
+  ratio=$((100 * gz / orig))
+  echo "  $(basename "$f"): ${ratio}% of original after gzip"
+done
+
+# Check API health if server is running
+echo "\n--- API health ---"
+if curl -sf http://localhost:4321/api/health > /dev/null 2>&1; then
+  echo "  /api/health reachable"
+else
+  echo "  SKIP: dev server not running (run 'bun dev' first to check latency)"
+fi
+
 echo "\n=== Done ==="

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -10,6 +10,7 @@
     queryStore,
     syncToastStore,
     appBootstrapStore,
+    toastStore,
   } from "@lib/store.svelte";
   import type {
     BuildingData,
@@ -298,11 +299,19 @@
   onMount(() => {
     applyData(EMPTY_DB_DATA);
     loaded = true;
-    dismissStaticLoadingShell();
-    appBootstrapStore.complete();
     appBootstrapStore.setRetryHandler(() => {
       void refreshFromNetwork(false);
     });
+
+    const onOffline = () => {
+      toastStore.show("You are offline. Campus data may be stale.", "info");
+    };
+    const onOnline = () => {
+      toastStore.show("Back online. Syncing latest data...", "success");
+      void refreshFromNetwork(appBootstrapStore.hasCachedData);
+    };
+    window.addEventListener("offline", onOffline);
+    window.addEventListener("online", onOnline);
 
     void (async () => {
       try {
@@ -319,11 +328,16 @@
         appBootstrapStore.setHasCachedData(hasCache);
         if (hasCache) {
           applyData(cached);
+          dismissStaticLoadingShell();
         }
 
         await refreshFromNetwork(hasCache);
+        if (!hasCache) {
+          dismissStaticLoadingShell();
+        }
       } catch (error) {
         console.error("Bootstrap failed", error);
+        dismissStaticLoadingShell();
         if (appBootstrapStore.hasCachedData) {
           appBootstrapStore.complete();
         } else {
@@ -336,6 +350,11 @@
         }
       }
     })();
+
+    return () => {
+      window.removeEventListener("offline", onOffline);
+      window.removeEventListener("online", onOnline);
+    };
   });
 
   setAppData(() => appData);

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -264,6 +264,12 @@
     --motion-duration-shelf: 260ms;
     --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
     --motion-ease-in: cubic-bezier(0.4, 0, 1, 1);
+    @media (prefers-reduced-motion: reduce) {
+      --motion-duration-fast: 0ms;
+      --motion-duration-micro: 0ms;
+      --motion-duration-panel: 0ms;
+      --motion-duration-shelf: 0ms;
+    }
     /* Stacking contract — highest first; blocking overlays dismiss ephemeral chrome.
        map(0) < side-panel(2) < search-elevated(12) < map-tools(15) < chrome-popover(17)
        < modal(100) < login-modal(200) < toast(1000). (#302) */

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -14,6 +14,7 @@
     sidePanelStore,
     floatingControlPanelStore,
     jeepneyStore,
+    appBootstrapStore,
   } from "@lib/store.svelte";
   import Modal from "@ui/modal/Modal.svelte";
   import MainControls from "@ui/controls/MainControls.svelte";
@@ -46,7 +47,6 @@
     localStorage.setItem("recent-search", JSON.stringify(queryHistory));
   };
   onMount(() => {
-    const hideLanding = localStorage.getItem("hideLandingModal");
     const recentSearchesLS = localStorage.getItem("recent-search");
     try {
       const parsedSearches: unknown[] = JSON.parse(recentSearchesLS ?? "[]");
@@ -78,8 +78,15 @@
       floatingControlPanelStore.openPanel = "suggest-addition";
       window.history.replaceState({}, "", window.location.pathname);
     }
+  });
 
-    if (!suppressLandingModal && hideLanding !== "true") {
+  $effect(() => {
+    if (
+      appBootstrapStore.phase === "ready" &&
+      !suppressLandingModal &&
+      localStorage.getItem("hideLandingModal") !== "true" &&
+      !modalStore.open
+    ) {
       modalStore.openModal("landing");
     }
   });
@@ -128,6 +135,8 @@
     if (e.key === "Escape") {
       if (modalStore.open) {
         modalStore.closeModal();
+      } else if (building3DStore.buildingName) {
+        building3DStore.close();
       } else if (adminAuthStore.loginOpen) {
         adminAuthStore.closeLogin();
       } else if (editorChromeStore.additionModalOpen) {
@@ -255,13 +264,12 @@
     --motion-duration-shelf: 260ms;
     --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
     --motion-ease-in: cubic-bezier(0.4, 0, 1, 1);
-    /* Stacking contract — highest first, only one primary overlay at a time.
-       map(0) < ui-layer(10) < map-tools(15) < chrome-popover(17) < modal(100)
-       < login-modal(200) < toast(1000) < term-selector(1200).
-       When a modal opens, Escape or backdrop-click closes lower layers first.
-       (#302) */
+    /* Stacking contract — highest first; blocking overlays dismiss ephemeral chrome.
+       map(0) < side-panel(2) < search-elevated(12) < map-tools(15) < chrome-popover(17)
+       < modal(100) < login-modal(200) < toast(1000). (#302) */
     --z-map: 0;
     --z-side-panel: 2;
+    --z-search-elevated: 12;
     --z-status-bar: 3;
     --z-map-tools: 15;
     --z-chrome-popover: 17;

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -1498,6 +1498,17 @@
         locationStore.routeOrigin,
         locationStore.destination,
       ]);
+      const map = mapStore.mapInstance;
+      if (map) {
+        const bounds = new mapGl.LngLatBounds();
+        bounds.extend(locationStore.routeOrigin);
+        bounds.extend(locationStore.destination);
+        map.fitBounds(bounds, {
+          padding: { top: 80, bottom: 120, left: 80, right: 80 },
+          duration: 1000,
+          maxZoom: 18,
+        });
+      }
     } else {
       directions.clear();
     }

--- a/src/components/svelte/OfflineMaps.svelte
+++ b/src/components/svelte/OfflineMaps.svelte
@@ -26,7 +26,7 @@
   function updatePopoverPosition() {
     if (!open || !triggerEl) return;
     const rect = triggerEl.getBoundingClientRect();
-    const width = Math.min(256, window.innerWidth - 16);
+    const width = Math.min(288, window.innerWidth - 16);
     const right = Math.max(8, window.innerWidth - rect.right);
     const bottom = Math.max(8, window.innerHeight - rect.top + 8);
     popoverStyle = `right: ${right}px; bottom: ${bottom}px; width: ${width}px;`;
@@ -79,7 +79,17 @@
     return `${Math.max(1, Math.round(bytes / 1024))} KB`;
   }
 
-  const pct = $derived(Math.round(offlineStore.progress * 100));
+  function fmtSyncedAt(iso: string | null): string {
+    if (!iso) return "Not downloaded";
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return "Downloaded";
+    return `Updated ${date.toLocaleDateString()}`;
+  }
+
+  const mapPct = $derived(Math.round(offlineStore.progress * 100));
+  const directoryPct = $derived(
+    Math.round(offlineStore.directoryProgress * 100),
+  );
 </script>
 
 <svelte:window onpointerdown={handleDocumentPointerDown} />
@@ -93,13 +103,13 @@
     aria-haspopup="dialog"
     aria-controls="offline-maps-dialog"
     onclick={toggleOpen}
-    title="Download the campus map for offline use"
+    title="Download campus data for offline use"
   >
-    <DownloadCloud size={16} />
+    <DownloadCloud size={16} aria-hidden="true" />
     {#if !compact}
-      <span>Offline maps</span>
+      <span>Offline</span>
     {:else}
-      <span class="sr-only">Offline maps</span>
+      <span class="sr-only">Offline downloads</span>
     {/if}
   </button>
 
@@ -111,51 +121,110 @@
       style={popoverStyle}
       role="dialog"
       aria-modal="true"
-      aria-label="Offline maps"
+      aria-label="Offline downloads"
       use:portal
     >
-      {#if offlineStore.status === "downloading"}
-        <p class="map-chrome-popover-line">
-          Downloading campus map… {pct}%
-        </p>
-        <div class="map-chrome-progress" aria-hidden="true">
-          <div class="map-chrome-progress__value" style:width={`${pct}%`}></div>
+      <p class="map-chrome-popover-line">Download for offline use</p>
+
+      <section class="offline-category" aria-labelledby="offline-map-heading">
+        <div class="offline-category__head">
+          <h3 id="offline-map-heading" class="offline-category__title">
+            Campus map
+          </h3>
+          <span class="offline-category__meta">
+            ~{fmtBytes(offlineStore.estimatedBytes)}
+          </span>
         </div>
-        <p class="map-chrome-popover-sub">
-          {offlineStore.tilesDone} / {offlineStore.tilesTotal} tiles ·
-          {fmtBytes(offlineStore.bytesDownloaded)}
-        </p>
-        <button class="offline-btn ghost" onclick={() => offlineStore.cancel()}>
-          Cancel
-        </button>
-      {:else if offlineStore.status === "done"}
-        <p class="map-chrome-popover-line">Campus map saved for offline use.</p>
-        <p class="map-chrome-popover-sub">
-          {offlineStore.tilesTotal} tiles · {fmtBytes(
-            offlineStore.bytesDownloaded,
-          )} downloaded
-        </p>
-        <button class="offline-btn ghost" onclick={() => offlineStore.clear()}>
-          Clear offline maps
-        </button>
-      {:else}
-        <p class="map-chrome-popover-line">
-          Download the campus map for offline use.
-        </p>
-        <p class="map-chrome-popover-sub">
-          Estimated download: ~{fmtBytes(offlineStore.estimatedBytes)}
-          ({offlineStore.tilesTotal} tiles)
-        </p>
-        {#if offlineStore.status === "error" && offlineStore.error}
-          <p class="offline-error">{offlineStore.error}</p>
+
+        {#if offlineStore.status === "downloading"}
+          <p class="map-chrome-popover-sub" role="status">
+            Downloading map tiles… {mapPct}%
+          </p>
+          <div class="map-chrome-progress" aria-hidden="true">
+            <div
+              class="map-chrome-progress__value"
+              style:width={`${mapPct}%`}
+            ></div>
+          </div>
+          <button class="offline-btn ghost" onclick={() => offlineStore.cancel()}>
+            Cancel map download
+          </button>
+        {:else if offlineStore.status === "done"}
+          <p class="map-chrome-popover-sub">
+            Saved · {offlineStore.tilesTotal} tiles · {fmtBytes(
+              offlineStore.bytesDownloaded,
+            )}
+          </p>
+          <button class="offline-btn ghost" onclick={() => offlineStore.clear()}>
+            Clear map tiles
+          </button>
+        {:else}
+          <p class="map-chrome-popover-sub">
+            Map tiles for campus bounds ({offlineStore.tilesTotal} tiles).
+          </p>
+          {#if offlineStore.status === "error" && offlineStore.error}
+            <p class="offline-error">{offlineStore.error}</p>
+          {/if}
+          <button class="offline-btn" onclick={() => offlineStore.downloadCampus()}>
+            Download campus map
+          </button>
         {/if}
-        <button
-          class="offline-btn"
-          onclick={() => offlineStore.downloadCampus()}
-        >
-          Download offline maps
-        </button>
-      {/if}
+      </section>
+
+      <section
+        class="offline-category"
+        aria-labelledby="offline-directory-heading"
+      >
+        <div class="offline-category__head">
+          <h3 id="offline-directory-heading" class="offline-category__title">
+            Campus directory
+          </h3>
+          <span class="offline-category__meta">
+            {fmtSyncedAt(offlineStore.directoryLastSyncedAt)}
+          </span>
+        </div>
+
+        {#if offlineStore.directoryStatus === "downloading"}
+          <p class="map-chrome-popover-sub" role="status">
+            {offlineStore.directoryProgressLabel} {directoryPct}%
+          </p>
+          <div class="map-chrome-progress" aria-hidden="true">
+            <div
+              class="map-chrome-progress__value"
+              style:width={`${directoryPct}%`}
+            ></div>
+          </div>
+        {:else if offlineStore.directoryStatus === "done"}
+          <p class="map-chrome-popover-sub">
+            Buildings, rooms, and search aliases saved for offline search.
+          </p>
+          <button
+            class="offline-btn ghost"
+            onclick={() => offlineStore.downloadCampusDirectory()}
+          >
+            Update directory
+          </button>
+          <button
+            class="offline-btn ghost"
+            onclick={() => offlineStore.clearCampusDirectory()}
+          >
+            Mark as not downloaded
+          </button>
+        {:else}
+          <p class="map-chrome-popover-sub">
+            Buildings, colleges, divisions, dorms, rooms, and aliases.
+          </p>
+          {#if offlineStore.directoryStatus === "error" && offlineStore.directoryError}
+            <p class="offline-error">{offlineStore.directoryError}</p>
+          {/if}
+          <button
+            class="offline-btn"
+            onclick={() => offlineStore.downloadCampusDirectory()}
+          >
+            Download campus directory
+          </button>
+        {/if}
+      </section>
 
       <p class="map-chrome-popover-footnote">
         On this device: {fmtBytes(offlineStore.storageUsed)}
@@ -188,6 +257,10 @@
   .offline-trigger:hover {
     background-color: hsla(0, 0%, 0%, 0.1);
   }
+  .offline-trigger:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 2px;
+  }
 
   .offline-maps.compact {
     flex: 0 0 auto;
@@ -213,6 +286,37 @@
     position: fixed;
     z-index: var(--z-chrome-popover, 17);
     border-radius: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .offline-category {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding-top: 0.25rem;
+    border-top: 1px solid hsl(0, 0%, 88%);
+  }
+
+  .offline-category__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .offline-category__title {
+    margin: 0;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 700;
+  }
+
+  .offline-category__meta {
+    font-size: 0.6875rem;
+    color: hsl(0, 0%, 40%);
+    text-align: right;
   }
 
   .offline-error {
@@ -235,6 +339,10 @@
   }
   .offline-btn:hover {
     background-color: hsl(5, 53%, 40%);
+  }
+  .offline-btn:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 2px;
   }
   .offline-btn.ghost {
     background-color: white;

--- a/src/components/svelte/TermSelector.svelte
+++ b/src/components/svelte/TermSelector.svelte
@@ -110,6 +110,7 @@
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-controls="term-picker-inline"
+        aria-label={active?.label ?? "Academic term for class schedules"}
         onclick={toggleOpen}
       >
         <span class="term-inline__trigger-label"
@@ -169,6 +170,7 @@
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-controls="term-picker-chip"
+        aria-label={active?.label ?? "Academic term for class schedules"}
         title={active?.label ?? "Academic term for class schedules"}
         onclick={toggleOpen}
       >
@@ -232,6 +234,11 @@
   .term-filter-chip__button {
     cursor: pointer;
     max-width: 100%;
+  }
+  .term-filter-chip__button:focus-visible,
+  .term-inline__trigger:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 2px;
   }
 
   .term-filter-chip__label {

--- a/src/components/svelte/controls/ClassQuery.svelte
+++ b/src/components/svelte/controls/ClassQuery.svelte
@@ -137,7 +137,19 @@
     {:else if classesLoading}
       <p class="status">Loading classes…</p>
     {:else if classesError}
-      <p class="status">{classesError}</p>
+      <div class="no-results">
+        <p class="status">{classesError}</p>
+        <button
+          type="button"
+          class="browse-all-btn"
+          onclick={() => {
+            classPage = 1;
+            classesError = null;
+          }}
+        >
+          Retry →
+        </button>
+      </div>
     {:else if classes.length > 0}
       <Classes {classes} />
       {#if classTotal > PAGE_SIZE}

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -9,11 +9,20 @@
   import PeopleAvatarGrid from "./PeopleAvatarGrid.svelte";
   import GithubContributorsSection from "./GithubContributorsSection.svelte";
   import LandingGuideSteps from "./LandingGuideSteps.svelte";
+  import Download from "@lucide/svelte/icons/download";
 
   type LandingTab = "welcome" | "campus";
 
   let activeTab = $state<LandingTab>("welcome");
   let dontShowAgain = $state(false);
+  let installPrompt = $state<
+    | (Event & {
+        prompt: () => Promise<void>;
+        userChoice: Promise<{ outcome: string }>;
+      })
+    | null
+  >(null);
+  let isInstalled = $state(false);
 
   let githubContributors = $state<GithubContributor[]>([]);
   let githubLoading = $state(false);
@@ -62,11 +71,34 @@
   }
 
   function handleGetStarted() {
+    if (installPrompt) {
+      void installPrompt.prompt();
+      installPrompt.userChoice.then(({ outcome }) => {
+        if (outcome === "accepted") isInstalled = true;
+      });
+      installPrompt = null;
+      return;
+    }
     if (dontShowAgain) {
       localStorage.setItem("hideLandingModal", "true");
     }
     modalStore.closeModal();
   }
+
+  $effect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault();
+      installPrompt = e as BeforeInstallPromptEvent;
+    };
+    window.addEventListener("beforeinstallprompt", handler);
+    const iosStandalone =
+      "standalone" in window.navigator &&
+      (window.navigator as unknown as { standalone: boolean }).standalone ===
+        true;
+    isInstalled =
+      iosStandalone || window.matchMedia("(display-mode: standalone)").matches;
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  });
 
   $effect(() => {
     if (!modalStore.open || modalStore.type !== "landing") return;
@@ -211,7 +243,16 @@
       ·
       <a href="/terms" class="inline-link">Terms</a>
     </p>
-    <button class="primary-btn" onclick={handleGetStarted}>Get Started</button>
+    {#if installPrompt && !isInstalled}
+      <button class="primary-btn install-btn" onclick={handleGetStarted}>
+        <Download size={16} aria-hidden="true" />
+        Install Room TBA
+      </button>
+    {:else}
+      <button class="primary-btn" onclick={() => modalStore.closeModal()}
+        >Get Started</button
+      >
+    {/if}
     <label class="checkbox-label">
       <input type="checkbox" bind:checked={dontShowAgain} />
       Don't show again
@@ -443,6 +484,13 @@
 
   .primary-btn:hover {
     background-color: hsl(5, 75%, 22%);
+  }
+
+  .install-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: hsl(5, 75%, 28%);
   }
 
   .checkbox-label {

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -264,7 +264,7 @@
               >
               <label class="sr-only" for="search">Search campus</label>
               <input
-                type="text"
+                type="search"
                 id="search"
                 autocomplete="off"
                 value={draftInput}
@@ -276,6 +276,9 @@
                 onblur={() => {
                   searchFocused = false;
                 }}
+                aria-expanded={showSearchDropdown}
+                aria-controls="search-suggestions"
+                aria-autocomplete="list"
                 placeholder="Search room, building, dorm, event, division..."
               />
               {#if draftInput !== "" || queryStore.category !== null}
@@ -342,8 +345,10 @@
 
       {#if showSearchDropdown}
         <div
+          id="search-suggestions"
           class="map-search-chrome__suggestions"
           role="listbox"
+          aria-label="Search suggestions"
           in:fade={dropdownFadeIn(reducedMotion.current)}
           out:fade={dropdownFadeOut(reducedMotion.current)}
         >

--- a/src/lib/__tests__/latency-tracker.test.ts
+++ b/src/lib/__tests__/latency-tracker.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "bun:test";
+import {
+  recordLatency,
+  getLatencyStats,
+  clearLatencySamples,
+} from "@lib/latency-tracker";
+
+describe("latency tracker", () => {
+  it("records and reports p50/p95/p99", () => {
+    clearLatencySamples();
+    for (let i = 1; i <= 100; i++) {
+      recordLatency("/api/test", i * 10);
+    }
+    const stats = getLatencyStats(10);
+    expect(stats.totalRequests).toBe(100);
+    expect(stats.overall?.p50).toBe(500);
+    expect(stats.overall?.p95).toBe(950);
+    expect(stats.overall?.p99).toBe(990);
+    const routeStats = stats.routes["/api/test"];
+    expect(routeStats).toBeDefined();
+    expect(routeStats!.count).toBe(100);
+  });
+
+  it("filters old samples", () => {
+    clearLatencySamples();
+    recordLatency("/api/old", 100);
+    const stats = getLatencyStats(-1);
+    expect(stats.totalRequests).toBe(0);
+  });
+});

--- a/src/lib/__tests__/og-meta.test.ts
+++ b/src/lib/__tests__/og-meta.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "bun:test";
+import { ogImageUrl, absoluteUrl } from "@lib/site";
+
+describe("OG meta helpers", () => {
+  it("ogImageUrl returns absolute image URL", () => {
+    const url = ogImageUrl();
+    expect(url).toContain("/socmed.png");
+    expect(url.startsWith("http")).toBe(true);
+  });
+
+  it("absoluteUrl joins site URL with path", () => {
+    expect(absoluteUrl("/room/ics-1/")).toContain("/room/ics-1/");
+  });
+});

--- a/src/lib/amis/import-classes.test.ts
+++ b/src/lib/amis/import-classes.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildRoomLookup,
+  classNaturalKey,
+  formatImportReport,
+  resolveImportRows,
+  summarizeImportChanges,
+} from "./import-classes";
+
+describe("classNaturalKey", () => {
+  test("normalizes case and whitespace", () => {
+    expect(
+      classNaturalKey({
+        termId: 1252,
+        courseCode: " eng 1 ",
+        section: " ab ",
+        type: "lec",
+      }),
+    ).toBe("1252|ENG 1|AB|LEC");
+  });
+});
+
+describe("buildRoomLookup", () => {
+  test("maps room codes and aliases", () => {
+    const lookup = buildRoomLookup(
+      [{ id: 1, code: "PS B 203" }],
+      [{ alias: "PS B-203", targetId: 1 }],
+    );
+    expect(lookup.directRoomIdByKey.get("PS B 203")).toBe(1);
+    expect(lookup.aliasRoomIdByKey.get("PS B 203")).toBe(1);
+    expect(lookup.combinedRoomIdByKey.get("PS B 203")).toBe(1);
+  });
+});
+
+describe("resolveImportRows", () => {
+  test("counts direct and alias matches separately", () => {
+    const lookup = buildRoomLookup(
+      [{ id: 10, code: "PS B 203" }],
+      [{ alias: "PSB203", targetId: 10 }],
+    );
+    const { stats, rows } = resolveImportRows(
+      [
+        {
+          courseCode: "ENG 1",
+          section: "AB",
+          type: "LEC",
+          courseTitle: "English",
+          schedule: ["MWF 8-9"],
+          facilityCode: "PS B 203",
+          termId: 1252,
+        },
+        {
+          courseCode: "ENG 2",
+          section: "CD",
+          type: "LAB",
+          courseTitle: "English 2",
+          schedule: ["TTH 1-4"],
+          facilityCode: "PSB203",
+          termId: 1252,
+        },
+        {
+          courseCode: "THESIS",
+          section: "A",
+          type: "THS",
+          courseTitle: "Thesis",
+          schedule: [],
+          facilityCode: "",
+          termId: 1252,
+        },
+      ],
+      lookup,
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(stats.directRoomMatch).toBe(1);
+    expect(stats.aliasRoomMatch).toBe(1);
+    expect(stats.skippedByType).toBe(1);
+    expect(stats.missingFacility).toBe(0);
+  });
+});
+
+describe("summarizeImportChanges", () => {
+  test("detects insert, update, unchanged, and stale removal", () => {
+    const existingByKey = new Map([
+      [
+        "1252|ENG 1|AB|LEC",
+        {
+          id: 1,
+          courseCode: "ENG 1",
+          section: "AB",
+          type: "LEC",
+          courseTitle: "Old title",
+          schedule: ["MWF 8-9"],
+          roomId: 10,
+        },
+      ],
+      [
+        "1252|ENG 2|CD|LAB",
+        {
+          id: 2,
+          courseCode: "ENG 2",
+          section: "CD",
+          type: "LAB",
+          courseTitle: "English 2",
+          schedule: ["TTH 1-4"],
+          roomId: 11,
+        },
+      ],
+    ]);
+
+    const { summary, inserts, updates, removeIds } = summarizeImportChanges({
+      replaceTerm: true,
+      existingKeys: new Set(existingByKey.keys()),
+      existingByKey,
+      incomingRows: [
+        {
+          courseCode: "ENG 1",
+          section: "AB",
+          type: "LEC",
+          courseTitle: "English 1",
+          schedule: ["MWF 8-9"],
+          roomId: 10,
+          termId: 1252,
+        },
+        {
+          courseCode: "ENG 3",
+          section: "EF",
+          type: "LEC",
+          courseTitle: "English 3",
+          schedule: ["MWF 10-11"],
+          roomId: 12,
+          termId: 1252,
+        },
+      ],
+    });
+
+    expect(summary).toEqual({
+      inserted: 1,
+      updated: 1,
+      unchanged: 0,
+      removed: 1,
+    });
+    expect(inserts).toHaveLength(1);
+    expect(updates).toHaveLength(1);
+    expect(removeIds).toEqual([2]);
+  });
+});
+
+describe("formatImportReport", () => {
+  test("includes categorized counts", () => {
+    const report = formatImportReport({
+      termId: 1252,
+      rawCount: 100,
+      normalizedCount: 95,
+      stats: {
+        directRoomMatch: 40,
+        aliasRoomMatch: 5,
+        missingFacility: 30,
+        unmatchedFacility: 10,
+        skippedByType: 10,
+      },
+      summary: {
+        inserted: 3,
+        updated: 2,
+        unchanged: 35,
+        removed: 1,
+      },
+      unmatched: new Map([
+        ["(missing facility)", 30],
+        ["PSLH-Z", 10],
+      ]),
+    });
+
+    expect(report).toContain("direct, 5 via alias");
+    expect(report).toContain("Missing facility: 30");
+    expect(report).toContain("+3 ~2 =35 -1");
+  });
+});

--- a/src/lib/amis/import-classes.ts
+++ b/src/lib/amis/import-classes.ts
@@ -1,0 +1,235 @@
+import type { NormalizedAmisClass } from "./types";
+import { normalizeFacilityKey } from "./normalize-class";
+import { isRoomScheduledClassType } from "./room-scheduled-types";
+
+export type ClassInsertRow = {
+  courseCode: string;
+  section: string;
+  type: string | null;
+  courseTitle: string | null;
+  schedule: string[];
+  roomId: number;
+  termId: number;
+};
+
+export type ImportRowStats = {
+  directRoomMatch: number;
+  aliasRoomMatch: number;
+  missingFacility: number;
+  unmatchedFacility: number;
+  skippedByType: number;
+};
+
+export type ImportRowOutcome =
+  | { kind: "insert"; row: ClassInsertRow }
+  | { kind: "skip-type"; type: string }
+  | { kind: "skip-missing-facility" }
+  | { kind: "skip-unmatched-facility"; facility: string };
+
+export type ImportChangeSummary = {
+  inserted: number;
+  updated: number;
+  unchanged: number;
+  removed: number;
+};
+
+export function classNaturalKey(row: {
+  termId: number;
+  courseCode: string;
+  section: string | null | undefined;
+  type: string | null | undefined;
+}) {
+  return [
+    row.termId,
+    row.courseCode.trim().toUpperCase(),
+    (row.section ?? "").trim().toUpperCase(),
+    (row.type ?? "").trim().toUpperCase(),
+  ].join("|");
+}
+
+export function buildRoomLookup(
+  rooms: { id: number; code: string }[],
+  roomAliases: { alias: string; targetId: number }[],
+) {
+  const directRoomIdByKey = new Map<string, number>();
+  const aliasRoomIdByKey = new Map<string, number>();
+  for (const room of rooms) {
+    directRoomIdByKey.set(normalizeFacilityKey(room.code), room.id);
+  }
+  for (const alias of roomAliases) {
+    aliasRoomIdByKey.set(normalizeFacilityKey(alias.alias), alias.targetId);
+  }
+  const combinedRoomIdByKey = new Map([
+    ...directRoomIdByKey,
+    ...aliasRoomIdByKey,
+  ]);
+  return { directRoomIdByKey, aliasRoomIdByKey, combinedRoomIdByKey };
+}
+
+export function resolveImportRows(
+  normalized: NormalizedAmisClass[],
+  lookup: ReturnType<typeof buildRoomLookup>,
+): { rows: ClassInsertRow[]; stats: ImportRowStats; unmatched: Map<string, number> } {
+  const stats: ImportRowStats = {
+    directRoomMatch: 0,
+    aliasRoomMatch: 0,
+    missingFacility: 0,
+    unmatchedFacility: 0,
+    skippedByType: 0,
+  };
+  const unmatched = new Map<string, number>();
+  const rows: ClassInsertRow[] = [];
+
+  for (const row of normalized) {
+    if (!isRoomScheduledClassType(row.type)) {
+      stats.skippedByType += 1;
+      continue;
+    }
+
+    const facility = row.facilityCode?.trim();
+    if (!facility) {
+      stats.missingFacility += 1;
+      unmatched.set(
+        "(missing facility)",
+        (unmatched.get("(missing facility)") ?? 0) + 1,
+      );
+      continue;
+    }
+
+    const key = normalizeFacilityKey(facility);
+    const roomId = lookup.combinedRoomIdByKey.get(key);
+    if (roomId == null) {
+      stats.unmatchedFacility += 1;
+      unmatched.set(facility, (unmatched.get(facility) ?? 0) + 1);
+      continue;
+    }
+
+    if (lookup.directRoomIdByKey.has(key)) {
+      stats.directRoomMatch += 1;
+    } else {
+      stats.aliasRoomMatch += 1;
+    }
+
+    rows.push({
+      courseCode: row.courseCode,
+      section: row.section,
+      type: row.type,
+      courseTitle: row.courseTitle,
+      schedule: row.schedule,
+      roomId,
+      termId: row.termId,
+    });
+  }
+
+  return { rows, stats, unmatched };
+}
+
+export function summarizeImportChanges(input: {
+  replaceTerm: boolean;
+  existingKeys: Set<string>;
+  incomingRows: ClassInsertRow[];
+  existingByKey: Map<
+    string,
+    {
+      id: number;
+      courseCode: string | null;
+      section: string | null;
+      type: string | null;
+      courseTitle: string | null;
+      schedule: string[] | null;
+      roomId: number | null;
+    }
+  >;
+}): {
+  summary: ImportChangeSummary;
+  inserts: ClassInsertRow[];
+  updates: Array<{ id: number; row: ClassInsertRow }>;
+  removeIds: number[];
+} {
+  const incomingByKey = new Map<string, ClassInsertRow>();
+  for (const row of input.incomingRows) {
+    incomingByKey.set(classNaturalKey(row), row);
+  }
+
+  let inserted = 0;
+  let updated = 0;
+  let unchanged = 0;
+  const inserts: ClassInsertRow[] = [];
+  const updates: Array<{ id: number; row: ClassInsertRow }> = [];
+  const removeIds: number[] = [];
+
+  for (const [key, row] of incomingByKey) {
+    const existing = input.existingByKey.get(key);
+    if (!existing) {
+      inserted += 1;
+      inserts.push(row);
+      continue;
+    }
+
+    const changed =
+      existing.courseCode !== row.courseCode ||
+      existing.section !== row.section ||
+      existing.type !== row.type ||
+      existing.courseTitle !== row.courseTitle ||
+      existing.roomId !== row.roomId ||
+      JSON.stringify(existing.schedule ?? []) !== JSON.stringify(row.schedule);
+
+    if (changed) {
+      updated += 1;
+      updates.push({ id: existing.id, row });
+    } else {
+      unchanged += 1;
+    }
+  }
+
+  if (input.replaceTerm) {
+    for (const [key, existing] of input.existingByKey) {
+      if (!incomingByKey.has(key)) {
+        removeIds.push(existing.id);
+      }
+    }
+  }
+
+  return {
+    summary: {
+      inserted,
+      updated,
+      unchanged,
+      removed: removeIds.length,
+    },
+    inserts,
+    updates,
+    removeIds,
+  };
+}
+
+export function formatImportReport(input: {
+  termId: number;
+  rawCount: number;
+  normalizedCount: number;
+  stats: ImportRowStats;
+  summary: ImportChangeSummary;
+  unmatched: Map<string, number>;
+}) {
+  const lines: string[] = [
+    `AMIS import summary (term_id=${input.termId})`,
+    `  Raw rows: ${input.rawCount}`,
+    `  Normalized: ${input.normalizedCount}`,
+    `  Room matches: ${input.stats.directRoomMatch} direct, ${input.stats.aliasRoomMatch} via alias`,
+    `  Skipped by type: ${input.stats.skippedByType}`,
+    `  Missing facility: ${input.stats.missingFacility}`,
+    `  Unmatched facility: ${input.stats.unmatchedFacility}`,
+    `  DB changes: +${input.summary.inserted} ~${input.summary.updated} =${input.summary.unchanged} -${input.summary.removed}`,
+  ];
+
+  if (input.unmatched.size > 0) {
+    lines.push("  Top unmatched facilities:");
+    for (const [facility, count] of [...input.unmatched.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 15)) {
+      lines.push(`    ${count}× ${facility}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/lib/latency-tracker.ts
+++ b/src/lib/latency-tracker.ts
@@ -1,0 +1,68 @@
+type LatencySample = {
+  pathname: string;
+  duration: number;
+  timestamp: number;
+};
+
+const MAX_SAMPLES = 500;
+let samples: LatencySample[] = [];
+
+export function recordLatency(pathname: string, duration: number) {
+  samples.push({ pathname, duration, timestamp: Date.now() });
+  if (samples.length > MAX_SAMPLES) samples = samples.slice(-MAX_SAMPLES);
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+export function getLatencyStats(cutoffMinutes = 10) {
+  const cutoff = Date.now() - cutoffMinutes * 60_000;
+  const recent = samples.filter((s) => s.timestamp >= cutoff);
+
+  const byRoute = new Map<string, number[]>();
+  for (const s of recent) {
+    const arr = byRoute.get(s.pathname);
+    if (arr) {
+      arr.push(s.duration);
+    } else {
+      byRoute.set(s.pathname, [s.duration]);
+    }
+  }
+
+  const routes: Record<
+    string,
+    { count: number; p50: number; p95: number; p99: number }
+  > = {};
+
+  for (const [pathname, durations] of byRoute) {
+    const sorted = durations.slice().sort((a, b) => a - b);
+    routes[pathname] = {
+      count: sorted.length,
+      p50: percentile(sorted, 50),
+      p95: percentile(sorted, 95),
+      p99: percentile(sorted, 99),
+    };
+  }
+
+  const all = recent.map((s) => s.duration).sort((a, b) => a - b);
+
+  return {
+    totalRequests: all.length,
+    windowMinutes: cutoffMinutes,
+    overall: all.length
+      ? {
+          p50: percentile(all, 50),
+          p95: percentile(all, 95),
+          p99: percentile(all, 99),
+        }
+      : null,
+    routes,
+  };
+}
+
+export function clearLatencySamples() {
+  samples = [];
+}

--- a/src/lib/local/data/campus-directory-sync.ts
+++ b/src/lib/local/data/campus-directory-sync.ts
@@ -1,0 +1,168 @@
+import type { BuildingData, CollegeData, DivisionData, DormData } from "@lib/types";
+import {
+  getBuildings,
+  getColleges,
+  getDivisions,
+  getDorms,
+  getBuildingRooms,
+  getCollegeRooms,
+  getDivisionRooms,
+} from "./utils";
+import {
+  checkLocalBuildingRoom,
+  checkLocalCollegeRoom,
+  checkLocalDivisionRoom,
+  localTableSyncCheck,
+  syncAliasCache,
+  syncBuildingRooms,
+  syncBuildings,
+  syncCollegeRooms,
+  syncColleges,
+  syncDivisionRooms,
+  syncDivisions,
+  syncDorms,
+} from "./sync";
+
+export const OFFLINE_DIRECTORY_SYNCED_AT_KEY = "offline-directory-synced-at";
+
+export type CampusDirectorySyncProgress = {
+  phase: "entities" | "rooms" | "aliases" | "done";
+  step: number;
+  totalSteps: number;
+  label: string;
+};
+
+export async function syncCampusDirectoryForOffline(options?: {
+  onProgress?: (progress: CampusDirectorySyncProgress) => void;
+}): Promise<{ ok: boolean; error?: string }> {
+  const report = (progress: CampusDirectorySyncProgress) => {
+    options?.onProgress?.(progress);
+  };
+
+  try {
+    const [buildingCheck, collegeCheck, divisionCheck, dormCheck] =
+      await Promise.all([
+        localTableSyncCheck("buildings"),
+        localTableSyncCheck("colleges"),
+        localTableSyncCheck("divisions"),
+        localTableSyncCheck("dorms"),
+      ]);
+
+    const [buildingLoad, collegeLoad, divisionLoad, dormLoad] =
+      await Promise.all([
+        getBuildings(buildingCheck),
+        getColleges(collegeCheck),
+        getDivisions(divisionCheck),
+        getDorms(dormCheck),
+      ]);
+
+    report({
+      phase: "entities",
+      step: 1,
+      totalSteps: 4,
+      label: "Syncing campus entities…",
+    });
+
+    await syncBuildings(
+      buildingCheck,
+      buildingLoad.rows,
+      buildingLoad.source === "remote",
+    );
+    await syncColleges(
+      collegeCheck,
+      collegeLoad.rows,
+      collegeLoad.source === "remote",
+    );
+    await syncDivisions(
+      divisionCheck,
+      divisionLoad.rows,
+      divisionLoad.source === "remote",
+    );
+    await syncDorms(dormCheck, dormLoad.rows, dormLoad.source === "remote");
+
+    const roomTargets: Array<{
+      kind: "building" | "college" | "division";
+      id: number;
+      label: string;
+    }> = [
+      ...buildingLoad.rows.map((b: BuildingData) => ({
+        kind: "building" as const,
+        id: b.id,
+        label: b.buildingName,
+      })),
+      ...collegeLoad.rows.map((c: CollegeData) => ({
+        kind: "college" as const,
+        id: c.id,
+        label: c.collegeName,
+      })),
+      ...divisionLoad.rows.map((d: DivisionData) => ({
+        kind: "division" as const,
+        id: d.id,
+        label: d.divisionName,
+      })),
+    ];
+
+    report({
+      phase: "rooms",
+      step: 2,
+      totalSteps: 4,
+      label: "Downloading room lists…",
+    });
+
+    let roomStep = 0;
+    for (const target of roomTargets) {
+      roomStep += 1;
+      report({
+        phase: "rooms",
+        step: 2,
+        totalSteps: 4,
+        label: `Rooms: ${target.label} (${roomStep}/${roomTargets.length})`,
+      });
+
+      if (target.kind === "building") {
+        const valid = await checkLocalBuildingRoom(target.id);
+        const rooms = await getBuildingRooms(valid, target.id);
+        await syncBuildingRooms(valid, target.id, rooms);
+      } else if (target.kind === "college") {
+        const valid = await checkLocalCollegeRoom(target.id);
+        const rooms = await getCollegeRooms(valid, target.id);
+        await syncCollegeRooms(valid, target.id, rooms);
+      } else {
+        const valid = await checkLocalDivisionRoom(target.id);
+        const rooms = await getDivisionRooms(valid, target.id);
+        await syncDivisionRooms(valid, target.id, rooms);
+      }
+    }
+
+    report({
+      phase: "aliases",
+      step: 3,
+      totalSteps: 4,
+      label: "Syncing search aliases…",
+    });
+    await syncAliasCache();
+
+    localStorage.setItem(
+      OFFLINE_DIRECTORY_SYNCED_AT_KEY,
+      new Date().toISOString(),
+    );
+
+    report({
+      phase: "done",
+      step: 4,
+      totalSteps: 4,
+      label: "Campus directory saved offline.",
+    });
+
+    return { ok: true };
+  } catch (error) {
+    console.error("Campus directory offline sync failed:", error);
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Campus directory download failed.",
+    };
+  }
+}

--- a/src/lib/schedule-renderer.ts
+++ b/src/lib/schedule-renderer.ts
@@ -58,8 +58,31 @@ export class ScheduleRenderer {
   }
 
   init() {
-    this.canvas.width = this.config.width;
-    this.canvas.height = this.config.height;
+    // Responsive canvas for mobile schedule UX (#241)
+    const dpr = window.devicePixelRatio || 1;
+    const cssWidth = Math.min(
+      this.config.width,
+      this.canvas.clientWidth || this.config.width,
+    );
+    const cssHeight = Math.min(
+      this.config.height,
+      this.canvas.clientHeight || this.config.height,
+    );
+    this.canvas.width = cssWidth * dpr;
+    this.canvas.height = cssHeight * dpr;
+    this.canvas.style.width = cssWidth + "px";
+    this.canvas.style.height = cssHeight + "px";
+    this.ctx.scale(dpr, dpr);
+    this.config.width = cssWidth;
+    this.config.height = cssHeight;
+    // Pull design tokens from CSS custom properties when available (#240).
+    const root = getComputedStyle(document.documentElement);
+    this.config.colors.background =
+      root.getPropertyValue("--map-chrome-surface").trim() ||
+      this.config.colors.background;
+    this.config.colors.header =
+      root.getPropertyValue("--map-chrome-border-accent").trim() ||
+      this.config.colors.header;
     this.cellWidth =
       (this.config.width - this.config.timeColumnWidth) /
       this.config.days.length;

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -22,6 +22,10 @@ import {
   MIN_ZOOM,
   tileUrl,
 } from "./local/offline-maps";
+import {
+  OFFLINE_DIRECTORY_SYNCED_AT_KEY,
+  syncCampusDirectoryForOffline,
+} from "./local/data/campus-directory-sync";
 import { clearProposeEventDraft } from "./contributor-drafts";
 import { recordSyncTelemetry } from "./telemetry";
 import type { BuildingTypeFilter } from "@constants/building-types";
@@ -1439,7 +1443,14 @@ class SyncToastStore {
 type OfflineStatus = "idle" | "downloading" | "done" | "error" | "cancelled";
 
 class OfflineStore {
+  /** Campus map tile download. */
   status = $state<OfflineStatus>("idle");
+  /** Buildings, rooms, aliases bundle for offline search. */
+  directoryStatus = $state<OfflineStatus>("idle");
+  directoryError = $state<string | null>(null);
+  directoryProgress = $state(0);
+  directoryProgressLabel = $state("");
+  directoryLastSyncedAt = $state<string | null>(null);
   tilesTotal = $state(0);
   tilesDone = $state(0);
   bytesDownloaded = $state(0);
@@ -1455,6 +1466,8 @@ class OfflineStore {
   // Compute the tile count up front so the size estimate shows before download.
   prepareEstimate = async () => {
     void this.refreshStorage();
+    this.directoryLastSyncedAt =
+      localStorage.getItem(OFFLINE_DIRECTORY_SYNCED_AT_KEY) ?? null;
     if (this.tilesTotal !== 0) return;
     const source = await getTileTemplate();
     this.tilesTotal = getCampusTileCoords(MIN_ZOOM, source?.maxZoom).length;
@@ -1529,6 +1542,41 @@ class OfflineStore {
     this.bytesDownloaded = 0;
     this.status = "idle";
     await this.refreshStorage();
+  };
+
+  downloadCampusDirectory = async () => {
+    if (this.directoryStatus === "downloading") return;
+    this.directoryError = null;
+    this.directoryProgress = 0;
+    this.directoryProgressLabel = "Starting…";
+    this.directoryStatus = "downloading";
+
+    const result = await syncCampusDirectoryForOffline({
+      onProgress: (progress) => {
+        this.directoryProgress = progress.step / progress.totalSteps;
+        this.directoryProgressLabel = progress.label;
+      },
+    });
+
+    if (result.ok) {
+      this.directoryStatus = "done";
+      this.directoryLastSyncedAt =
+        localStorage.getItem(OFFLINE_DIRECTORY_SYNCED_AT_KEY) ?? null;
+      this.directoryProgress = 1;
+    } else {
+      this.directoryStatus = "error";
+      this.directoryError =
+        result.error ?? "Campus directory download failed.";
+    }
+  };
+
+  clearCampusDirectory = () => {
+    localStorage.removeItem(OFFLINE_DIRECTORY_SYNCED_AT_KEY);
+    this.directoryStatus = "idle";
+    this.directoryError = null;
+    this.directoryProgress = 0;
+    this.directoryProgressLabel = "";
+    this.directoryLastSyncedAt = null;
   };
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,7 @@ import {
   applySupabaseCacheHeaders,
   refreshSupabaseSession,
 } from "./lib/supabase/session";
+import { recordLatency } from "./lib/latency-tracker";
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url;
@@ -37,6 +38,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   const response = await next();
   const duration = Math.round(performance.now() - start);
+  recordLatency(pathname, duration);
 
   // Add Server-Timing header for API routes so Vercel logs and browsers
   // can surface slow endpoints during QA (#313).

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from "astro";
+import { getLatencyStats } from "@lib/latency-tracker";
+
+export const prerender = false;
+
+export const GET: APIRoute = async () => {
+  const stats = getLatencyStats(10);
+
+  return new Response(
+    JSON.stringify(
+      {
+        status: "ok",
+        timestamp: new Date().toISOString(),
+        latency: stats,
+      },
+      null,
+      2,
+    ),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+};


### PR DESCRIPTION
Promotes the small-ticket batch from PR #374.

Tickets: #94 #213 #246 #240 #241 #128 #268 #269 #270 #237

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default AMIS import semantics changed from term-wide replace to upsert (stale rows persist unless `--replace-term`), which affects production class data operations; new offline directory sync adds another client data path.
> 
> **Overview**
> **AMIS class import** now **upserts** by term + course + section + type instead of defaulting to wiping the whole term. Optional **`--replace-term`** deletes sections missing from the export (COM cleanup). Room matching adds **`aliases`** (`target_type = room`) with a categorized import report; logic lives in **`import-classes`** (+ unit tests). New runbooks: **`docs/amis-com-refresh-runbook.md`**, **`docs/amis-facility-aliases.md`**.
> 
> **Offline UI** splits **campus map tiles** and a new **campus directory** download (entities, per-building/college/division rooms, alias cache) via **`campus-directory-sync`** and extended **`offlineStore`**.
> 
> **Map/product polish:** directions **`fitBounds`** for route waypoints; landing modal **Install Room TBA** when `beforeinstallprompt` fires; search **`type="search"`** + listbox ARIA; class load **Retry**; schedule canvas **DPR/responsive** + map-chrome CSS colors; **`prefers-reduced-motion`** zeroes motion tokens.
> 
> **Deps/docs:** drops **`better-sqlite3`** (legacy seed stays **`bun:sqlite`**); README/`.env.example` clarify Postgres vs **`data/info.db`**. Small **OG meta** unit test; assorted **focus/chip** styling on copy links and map chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61cdfe04f0b82ce620679d5092e4795e28d170de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->