### PR TITLE
docs(changelog): backfill v1.10.0–v1.16.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,152 @@
 * **schedule-route:** import personal schedule and multi-stop routing ([#329](https://github.com/uplbtools/room-tba/issues/329)) ([c0205c7](https://github.com/uplbtools/room-tba/commit/c0205c7a81e3450a25f9271f03d94a598e19be78))
 * **ui:** overlay stacking, PWA guards, changelog overview ([#302](https://github.com/uplbtools/room-tba/issues/302), [#321](https://github.com/uplbtools/room-tba/issues/321)-323, [#212](https://github.com/uplbtools/room-tba/issues/212)) ([f4a0c8b](https://github.com/uplbtools/room-tba/commit/f4a0c8b42160f394cf333e0943061d4c61f4a7df)), closes [#321-323](https://github.com/uplbtools/room-tba/issues/321-323) [#322](https://github.com/uplbtools/room-tba/issues/322) [#323](https://github.com/uplbtools/room-tba/issues/323)
 
+# [1.16.0](https://github.com/uplbtools/room-tba/compare/v1.15.0...v1.16.0) (2026-06-29)
+
+
+### Features
+
+* **batch:** 5 small tickets — pin validation, schedule theme, PWA install, changelog, offline ([#354](https://github.com/uplbtools/room-tba/issues/354)) ([#355](https://github.com/uplbtools/room-tba/issues/355)) ([89969c1](https://github.com/uplbtools/room-tba/commit/89969c169795f0880a1ea4f92a753ea5d9adb9c7)), closes [#283](https://github.com/uplbtools/room-tba/issues/283) [#240](https://github.com/uplbtools/room-tba/issues/240) [#213](https://github.com/uplbtools/room-tba/issues/213) [#212](https://github.com/uplbtools/room-tba/issues/212) [#101](https://github.com/uplbtools/room-tba/issues/101)
+
+# [1.15.0](https://github.com/uplbtools/room-tba/compare/v1.14.0...v1.15.0) (2026-06-29)
+
+
+### Features
+
+* **ui:** sync copy, action chips, LEC/LAB grouping ([#338](https://github.com/uplbtools/room-tba/issues/338), [#319](https://github.com/uplbtools/room-tba/issues/319), [#301](https://github.com/uplbtools/room-tba/issues/301)) ([ec503e5](https://github.com/uplbtools/room-tba/commit/ec503e53fc6d698dd7f5cd9f0d67dac86fb91504))
+
+# [1.14.0](https://github.com/uplbtools/room-tba/compare/v1.13.1...v1.14.0) (2026-06-29)
+
+
+### Bug Fixes
+
+* **pwa:** load legal pages outside fallback ([5571e79](https://github.com/uplbtools/room-tba/commit/5571e7939f0e58e430bf2c6cdc602c344ab6e601))
+* **schedule:** bind canvas element ref instead of getElementById ([8738719](https://github.com/uplbtools/room-tba/commit/873871910ad2b27243414c072b17e1dd221adb76)), closes [#330](https://github.com/uplbtools/room-tba/issues/330)
+* **search:** make recent search remove button work ([28454da](https://github.com/uplbtools/room-tba/commit/28454da4b209c8b4a2d55c60b6f0c1c52b36d764)), closes [#326](https://github.com/uplbtools/room-tba/issues/326)
+* **ui:** close jeepney stop panel when query changes ([ff86769](https://github.com/uplbtools/room-tba/commit/ff86769d771ada9ece6d6913c87562f24df333a7)), closes [#324](https://github.com/uplbtools/room-tba/issues/324)
+* **ux:** open Contributors on Campus team tab ([dae07dd](https://github.com/uplbtools/room-tba/commit/dae07dd0cb4e16bc365ca13e98a3513baf4f5c40)), closes [#320](https://github.com/uplbtools/room-tba/issues/320)
+
+
+### Features
+
+* **batch:** 5 small tickets — refresh, class counts, transit exclusivity, stop panel, z-index fix ([#344](https://github.com/uplbtools/room-tba/issues/344)) ([6b8eb45](https://github.com/uplbtools/room-tba/commit/6b8eb4583e9d4fb353b4392160fd722d5ce16aa9)), closes [#340](https://github.com/uplbtools/room-tba/issues/340) [#337](https://github.com/uplbtools/room-tba/issues/337) [#342](https://github.com/uplbtools/room-tba/issues/342) [#324](https://github.com/uplbtools/room-tba/issues/324) [#339](https://github.com/uplbtools/room-tba/issues/339)
+
+# [1.13.1](https://github.com/uplbtools/room-tba/compare/v1.13.0...v1.13.1) (2026-06-28)
+
+
+### Bug Fixes
+
+* **amis:** correct CRS term IDs and harden import pipeline ([a93b89e](https://github.com/uplbtools/room-tba/commit/a93b89ee472e820e522105184ee1451cb4582555))
+
+# [1.13.0](https://github.com/uplbtools/room-tba/compare/v1.12.0...v1.13.0) (2026-06-28)
+
+
+### Bug Fixes
+
+* **copy:** repair terms typos and finish em-dash cleanup ([bf3ae16](https://github.com/uplbtools/room-tba/commit/bf3ae1655d7cdf30a492158d2def128384812f25))
+* **map:** tighten map chrome layout and mobile panel exclusivity ([8a3974e](https://github.com/uplbtools/room-tba/commit/8a3974e71119f5ef75281b420c3f91b6ec58f561))
+* **ui:** improve entity detail panels on mobile and narrow widths ([70e511e](https://github.com/uplbtools/room-tba/commit/70e511e061e1ea3ac4e1a816accf8bcff8baaddf))
+* **ui:** keep term selector visible in map edit mode ([5229493](https://github.com/uplbtools/room-tba/commit/5229493c0b5c4f0b1d8bfea0e6cb51bc22898f6f))
+
+
+### Features
+
+* AMIS class import, term calendar, and map UI fixes ([#314](https://github.com/uplbtools/room-tba/issues/314)) ([7ec9f02](https://github.com/uplbtools/room-tba/commit/7ec9f02d1ef9b2d9360330d45924f10a2fb5d597))
+* **amis:** add import pipeline with sanitized local cache ([b046501](https://github.com/uplbtools/room-tba/commit/b04650146fd035435430e94edf10ffcd53a5b090))
+* **db:** add term calendar migrations and midyear fixes ([9b2778f](https://github.com/uplbtools/room-tba/commit/9b2778f7f737ecc2058141cfbe5f7b01ab14f9ec))
+* **ui:** polish term selector and add jeepney stop modal ([1684b13](https://github.com/uplbtools/room-tba/commit/1684b136852a5e75855347f137162ee32ab8821e))
+* **ui:** sync term selection through URLs and static entity pages ([4a45d10](https://github.com/uplbtools/room-tba/commit/4a45d10f24e99fe8587f1cb20441691fb39a70c0))
+
+# [1.12.0](https://github.com/uplbtools/room-tba/compare/v1.11.0...v1.12.0) (2026-06-28)
+
+
+### Features
+
+* **chrome:** legal pages, community links, and status bar rework ([#303](https://github.com/uplbtools/room-tba/issues/303)) ([39ace06](https://github.com/uplbtools/room-tba/commit/39ace060a779c054dab089443774837200b70e36))
+
+# [1.11.0](https://github.com/uplbtools/room-tba/compare/v1.10.0...v1.11.0) (2026-06-28)
+
+
+### Bug Fixes
+
+* **a11y:** fix clipped focus rings and unify action chip hovers ([07ff6cb](https://github.com/uplbtools/room-tba/commit/07ff6cbb3ab1559b7bad3b67c14fd9cb239ce71d))
+* **a11y:** improve map UI accessibility for dialogs and panels ([e4c3c21](https://github.com/uplbtools/room-tba/commit/e4c3c213a3b566fdd3dd4e66005cbe2b46250d6f))
+* **contributor:** hide event propose name field until propose is clicked ([865c220](https://github.com/uplbtools/room-tba/commit/865c2208e5110366c8753d038f5244116a0cf6cd))
+* **dorms:** harden amenity parsing for quoted Postgres arrays ([224f07d](https://github.com/uplbtools/room-tba/commit/224f07d0004c5114752470dd3005674065e1e7eb))
+* **dorms:** strip quote wrappers from amenity chips ([d5cc921](https://github.com/uplbtools/room-tba/commit/d5cc92150235dca13479727193124d88ec76d1f3))
+* **map-chrome:** clarify status bar directions progress and catalog date ([e999233](https://github.com/uplbtools/room-tba/commit/e9992333b89b8255ef3260a15878a9832cf82ac3))
+* **map-chrome:** collapse status bar details by default on narrow layouts ([1206df4](https://github.com/uplbtools/room-tba/commit/1206df4a533960002b82f7f5cf96001f67900e72))
+* **map-chrome:** fix attribution expand lifting FABs and dedupe editor entry ([11a1756](https://github.com/uplbtools/room-tba/commit/11a17560ec27c87758a5f70fdbd729090221af1d))
+* **map-chrome:** fix bottom gradient leaking map pixels ([4e8b549](https://github.com/uplbtools/room-tba/commit/4e8b549e2d479528e02c477bae2997790941c890))
+* **map-chrome:** fix map tools mode row and restore campus tour toggle ([7578d37](https://github.com/uplbtools/room-tba/commit/7578d37dc320e0d8f00868d276d1eec66ddd669f))
+* **map-chrome:** fix map tools panel positioning after motion pass ([a01d04c](https://github.com/uplbtools/room-tba/commit/a01d04c9a2efb9cdf15fbce60c93b5061b3ae258))
+* **map-chrome:** fix mobile padding and FAB placement ([848d43b](https://github.com/uplbtools/room-tba/commit/848d43b471b35ca6bdbc8c2469faf85777c1fb09))
+* **map-chrome:** prevent editor shelf clip in search chrome ([6b42d0d](https://github.com/uplbtools/room-tba/commit/6b42d0d1884180070411e5123a95860b3f3d0c16))
+* **map-chrome:** remove hover-triggered scrollbar from search chip row ([78d1550](https://github.com/uplbtools/room-tba/commit/78d1550777c941062e5c3b4791437970a9cc2ef6))
+* **map-chrome:** remove unnecessary horizontal scroll from map tools ([016b1cd](https://github.com/uplbtools/room-tba/commit/016b1cd6ca532fad926f1f808a104b968e73c49b))
+* **map-chrome:** restore spacious mobile map tools sheet ([0ab45bb](https://github.com/uplbtools/room-tba/commit/0ab45bbeb9a98e71cbce44e3cdc99ddf59ba134b))
+* **map-chrome:** restore two-row expanded status bar with sync transparency ([3aa63d2](https://github.com/uplbtools/room-tba/commit/3aa63d2e38bb4621f35dbedc47af2fc8b57bb46d))
+* **map:** align compass icon when map bearing is north ([1c530b1](https://github.com/uplbtools/room-tba/commit/1c530b1227ac429fb0f8267f865c4cc1424b3dea))
+* **map:** hide 3D building extrusions in flat 2D view ([5400f15](https://github.com/uplbtools/room-tba/commit/5400f1515d3688b420a68595b66a2ee4211c1143))
+* **map:** raise building pins above events and dedupe pin labels ([3d278cb](https://github.com/uplbtools/room-tba/commit/3d278cb62af0989aea2eb14992dccbe8b8869dcb))
+* **map:** remove dead campus tour control that broke hydration ([939fc9d](https://github.com/uplbtools/room-tba/commit/939fc9dba8cd42094fc777b47c4f38384102456b))
+* **map:** set basemap preset to warm stone not neutral greige ([c6b6dd8](https://github.com/uplbtools/room-tba/commit/c6b6dd85b05926e6d20b2ce5f1c6f2a9786b4802))
+* **security:** harden image URL validation and layout observer crash ([9b10199](https://github.com/uplbtools/room-tba/commit/9b1019995cec2b808fa8dabecd989cb3a7f560ef))
+* **ui:** dismiss loading shell when hydration fails to start ([b8cd003](https://github.com/uplbtools/room-tba/commit/b8cd003eb107843003932f43adf472c4239fc699))
+* **ui:** fix bootstrap loading overlay that never dismisses ([52a7c00](https://github.com/uplbtools/room-tba/commit/52a7c00f97e2c17e3fefaabf6b145899eed585e6))
+* **ui:** landing modal tabs and stale events cache on boot ([01a91fa](https://github.com/uplbtools/room-tba/commit/01a91fa00292a1d1e3ea31dbce3909c8558f1056))
+
+
+### Features
+
+* **api:** add term-aware class queries and GET /api/terms ([9f897c8](https://github.com/uplbtools/room-tba/commit/9f897c8d79bcb5b0715d65d27b25df033bd0b0b9))
+* **contributor:** replace Google Forms links with in-app propose flow ([896bbb2](https://github.com/uplbtools/room-tba/commit/896bbb23fda6c115f43e0f0b3066348251be886d))
+* **db:** add terms table and seed UPLB semesters ([6d5b82f](https://github.com/uplbtools/room-tba/commit/6d5b82fef27f771d6fe3653935c470874a1f1694))
+* **editor:** foundation refactor and map chrome componentization ([8d4cfa4](https://github.com/uplbtools/room-tba/commit/8d4cfa461ab5ad7adac1f0ba749d2e27358dfc86))
+* **editor:** move tools to top-bar chip, shelf, and add-to-map modal ([327dd07](https://github.com/uplbtools/room-tba/commit/327dd07da68464ae7d2f31b41058858764c03509))
+* **editor:** open dashboard full-screen on mobile ([533e1ff](https://github.com/uplbtools/room-tba/commit/533e1ff789a0233eeec870f9400021e751000170))
+* **events:** add Cloudflare R2 image upload for event photos ([a58708b](https://github.com/uplbtools/room-tba/commit/a58708b3bc88c01ea65cb4c2734ad1b5eff7bf74))
+* **events:** include campus date in map pin labels ([54edf54](https://github.com/uplbtools/room-tba/commit/54edf541cb2f5b1f6235fbf6901f0aece6a4a3bc))
+* **map-chrome:** add functional motion transitions ([c229b2e](https://github.com/uplbtools/room-tba/commit/c229b2ea74b1901271d227739c1ab46ab44ceb57))
+* **map-chrome:** unify bottom tray, transit chip, Supabase, and event images ([267e6e9](https://github.com/uplbtools/room-tba/commit/267e6e9d8ca2e5b52a367ddf587a485cbda3adc3))
+* **map:** gate auto-rotate behind opt-in and motion policy ([ac3bc81](https://github.com/uplbtools/room-tba/commit/ac3bc81923a27539902fecb156383572b11c3311))
+* **map:** sync entity selection to canonical browser URLs ([cec355e](https://github.com/uplbtools/room-tba/commit/cec355e7535ad3891184d04d78c6b6f3214d498a))
+* **side-panel:** add copy-link actions for room and dorm panels ([ba5b19d](https://github.com/uplbtools/room-tba/commit/ba5b19d9c4ad8f263004c6e5de382cd4bdc74dc7))
+* **store:** add term selection and room class cache ([0b9ec4a](https://github.com/uplbtools/room-tba/commit/0b9ec4af2cec98a0c52243b53e26d9afe5727a7d))
+* **ui:** add term selector to expanded status bar ([df119a5](https://github.com/uplbtools/room-tba/commit/df119a577591737cf50d0168851ca3e4dd295ae3))
+* **ui:** filter room schedule by active term ([185c83d](https://github.com/uplbtools/room-tba/commit/185c83df13cf23c1a6f23ee839cac0cea4aae9a9))
+* **ui:** show loading state while campus data sync is pending ([6626e80](https://github.com/uplbtools/room-tba/commit/6626e8039021e94844dddf842fd0ef3c2ae13917))
+* **ui:** show map immediately and sync campus data in background ([902a038](https://github.com/uplbtools/room-tba/commit/902a03830f6d401553c31431b92d57c535d45889))
+
+# [1.10.0](https://github.com/uplbtools/room-tba/compare/v1.9.0...v1.10.0) (2026-06-25)
+
+
+### Bug Fixes
+
+* **auth:** rename isAdmin store flag to isLoggedIn ([#203](https://github.com/uplbtools/room-tba/issues/203)) ([f18a160](https://github.com/uplbtools/room-tba/commit/f18a160234c85db586a2c565c410a31da3b1eb52))
+* **ci:** do not fail release when version sync PR is blocked ([6170b5b](https://github.com/uplbtools/room-tba/commit/6170b5ba44121b9f7d4edde22598554ba866b916))
+* **proposals:** harden approval flow, entity checks, and GET access ([#208](https://github.com/uplbtools/room-tba/issues/208)) ([b5e9573](https://github.com/uplbtools/room-tba/commit/b5e957368be5714fd876f453b8aad3b837babb65))
+* **pwa:** raise Workbox precache limit for AppRoot bundle ([447212c](https://github.com/uplbtools/room-tba/commit/447212c1bc320773b74d23bb9eadf3e20b8b619f))
+* **search:** unblock typing after event selection and stale room fallback ([8e58322](https://github.com/uplbtools/room-tba/commit/8e583228f1a7e085fc838536bff80c6dd38a9f2f))
+* **ui:** improve landing modal scroll and backdrop blur ([bdd4944](https://github.com/uplbtools/room-tba/commit/bdd4944d31fac510c3516504fa43efeab5ad9146))
+
+
+### Features
+
+* **auth:** add multi-user editor sessions and publish role gates ([#203](https://github.com/uplbtools/room-tba/issues/203)) ([a86c3c3](https://github.com/uplbtools/room-tba/commit/a86c3c34e82efe6038cd293671fd517bc2eefed8))
+* **db:** add admin_users and edit_proposals schema migrations ([610150c](https://github.com/uplbtools/room-tba/commit/610150c4d26158eefe25347207169ad254e2643b)), closes [#203](https://github.com/uplbtools/room-tba/issues/203) [#208](https://github.com/uplbtools/room-tba/issues/208)
+* **editor:** add admin POST routes for direct entity creation ([a0b9246](https://github.com/uplbtools/room-tba/commit/a0b9246bf25e8aa348ecaa19a1c1d0ab4404837a))
+* **editor:** add create affordances in publisher shield menu ([e3ad02a](https://github.com/uplbtools/room-tba/commit/e3ad02a13f9edd79ed9571e0e8d1439d34b2df6e))
+* **proposals:** add addition proposal store and event placement state ([#208](https://github.com/uplbtools/room-tba/issues/208)) ([b676581](https://github.com/uplbtools/room-tba/commit/b6765817022c7736cc4c4a2801372f4d5359f6f3))
+* **proposals:** add admin create helpers for new entities ([#208](https://github.com/uplbtools/room-tba/issues/208)) ([16387e0](https://github.com/uplbtools/room-tba/commit/16387e08888b4a0c37c2e9a810dbe94340f55659))
+* **proposals:** add client helpers for create proposals ([#208](https://github.com/uplbtools/room-tba/issues/208)) ([f988fd6](https://github.com/uplbtools/room-tba/commit/f988fd635f89cf4821222451b71ed60b0a1d320f))
+* **proposals:** add edit proposal service and API routes ([#208](https://github.com/uplbtools/room-tba/issues/208)) ([cfa62d3](https://github.com/uplbtools/room-tba/commit/cfa62d301ec74281dfbf980832bfafa4ac7e80e4))
+* **proposals:** add map UI for proposing new campus entities ([#208](https://github.com/uplbtools/room-tba/issues/208)) ([71239e2](https://github.com/uplbtools/room-tba/commit/71239e2ba509a1679d9754210bad231e71af7bc6))
+* **proposals:** add suggest-edit UI, review panel, and map pin proposals ([#208](https://github.com/uplbtools/room-tba/issues/208)) ([30c6d80](https://github.com/uplbtools/room-tba/commit/30c6d80b28238d459de13cbdf01ab9659260aaef))
+* **proposals:** support create proposals in service and review UI ([#208](https://github.com/uplbtools/room-tba/issues/208)) ([a600947](https://github.com/uplbtools/room-tba/commit/a600947a88db04b45c07417f1b84f7a51271bb8a))
+* **rooms:** detect duplicate names and offer in-app merge ([489da72](https://github.com/uplbtools/room-tba/commit/489da723ef01d04de9d0bb213b0a15158f990952))
+* **taxonomy:** link divisions to parent colleges ([e81e509](https://github.com/uplbtools/room-tba/commit/e81e509139cf474ce0dc6bfbd2742234b5b0dd2a))
+
 # [1.9.0](https://github.com/uplbtools/room-tba/compare/v1.8.0...v1.9.0) (2026-06-25)
 
 


### PR DESCRIPTION
## Summary

Inserts missing **1.10.0 through 1.16.0** sections into `CHANGELOG.md` (including **1.13.1**), sourced from existing GitHub Release bodies. Closes the gap between **1.17.0** and **1.9.0** that formed while semantic-release published tags but repo sync PRs could not land.

## Test plan

- [x] Version headings run 1.17.1 → 1.9.0 without gaps
- [x] `bun test src/lib/changelog-highlights.test.ts`
- [ ] After deploy, `/changelog` lists 1.10–1.16 entries

Includes `[skip ci]` — docs only, no version bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to `CHANGELOG.md`; no code, config, or release pipeline behavior changes.
> 
> **Overview**
> **Backfills missing release history** in `CHANGELOG.md` so the file is continuous from **1.17.x** down through **1.9.0**.
> 
> Inserts new version sections for **1.16.0, 1.15.0, 1.14.0, 1.13.1, 1.13.0, 1.12.0, 1.11.0, and 1.10.0**, each with the usual compare links, dates, and grouped **Features** / **Bug Fixes** bullets copied from existing GitHub Release bodies. This closes the gap that appeared when semantic-release tagged releases but repo sync PRs could not land the changelog updates.
> 
> Docs-only (`[skip ci]`); no application or runtime behavior changes beyond what `/changelog` and changelog highlight parsing already read from this file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58790cd3b2c8a36c42078e80463d0718e45b2279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->