### PR TITLE
Move contributor progress to landing Campus tab

### DIFF
--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -2,7 +2,6 @@
   import WifiOff from "@lucide/svelte/icons/wifi-off";
   import { onMount } from "svelte";
   import { registerSW } from "virtual:pwa-register";
-  import { getAppData } from "@lib/context";
   import {
     appBootstrapStore,
     syncToastStore,
@@ -13,19 +12,8 @@
   import AppMenu from "./status-bar/AppMenu.svelte";
   import "./status-bar/status-bar.css";
 
-  const appData = getAppData();
-  const { directionCount, totalRooms } = $derived(appData());
   let isOnline = $state(true);
 
-  const progressPercent = $derived(
-    totalRooms > 0 ? Math.floor((directionCount / totalRooms) * 100) : 0,
-  );
-  const showDirectionsProgress = $derived(
-    directionCount != null &&
-      totalRooms != null &&
-      totalRooms > 0 &&
-      !syncToastStore.isSyncing,
-  );
   const showUrgentSync = $derived(
     appBootstrapStore.phase === "error" ||
       syncToastStore.syncError !== null ||
@@ -74,13 +62,7 @@
 </script>
 
 <div class="status-bar">
-  <AppMenu
-    {directionCount}
-    {totalRooms}
-    {progressPercent}
-    {showDirectionsProgress}
-    onSignOut={handleSignOut}
-  />
+  <AppMenu onSignOut={handleSignOut} />
 
   <div class="status-bar__badges" aria-live="polite">
     {#if showUrgentSync}

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -9,6 +9,7 @@
   import PeopleAvatarGrid from "./PeopleAvatarGrid.svelte";
   import GithubContributorsSection from "./GithubContributorsSection.svelte";
   import LandingGuideSteps from "./LandingGuideSteps.svelte";
+  import ContributorProgressPanel from "@ui/status-bar/ContributorProgressPanel.svelte";
   import Download from "@lucide/svelte/icons/download";
 
   type LandingTab = "welcome" | "campus";
@@ -158,6 +159,14 @@
         id="landing-panel-campus"
         aria-labelledby="landing-tab-campus"
       >
+        <section class="coverage-block">
+          <h3>Campus data coverage</h3>
+          <p class="section-note">
+            Track directions, schedules, and map pins across campus buildings.
+          </p>
+          <ContributorProgressPanel />
+        </section>
+
         <GithubContributorsSection
           title="Developers"
           note="From GitHub commit history on the Room TBA repo."
@@ -396,6 +405,25 @@
     font-size: 0.9375rem;
     font-weight: 700;
     color: hsl(5, 53%, 28%);
+  }
+
+  .coverage-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
+  .coverage-block h3 {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: hsl(5, 53%, 28%);
+    text-align: center;
+  }
+
+  .coverage-block :global(.contributor-progress) {
+    width: 100%;
   }
 
   .section-note {

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -19,30 +19,16 @@
   import SyncStatus from "@ui/SyncStatus.svelte";
   import PWAInstallPrompt from "@ui/PWAInstallPrompt.svelte";
   import MapChromeSession from "@ui/map-chrome/MapChromeSession.svelte";
-  import MapChromeGhostButton from "@ui/map-chrome/MapChromeGhostButton.svelte";
-  import ContributorProgressPanel from "./ContributorProgressPanel.svelte";
-  import StatusBarDirectionsStat from "./StatusBarDirectionsStat.svelte";
   import StatusBarLinkGroups from "./StatusBarLinkGroups.svelte";
   import "../map-chrome/map-chrome.css";
 
   type Props = {
-    directionCount: number;
-    totalRooms: number;
-    progressPercent: number;
-    showDirectionsProgress: boolean;
     onSignOut: () => void | Promise<void>;
   };
 
-  const {
-    directionCount,
-    totalRooms,
-    progressPercent,
-    showDirectionsProgress,
-    onSignOut,
-  }: Props = $props();
+  const { onSignOut }: Props = $props();
 
   let open = $state(false);
-  let showCoveragePanel = $state(false);
   let triggerEl = $state<HTMLButtonElement | null>(null);
   let panelEl = $state<HTMLDivElement | null>(null);
   let panelStyle = $state("");
@@ -205,38 +191,6 @@
         <p class="app-menu__meta">Updated {catalogUpdatedLabel}</p>
       </section>
 
-      {#if showDirectionsProgress}
-        <section
-          class="app-menu__section"
-          aria-labelledby="app-menu-coverage-heading"
-        >
-          <h3 id="app-menu-coverage-heading" class="app-menu__heading">
-            Coverage
-          </h3>
-          <StatusBarDirectionsStat
-            {directionCount}
-            {totalRooms}
-            {progressPercent}
-            variant="expanded"
-          />
-          <MapChromeGhostButton
-            variant="muted"
-            aria-expanded={showCoveragePanel}
-            aria-controls="app-menu-coverage-panel"
-            onclick={() => (showCoveragePanel = !showCoveragePanel)}
-          >
-            {showCoveragePanel
-              ? "Hide building breakdown"
-              : "Progress by building"}
-          </MapChromeGhostButton>
-          {#if showCoveragePanel}
-            <div id="app-menu-coverage-panel" class="app-menu__coverage">
-              <ContributorProgressPanel />
-            </div>
-          {/if}
-        </section>
-      {/if}
-
       <section
         class="app-menu__section"
         aria-labelledby="app-menu-links-heading"
@@ -315,10 +269,6 @@
 
   .app-menu__offline :global(.offline-maps) {
     width: 100%;
-  }
-
-  .app-menu__coverage {
-    margin-top: 0.25rem;
   }
 
   .app-menu__section--install :global(.pwa-install-prompt) {


### PR DESCRIPTION
## Summary
- Remove per-building coverage panel from app menu (bottom chrome)
- Show `ContributorProgressPanel` on landing modal → Campus team tab instead

## Test plan
- [ ] Menu no longer shows Coverage / Progress by building
- [ ] Landing → Campus team → Campus data coverage shows building breakdown
- [x] `bun test src`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI relocation of an existing read-only progress panel; no changes to auth, sync, or data APIs.
> 
> **Overview**
> **Campus data coverage** moves out of the bottom **App menu** and into the landing modal’s **Campus team** tab, where `ContributorProgressPanel` is shown up front with a short “Campus data coverage” intro.
> 
> The status bar and app menu no longer pull direction/room counts from app context or pass coverage props. The menu **Coverage** block (aggregate stats, “Progress by building” toggle, and per-building panel) is removed; the menu trigger only needs `onSignOut` again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8fac3f3f32661d69016f6c157db9bc9ad4189bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->