### PR TITLE
chore: prettier + entity action chip overflow fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,17 @@ Open **http://localhost:4321**. Without `DATABASE_URL`, the dev server starts bu
 
 ### Commands worth knowing
 
-| Command                      | Does what                                                                                    |
-| ---------------------------- | -------------------------------------------------------------------------------------------- |
-| `bun dev`                    | Dev server                                                                                   |
-| `bun run build`              | Production build (**needs** `DATABASE_URL`)                                                  |
-| `bun test src`               | Unit tests (no DB required)                                                                  |
-| `bun run lint`               | Prettier + ESLint                                                                            |
-| `bun run format`             | Prettier write                                                                               |
-| `bunx drizzle-kit studio`    | Browse/edit Postgres visually                                                                |
-| `bun run seed:aliases`       | Seed building aliases from `public/room_info.json`                                           |
-| `bun run import:amis-classes` | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`)                                   |
-| `bun run import:final-exams` | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`) |
+| Command                       | Does what                                                                                    |
+| ----------------------------- | -------------------------------------------------------------------------------------------- |
+| `bun dev`                     | Dev server                                                                                   |
+| `bun run build`               | Production build (**needs** `DATABASE_URL`)                                                  |
+| `bun test src`                | Unit tests (no DB required)                                                                  |
+| `bun run lint`                | Prettier + ESLint                                                                            |
+| `bun run format`              | Prettier write                                                                               |
+| `bunx drizzle-kit studio`     | Browse/edit Postgres visually                                                                |
+| `bun run seed:aliases`        | Seed building aliases from `public/room_info.json`                                           |
+| `bun run import:amis-classes` | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`)                                     |
+| `bun run import:final-exams`  | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`) |
 
 Legacy **`data/info.db`** SQLite is only for old seed/export scripts (`bun:sqlite`, not runtime). Production uses Supabase Postgres via `DATABASE_URL`. Archived SQLite migrations live in `drizzle-migrations/` — do not edit; active schema is `drizzle/`.
 

--- a/docs/amis-facility-aliases.md
+++ b/docs/amis-facility-aliases.md
@@ -18,11 +18,11 @@ Re-run the import for the term; the report shows **alias-matched** counts separa
 
 ## Import report categories
 
-| Category | Meaning |
-| --- | --- |
-| Direct room match | Facility string matched `rooms.room_code` |
-| Via alias | Matched through `aliases` (`target_type = room`) |
-| Missing facility | AMIS row has no facility (TBA) — **skipped**, not pinned |
+| Category           | Meaning                                                         |
+| ------------------ | --------------------------------------------------------------- |
+| Direct room match  | Facility string matched `rooms.room_code`                       |
+| Via alias          | Matched through `aliases` (`target_type = room`)                |
+| Missing facility   | AMIS row has no facility (TBA) — **skipped**, not pinned        |
 | Unmatched facility | Non-empty string with no room or alias — fix alias or room data |
 
 ## TBA policy

--- a/scripts/import-amis-classes.ts
+++ b/scripts/import-amis-classes.ts
@@ -240,7 +240,9 @@ async function main() {
 
   try {
     const [rooms, roomAliases, existingClasses] = await Promise.all([
-      db.select({ id: roomsTable.id, code: roomsTable.roomCode }).from(roomsTable),
+      db
+        .select({ id: roomsTable.id, code: roomsTable.roomCode })
+        .from(roomsTable),
       db
         .select({
           alias: aliasesTable.alias,
@@ -265,15 +267,13 @@ async function main() {
 
     const roomLookup = buildRoomLookup(rooms, roomAliases);
 
-    const { rows: incomingRows, stats, unmatched } = resolveImportRows(
-      normalized,
-      roomLookup,
-    );
+    const {
+      rows: incomingRows,
+      stats,
+      unmatched,
+    } = resolveImportRows(normalized, roomLookup);
 
-    const existingByKey = new Map<
-      string,
-      (typeof existingClasses)[number]
-    >();
+    const existingByKey = new Map<string, (typeof existingClasses)[number]>();
     for (const row of existingClasses) {
       if (row.termId == null) continue;
       existingByKey.set(

--- a/src/components/svelte/CopyLinkButton.svelte
+++ b/src/components/svelte/CopyLinkButton.svelte
@@ -80,8 +80,8 @@
     disabled={copying}
     onclick={handleCopy}
   >
-    <span>{label}</span>
     <Copy size={14} aria-hidden="true" />
+    <span class="copy-link-btn__label">{label}</span>
   </button>
   {#if feedback === "inline"}
     <span class="copy-link-status" role="status" aria-live="polite">
@@ -130,20 +130,26 @@
   }
 
   .copy-link-btn :global(svg) {
+    display: block;
     flex: 0 0 auto;
+    width: 14px;
+    height: 14px;
   }
 
   [data-variant="chip"] .copy-link-btn {
     box-sizing: border-box;
     width: max-content;
     min-height: 1.75rem;
-    height: 1.75rem;
-    padding: 0 0.5rem;
+    padding: 0.3125rem 0.5rem;
     border-radius: 0.75rem;
     background: #fffafa;
     font-size: 0.6875rem;
     font-weight: 600;
-    line-height: 1;
+    line-height: 1.2;
+  }
+
+  .copy-link-btn__label {
+    line-height: 1.2;
   }
 
   [data-variant="chip"] .copy-link-btn:hover:not(:disabled) {

--- a/src/components/svelte/OfflineMaps.svelte
+++ b/src/components/svelte/OfflineMaps.svelte
@@ -146,7 +146,10 @@
               style:width={`${mapPct}%`}
             ></div>
           </div>
-          <button class="offline-btn ghost" onclick={() => offlineStore.cancel()}>
+          <button
+            class="offline-btn ghost"
+            onclick={() => offlineStore.cancel()}
+          >
             Cancel map download
           </button>
         {:else if offlineStore.status === "done"}
@@ -155,7 +158,10 @@
               offlineStore.bytesDownloaded,
             )}
           </p>
-          <button class="offline-btn ghost" onclick={() => offlineStore.clear()}>
+          <button
+            class="offline-btn ghost"
+            onclick={() => offlineStore.clear()}
+          >
             Clear map tiles
           </button>
         {:else}
@@ -165,7 +171,10 @@
           {#if offlineStore.status === "error" && offlineStore.error}
             <p class="offline-error">{offlineStore.error}</p>
           {/if}
-          <button class="offline-btn" onclick={() => offlineStore.downloadCampus()}>
+          <button
+            class="offline-btn"
+            onclick={() => offlineStore.downloadCampus()}
+          >
             Download campus map
           </button>
         {/if}
@@ -186,7 +195,8 @@
 
         {#if offlineStore.directoryStatus === "downloading"}
           <p class="map-chrome-popover-sub" role="status">
-            {offlineStore.directoryProgressLabel} {directoryPct}%
+            {offlineStore.directoryProgressLabel}
+            {directoryPct}%
           </p>
           <div class="map-chrome-progress" aria-hidden="true">
             <div

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -177,6 +177,7 @@
     min-height: 0;
     overflow-y: auto;
     overscroll-behavior: contain;
+    scroll-padding: 4px;
     scrollbar-width: thin;
     scrollbar-color: hsl(6, 63%, 48%) hsl(0, 0%, 98%);
   }

--- a/src/components/svelte/controls/entity-detail.css
+++ b/src/components/svelte/controls/entity-detail.css
@@ -109,9 +109,6 @@
   align-items: center;
   align-content: flex-start;
   gap: 0.375rem;
-  /* Scroll containers (overflow-y: auto) clip outline rings; inset focus + padding avoids trim. */
-  padding: 2px;
-  margin: -2px;
   overflow: visible;
 }
 
@@ -127,7 +124,7 @@
 }
 
 .entity-directions__nav {
-  padding-top: calc(0.125rem + 2px);
+  padding-top: 0.125rem;
 }
 
 .entity-actions :global(.map-chrome-action-chip),
@@ -140,15 +137,15 @@
   justify-content: center;
   gap: 0.25rem;
   min-height: 1.75rem;
-  height: 1.75rem;
-  padding: 0 0.5rem;
+  padding: 0.3125rem 0.5rem;
   font-size: 0.6875rem;
   font-weight: 600;
-  line-height: 1;
+  line-height: 1.2;
   border-radius: 0.75rem;
   border: 1px solid #d8b9ba;
   background: #fffafa;
   color: #7b1113;
+  white-space: nowrap;
   transition:
     background-color 0.16s,
     border-color 0.16s,

--- a/src/components/svelte/editor/entity-editor.css
+++ b/src/components/svelte/editor/entity-editor.css
@@ -31,15 +31,14 @@
   justify-content: center;
   width: max-content;
   min-height: 1.75rem;
-  height: 1.75rem;
-  padding: 0 0.5rem;
+  padding: 0.3125rem 0.5rem;
   border: 1px solid #d8b9ba;
   border-radius: 0.75rem;
   background: #fffafa;
   color: #7b1113;
   font-size: 0.6875rem;
   font-weight: 600;
-  line-height: 1;
+  line-height: 1.2;
   white-space: nowrap;
   flex-shrink: 0;
 }

--- a/src/components/svelte/map-chrome/MapChromeActionChip.svelte
+++ b/src/components/svelte/map-chrome/MapChromeActionChip.svelte
@@ -18,5 +18,25 @@
 </script>
 
 <button {type} class="map-chrome-action-chip" {disabled} {onclick}>
-  {@render children?.()}
+  <span class="map-chrome-action-chip__inner">
+    {@render children?.()}
+  </span>
 </button>
+
+<style>
+  .map-chrome-action-chip__inner {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    min-width: 0;
+    line-height: 1.2;
+  }
+
+  .map-chrome-action-chip__inner :global(svg) {
+    display: block;
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+  }
+</style>

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -183,10 +183,8 @@ button.chrome-toggle-btn[aria-expanded="true"] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
   min-height: 1.75rem;
-  height: 1.75rem;
-  padding: 0 0.5rem;
+  padding: 0.3125rem 0.5rem;
   white-space: nowrap;
   border: 1px solid #d8b9ba;
   border-radius: 0.75rem;
@@ -196,7 +194,7 @@ button.chrome-toggle-btn[aria-expanded="true"] {
   font: inherit;
   font-size: 0.6875rem;
   font-weight: 600;
-  line-height: 1;
+  line-height: 1.2;
   text-decoration: none;
   transition:
     background-color 0.16s,

--- a/src/lib/amis/import-classes.ts
+++ b/src/lib/amis/import-classes.ts
@@ -69,7 +69,11 @@ export function buildRoomLookup(
 export function resolveImportRows(
   normalized: NormalizedAmisClass[],
   lookup: ReturnType<typeof buildRoomLookup>,
-): { rows: ClassInsertRow[]; stats: ImportRowStats; unmatched: Map<string, number> } {
+): {
+  rows: ClassInsertRow[];
+  stats: ImportRowStats;
+  unmatched: Map<string, number>;
+} {
   const stats: ImportRowStats = {
     directRoomMatch: 0,
     aliasRoomMatch: 0,

--- a/src/lib/local/data/campus-directory-sync.ts
+++ b/src/lib/local/data/campus-directory-sync.ts
@@ -1,4 +1,9 @@
-import type { BuildingData, CollegeData, DivisionData, DormData } from "@lib/types";
+import type {
+  BuildingData,
+  CollegeData,
+  DivisionData,
+  DormData,
+} from "@lib/types";
 import {
   getBuildings,
   getColleges,

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -1565,8 +1565,7 @@ class OfflineStore {
       this.directoryProgress = 1;
     } else {
       this.directoryStatus = "error";
-      this.directoryError =
-        result.error ?? "Campus directory download failed.";
+      this.directoryError = result.error ?? "Campus directory download failed.";
     }
   };
 


### PR DESCRIPTION
## Summary
- Prettier formatting on files from #374 so CI `verify` passes on staging
- Includes entity action chip label overflow fix (#377)

## Test plan
- [x] `bun test src`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly formatting and CSS-only chip/side-panel tweaks with no auth, data, or API behavior changes.
> 
> **Overview**
> Applies **Prettier** across README/docs tables, AMIS import script/lib, offline sync imports, and minor store formatting so CI verify passes.
> 
> **Entity detail action chips** (Copy link, Directions, editor toggles) get a layout fix: chips drop fixed `height` in favor of vertical padding and `line-height: 1.2`, add `white-space: nowrap`, and normalize 14px icons. `MapChromeActionChip` wraps slot content in an inner flex row; `CopyLinkButton` shows the icon before the label with matching chip styles. `entity-detail.css` removes the scroll-container padding/margin workaround; the side panel scroll area adds `scroll-padding: 4px` instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f88f15ec6f5430fa772508eab05b7735ae0230a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->