### PR TITLE
chore(release): 1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.17.1](https://github.com/uplbtools/room-tba/compare/v1.17.0...v1.17.1) (2026-06-29)
+
+
+### Bug Fixes
+
+* **store:** compile runes module as index.svelte.ts ([67acd53](https://github.com/uplbtools/room-tba/commit/67acd535a9410e94c44625bb824dc23131c45ecf)), closes [#295](https://github.com/uplbtools/room-tba/issues/295)
+
 # [1.17.0](https://github.com/uplbtools/room-tba/compare/v1.16.0...v1.17.0) (2026-06-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-room",
   "type": "module",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Sync `package.json` and `CHANGELOG.md` after semantic-release published [v1.17.1](https://github.com/uplbtools/room-tba/releases/tag/v1.17.1). Automated sync PR failed because Actions cannot open PRs in this org.

Includes `[skip ci]` so merge does not re-run release. Merging triggers a Vercel production redeploy with updated version metadata for the in-app label and `/changelog`.

## Test plan
- [ ] Merge to `main`
- [ ] Confirm Vercel production deploy succeeds
- [ ] Verify `/changelog` leads with 1.17.1
- [ ] Verify app menu shows v1.17.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version bump only; no logic, auth, or data-path changes in the diff.
> 
> **Overview**
> **Release metadata sync** for **v1.17.1** after semantic-release published the tag: `package.json` moves from **1.17.0** to **1.17.1**, and `CHANGELOG.md` gains a new top section for that release.
> 
> The changelog entry records the shipped fix (**store:** compile the runes module as `index.svelte.ts`, [#295](https://github.com/uplbtools/room-tba/issues/295)). There is **no application code** in this diff—only version and changelog alignment so the app menu, build metadata, and `/changelog` match the published release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54e0fc393d7c034fe823b215a156c6b7f9a58777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->