### PR TITLE
fix(ui): store split build + overlay click regressions

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -38,6 +38,7 @@
     dispatchGlobalShortcut,
     getGlobalShortcutAction,
   } from "@lib/keyboard-shortcuts";
+  import { dismissEphemeralOverlays } from "@lib/overlay-stack";
 
   type Props = {
     initialSearch?: InitialSearchState;
@@ -143,6 +144,7 @@
     }
 
     if (e.key === "Escape") {
+      dismissEphemeralOverlays();
       if (modalStore.open) {
         modalStore.closeModal();
       } else if (building3DStore.buildingName) {

--- a/src/components/svelte/OfflineMaps.svelte
+++ b/src/components/svelte/OfflineMaps.svelte
@@ -2,7 +2,10 @@
   import { onMount } from "svelte";
   import DownloadCloud from "@lucide/svelte/icons/download-cloud";
   import { mapToolsStore, offlineStore } from "@lib/store.svelte";
-  import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
+  import {
+    registerEphemeralOverlayDismisser,
+    openEphemeralOverlay,
+  } from "@lib/overlay-stack";
   import { rafThrottle } from "@lib/layout-css-vars";
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
@@ -51,12 +54,14 @@
 
   function toggleOpen() {
     if (!open) {
-      mapToolsStore.close();
+      openEphemeralOverlay(() => {
+        mapToolsStore.close();
+        open = true;
+        queueMicrotask(updatePopoverPosition);
+      });
+      return;
     }
-    open = !open;
-    if (open) {
-      queueMicrotask(updatePopoverPosition);
-    }
+    open = false;
   }
 
   function closePopover() {

--- a/src/components/svelte/TermSelector.svelte
+++ b/src/components/svelte/TermSelector.svelte
@@ -7,7 +7,10 @@
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
   import { mapToolsStore, termStore } from "@lib/store.svelte";
-  import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
+  import {
+    registerEphemeralOverlayDismisser,
+    openEphemeralOverlay,
+  } from "@lib/overlay-stack";
   import type { TermWithCount } from "@lib/types";
   import "./map-chrome/map-chrome.css";
 
@@ -69,10 +72,14 @@
 
   function toggleOpen() {
     if (!open) {
-      mapToolsStore.close();
+      openEphemeralOverlay(() => {
+        mapToolsStore.close();
+        open = true;
+        queueMicrotask(updatePanelPosition);
+      });
+      return;
     }
-    open = !open;
-    if (open) queueMicrotask(updatePanelPosition);
+    open = false;
   }
 
   function closePanel() {

--- a/src/components/svelte/map-chrome/KeyboardShortcutsChip.svelte
+++ b/src/components/svelte/map-chrome/KeyboardShortcutsChip.svelte
@@ -8,7 +8,10 @@
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
   import { mapToolsStore } from "@lib/store.svelte";
-  import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
+  import {
+    registerEphemeralOverlayDismisser,
+    openEphemeralOverlay,
+  } from "@lib/overlay-stack";
   import "./map-chrome.css";
 
   type Props = {
@@ -57,9 +60,15 @@
   });
 
   function toggleOpen() {
-    if (!open) mapToolsStore.close();
-    open = !open;
-    if (open) queueMicrotask(updatePanelPosition);
+    if (!open) {
+      openEphemeralOverlay(() => {
+        mapToolsStore.close();
+        open = true;
+        queueMicrotask(updatePanelPosition);
+      });
+      return;
+    }
+    open = false;
   }
 
   function closePanel() {

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -6,7 +6,10 @@
   import { statusBarNavGroups } from "@constants/status-bar-links";
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
-  import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
+  import {
+    registerEphemeralOverlayDismisser,
+    openEphemeralOverlay,
+  } from "@lib/overlay-stack";
   import { rafThrottle } from "@lib/layout-css-vars";
   import {
     adminAuthStore,
@@ -88,9 +91,15 @@
   });
 
   function toggleOpen() {
-    if (!open) mapToolsStore.close();
-    open = !open;
-    if (open) queueMicrotask(updatePanelPosition);
+    if (!open) {
+      openEphemeralOverlay(() => {
+        mapToolsStore.close();
+        open = true;
+        queueMicrotask(updatePanelPosition);
+      });
+      return;
+    }
+    open = false;
   }
 
   function closePanel() {
@@ -108,7 +117,7 @@
     if (!(target instanceof Node)) return;
     if (triggerEl?.contains(target)) return;
     if (panelEl?.contains(target)) return;
-    if (target instanceof Element && target.closest(".map-chrome-popover")) {
+    if (target instanceof Element && target.closest("#offline-maps-dialog")) {
       return;
     }
     closePanel();

--- a/src/lib/focus-trap.ts
+++ b/src/lib/focus-trap.ts
@@ -16,6 +16,7 @@ export function trapFocus(
   const handleKeydown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
       options?.onEscape?.();
+      event.stopPropagation();
       return;
     }
     if (event.key !== "Tab") return;

--- a/src/lib/overlay-stack.ts
+++ b/src/lib/overlay-stack.ts
@@ -17,3 +17,9 @@ export function dismissEphemeralOverlays() {
     dismiss();
   }
 }
+
+/** Close sibling flyouts, then open the requested panel (#302). */
+export function openEphemeralOverlay(open: () => void) {
+  dismissEphemeralOverlays();
+  open();
+}

--- a/src/lib/stores/data-stores.svelte.ts
+++ b/src/lib/stores/data-stores.svelte.ts
@@ -1,4 +1,13 @@
-class TermStore {
+import { getJSONFetch } from "../local/data/utils.js";
+import { parseTermIdFromSearch, syncTermQueryParam } from "../term-url.js";
+import {
+  resolveDefaultTermFromList,
+  resolveInitialTermId,
+} from "../term-calendar.js";
+import type { TermWithCount } from "@lib/types";
+import { ACTIVE_TERM_LS_KEY } from "./store-types.js";
+
+export class TermStore {
   terms = $state<TermWithCount[]>([]);
   activeTermId = $state<number | null>(null);
   loaded = $state(false);
@@ -77,7 +86,7 @@ class TermStore {
   };
 }
 
-class RoomClassesStore {
+export class RoomClassesStore {
   classes = $state<ClassMapValue[]>([]);
   loading = $state(false);
   private _cache = new Map<string, ClassMapValue[]>();

--- a/src/lib/stores/editor-stores.svelte.ts
+++ b/src/lib/stores/editor-stores.svelte.ts
@@ -1,4 +1,8 @@
-class EditorChromeStore {
+import { clearProposeEventDraft } from "../contributor-drafts.js";
+import { deactivateMapModesExcept } from "./map-modes.js";
+import type { EventPlacementDraft, MapProposalTarget } from "./store-types.js";
+
+export class EditorChromeStore {
   shelfOpen = $state(false);
   additionModalOpen = $state(false);
 
@@ -24,7 +28,7 @@ class EditorChromeStore {
   };
 }
 
-class MapEditStore {
+export class MapEditStore {
   enabled: boolean = $state(false);
 
   enable = () => {
@@ -43,7 +47,7 @@ class MapEditStore {
   };
 }
 
-class MapProposalStore {
+export class MapProposalStore {
   target: MapProposalTarget | null = $state(null);
   submitterName = $state("");
   proposalId: number | null = $state(null);
@@ -78,7 +82,7 @@ class MapProposalStore {
   }
 }
 
-class AdditionProposalStore {
+export class AdditionProposalStore {
   pinPickActive = $state(false);
   draftPin: { lat: number; lon: number } | null = $state(null);
   private pinResolver: ((coords: { lat: number; lon: number }) => void) | null =
@@ -121,7 +125,7 @@ class AdditionProposalStore {
   }
 }
 
-class EventPlacementStore {
+export class EventPlacementStore {
   draft: EventPlacementDraft | null = $state(null);
   creating: boolean = $state(false);
   createdEventId: number | null = $state(null);

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,50 +1,60 @@
 // src/lib/store.svelte.ts
 
-import { modalOptions } from "@constants/modal-states";
 import {
   DEFAULT_TERRAIN_EXAGGERATION,
   CAMPUS_BOUNDS,
 } from "@constants/map-terrain";
-import { SvelteMap } from "svelte/reactivity";
-import * as maplibre from "maplibre-gl";
-import { getJSONFetch, getLocalRoomByCode } from "./local/data/utils";
-import { parseTermIdFromSearch, syncTermQueryParam } from "./term-url";
-import {
-  resolveDefaultTermFromList,
-  resolveInitialTermId,
-} from "./term-calendar";
-import {
-  AVG_TILE_BYTES,
-  clearMapCaches,
-  getCampusTileCoords,
-  getStorageUsage,
-  getTileTemplate,
-  MIN_ZOOM,
-  tileUrl,
-} from "./local/offline-maps";
-import {
-  OFFLINE_DIRECTORY_SYNCED_AT_KEY,
-  syncCampusDirectoryForOffline,
-} from "./local/data/campus-directory-sync";
-import {
-  OFFLINE_CLASSES_SYNCED_AT_KEY,
-  syncClassSchedulesForOffline,
-} from "./local/data/class-schedules-offline-sync";
-import { dismissEphemeralOverlays } from "./overlay-stack";
-import { clearProposeEventDraft } from "./contributor-drafts";
-import { recordSyncTelemetry } from "./telemetry";
+import { getJSONFetch, getLocalRoomByCode } from "../local/data/utils.js";
 import type { BuildingTypeFilter } from "@constants/building-types";
-import { orderDayStops, type Weekday } from "./schedule-import/day-stops";
-import { matchImportedScheduleRows } from "./schedule-import/match-classes";
-import { parseScheduleImport } from "./schedule-import/parse-import";
+import { orderDayStops, type Weekday } from "../schedule-import/day-stops.js";
+import { matchImportedScheduleRows } from "../schedule-import/match-classes.js";
+import { parseScheduleImport } from "../schedule-import/parse-import.js";
 import type {
   ImportedScheduleRow,
-  ScheduleDayStop,
   ScheduleMatchResult,
-} from "./schedule-import/types";
-import { ROOM_SCHEDULE_SCOPE_NOTE } from "./amis/room-scheduled-types";
+} from "../schedule-import/types.js";
+import { ROOM_SCHEDULE_SCOPE_NOTE } from "../amis/room-scheduled-types.js";
+import { dismissEphemeralOverlays } from "../overlay-stack.js";
+import {
+  deactivateMapModesExcept,
+  registerMapMode,
+  type ExclusiveMapMode,
+} from "./map-modes.js";
+import {
+  SCHEDULE_IMPORT_SS_KEY,
+  type ScheduleImportPersisted,
+  syncTableLabel,
+  type AppBootstrapPhase,
+  type EventPlacementDraft,
+  type FloatingControlPanel,
+  type LandingModalTab,
+  type MapProposalTarget,
+  type MapToolsSection,
+  type OfflineStatus,
+  type QueryStoreState,
+  type SyncActivity,
+  type SyncInfo,
+  type SyncTableKey,
+  type TerrainStatus,
+} from "./store-types.js";
 
 export type { BuildingTypeFilter };
+export type {
+  AppBootstrapPhase,
+  EventPlacementDraft,
+  ExclusiveMapMode,
+  FloatingControlPanel,
+  LandingModalTab,
+  MapProposalTarget,
+  MapToolsSection,
+  OfflineStatus,
+  QueryStoreState,
+  SyncActivity,
+  SyncInfo,
+  SyncTableKey,
+  TerrainStatus,
+};
+export { deactivateMapModesExcept, syncTableLabel };
 
 type RoomData = {
   id: number;
@@ -66,37 +76,6 @@ type RoomData = {
 };
 
 export type DormFilterType = "all" | "up" | "private";
-export type SyncInfo = {
-  synced: number;
-  total: number;
-};
-
-export type SyncTableKey =
-  | "buildings"
-  | "colleges"
-  | "divisions"
-  | "dorms"
-  | "events"
-  | "aliases"
-  | "rooms"
-  | "classes";
-
-export type SyncActivity = "idle" | "checking" | "fetching" | "writing";
-
-const SYNC_TABLE_LABELS: Record<SyncTableKey, string> = {
-  buildings: "building list",
-  colleges: "colleges",
-  divisions: "divisions",
-  dorms: "dorms",
-  events: "events",
-  aliases: "search aliases",
-  rooms: "room stats",
-  classes: "classes",
-};
-
-export function syncTableLabel(table: SyncTableKey): string {
-  return SYNC_TABLE_LABELS[table];
-}
 
 let _dormFilter = $state<DormFilterType>("all");
 export const dormFilter = {
@@ -148,39 +127,6 @@ export const currentRoom = {
   setRoom(room: RoomData) {
     _currentRoom = room;
   },
-};
-
-export type LandingModalTab = "welcome" | "campus";
-
-interface ModalStoreState {
-  open: boolean;
-  type: (typeof modalOptions)[number] | null;
-  landingTab?: LandingModalTab;
-}
-
-export interface QueryStoreState {
-  type: "query" | "result";
-  category:
-    | "building"
-    | "division"
-    | "college"
-    | "room"
-    | "class"
-    | "classes"
-    | "dorm"
-    | "event"
-    | "events"
-    | null;
-  value: string;
-  // Stable, unique identifier for a selected event. Event titles are not
-  // unique, so event lookups should prefer this slug over `value`/`inputValue`.
-  eventSlug?: string;
-}
-
-type RecentSearch = {
-  category: Exclude<QueryStoreState["category"], null>;
-  value: string;
-  eventSlug?: string;
 };
 
 // Domain store modules
@@ -815,21 +761,20 @@ export const building3DStore = new Building3DStore();
 export const adminAuthStore = new AdminAuthStore();
 export const proposalsStore = new ProposalsStore();
 
-// Map modes (edit, jeepney routes, Makiling terrain) are mutually exclusive:
-// they take over the camera, pins, and map interactions. Location/propose
-// actions live in the bottom chrome tray. Activating one mode tears the others
-// down via deactivateMapModesExcept().
-export type ExclusiveMapMode = "edit" | "routes" | "terrain";
-
-export function deactivateMapModesExcept(active: ExclusiveMapMode) {
-  if (active !== "edit") {
+// Map modes (edit, jeepney routes, Makiling terrain) are mutually exclusive.
+registerMapMode("edit", {
+  disable: () => {
     mapEditStore.close();
     eventPlacementStore.cancel();
-  }
-  if (active !== "routes") {
+  },
+});
+registerMapMode("routes", {
+  disable: () => {
     jeepneyStore.disableLayer();
-  }
-  if (active !== "terrain") {
+  },
+});
+registerMapMode("terrain", {
+  disable: () => {
     terrainStore.disable();
-  }
-}
+  },
+});

--- a/src/lib/stores/map-modes.ts
+++ b/src/lib/stores/map-modes.ts
@@ -1,0 +1,15 @@
+export type ExclusiveMapMode = "edit" | "routes" | "terrain";
+
+type MapModeHandle = { disable: () => void };
+
+const registry = new Map<ExclusiveMapMode, MapModeHandle>();
+
+export function registerMapMode(mode: ExclusiveMapMode, handle: MapModeHandle) {
+  registry.set(mode, handle);
+}
+
+export function deactivateMapModesExcept(active: ExclusiveMapMode) {
+  for (const [mode, handle] of registry) {
+    if (mode !== active) handle.disable();
+  }
+}

--- a/src/lib/stores/map-stores.svelte.ts
+++ b/src/lib/stores/map-stores.svelte.ts
@@ -1,8 +1,14 @@
-class MapStore {
+import * as maplibre from "maplibre-gl";
+import { DEFAULT_TERRAIN_EXAGGERATION } from "@constants/map-terrain";
+import { dismissEphemeralOverlays } from "../overlay-stack.js";
+import { deactivateMapModesExcept } from "./map-modes.js";
+import type { MapToolsSection, TerrainStatus } from "./store-types.js";
+
+export class MapStore {
   mapInstance: maplibre.MapLibreMap | undefined = $state.raw();
 }
 
-class MapViewStore {
+export class MapViewStore {
   eventsOnly: boolean = $state(false);
 
   toggleEventsOnly = () => {
@@ -14,10 +20,9 @@ class MapViewStore {
   };
 }
 
-class MapToolsStore {
+export class MapToolsStore {
   open = $state(false);
   activeSection: MapToolsSection | null = $state("view");
-  /** Accordion: view only by default; legend/terrain/transit collapsed. */
   expandedSections = $state<Set<MapToolsSection>>(new Set(["view"]));
 
   toggle = () => {
@@ -52,7 +57,7 @@ class MapToolsStore {
   };
 }
 
-class TerrainStore {
+export class TerrainStore {
   enabled: boolean = $state(false);
   menuOpen: boolean = $state(false);
   exaggeration: number = $state(DEFAULT_TERRAIN_EXAGGERATION);
@@ -113,7 +118,7 @@ class TerrainStore {
   };
 }
 
-class Building3DStore {
+export class Building3DStore {
   buildingName: string | null = $state(null);
 
   open = (name: string) => {

--- a/src/lib/stores/store-types.ts
+++ b/src/lib/stores/store-types.ts
@@ -1,0 +1,104 @@
+import { modalOptions } from "@constants/modal-states";
+import type { Weekday } from "../schedule-import/day-stops.js";
+import type { ImportedScheduleRow } from "../schedule-import/types.js";
+
+export type LandingModalTab = "welcome" | "campus";
+
+export interface ModalStoreState {
+  open: boolean;
+  type: (typeof modalOptions)[number] | null;
+  landingTab?: LandingModalTab;
+}
+
+export interface QueryStoreState {
+  type: "query" | "result";
+  category:
+    | "building"
+    | "division"
+    | "college"
+    | "room"
+    | "class"
+    | "classes"
+    | "dorm"
+    | "event"
+    | "events"
+    | null;
+  value: string;
+  eventSlug?: string;
+}
+
+export type RecentSearch = {
+  category: Exclude<QueryStoreState["category"], null>;
+  value: string;
+  eventSlug?: string;
+};
+
+export type FloatingControlPanel =
+  "legend" | "building-type" | "terrain" | "admin" | "suggest-addition";
+
+export type MapToolsSection = "view" | "legend" | "terrain" | "jeepney";
+
+export type MapProposalTarget = {
+  type: "building" | "dorm" | "event";
+  id: number;
+  label: string;
+  version: number;
+};
+
+export type EventPlacementDraft = {
+  slug: string;
+  title: string;
+  startsAt: string;
+  endsAt: string;
+  category: "tradition" | "fair" | "ceremony" | "sports" | "other";
+  imageUrl: string | null;
+};
+
+export type TerrainStatus = "idle" | "loading" | "active" | "unavailable";
+
+export type AppBootstrapPhase =
+  "idle" | "local" | "remote" | "sync" | "ready" | "error";
+
+export type OfflineStatus =
+  "idle" | "downloading" | "done" | "error" | "cancelled";
+
+export type SyncInfo = {
+  synced: number;
+  total: number;
+};
+
+export type SyncTableKey =
+  | "buildings"
+  | "colleges"
+  | "divisions"
+  | "dorms"
+  | "events"
+  | "aliases"
+  | "rooms"
+  | "classes";
+
+export type SyncActivity = "idle" | "checking" | "fetching" | "writing";
+
+const SYNC_TABLE_LABELS: Record<SyncTableKey, string> = {
+  buildings: "building list",
+  colleges: "colleges",
+  divisions: "divisions",
+  dorms: "dorms",
+  events: "events",
+  aliases: "search aliases",
+  rooms: "room stats",
+  classes: "classes",
+};
+
+export function syncTableLabel(table: SyncTableKey): string {
+  return SYNC_TABLE_LABELS[table];
+}
+
+export const ACTIVE_TERM_LS_KEY = "active-term-id";
+
+export const SCHEDULE_IMPORT_SS_KEY = "room-tba-schedule-import";
+
+export type ScheduleImportPersisted = {
+  importedRows: ImportedScheduleRow[];
+  selectedWeekday: Weekday;
+};

--- a/src/lib/stores/sync-stores.svelte.ts
+++ b/src/lib/stores/sync-stores.svelte.ts
@@ -1,10 +1,36 @@
-class AppBootstrapStore {
+import {
+  AVG_TILE_BYTES,
+  clearMapCaches,
+  getCampusTileCoords,
+  getStorageUsage,
+  getTileTemplate,
+  MIN_ZOOM,
+  tileUrl,
+} from "../local/offline-maps.js";
+import {
+  OFFLINE_DIRECTORY_SYNCED_AT_KEY,
+  syncCampusDirectoryForOffline,
+} from "../local/data/campus-directory-sync.js";
+import {
+  OFFLINE_CLASSES_SYNCED_AT_KEY,
+  syncClassSchedulesForOffline,
+} from "../local/data/class-schedules-offline-sync.js";
+import { recordSyncTelemetry } from "../telemetry.js";
+import type {
+  AppBootstrapPhase,
+  OfflineStatus,
+  SyncActivity,
+  SyncInfo,
+  SyncTableKey,
+} from "./store-types.js";
+import { syncTableLabel } from "./store-types.js";
+
+export class AppBootstrapStore {
   phase = $state<AppBootstrapPhase>("idle");
   errorMessage = $state<string | null>(null);
   hasCachedData = $state(false);
   private retryHandler: (() => void) | null = null;
 
-  /** Bootstrap never blocks the map; static HTML shell only until hydration. */
   showBlockingOverlay = $derived(false);
 
   statusLabel = $derived.by(() => {
@@ -75,7 +101,7 @@ class AppBootstrapStore {
   }
 }
 
-class SyncToastStore {
+export class SyncToastStore {
   activity = $state<SyncActivity>("idle");
   activityTable = $state<SyncTableKey | null>(null);
   fetchProgress = $state<{ done: number; total: number } | null>(null);
@@ -185,9 +211,7 @@ class SyncToastStore {
     return null;
   });
 
-  // Service worker "new content available" update, surfaced inside this same
-  // bottom offline toast instead of a separate floating prompt.
-  public needRefresh = $state<boolean>(false);
+  needRefresh = $state<boolean>(false);
   private _refresh: (() => void) | null = null;
   private _syncRetry: (() => void) | null = null;
 
@@ -373,16 +397,13 @@ class SyncToastStore {
   }
 }
 
-class OfflineStore {
-  /** Campus map tile download. */
+export class OfflineStore {
   status = $state<OfflineStatus>("idle");
-  /** Buildings, rooms, aliases bundle for offline search. */
   directoryStatus = $state<OfflineStatus>("idle");
   directoryError = $state<string | null>(null);
   directoryProgress = $state(0);
   directoryProgressLabel = $state("");
   directoryLastSyncedAt = $state<string | null>(null);
-  /** Class schedules for active term in PGlite. */
   schedulesStatus = $state<OfflineStatus>("idle");
   schedulesError = $state<string | null>(null);
   schedulesProgressLabel = $state("");
@@ -400,7 +421,6 @@ class OfflineStore {
   );
   estimatedBytes = $derived(this.tilesTotal * AVG_TILE_BYTES);
 
-  // Compute the tile count up front so the size estimate shows before download.
   prepareEstimate = async () => {
     void this.refreshStorage();
     this.directoryLastSyncedAt =
@@ -464,7 +484,6 @@ class OfflineStore {
     };
 
     try {
-      // Modest concurrency to fill the cache quickly without hammering the API.
       await Promise.all(Array.from({ length: 6 }, () => worker()));
       await this.refreshStorage();
       this.status = this.cancelRequested ? "cancelled" : "done";

--- a/src/lib/stores/ui-stores.svelte.ts
+++ b/src/lib/stores/ui-stores.svelte.ts
@@ -1,4 +1,14 @@
-class ModalStore {
+import { SvelteMap } from "svelte/reactivity";
+import { dismissEphemeralOverlays } from "../overlay-stack.js";
+import type {
+  FloatingControlPanel,
+  LandingModalTab,
+  ModalStoreState,
+  QueryStoreState,
+  RecentSearch,
+} from "./store-types.js";
+
+export class ModalStore {
   private _modalStore: ModalStoreState = $state({
     open: false,
     type: null,
@@ -26,7 +36,7 @@ class ModalStore {
   };
 }
 
-class QueryStore {
+export class QueryStore {
   private _queryStore: QueryStoreState = $state({
     category: null,
     type: "query",
@@ -51,7 +61,6 @@ class QueryStore {
     ),
   );
 
-  // onclick of query buttons
   updateQuery = (obj: QueryStoreState) => {
     this._queryStore = obj;
     this.inputValue = obj.value;
@@ -92,7 +101,6 @@ class QueryStore {
     this.recentSearches.splice(id, 1);
   }
 
-  // when clicking the x button
   clearQuery = () => {
     this._queryStore = {
       category: null,
@@ -102,7 +110,6 @@ class QueryStore {
     this.inputValue = "";
   };
 
-  /** Drop an active result selection while keeping the search field editable. */
   exitResultMode = () => {
     this._queryStore = {
       category: null,
@@ -135,7 +142,7 @@ class QueryStore {
   };
 }
 
-class ToastStore {
+export class ToastStore {
   message: string | null = $state(null);
   type: "info" | "error" | "success" = $state("info");
 
@@ -149,7 +156,7 @@ class ToastStore {
   };
 }
 
-class MainControlsStore {
+export class MainControlsStore {
   collapsed: boolean = $state(false);
 
   toggle = () => {
@@ -165,7 +172,7 @@ class MainControlsStore {
   };
 }
 
-class FloatingControlPanelStore {
+export class FloatingControlPanelStore {
   openPanel: FloatingControlPanel | null = $state(null);
 
   toggle = (panel: FloatingControlPanel) => {


### PR DESCRIPTION
## Summary
- Fixes broken `#295` store split: correct `../` imports, shared `store-types.ts`, exported satellite store classes, and a `map-modes` registry so production builds resolve again.
- Restores ephemeral overlay stacking (`#302`): flyouts dismiss siblings on open, App menu only ignores the nested offline dialog (not every `.map-chrome-popover`), and Escape dismisses flyouts before clearing search.
- Adds `stopPropagation` on Escape in focus traps so closing a popover does not also clear the search field.

## Test plan
- [ ] `bun test src` passes
- [ ] `bun run build` completes (Vite bundle; prerender needs `DATABASE_URL`)
- [ ] Open app menu, term picker, shortcuts, and offline popover — only one flyout at a time
- [ ] Click map/buildings while flyouts were previously stacked — clicks register correctly
- [ ] Press Escape with app menu open — menu closes, search query unchanged
- [ ] Press Escape with no flyouts — search/destination clear as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches central store wiring and global Escape/pointer behavior; regressions could affect builds, map interaction, or search clearing, but changes are localized UI/stack fixes without auth or data-model changes.
> 
> **Overview**
> Repairs the **#295 store split** so production builds resolve again: shared types in `store-types.ts`, exported satellite store classes, corrected `../` module imports, and a **`map-modes` registry** for mutually exclusive edit / routes / terrain teardown.
> 
> Restores **ephemeral overlay stacking (#302)**: `openEphemeralOverlay` dismisses sibling flyouts before opening; map chrome flyouts (app menu, term picker, shortcuts, offline) use it. **Escape** in `Entry` calls `dismissEphemeralOverlays` first; **`trapFocus`** stops Escape propagation so closing a popover does not clear search. **App menu** outside-click handling only exempts `#offline-maps-dialog`, not every `.map-chrome-popover`, so map clicks register when menus were stacked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625949e6cfb8e48e640c78f852e7c004f09b1f70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->