### PR TITLE
release: staging → main (UI fixes, semantic-release, batch #388)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,15 +3,18 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
-    "@semantic-release/npm",
-    "@semantic-release/github",
     [
-      "@semantic-release/git",
+      "@semantic-release/changelog",
       {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]"
+        "changelogFile": "CHANGELOG.md"
       }
-    ]
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    "@semantic-release/github"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,24 @@ Issues are living specs (paths, schema, acceptance criteria). When coding quickl
 
 Full checklist: [docs/issue-hygiene.md](docs/issue-hygiene.md).
 
+### Do NOT auto-close issues with human coordination requirements
+
+Some issues cannot be resolved purely through code. Issues that require **external human coordination** must remain open until the human work is complete, even if the technical implementation is merged. Examples include:
+
+- **Partnerships** (e.g., #257): Legal agreements, MOUs, and organizational approvals require human signatures and back-and-forth negotiation.
+- **External integrations** requiring third-party API keys, approvals, or contracts.
+- **Content moderation policies** needing stakeholder review.
+- **Volunteer onboarding** or training workflows dependent on human scheduling.
+
+**Agent protocol for human-dependent issues:**
+1. Implement the technical infrastructure (schema, UI stubs, API routes) and reference the issue in the PR.
+2. **Do NOT comment "Closes #NNN"** on PRs for human-dependent issues.
+3. After merge, **comment on the issue** with what was built and what remains for human coordination.
+4. **Keep the issue open** until the user or project lead confirms the human work is complete.
+5. If the issue needs splitting, file a follow-up technical issue and rename the original to focus on the human aspect.
+
+When in doubt, ask the user: "Does this issue require external coordination, or can it be closed with the technical implementation?"
+
 ## Verify before done
 
 Adjust checks to change size. PR CI runs **Prettier + unit tests** (no `DATABASE_URL`); full `bun run lint` (includes ESLint) and build remain local/agent responsibilities before merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ Some issues cannot be resolved purely through code. Issues that require **extern
 - **Volunteer onboarding** or training workflows dependent on human scheduling.
 
 **Agent protocol for human-dependent issues:**
+
 1. Implement the technical infrastructure (schema, UI stubs, API routes) and reference the issue in the PR.
 2. **Do NOT comment "Closes #NNN"** on PRs for human-dependent issues.
 3. After merge, **comment on the issue** with what was built and what remains for human coordination.

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -38,6 +38,7 @@
     dispatchGlobalShortcut,
     getGlobalShortcutAction,
   } from "@lib/keyboard-shortcuts";
+  import { dismissEphemeralOverlays } from "@lib/overlay-stack";
 
   type Props = {
     initialSearch?: InitialSearchState;
@@ -143,6 +144,7 @@
     }
 
     if (e.key === "Escape") {
+      dismissEphemeralOverlays();
       if (modalStore.open) {
         modalStore.closeModal();
       } else if (building3DStore.buildingName) {

--- a/src/components/svelte/OfflineMaps.svelte
+++ b/src/components/svelte/OfflineMaps.svelte
@@ -2,7 +2,10 @@
   import { onMount } from "svelte";
   import DownloadCloud from "@lucide/svelte/icons/download-cloud";
   import { mapToolsStore, offlineStore } from "@lib/store.svelte";
-  import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
+  import {
+    registerEphemeralOverlayDismisser,
+    openEphemeralOverlay,
+  } from "@lib/overlay-stack";
   import { rafThrottle } from "@lib/layout-css-vars";
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
@@ -51,12 +54,14 @@
 
   function toggleOpen() {
     if (!open) {
-      mapToolsStore.close();
+      openEphemeralOverlay(() => {
+        mapToolsStore.close();
+        open = true;
+        queueMicrotask(updatePopoverPosition);
+      });
+      return;
     }
-    open = !open;
-    if (open) {
-      queueMicrotask(updatePopoverPosition);
-    }
+    open = false;
   }
 
   function closePopover() {

--- a/src/components/svelte/TermSelector.svelte
+++ b/src/components/svelte/TermSelector.svelte
@@ -7,7 +7,10 @@
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
   import { mapToolsStore, termStore } from "@lib/store.svelte";
-  import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
+  import {
+    registerEphemeralOverlayDismisser,
+    openEphemeralOverlay,
+  } from "@lib/overlay-stack";
   import type { TermWithCount } from "@lib/types";
   import "./map-chrome/map-chrome.css";
 
@@ -69,10 +72,14 @@
 
   function toggleOpen() {
     if (!open) {
-      mapToolsStore.close();
+      openEphemeralOverlay(() => {
+        mapToolsStore.close();
+        open = true;
+        queueMicrotask(updatePanelPosition);
+      });
+      return;
     }
-    open = !open;
-    if (open) queueMicrotask(updatePanelPosition);
+    open = false;
   }
 
   function closePanel() {

--- a/src/components/svelte/map-chrome/KeyboardShortcutsChip.svelte
+++ b/src/components/svelte/map-chrome/KeyboardShortcutsChip.svelte
@@ -8,7 +8,10 @@
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
   import { mapToolsStore } from "@lib/store.svelte";
-  import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
+  import {
+    registerEphemeralOverlayDismisser,
+    openEphemeralOverlay,
+  } from "@lib/overlay-stack";
   import "./map-chrome.css";
 
   type Props = {
@@ -57,9 +60,15 @@
   });
 
   function toggleOpen() {
-    if (!open) mapToolsStore.close();
-    open = !open;
-    if (open) queueMicrotask(updatePanelPosition);
+    if (!open) {
+      openEphemeralOverlay(() => {
+        mapToolsStore.close();
+        open = true;
+        queueMicrotask(updatePanelPosition);
+      });
+      return;
+    }
+    open = false;
   }
 
   function closePanel() {

--- a/src/components/svelte/search/Suggestion.svelte
+++ b/src/components/svelte/search/Suggestion.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
+  import type { BuildingData, EventData } from "@lib/types";
   import { queryStore, type QueryStoreState } from "@lib/store.svelte";
+  import {
+    entityHoverPreviewStore,
+    buildingPreviewFromRow,
+    eventPreviewFromRow,
+  } from "@lib/entity-hover-preview.svelte";
   import ArrowUpRight from "@lucide/svelte/icons/arrow-up-right";
   import BookText from "@lucide/svelte/icons/book-text";
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
@@ -15,14 +21,19 @@
     category,
     id,
     eventSlug,
+    building,
+    event: eventData,
   }: {
     value: string;
     category: Exclude<QueryStoreState["category"], null>;
     id?: number;
     eventSlug?: string;
+    building?: BuildingData;
+    event?: EventData;
   } = $props();
 
   function handleSuggestionClick() {
+    entityHoverPreviewStore.hideNow();
     queryStore.updateQuery({
       type: "result",
       category,
@@ -36,6 +47,32 @@
     event.stopPropagation();
     if (typeof id === "undefined") return;
     queryStore.removeRecentSearch(id);
+  }
+
+  // Hover preview for buildings and events (#288)
+  function handleMouseEnter(event: MouseEvent) {
+    if (category === "building" && building) {
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      entityHoverPreviewStore.show(buildingPreviewFromRow(building), {
+        x: rect.right,
+        y: rect.top + rect.height / 2,
+      });
+    } else if (category === "event" && eventData) {
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      entityHoverPreviewStore.show(eventPreviewFromRow(eventData), {
+        x: rect.right,
+        y: rect.top + rect.height / 2,
+      });
+    }
+  }
+
+  function handleMouseLeave() {
+    entityHoverPreviewStore.scheduleHide();
+  }
+
+  function handleFocus(event: FocusEvent) {
+    // Show preview on keyboard focus too
+    handleMouseEnter(event as unknown as MouseEvent);
   }
 </script>
 
@@ -60,7 +97,14 @@
 {/snippet}
 
 <div class="suggestion-row">
-  <button type="button" class="suggestion" onclick={handleSuggestionClick}>
+  <button
+    type="button"
+    class="suggestion"
+    onclick={handleSuggestionClick}
+    onmouseenter={handleMouseEnter}
+    onmouseleave={handleMouseLeave}
+    onfocus={handleFocus}
+  >
     {@render icon(category)}
     <div class="text">{value}</div>
     {#if typeof id === "undefined"}

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -6,7 +6,10 @@
   import { statusBarNavGroups } from "@constants/status-bar-links";
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
-  import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
+  import {
+    registerEphemeralOverlayDismisser,
+    openEphemeralOverlay,
+  } from "@lib/overlay-stack";
   import { rafThrottle } from "@lib/layout-css-vars";
   import {
     adminAuthStore,
@@ -88,9 +91,15 @@
   });
 
   function toggleOpen() {
-    if (!open) mapToolsStore.close();
-    open = !open;
-    if (open) queueMicrotask(updatePanelPosition);
+    if (!open) {
+      openEphemeralOverlay(() => {
+        mapToolsStore.close();
+        open = true;
+        queueMicrotask(updatePanelPosition);
+      });
+      return;
+    }
+    open = false;
   }
 
   function closePanel() {
@@ -108,7 +117,7 @@
     if (!(target instanceof Node)) return;
     if (triggerEl?.contains(target)) return;
     if (panelEl?.contains(target)) return;
-    if (target instanceof Element && target.closest(".map-chrome-popover")) {
+    if (target instanceof Element && target.closest("#offline-maps-dialog")) {
       return;
     }
     closePanel();

--- a/src/lib/focus-trap.ts
+++ b/src/lib/focus-trap.ts
@@ -16,6 +16,7 @@ export function trapFocus(
   const handleKeydown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
       options?.onEscape?.();
+      event.stopPropagation();
       return;
     }
     if (event.key !== "Tab") return;

--- a/src/lib/overlay-stack.ts
+++ b/src/lib/overlay-stack.ts
@@ -17,3 +17,9 @@ export function dismissEphemeralOverlays() {
     dismiss();
   }
 }
+
+/** Close sibling flyouts, then open the requested panel (#302). */
+export function openEphemeralOverlay(open: () => void) {
+  dismissEphemeralOverlays();
+  open();
+}

--- a/src/lib/search-suggestions.ts
+++ b/src/lib/search-suggestions.ts
@@ -5,6 +5,8 @@ type Suggestion = {
   value: string;
   category: Exclude<QueryStoreState["category"], null>;
   eventSlug?: string;
+  building?: BuildingData;
+  event?: EventData;
 };
 
 const MAX_SUGGESTIONS = 8;
@@ -42,7 +44,7 @@ export function buildEntitySuggestions(
     ...takeMatches(
       data.filteredBuildings,
       ({ buildingName }) => buildingName.toLowerCase().includes(needle),
-      ({ buildingName }) => ({ value: buildingName, category: "building" }),
+      (b) => ({ value: b.buildingName, category: "building", building: b }),
     ),
     ...takeMatches(
       data.colleges,
@@ -66,10 +68,11 @@ export function buildEntitySuggestions(
       ({ title, description }) =>
         title.toLowerCase().includes(needle) ||
         Boolean(description && description.toLowerCase().includes(needle)),
-      ({ title, slug }) => ({
-        value: title,
+      (e) => ({
+        value: e.title,
         category: "event",
-        eventSlug: slug,
+        eventSlug: e.slug,
+        event: e,
       }),
     ),
   ];

--- a/src/lib/services/event-service.ts
+++ b/src/lib/services/event-service.ts
@@ -12,6 +12,7 @@ import {
   eventsTable,
 } from "@drizzle/schema";
 import { db } from "@lib/db";
+import { getBuildCache } from "./ssg-cache";
 import type {
   BuildingData,
   DormData,
@@ -100,6 +101,15 @@ export async function getEventById(
 
 export async function getSeoEvents(): Promise<EventData[]> {
   return (await getAllEvents()).filter((event) => event.includeInSeo);
+}
+
+// Cached version for SSG (#331)
+export async function getSeoEventsCached(): Promise<EventData[]> {
+  const cache = getBuildCache();
+  if (cache.events) return cache.events;
+  const events = await getSeoEvents();
+  cache.events = events;
+  return events;
 }
 
 async function loadEventRows(includeInactive = false) {

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -13,6 +13,7 @@ import { db } from "@lib/db";
 import { normalizeCourseCode } from "@lib/final-exams/normalize";
 import { normalizeAlias } from "@lib/site";
 import { normalizeDormListFields } from "@lib/string-lists";
+import { getBuildCache } from "./ssg-cache";
 import type {
   BuildingData,
   ClassMapValue,
@@ -23,6 +24,70 @@ import type {
   RoomData,
 } from "@lib/types";
 
+// Cached getters for SSG (#331)
+export async function getAllBuildingsCached(): Promise<BuildingData[]> {
+  const cache = getBuildCache();
+  if (cache.buildings) return cache.buildings;
+  const data = await db.select().from(buildingsTable);
+  cache.buildings = data;
+  return data;
+}
+
+export async function getAllRoomsCached(): Promise<RoomData[]> {
+  const cache = getBuildCache();
+  if (cache.rooms) return cache.rooms;
+  const data = await db
+    .select({
+      id: roomsTable.id,
+      code: roomsTable.roomCode,
+      directions: roomsTable.directions,
+      building: {
+        name: buildingsTable.buildingName,
+        lat: buildingsTable.lat,
+        lon: buildingsTable.lon,
+        directions: buildingsTable.directions,
+      },
+      collegeName: collegesTable.collegeName,
+      divisionName: divisionsTable.divisionName,
+      buildingId: roomsTable.buildingId,
+      collegeId: roomsTable.collegeId,
+      divisionId: roomsTable.divisionId,
+      version: roomsTable.version,
+      updatedAt: roomsTable.updatedAt,
+    })
+    .from(roomsTable)
+    .leftJoin(buildingsTable, eq(buildingsTable.id, roomsTable.buildingId))
+    .leftJoin(collegesTable, eq(collegesTable.id, roomsTable.collegeId))
+    .leftJoin(divisionsTable, eq(divisionsTable.id, roomsTable.divisionId));
+  cache.rooms = data;
+  return data;
+}
+
+export async function getAllCollegesCached(): Promise<CollegeData[]> {
+  const cache = getBuildCache();
+  if (cache.colleges) return cache.colleges;
+  const data = await db.select().from(collegesTable);
+  cache.colleges = data;
+  return data;
+}
+
+export async function getAllDivisionsCached(): Promise<DivisionData[]> {
+  const cache = getBuildCache();
+  if (cache.divisions) return cache.divisions;
+  const data = await db.select().from(divisionsTable);
+  cache.divisions = data;
+  return data;
+}
+
+export async function getAllDormsCached(): Promise<DormData[]> {
+  const cache = getBuildCache();
+  if (cache.dorms) return cache.dorms;
+  const data = await db.select().from(dormsTable);
+  cache.dorms = data;
+  return data;
+}
+
+// Legacy non-cached versions for runtime use
 export async function getAllBuildings(): Promise<BuildingData[]> {
   try {
     const data = await db.select().from(buildingsTable);

--- a/src/lib/services/ssg-cache.ts
+++ b/src/lib/services/ssg-cache.ts
@@ -1,0 +1,72 @@
+/**
+ * Build-time cache for SSG entity data.
+ *
+ * During Astro builds, getStaticPaths() is called for each entity type.
+ * This cache deduplicates repeated DB queries across pages.
+ *
+ * #331 - Minimize build and deploy time
+ */
+
+import type {
+  BuildingData,
+  CollegeData,
+  DivisionData,
+  DormData,
+  EventData,
+  RoomData,
+} from "@lib/types";
+
+interface SSGCache {
+  buildings: BuildingData[] | null;
+  rooms: RoomData[] | null;
+  colleges: CollegeData[] | null;
+  divisions: DivisionData[] | null;
+  dorms: DormData[] | null;
+  events: EventData[] | null;
+  defaultTerm: { id: number; label: string } | null;
+  classCounts: Map<string, number>;
+  roomClassCounts: Map<string, number>;
+}
+
+const cache: SSGCache = {
+  buildings: null,
+  rooms: null,
+  colleges: null,
+  divisions: null,
+  dorms: null,
+  events: null,
+  defaultTerm: null,
+  classCounts: new Map(),
+  roomClassCounts: new Map(),
+};
+
+export function getBuildCache() {
+  return cache;
+}
+
+export function clearBuildCache() {
+  cache.buildings = null;
+  cache.rooms = null;
+  cache.colleges = null;
+  cache.divisions = null;
+  cache.dorms = null;
+  cache.events = null;
+  cache.defaultTerm = null;
+  cache.classCounts.clear();
+  cache.roomClassCounts.clear();
+}
+
+// Helper to cache class counts by composite key
+export function getCachedClassCountKey(
+  buildingId: number,
+  termId: number,
+): string {
+  return `${buildingId}:${termId}`;
+}
+
+export function getCachedRoomClassCountKey(
+  roomId: number,
+  termId: number,
+): string {
+  return `${roomId}:${termId}`;
+}

--- a/src/lib/stores/data-stores.svelte.ts
+++ b/src/lib/stores/data-stores.svelte.ts
@@ -1,4 +1,13 @@
-class TermStore {
+import { getJSONFetch } from "../local/data/utils.js";
+import { parseTermIdFromSearch, syncTermQueryParam } from "../term-url.js";
+import {
+  resolveDefaultTermFromList,
+  resolveInitialTermId,
+} from "../term-calendar.js";
+import type { TermWithCount } from "@lib/types";
+import { ACTIVE_TERM_LS_KEY } from "./store-types.js";
+
+export class TermStore {
   terms = $state<TermWithCount[]>([]);
   activeTermId = $state<number | null>(null);
   loaded = $state(false);
@@ -77,7 +86,7 @@ class TermStore {
   };
 }
 
-class RoomClassesStore {
+export class RoomClassesStore {
   classes = $state<ClassMapValue[]>([]);
   loading = $state(false);
   private _cache = new Map<string, ClassMapValue[]>();

--- a/src/lib/stores/editor-stores.svelte.ts
+++ b/src/lib/stores/editor-stores.svelte.ts
@@ -1,4 +1,8 @@
-class EditorChromeStore {
+import { clearProposeEventDraft } from "../contributor-drafts.js";
+import { deactivateMapModesExcept } from "./map-modes.js";
+import type { EventPlacementDraft, MapProposalTarget } from "./store-types.js";
+
+export class EditorChromeStore {
   shelfOpen = $state(false);
   additionModalOpen = $state(false);
 
@@ -24,7 +28,7 @@ class EditorChromeStore {
   };
 }
 
-class MapEditStore {
+export class MapEditStore {
   enabled: boolean = $state(false);
 
   enable = () => {
@@ -43,7 +47,7 @@ class MapEditStore {
   };
 }
 
-class MapProposalStore {
+export class MapProposalStore {
   target: MapProposalTarget | null = $state(null);
   submitterName = $state("");
   proposalId: number | null = $state(null);
@@ -78,7 +82,7 @@ class MapProposalStore {
   }
 }
 
-class AdditionProposalStore {
+export class AdditionProposalStore {
   pinPickActive = $state(false);
   draftPin: { lat: number; lon: number } | null = $state(null);
   private pinResolver: ((coords: { lat: number; lon: number }) => void) | null =
@@ -121,7 +125,7 @@ class AdditionProposalStore {
   }
 }
 
-class EventPlacementStore {
+export class EventPlacementStore {
   draft: EventPlacementDraft | null = $state(null);
   creating: boolean = $state(false);
   createdEventId: number | null = $state(null);

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,50 +1,60 @@
 // src/lib/store.svelte.ts
 
-import { modalOptions } from "@constants/modal-states";
 import {
   DEFAULT_TERRAIN_EXAGGERATION,
   CAMPUS_BOUNDS,
 } from "@constants/map-terrain";
-import { SvelteMap } from "svelte/reactivity";
-import * as maplibre from "maplibre-gl";
-import { getJSONFetch, getLocalRoomByCode } from "./local/data/utils";
-import { parseTermIdFromSearch, syncTermQueryParam } from "./term-url";
-import {
-  resolveDefaultTermFromList,
-  resolveInitialTermId,
-} from "./term-calendar";
-import {
-  AVG_TILE_BYTES,
-  clearMapCaches,
-  getCampusTileCoords,
-  getStorageUsage,
-  getTileTemplate,
-  MIN_ZOOM,
-  tileUrl,
-} from "./local/offline-maps";
-import {
-  OFFLINE_DIRECTORY_SYNCED_AT_KEY,
-  syncCampusDirectoryForOffline,
-} from "./local/data/campus-directory-sync";
-import {
-  OFFLINE_CLASSES_SYNCED_AT_KEY,
-  syncClassSchedulesForOffline,
-} from "./local/data/class-schedules-offline-sync";
-import { dismissEphemeralOverlays } from "./overlay-stack";
-import { clearProposeEventDraft } from "./contributor-drafts";
-import { recordSyncTelemetry } from "./telemetry";
+import { getJSONFetch, getLocalRoomByCode } from "../local/data/utils.js";
 import type { BuildingTypeFilter } from "@constants/building-types";
-import { orderDayStops, type Weekday } from "./schedule-import/day-stops";
-import { matchImportedScheduleRows } from "./schedule-import/match-classes";
-import { parseScheduleImport } from "./schedule-import/parse-import";
+import { orderDayStops, type Weekday } from "../schedule-import/day-stops.js";
+import { matchImportedScheduleRows } from "../schedule-import/match-classes.js";
+import { parseScheduleImport } from "../schedule-import/parse-import.js";
 import type {
   ImportedScheduleRow,
-  ScheduleDayStop,
   ScheduleMatchResult,
-} from "./schedule-import/types";
-import { ROOM_SCHEDULE_SCOPE_NOTE } from "./amis/room-scheduled-types";
+} from "../schedule-import/types.js";
+import { ROOM_SCHEDULE_SCOPE_NOTE } from "../amis/room-scheduled-types.js";
+import { dismissEphemeralOverlays } from "../overlay-stack.js";
+import {
+  deactivateMapModesExcept,
+  registerMapMode,
+  type ExclusiveMapMode,
+} from "./map-modes.js";
+import {
+  SCHEDULE_IMPORT_SS_KEY,
+  type ScheduleImportPersisted,
+  syncTableLabel,
+  type AppBootstrapPhase,
+  type EventPlacementDraft,
+  type FloatingControlPanel,
+  type LandingModalTab,
+  type MapProposalTarget,
+  type MapToolsSection,
+  type OfflineStatus,
+  type QueryStoreState,
+  type SyncActivity,
+  type SyncInfo,
+  type SyncTableKey,
+  type TerrainStatus,
+} from "./store-types.js";
 
 export type { BuildingTypeFilter };
+export type {
+  AppBootstrapPhase,
+  EventPlacementDraft,
+  ExclusiveMapMode,
+  FloatingControlPanel,
+  LandingModalTab,
+  MapProposalTarget,
+  MapToolsSection,
+  OfflineStatus,
+  QueryStoreState,
+  SyncActivity,
+  SyncInfo,
+  SyncTableKey,
+  TerrainStatus,
+};
+export { deactivateMapModesExcept, syncTableLabel };
 
 type RoomData = {
   id: number;
@@ -66,37 +76,6 @@ type RoomData = {
 };
 
 export type DormFilterType = "all" | "up" | "private";
-export type SyncInfo = {
-  synced: number;
-  total: number;
-};
-
-export type SyncTableKey =
-  | "buildings"
-  | "colleges"
-  | "divisions"
-  | "dorms"
-  | "events"
-  | "aliases"
-  | "rooms"
-  | "classes";
-
-export type SyncActivity = "idle" | "checking" | "fetching" | "writing";
-
-const SYNC_TABLE_LABELS: Record<SyncTableKey, string> = {
-  buildings: "building list",
-  colleges: "colleges",
-  divisions: "divisions",
-  dorms: "dorms",
-  events: "events",
-  aliases: "search aliases",
-  rooms: "room stats",
-  classes: "classes",
-};
-
-export function syncTableLabel(table: SyncTableKey): string {
-  return SYNC_TABLE_LABELS[table];
-}
 
 let _dormFilter = $state<DormFilterType>("all");
 export const dormFilter = {
@@ -148,39 +127,6 @@ export const currentRoom = {
   setRoom(room: RoomData) {
     _currentRoom = room;
   },
-};
-
-export type LandingModalTab = "welcome" | "campus";
-
-interface ModalStoreState {
-  open: boolean;
-  type: (typeof modalOptions)[number] | null;
-  landingTab?: LandingModalTab;
-}
-
-export interface QueryStoreState {
-  type: "query" | "result";
-  category:
-    | "building"
-    | "division"
-    | "college"
-    | "room"
-    | "class"
-    | "classes"
-    | "dorm"
-    | "event"
-    | "events"
-    | null;
-  value: string;
-  // Stable, unique identifier for a selected event. Event titles are not
-  // unique, so event lookups should prefer this slug over `value`/`inputValue`.
-  eventSlug?: string;
-}
-
-type RecentSearch = {
-  category: Exclude<QueryStoreState["category"], null>;
-  value: string;
-  eventSlug?: string;
 };
 
 // Domain store modules
@@ -815,21 +761,20 @@ export const building3DStore = new Building3DStore();
 export const adminAuthStore = new AdminAuthStore();
 export const proposalsStore = new ProposalsStore();
 
-// Map modes (edit, jeepney routes, Makiling terrain) are mutually exclusive:
-// they take over the camera, pins, and map interactions. Location/propose
-// actions live in the bottom chrome tray. Activating one mode tears the others
-// down via deactivateMapModesExcept().
-export type ExclusiveMapMode = "edit" | "routes" | "terrain";
-
-export function deactivateMapModesExcept(active: ExclusiveMapMode) {
-  if (active !== "edit") {
+// Map modes (edit, jeepney routes, Makiling terrain) are mutually exclusive.
+registerMapMode("edit", {
+  disable: () => {
     mapEditStore.close();
     eventPlacementStore.cancel();
-  }
-  if (active !== "routes") {
+  },
+});
+registerMapMode("routes", {
+  disable: () => {
     jeepneyStore.disableLayer();
-  }
-  if (active !== "terrain") {
+  },
+});
+registerMapMode("terrain", {
+  disable: () => {
     terrainStore.disable();
-  }
-}
+  },
+});

--- a/src/lib/stores/map-modes.ts
+++ b/src/lib/stores/map-modes.ts
@@ -1,0 +1,15 @@
+export type ExclusiveMapMode = "edit" | "routes" | "terrain";
+
+type MapModeHandle = { disable: () => void };
+
+const registry = new Map<ExclusiveMapMode, MapModeHandle>();
+
+export function registerMapMode(mode: ExclusiveMapMode, handle: MapModeHandle) {
+  registry.set(mode, handle);
+}
+
+export function deactivateMapModesExcept(active: ExclusiveMapMode) {
+  for (const [mode, handle] of registry) {
+    if (mode !== active) handle.disable();
+  }
+}

--- a/src/lib/stores/map-stores.svelte.ts
+++ b/src/lib/stores/map-stores.svelte.ts
@@ -1,8 +1,14 @@
-class MapStore {
+import * as maplibre from "maplibre-gl";
+import { DEFAULT_TERRAIN_EXAGGERATION } from "@constants/map-terrain";
+import { dismissEphemeralOverlays } from "../overlay-stack.js";
+import { deactivateMapModesExcept } from "./map-modes.js";
+import type { MapToolsSection, TerrainStatus } from "./store-types.js";
+
+export class MapStore {
   mapInstance: maplibre.MapLibreMap | undefined = $state.raw();
 }
 
-class MapViewStore {
+export class MapViewStore {
   eventsOnly: boolean = $state(false);
 
   toggleEventsOnly = () => {
@@ -14,10 +20,9 @@ class MapViewStore {
   };
 }
 
-class MapToolsStore {
+export class MapToolsStore {
   open = $state(false);
   activeSection: MapToolsSection | null = $state("view");
-  /** Accordion: view only by default; legend/terrain/transit collapsed. */
   expandedSections = $state<Set<MapToolsSection>>(new Set(["view"]));
 
   toggle = () => {
@@ -52,7 +57,7 @@ class MapToolsStore {
   };
 }
 
-class TerrainStore {
+export class TerrainStore {
   enabled: boolean = $state(false);
   menuOpen: boolean = $state(false);
   exaggeration: number = $state(DEFAULT_TERRAIN_EXAGGERATION);
@@ -113,7 +118,7 @@ class TerrainStore {
   };
 }
 
-class Building3DStore {
+export class Building3DStore {
   buildingName: string | null = $state(null);
 
   open = (name: string) => {

--- a/src/lib/stores/store-types.ts
+++ b/src/lib/stores/store-types.ts
@@ -1,0 +1,104 @@
+import { modalOptions } from "@constants/modal-states";
+import type { Weekday } from "../schedule-import/day-stops.js";
+import type { ImportedScheduleRow } from "../schedule-import/types.js";
+
+export type LandingModalTab = "welcome" | "campus";
+
+export interface ModalStoreState {
+  open: boolean;
+  type: (typeof modalOptions)[number] | null;
+  landingTab?: LandingModalTab;
+}
+
+export interface QueryStoreState {
+  type: "query" | "result";
+  category:
+    | "building"
+    | "division"
+    | "college"
+    | "room"
+    | "class"
+    | "classes"
+    | "dorm"
+    | "event"
+    | "events"
+    | null;
+  value: string;
+  eventSlug?: string;
+}
+
+export type RecentSearch = {
+  category: Exclude<QueryStoreState["category"], null>;
+  value: string;
+  eventSlug?: string;
+};
+
+export type FloatingControlPanel =
+  "legend" | "building-type" | "terrain" | "admin" | "suggest-addition";
+
+export type MapToolsSection = "view" | "legend" | "terrain" | "jeepney";
+
+export type MapProposalTarget = {
+  type: "building" | "dorm" | "event";
+  id: number;
+  label: string;
+  version: number;
+};
+
+export type EventPlacementDraft = {
+  slug: string;
+  title: string;
+  startsAt: string;
+  endsAt: string;
+  category: "tradition" | "fair" | "ceremony" | "sports" | "other";
+  imageUrl: string | null;
+};
+
+export type TerrainStatus = "idle" | "loading" | "active" | "unavailable";
+
+export type AppBootstrapPhase =
+  "idle" | "local" | "remote" | "sync" | "ready" | "error";
+
+export type OfflineStatus =
+  "idle" | "downloading" | "done" | "error" | "cancelled";
+
+export type SyncInfo = {
+  synced: number;
+  total: number;
+};
+
+export type SyncTableKey =
+  | "buildings"
+  | "colleges"
+  | "divisions"
+  | "dorms"
+  | "events"
+  | "aliases"
+  | "rooms"
+  | "classes";
+
+export type SyncActivity = "idle" | "checking" | "fetching" | "writing";
+
+const SYNC_TABLE_LABELS: Record<SyncTableKey, string> = {
+  buildings: "building list",
+  colleges: "colleges",
+  divisions: "divisions",
+  dorms: "dorms",
+  events: "events",
+  aliases: "search aliases",
+  rooms: "room stats",
+  classes: "classes",
+};
+
+export function syncTableLabel(table: SyncTableKey): string {
+  return SYNC_TABLE_LABELS[table];
+}
+
+export const ACTIVE_TERM_LS_KEY = "active-term-id";
+
+export const SCHEDULE_IMPORT_SS_KEY = "room-tba-schedule-import";
+
+export type ScheduleImportPersisted = {
+  importedRows: ImportedScheduleRow[];
+  selectedWeekday: Weekday;
+};

--- a/src/lib/stores/sync-stores.svelte.ts
+++ b/src/lib/stores/sync-stores.svelte.ts
@@ -1,10 +1,36 @@
-class AppBootstrapStore {
+import {
+  AVG_TILE_BYTES,
+  clearMapCaches,
+  getCampusTileCoords,
+  getStorageUsage,
+  getTileTemplate,
+  MIN_ZOOM,
+  tileUrl,
+} from "../local/offline-maps.js";
+import {
+  OFFLINE_DIRECTORY_SYNCED_AT_KEY,
+  syncCampusDirectoryForOffline,
+} from "../local/data/campus-directory-sync.js";
+import {
+  OFFLINE_CLASSES_SYNCED_AT_KEY,
+  syncClassSchedulesForOffline,
+} from "../local/data/class-schedules-offline-sync.js";
+import { recordSyncTelemetry } from "../telemetry.js";
+import type {
+  AppBootstrapPhase,
+  OfflineStatus,
+  SyncActivity,
+  SyncInfo,
+  SyncTableKey,
+} from "./store-types.js";
+import { syncTableLabel } from "./store-types.js";
+
+export class AppBootstrapStore {
   phase = $state<AppBootstrapPhase>("idle");
   errorMessage = $state<string | null>(null);
   hasCachedData = $state(false);
   private retryHandler: (() => void) | null = null;
 
-  /** Bootstrap never blocks the map; static HTML shell only until hydration. */
   showBlockingOverlay = $derived(false);
 
   statusLabel = $derived.by(() => {
@@ -75,7 +101,7 @@ class AppBootstrapStore {
   }
 }
 
-class SyncToastStore {
+export class SyncToastStore {
   activity = $state<SyncActivity>("idle");
   activityTable = $state<SyncTableKey | null>(null);
   fetchProgress = $state<{ done: number; total: number } | null>(null);
@@ -185,9 +211,7 @@ class SyncToastStore {
     return null;
   });
 
-  // Service worker "new content available" update, surfaced inside this same
-  // bottom offline toast instead of a separate floating prompt.
-  public needRefresh = $state<boolean>(false);
+  needRefresh = $state<boolean>(false);
   private _refresh: (() => void) | null = null;
   private _syncRetry: (() => void) | null = null;
 
@@ -373,16 +397,13 @@ class SyncToastStore {
   }
 }
 
-class OfflineStore {
-  /** Campus map tile download. */
+export class OfflineStore {
   status = $state<OfflineStatus>("idle");
-  /** Buildings, rooms, aliases bundle for offline search. */
   directoryStatus = $state<OfflineStatus>("idle");
   directoryError = $state<string | null>(null);
   directoryProgress = $state(0);
   directoryProgressLabel = $state("");
   directoryLastSyncedAt = $state<string | null>(null);
-  /** Class schedules for active term in PGlite. */
   schedulesStatus = $state<OfflineStatus>("idle");
   schedulesError = $state<string | null>(null);
   schedulesProgressLabel = $state("");
@@ -400,7 +421,6 @@ class OfflineStore {
   );
   estimatedBytes = $derived(this.tilesTotal * AVG_TILE_BYTES);
 
-  // Compute the tile count up front so the size estimate shows before download.
   prepareEstimate = async () => {
     void this.refreshStorage();
     this.directoryLastSyncedAt =
@@ -464,7 +484,6 @@ class OfflineStore {
     };
 
     try {
-      // Modest concurrency to fill the cache quickly without hammering the API.
       await Promise.all(Array.from({ length: 6 }, () => worker()));
       await this.refreshStorage();
       this.status = this.cancelRequested ? "cancelled" : "done";

--- a/src/lib/stores/ui-stores.svelte.ts
+++ b/src/lib/stores/ui-stores.svelte.ts
@@ -1,4 +1,14 @@
-class ModalStore {
+import { SvelteMap } from "svelte/reactivity";
+import { dismissEphemeralOverlays } from "../overlay-stack.js";
+import type {
+  FloatingControlPanel,
+  LandingModalTab,
+  ModalStoreState,
+  QueryStoreState,
+  RecentSearch,
+} from "./store-types.js";
+
+export class ModalStore {
   private _modalStore: ModalStoreState = $state({
     open: false,
     type: null,
@@ -26,7 +36,7 @@ class ModalStore {
   };
 }
 
-class QueryStore {
+export class QueryStore {
   private _queryStore: QueryStoreState = $state({
     category: null,
     type: "query",
@@ -51,7 +61,6 @@ class QueryStore {
     ),
   );
 
-  // onclick of query buttons
   updateQuery = (obj: QueryStoreState) => {
     this._queryStore = obj;
     this.inputValue = obj.value;
@@ -92,7 +101,6 @@ class QueryStore {
     this.recentSearches.splice(id, 1);
   }
 
-  // when clicking the x button
   clearQuery = () => {
     this._queryStore = {
       category: null,
@@ -102,7 +110,6 @@ class QueryStore {
     this.inputValue = "";
   };
 
-  /** Drop an active result selection while keeping the search field editable. */
   exitResultMode = () => {
     this._queryStore = {
       category: null,
@@ -135,7 +142,7 @@ class QueryStore {
   };
 }
 
-class ToastStore {
+export class ToastStore {
   message: string | null = $state(null);
   type: "info" | "error" | "success" = $state("info");
 
@@ -149,7 +156,7 @@ class ToastStore {
   };
 }
 
-class MainControlsStore {
+export class MainControlsStore {
   collapsed: boolean = $state(false);
 
   toggle = () => {
@@ -165,7 +172,7 @@ class MainControlsStore {
   };
 }
 
-class FloatingControlPanelStore {
+export class FloatingControlPanelStore {
   openPanel: FloatingControlPanel | null = $state(null);
 
   toggle = (panel: FloatingControlPanel) => {

--- a/src/pages/building/[slug].astro
+++ b/src/pages/building/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import EntityPage from "@seo/EntityPage.astro";
 import { getBuildingSlug } from "@lib/app-data";
-import { getAllBuildings } from "@lib/services/map-data-service";
+import { getAllBuildingsCached } from "@lib/services/map-data-service";
 import { getBuildingPageData } from "@lib/services/ssg-service";
 import {
   absoluteUrl,
@@ -12,7 +12,7 @@ import {
 } from "@lib/site";
 
 export async function getStaticPaths() {
-  const buildings = await getAllBuildings();
+  const buildings = await getAllBuildingsCached();
 
   return buildings.map((building) => ({
     params: { slug: getBuildingSlug(building) },

--- a/src/pages/college/[slug].astro
+++ b/src/pages/college/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import EntityPage from "@seo/EntityPage.astro";
 import { getCollegeSlug } from "@lib/app-data";
-import { getAllColleges } from "@lib/services/map-data-service";
+import { getAllCollegesCached } from "@lib/services/map-data-service";
 import { getCollegePageData } from "@lib/services/ssg-service";
 import {
   absoluteUrl,
@@ -12,7 +12,7 @@ import {
 } from "@lib/site";
 
 export async function getStaticPaths() {
-  const colleges = await getAllColleges();
+  const colleges = await getAllCollegesCached();
 
   return colleges.map((college) => ({
     params: { slug: getCollegeSlug(college) },

--- a/src/pages/division/[slug].astro
+++ b/src/pages/division/[slug].astro
@@ -2,7 +2,7 @@
 import EntityPage from "@seo/EntityPage.astro";
 import { getDivisionSlug } from "@lib/app-data";
 import { getDivisionPageData } from "@lib/services/ssg-service";
-import { getAllDivisions } from "@lib/services/map-data-service";
+import { getAllDivisionsCached } from "@lib/services/map-data-service";
 import {
   absoluteUrl,
   breadcrumbSchema,
@@ -12,7 +12,7 @@ import {
 } from "@lib/site";
 
 export async function getStaticPaths() {
-  const divisions = await getAllDivisions();
+  const divisions = await getAllDivisionsCached();
 
   return divisions.map((division) => ({
     params: { slug: getDivisionSlug(division) },

--- a/src/pages/dorm/[slug].astro
+++ b/src/pages/dorm/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import EntityPage from "@seo/EntityPage.astro";
 import { getDormRouteSlug } from "@lib/app-data";
-import { getAllDorms } from "@lib/services/map-data-service";
+import { getAllDormsCached } from "@lib/services/map-data-service";
 import { getDormPageData } from "@lib/services/ssg-service";
 import {
   absoluteUrl,
@@ -12,7 +12,7 @@ import {
 } from "@lib/site";
 
 export async function getStaticPaths() {
-  const dorms = await getAllDorms();
+  const dorms = await getAllDormsCached();
 
   return dorms.map((dorm) => ({
     params: { slug: getDormRouteSlug(dorm) },

--- a/src/pages/event/[slug].astro
+++ b/src/pages/event/[slug].astro
@@ -11,9 +11,10 @@ import {
   jsonLd,
   webpageSchema,
 } from "@lib/site";
+import { getSeoEventsCached } from "@lib/services/event-service";
 
 export async function getStaticPaths() {
-  const events = await getSeoEvents();
+  const events = await getSeoEventsCached();
   return events.map((event) => ({
     params: { slug: event.slug },
   }));

--- a/src/pages/room/[slug].astro
+++ b/src/pages/room/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import EntityPage from "@seo/EntityPage.astro";
 import { getRoomRouteSlug } from "@lib/app-data";
-import { getAllRooms } from "@lib/services/map-data-service";
+import { getAllRoomsCached } from "@lib/services/map-data-service";
 import { getRoomPageData } from "@lib/services/ssg-service";
 import {
   absoluteUrl,
@@ -12,7 +12,7 @@ import {
 } from "@lib/site";
 
 export async function getStaticPaths() {
-  const rooms = await getAllRooms();
+  const rooms = await getAllRoomsCached();
 
   return rooms.map((room) => ({
     params: { slug: getRoomRouteSlug(room) },


### PR DESCRIPTION
## Summary
- **#389** — Fix store split build break and overlay click regressions
- **#390** — Restore semantic-release (`npmPublish: false`, remove `@semantic-release/git`)
- **#388** — Batch: hover preview, SSG cache, merge pipeline, dark mode, contributor profiles, and related tickets
- **#391** — AGENTS.md guidance on human-dependent issues

## Test plan
- [ ] CI green on merge
- [ ] Release workflow on `main` completes without `ENONPMTOKEN`
- [ ] Vercel production deploy succeeds
- [ ] App menu / flyouts / map clicks behave correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global Escape/overlay behavior and a broad store-module refactor alongside release config; SSG cache is build-scoped only and should not affect runtime API semantics.
> 
> **Overview**
> **Release batch** merging staging fixes for map chrome, build performance, release automation, and agent docs.
> 
> **semantic-release** no longer runs `@semantic-release/git` or publishes to npm (`npmPublish: false`), which should stop `ENONPMTOKEN` failures on `main` while still generating changelog and GitHub releases.
> 
> **Map chrome / overlays (#302):** New `openEphemeralOverlay` dismisses sibling flyouts before opening; global **Escape** calls `dismissEphemeralOverlays` first. Flyouts (app menu, term picker, shortcuts, offline maps) use that helper. **Focus traps** stop Escape propagation so nested dialogs don’t bubble to the app handler. **App menu** outside-click ignores `#offline-maps-dialog` so nested offline UI doesn’t close the menu.
> 
> **Search (#288):** Building/event suggestions carry full row data and show **entity hover previews** on hover/focus; previews clear on select.
> 
> **SSG (#331):** In-memory **build cache** (`ssg-cache`) plus `getAll*Cached` / `getSeoEventsCached`; entity `getStaticPaths` pages use cached loaders to cut duplicate DB work during Astro builds.
> 
> **Stores:** Shared types move to `store-types.ts`; domain store classes are **exported** from split modules; exclusive map modes use a **`registerMapMode` registry** instead of inline `deactivateMapModesExcept` branches.
> 
> **AGENTS.md:** Protocol for issues that need human coordination—don’t auto-close with `Closes #NNN`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1639b58a8a24b47e1598fe78d2d1fbc1821b13c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->