### PR TITLE
fix(ci): restore semantic-release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,15 +3,18 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
-    "@semantic-release/npm",
-    "@semantic-release/github",
     [
-      "@semantic-release/git",
+      "@semantic-release/changelog",
       {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]"
+        "changelogFile": "CHANGELOG.md"
       }
-    ]
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- Restores `"npmPublish": false` on `@semantic-release/npm` so Release workflow no longer requires `NPM_TOKEN` for a private web app.
- Removes `@semantic-release/git` (re-added in #357); protected `main` rejects direct release commits — version sync already handled by the follow-up PR in `.github/workflows/release.yml`.

Fixes the regression introduced in #357 (`ENONPMTOKEN` on every push to `main` since 2026-06-29 12:17 UTC).

## Test plan
- [ ] Merge to `main` (via staging release PR)
- [ ] Confirm Release workflow on next `main` push completes without `ENONPMTOKEN`
- [ ] Confirm GitHub release is created and sync PR opens for `package.json` + `CHANGELOG.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release tooling only; no runtime app logic, with version bumps still gated by the existing sync PR workflow.
> 
> **Overview**
> Fixes **Release** failures on `main` by restoring **`npmPublish: false`** on `@semantic-release/npm`, so semantic-release no longer expects an **`NPM_TOKEN`** for this private app.
> 
> **Removes `@semantic-release/git`** (regression from #357): direct release commits on protected `main` are not used anymore. **`CHANGELOG.md`** is still updated via an explicit changelog plugin config; **`package.json`** / changelog land on `main` through the existing **version sync PR** step in `.github/workflows/release.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61f2f9ace2667b361f649166ee86465f1fa6c7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->