### PR TITLE
fix(ui): entity action chip label overflow

### DIFF
--- a/src/components/svelte/CopyLinkButton.svelte
+++ b/src/components/svelte/CopyLinkButton.svelte
@@ -80,8 +80,8 @@
     disabled={copying}
     onclick={handleCopy}
   >
-    <span>{label}</span>
     <Copy size={14} aria-hidden="true" />
+    <span class="copy-link-btn__label">{label}</span>
   </button>
   {#if feedback === "inline"}
     <span class="copy-link-status" role="status" aria-live="polite">
@@ -130,20 +130,26 @@
   }
 
   .copy-link-btn :global(svg) {
+    display: block;
     flex: 0 0 auto;
+    width: 14px;
+    height: 14px;
   }
 
   [data-variant="chip"] .copy-link-btn {
     box-sizing: border-box;
     width: max-content;
     min-height: 1.75rem;
-    height: 1.75rem;
-    padding: 0 0.5rem;
+    padding: 0.3125rem 0.5rem;
     border-radius: 0.75rem;
     background: #fffafa;
     font-size: 0.6875rem;
     font-weight: 600;
-    line-height: 1;
+    line-height: 1.2;
+  }
+
+  .copy-link-btn__label {
+    line-height: 1.2;
   }
 
   [data-variant="chip"] .copy-link-btn:hover:not(:disabled) {

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -177,6 +177,7 @@
     min-height: 0;
     overflow-y: auto;
     overscroll-behavior: contain;
+    scroll-padding: 4px;
     scrollbar-width: thin;
     scrollbar-color: hsl(6, 63%, 48%) hsl(0, 0%, 98%);
   }

--- a/src/components/svelte/controls/entity-detail.css
+++ b/src/components/svelte/controls/entity-detail.css
@@ -109,9 +109,6 @@
   align-items: center;
   align-content: flex-start;
   gap: 0.375rem;
-  /* Scroll containers (overflow-y: auto) clip outline rings; inset focus + padding avoids trim. */
-  padding: 2px;
-  margin: -2px;
   overflow: visible;
 }
 
@@ -127,7 +124,7 @@
 }
 
 .entity-directions__nav {
-  padding-top: calc(0.125rem + 2px);
+  padding-top: 0.125rem;
 }
 
 .entity-actions :global(.map-chrome-action-chip),
@@ -140,15 +137,15 @@
   justify-content: center;
   gap: 0.25rem;
   min-height: 1.75rem;
-  height: 1.75rem;
-  padding: 0 0.5rem;
+  padding: 0.3125rem 0.5rem;
   font-size: 0.6875rem;
   font-weight: 600;
-  line-height: 1;
+  line-height: 1.2;
   border-radius: 0.75rem;
   border: 1px solid #d8b9ba;
   background: #fffafa;
   color: #7b1113;
+  white-space: nowrap;
   transition:
     background-color 0.16s,
     border-color 0.16s,

--- a/src/components/svelte/editor/entity-editor.css
+++ b/src/components/svelte/editor/entity-editor.css
@@ -31,15 +31,14 @@
   justify-content: center;
   width: max-content;
   min-height: 1.75rem;
-  height: 1.75rem;
-  padding: 0 0.5rem;
+  padding: 0.3125rem 0.5rem;
   border: 1px solid #d8b9ba;
   border-radius: 0.75rem;
   background: #fffafa;
   color: #7b1113;
   font-size: 0.6875rem;
   font-weight: 600;
-  line-height: 1;
+  line-height: 1.2;
   white-space: nowrap;
   flex-shrink: 0;
 }

--- a/src/components/svelte/map-chrome/MapChromeActionChip.svelte
+++ b/src/components/svelte/map-chrome/MapChromeActionChip.svelte
@@ -18,5 +18,25 @@
 </script>
 
 <button {type} class="map-chrome-action-chip" {disabled} {onclick}>
-  {@render children?.()}
+  <span class="map-chrome-action-chip__inner">
+    {@render children?.()}
+  </span>
 </button>
+
+<style>
+  .map-chrome-action-chip__inner {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    min-width: 0;
+    line-height: 1.2;
+  }
+
+  .map-chrome-action-chip__inner :global(svg) {
+    display: block;
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+  }
+</style>

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -183,10 +183,8 @@ button.chrome-toggle-btn[aria-expanded="true"] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
   min-height: 1.75rem;
-  height: 1.75rem;
-  padding: 0 0.5rem;
+  padding: 0.3125rem 0.5rem;
   white-space: nowrap;
   border: 1px solid #d8b9ba;
   border-radius: 0.75rem;
@@ -196,7 +194,7 @@ button.chrome-toggle-btn[aria-expanded="true"] {
   font: inherit;
   font-size: 0.6875rem;
   font-weight: 600;
-  line-height: 1;
+  line-height: 1.2;
   text-decoration: none;
   transition:
     background-color 0.16s,


### PR DESCRIPTION
## Summary
- Fixes 3D view / Directions / Copy link labels rendering outside their pill borders in entity detail headers (e.g. CHE Building)
- Root cause: fixed `height: 1.75rem` on icon+text chips; text line boxes overflowed the box while icons stayed centered
- Uses padding-based chip sizing, inner flex wrapper in `MapChromeActionChip`, and removes the negative-margin focus workaround (inset focus ring already in place)

## Test plan
- [ ] Open a building with map pin (CHE Building) on mobile width
- [ ] Confirm action row chips keep icon + label inside the border when wrapped
- [ ] Tab through chips — focus ring still visible inside scroll panel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation changes to map chrome and entity detail chips; no auth, data, or behavior logic.
> 
> **Overview**
> Fixes **3D view**, **Directions**, and **Copy link** labels spilling past pill borders in entity detail headers (notably on narrow widths).
> 
> **Root cause:** chips used a fixed `height: 1.75rem` while icon+text line boxes could exceed that box.
> 
> **Changes:** sizing is **padding + `min-height`** instead of fixed height, with **`line-height: 1.2`** and explicit **14px SVG** rules. `CopyLinkButton` puts the icon before the label; `MapChromeActionChip` wraps slot content in an inner flex row for alignment. Shared entity-action styles drop the old **negative-margin / extra padding** focus workaround (inset focus ring remains). The side panel scroll area gets **`scroll-padding: 4px`** so keyboard focus stays visible when scrolling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2235e7e5d0eaa5a4f04887f6b1d5cf0e10d682a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->