### PR TITLE
fix(ui): landing modal cannot be dismissed on prod

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -39,6 +39,7 @@
     getGlobalShortcutAction,
   } from "@lib/keyboard-shortcuts";
   import { dismissEphemeralOverlays } from "@lib/overlay-stack";
+  import { shouldAutoOpenLandingModal } from "@lib/landing-modal-auto-open";
 
   type Props = {
     initialSearch?: InitialSearchState;
@@ -84,15 +85,22 @@
     }
   });
 
+  let landingModalAutoOpenConsumed = $state(false);
+
   $effect(() => {
     if (
-      appBootstrapStore.phase === "ready" &&
-      !suppressLandingModal &&
-      localStorage.getItem("hideLandingModal") !== "true" &&
-      !modalStore.open
+      !shouldAutoOpenLandingModal({
+        consumed: landingModalAutoOpenConsumed,
+        phase: appBootstrapStore.phase,
+        suppressLandingModal,
+        hideLandingModal: localStorage.getItem("hideLandingModal") === "true",
+        modalOpen: modalStore.open,
+      })
     ) {
-      modalStore.openModal("landing");
+      return;
     }
+    landingModalAutoOpenConsumed = true;
+    modalStore.openModal("landing");
   });
   $effect(() => {
     updateData(queryStore.recentSearches);

--- a/src/lib/landing-modal-auto-open.test.ts
+++ b/src/lib/landing-modal-auto-open.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { shouldAutoOpenLandingModal } from "./landing-modal-auto-open";
+
+describe("shouldAutoOpenLandingModal", () => {
+  const ready = {
+    consumed: false,
+    phase: "ready",
+    suppressLandingModal: false,
+    hideLandingModal: false,
+    modalOpen: false,
+  };
+
+  it("opens once when bootstrap is ready", () => {
+    expect(shouldAutoOpenLandingModal(ready)).toBe(true);
+  });
+
+  it("does not reopen after the auto-open slot was consumed", () => {
+    expect(shouldAutoOpenLandingModal({ ...ready, consumed: true })).toBe(
+      false,
+    );
+  });
+
+  it("does not reopen when the user closes the modal", () => {
+    expect(
+      shouldAutoOpenLandingModal({
+        ...ready,
+        consumed: true,
+        modalOpen: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("respects hideLandingModal", () => {
+    expect(
+      shouldAutoOpenLandingModal({ ...ready, hideLandingModal: true }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/landing-modal-auto-open.ts
+++ b/src/lib/landing-modal-auto-open.ts
@@ -1,0 +1,20 @@
+export type LandingModalAutoOpenInput = {
+  /** Set after the one-time bootstrap auto-open has run. */
+  consumed: boolean;
+  phase: string;
+  suppressLandingModal: boolean;
+  hideLandingModal: boolean;
+  modalOpen: boolean;
+};
+
+/** Whether the welcome modal should auto-open once after bootstrap (#302). */
+export function shouldAutoOpenLandingModal(
+  input: LandingModalAutoOpenInput,
+): boolean {
+  if (input.consumed) return false;
+  if (input.phase !== "ready") return false;
+  if (input.suppressLandingModal) return false;
+  if (input.hideLandingModal) return false;
+  if (input.modalOpen) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary

Fixes the production bug where the welcome modal could not be closed (Escape, backdrop click, or **Get Started** appeared to do nothing).

**Root cause:** `Entry.svelte` had a `$effect` that auto-opened the landing modal whenever `modalStore.open` was false. Closing the modal set `open` to false, which immediately re-ran the effect and reopened it — unless the user had previously set `hideLandingModal` in localStorage.

This was introduced with the bootstrap auto-open logic and is unrelated to the store split / overlay stacking work.

## Fix

- Track a one-time `landingModalAutoOpenConsumed` flag so bootstrap auto-open runs only once per page load.
- Extract `shouldAutoOpenLandingModal()` with unit tests covering the close-after-open case.

## Test plan

- [x] `bun test src/lib/landing-modal-auto-open.test.ts`
- [ ] Open prod/staging — dismiss welcome modal via Get Started, Escape, and backdrop
- [ ] Confirm modal stays closed until explicitly reopened from the app menu
- [ ] Confirm "Don't show again" still persists across reloads

## Accountability

Hotfix PR directly to `main` per user request. Merge triggers Vercel production deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI bootstrap change with extracted pure helper and unit tests; no auth, data, or API impact.
> 
> **Overview**
> Fixes the welcome modal **reopening immediately** after dismiss (Escape, backdrop, Get Started) because `Entry.svelte`’s bootstrap `$effect` treated `modalStore.open === false` as a signal to auto-open again.
> 
> **Changes:** Adds a one-time `landingModalAutoOpenConsumed` flag set when the auto-open runs, and moves the open/close gating into `shouldAutoOpenLandingModal()` (bootstrap ready, not suppressed, not hidden via localStorage, modal not already open, slot not consumed). Unit tests cover the consumed and `hideLandingModal` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d339834ed8223940a0e3fc22718519ea97231937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->