### PR TITLE
release: staging → main (contributor progress relocation)

### DIFF
--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -2,7 +2,6 @@
   import WifiOff from "@lucide/svelte/icons/wifi-off";
   import { onMount } from "svelte";
   import { registerSW } from "virtual:pwa-register";
-  import { getAppData } from "@lib/context";
   import {
     appBootstrapStore,
     syncToastStore,
@@ -13,19 +12,8 @@
   import AppMenu from "./status-bar/AppMenu.svelte";
   import "./status-bar/status-bar.css";
 
-  const appData = getAppData();
-  const { directionCount, totalRooms } = $derived(appData());
   let isOnline = $state(true);
 
-  const progressPercent = $derived(
-    totalRooms > 0 ? Math.floor((directionCount / totalRooms) * 100) : 0,
-  );
-  const showDirectionsProgress = $derived(
-    directionCount != null &&
-      totalRooms != null &&
-      totalRooms > 0 &&
-      !syncToastStore.isSyncing,
-  );
   const showUrgentSync = $derived(
     appBootstrapStore.phase === "error" ||
       syncToastStore.syncError !== null ||
@@ -74,13 +62,7 @@
 </script>
 
 <div class="status-bar">
-  <AppMenu
-    {directionCount}
-    {totalRooms}
-    {progressPercent}
-    {showDirectionsProgress}
-    onSignOut={handleSignOut}
-  />
+  <AppMenu onSignOut={handleSignOut} />
 
   <div class="status-bar__badges" aria-live="polite">
     {#if showUrgentSync}

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -9,6 +9,7 @@
   import PeopleAvatarGrid from "./PeopleAvatarGrid.svelte";
   import GithubContributorsSection from "./GithubContributorsSection.svelte";
   import LandingGuideSteps from "./LandingGuideSteps.svelte";
+  import ContributorProgressPanel from "@ui/status-bar/ContributorProgressPanel.svelte";
   import Download from "@lucide/svelte/icons/download";
 
   type LandingTab = "welcome" | "campus";
@@ -158,6 +159,14 @@
         id="landing-panel-campus"
         aria-labelledby="landing-tab-campus"
       >
+        <section class="coverage-block">
+          <h3>Campus data coverage</h3>
+          <p class="section-note">
+            Track directions, schedules, and map pins across campus buildings.
+          </p>
+          <ContributorProgressPanel />
+        </section>
+
         <GithubContributorsSection
           title="Developers"
           note="From GitHub commit history on the Room TBA repo."
@@ -396,6 +405,25 @@
     font-size: 0.9375rem;
     font-weight: 700;
     color: hsl(5, 53%, 28%);
+  }
+
+  .coverage-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
+  .coverage-block h3 {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: hsl(5, 53%, 28%);
+    text-align: center;
+  }
+
+  .coverage-block :global(.contributor-progress) {
+    width: 100%;
   }
 
   .section-note {

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -19,30 +19,16 @@
   import SyncStatus from "@ui/SyncStatus.svelte";
   import PWAInstallPrompt from "@ui/PWAInstallPrompt.svelte";
   import MapChromeSession from "@ui/map-chrome/MapChromeSession.svelte";
-  import MapChromeGhostButton from "@ui/map-chrome/MapChromeGhostButton.svelte";
-  import ContributorProgressPanel from "./ContributorProgressPanel.svelte";
-  import StatusBarDirectionsStat from "./StatusBarDirectionsStat.svelte";
   import StatusBarLinkGroups from "./StatusBarLinkGroups.svelte";
   import "../map-chrome/map-chrome.css";
 
   type Props = {
-    directionCount: number;
-    totalRooms: number;
-    progressPercent: number;
-    showDirectionsProgress: boolean;
     onSignOut: () => void | Promise<void>;
   };
 
-  const {
-    directionCount,
-    totalRooms,
-    progressPercent,
-    showDirectionsProgress,
-    onSignOut,
-  }: Props = $props();
+  const { onSignOut }: Props = $props();
 
   let open = $state(false);
-  let showCoveragePanel = $state(false);
   let triggerEl = $state<HTMLButtonElement | null>(null);
   let panelEl = $state<HTMLDivElement | null>(null);
   let panelStyle = $state("");
@@ -205,38 +191,6 @@
         <p class="app-menu__meta">Updated {catalogUpdatedLabel}</p>
       </section>
 
-      {#if showDirectionsProgress}
-        <section
-          class="app-menu__section"
-          aria-labelledby="app-menu-coverage-heading"
-        >
-          <h3 id="app-menu-coverage-heading" class="app-menu__heading">
-            Coverage
-          </h3>
-          <StatusBarDirectionsStat
-            {directionCount}
-            {totalRooms}
-            {progressPercent}
-            variant="expanded"
-          />
-          <MapChromeGhostButton
-            variant="muted"
-            aria-expanded={showCoveragePanel}
-            aria-controls="app-menu-coverage-panel"
-            onclick={() => (showCoveragePanel = !showCoveragePanel)}
-          >
-            {showCoveragePanel
-              ? "Hide building breakdown"
-              : "Progress by building"}
-          </MapChromeGhostButton>
-          {#if showCoveragePanel}
-            <div id="app-menu-coverage-panel" class="app-menu__coverage">
-              <ContributorProgressPanel />
-            </div>
-          {/if}
-        </section>
-      {/if}
-
       <section
         class="app-menu__section"
         aria-labelledby="app-menu-links-heading"
@@ -315,10 +269,6 @@
 
   .app-menu__offline :global(.offline-maps) {
     width: 100%;
-  }
-
-  .app-menu__coverage {
-    margin-top: 0.25rem;
   }
 
   .app-menu__section--install :global(.pwa-install-prompt) {


### PR DESCRIPTION
## Summary
- Move per-building contributor progress out of app menu into landing Campus team tab (#386)

## Test plan
- [x] `bun test src`
- [ ] Menu → no Coverage section; Contributors → Campus team shows coverage panel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only relocation of existing coverage components; no changes to auth, sync, or data loading.
> 
> **Overview**
> **Campus data coverage** (per-building contributor progress) moves out of the status bar app menu and into the landing modal’s **Campus team** tab.
> 
> `StatusBar` and `AppMenu` no longer pull `directionCount` / `totalRooms` from app context or show the **Coverage** section (aggregate directions stat, “Progress by building” toggle, and embedded `ContributorProgressPanel`). The menu now only passes `onSignOut` into `AppMenu`.
> 
> On **Campus team**, a new **Campus data coverage** block renders `ContributorProgressPanel` at the top of the tab (with matching section styles), so contributors still reach breakdown via **Menu → Contributors**, which already opens that tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b313c37c2210be0e97156b499374f92515ee87fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->