### PR TITLE
fix(ui): search chrome UX → main

### DIFF
--- a/src/components/svelte/map-chrome/KeyboardShortcutsChip.svelte
+++ b/src/components/svelte/map-chrome/KeyboardShortcutsChip.svelte
@@ -39,16 +39,41 @@
     };
   });
 
+  const PANEL_MAX_HEIGHT = 20 * 16;
+  const VIEWPORT_MARGIN = 8;
+  const TRIGGER_GAP = 6;
+
   function updatePanelPosition() {
     if (!open || !triggerEl) return;
     const rect = triggerEl.getBoundingClientRect();
-    const width = Math.min(18 * 16, window.innerWidth - 16);
+    const width = Math.min(18 * 16, window.innerWidth - VIEWPORT_MARGIN * 2);
     const left = Math.min(
-      Math.max(8, rect.right - width),
-      window.innerWidth - width - 8,
+      Math.max(VIEWPORT_MARGIN, rect.left),
+      window.innerWidth - width - VIEWPORT_MARGIN,
     );
-    const bottom = Math.max(8, window.innerHeight - rect.top + 8);
-    panelStyle = `left: ${left}px; bottom: ${bottom}px; width: ${width}px;`;
+
+    const measuredHeight = panelEl?.offsetHeight ?? PANEL_MAX_HEIGHT;
+    const maxHeight = Math.min(
+      PANEL_MAX_HEIGHT,
+      window.innerHeight - VIEWPORT_MARGIN * 2,
+    );
+    const spaceBelow =
+      window.innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN;
+    const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN;
+    const preferredHeight = Math.min(maxHeight, measuredHeight);
+
+    let top: number;
+    let heightCap: number;
+
+    if (spaceBelow >= preferredHeight || spaceBelow >= spaceAbove) {
+      top = rect.bottom + TRIGGER_GAP;
+      heightCap = Math.max(0, Math.min(maxHeight, spaceBelow));
+    } else {
+      heightCap = Math.max(0, Math.min(maxHeight, spaceAbove));
+      top = Math.max(VIEWPORT_MARGIN, rect.top - TRIGGER_GAP - heightCap);
+    }
+
+    panelStyle = `left: ${left}px; top: ${top}px; width: ${width}px; max-height: ${heightCap}px;`;
   }
 
   $effect(() => {
@@ -56,7 +81,19 @@
     updatePanelPosition();
     const handleLayout = () => updatePanelPosition();
     window.addEventListener("resize", handleLayout);
-    return () => window.removeEventListener("resize", handleLayout);
+    window.addEventListener("scroll", handleLayout, true);
+    return () => {
+      window.removeEventListener("resize", handleLayout);
+      window.removeEventListener("scroll", handleLayout, true);
+    };
+  });
+
+  $effect(() => {
+    if (!open || !panelEl) return;
+    updatePanelPosition();
+    const observer = new ResizeObserver(() => updatePanelPosition());
+    observer.observe(panelEl);
+    return () => observer.disconnect();
   });
 
   function toggleOpen() {
@@ -169,8 +206,8 @@
     display: flex;
     flex-direction: column;
     gap: 0.625rem;
-    max-height: min(60vh, 20rem);
     overflow-y: auto;
+    box-sizing: border-box;
   }
 
   .shortcuts-panel__lead {

--- a/src/components/svelte/modal/FilterModalContent.svelte
+++ b/src/components/svelte/modal/FilterModalContent.svelte
@@ -21,10 +21,12 @@
     filter_name: string,
   ) {
     return () => {
-      queryStore.updateQuery(
-        { type: "result", category: filter_type },
-        filter_name,
-      );
+      queryStore.updateQuery({
+        type: "result",
+        category: filter_type,
+        value: filter_name,
+      });
+      queryStore.inputValue = filter_name;
       modalStore.closeModal();
     };
   }
@@ -40,6 +42,10 @@
   function formatDivisionLabel(name: string) {
     return name.replace(/(Department of |Institute of)/, "");
   }
+  $effect(() => {
+    if (!modalStore.open || modalStore.type !== "filter") return;
+    activeTab = modalStore.filterTab ?? "buildings";
+  });
 </script>
 
 <div class="filter-modal">

--- a/src/components/svelte/search/CampusBrowseChips.svelte
+++ b/src/components/svelte/search/CampusBrowseChips.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import BookText from "@lucide/svelte/icons/book-text";
+  import GraduationCap from "@lucide/svelte/icons/graduation-cap";
+  import Landmark from "@lucide/svelte/icons/landmark";
+  import University from "@lucide/svelte/icons/university";
+  import {
+    openBrowseClasses,
+    openCampusBrowseModal,
+    type CampusBrowseTab,
+  } from "@lib/browse-campus";
+  import { modalStore, queryStore, sidePanelStore } from "@lib/store.svelte";
+
+  type Props = {
+    /** Compact chips for the search chip row; default fits the suggestions panel. */
+    variant?: "inline" | "panel";
+  };
+
+  const { variant = "panel" }: Props = $props();
+
+  const tabs: {
+    id: CampusBrowseTab | "classes";
+    label: string;
+    icon: typeof University;
+  }[] = [
+    { id: "buildings", label: "Buildings", icon: University },
+    { id: "colleges", label: "Colleges", icon: GraduationCap },
+    { id: "divisions", label: "Divisions", icon: Landmark },
+    { id: "classes", label: "Classes", icon: BookText },
+  ];
+
+  function handleBrowse(id: CampusBrowseTab | "classes") {
+    if (id === "classes") {
+      openBrowseClasses(queryStore, sidePanelStore);
+      return;
+    }
+    openCampusBrowseModal(modalStore, id);
+  }
+</script>
+
+<div
+  class="campus-browse-chips"
+  class:campus-browse-chips--inline={variant === "inline"}
+  role="toolbar"
+  aria-label="Browse campus"
+>
+  {#each tabs as tab (tab.id)}
+    <button
+      type="button"
+      class="campus-browse-chip"
+      onclick={() => handleBrowse(tab.id)}
+    >
+      <tab.icon size={14} aria-hidden="true" />
+      <span>{tab.label}</span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .campus-browse-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    padding: 0 0.5rem 0.375rem;
+  }
+
+  .campus-browse-chips--inline {
+    flex-wrap: nowrap;
+    padding: 0;
+  }
+
+  .campus-browse-chip {
+    all: unset;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3125rem;
+    min-height: 2rem;
+    padding: 0.3125rem 0.625rem;
+    border: 1px solid var(--map-chrome-border, hsl(5 10% 68%));
+    border-radius: 999px;
+    background: var(--map-chrome-surface, hsl(5 20% 97%));
+    color: hsl(5, 53%, 28%);
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1.2;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .campus-browse-chips--inline .campus-browse-chip {
+    flex: 0 0 auto;
+  }
+
+  .campus-browse-chip:hover,
+  .campus-browse-chip:focus-visible {
+    border-color: hsl(5, 53%, 32%);
+    background: hsl(5, 53%, 96%);
+  }
+
+  .campus-browse-chip:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 1px;
+  }
+</style>

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -26,6 +26,7 @@
   import MapDimensionToggle from "@ui/MapDimensionToggle.svelte";
   import MapChromeToggleButton from "@ui/map-chrome/MapChromeToggleButton.svelte";
   import KeyboardShortcutsChip from "@ui/map-chrome/KeyboardShortcutsChip.svelte";
+  import CampusBrowseChips from "@ui/search/CampusBrowseChips.svelte";
   import { observeBlockHeight } from "@lib/layout-css-vars";
   import { registerSearchFocus } from "@lib/search-focus";
   import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
@@ -283,7 +284,9 @@
               >
               <label class="sr-only" for="search">Search campus</label>
               <input
-                type="search"
+                type="text"
+                role="searchbox"
+                enterkeyhint="search"
                 id="search"
                 autocomplete="off"
                 value={draftInput}
@@ -368,6 +371,7 @@
           class="map-search-chrome__suggestions"
           role="listbox"
           aria-label="Search suggestions"
+          onmousedown={(event) => event.preventDefault()}
           in:fade={dropdownFadeIn(reducedMotion.current)}
           out:fade={dropdownFadeOut(reducedMotion.current)}
         >
@@ -382,6 +386,9 @@
           {/if}
           <TermSelector />
           {#if chrome.showSearchSuggestions}
+            {#if !showSearchDropdown}
+              <CampusBrowseChips variant="inline" />
+            {/if}
             {#if showIdleEventsChrome}
               <button
                 type="button"
@@ -407,7 +414,9 @@
             <BuildingTypeFilterBar />
             <TransitFilterChip />
           {/if}
-          <KeyboardShortcutsChip compact={mobile.current} />
+          {#if !(showSearchDropdown && draftInput.trim() === "")}
+            <KeyboardShortcutsChip compact={mobile.current} />
+          {/if}
         </div>
       {/if}
 
@@ -548,7 +557,7 @@
     min-width: 0;
   }
 
-  .search-root.mobile-shell input[type="text"] {
+  .search-root.mobile-shell .map-search-chrome__pill input {
     min-width: 0;
   }
 
@@ -734,7 +743,7 @@
     color: hsl(0, 0%, 28%);
   }
 
-  input[type="text"] {
+  .map-search-chrome__pill input {
     flex: 1 1 auto;
     min-width: 8.5rem;
     border: none;
@@ -745,11 +754,11 @@
     text-overflow: ellipsis;
   }
 
-  .search-root:not(.mobile-shell) input[type="text"] {
+  .search-root:not(.mobile-shell) .map-search-chrome__pill input {
     min-width: 15rem;
   }
 
-  input[type="text"]::placeholder {
+  .map-search-chrome__pill input::placeholder {
     color: #6b6b6b;
   }
 

--- a/src/components/svelte/search/Suggestion.svelte
+++ b/src/components/svelte/search/Suggestion.svelte
@@ -44,6 +44,7 @@
   }
 
   function handleRemoveRecent(event: MouseEvent) {
+    event.preventDefault();
     event.stopPropagation();
     if (typeof id === "undefined") return;
     queryStore.removeRecentSearch(id);
@@ -116,7 +117,7 @@
       type="button"
       class="suggestion-remove"
       aria-label={`Remove ${value} from recent searches`}
-      onclick={handleRemoveRecent}
+      onmousedown={handleRemoveRecent}
     >
       <X size={18} aria-hidden="true" />
     </button>

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -6,10 +6,7 @@
     searchLocalRooms,
   } from "@lib/local/data/utils";
   import { buildEntitySuggestions } from "@lib/search-suggestions";
-  import {
-    queryStore,
-    buildingTypeFilter,
-  } from "@lib/store.svelte";
+  import { queryStore, buildingTypeFilter } from "@lib/store.svelte";
   import {
     buildingMatchesTypeFilter,
     dormMatchesTypeFilter,

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -9,7 +9,6 @@
   import {
     queryStore,
     buildingTypeFilter,
-    modalStore,
   } from "@lib/store.svelte";
   import {
     buildingMatchesTypeFilter,
@@ -18,6 +17,8 @@
   import SearchQuerySuggestion from "./SearchQuerySuggestion.svelte";
   import FinalExamSuggestion from "./FinalExamSuggestion.svelte";
   import Suggestion from "./Suggestion.svelte";
+  import CampusBrowseChips from "./CampusBrowseChips.svelte";
+  import KeyboardShortcutsChip from "@ui/map-chrome/KeyboardShortcutsChip.svelte";
 
   const appData = getAppData();
   const { buildings, colleges, divisions, dorms, events, loaded } =
@@ -135,17 +136,15 @@
 </script>
 
 <!-- class:visible={queryStore.inputValue === ""} -->
-<div class="suggestions-container search-suggestions">
+<div
+  class="suggestions-container search-suggestions"
+  onmousedown={(event) => event.preventDefault()}
+>
   <!-- class:force-visible={queryStore.inputValue === ""} -->
   {#if queryStore.inputValue === ""}
-    <div class="browse-campus-row">
-      <button
-        type="button"
-        class="browse-campus-btn"
-        onclick={() => modalStore.openModal("filter")}
-      >
-        Browse buildings & rooms
-      </button>
+    <CampusBrowseChips />
+    <div class="suggestions-toolbar">
+      <KeyboardShortcutsChip compact />
     </div>
     {#if queryStore.recentSearches.length !== 0}
       <h2 class="suggestions-header">Recent searches</h2>
@@ -212,6 +211,12 @@
     contain: layout style;
   }
 
+  .suggestions-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 0.5rem 0.25rem;
+  }
+
   .suggestions-header {
     margin: 0;
     padding: 0.125rem 0.5rem 0.25rem;
@@ -220,43 +225,6 @@
     letter-spacing: 0.02em;
     text-transform: uppercase;
     color: hsl(0, 0%, 45%);
-  }
-
-  .browse-campus-row {
-    padding: 0 0.5rem 0.375rem;
-  }
-
-  .browse-campus-btn {
-    box-sizing: border-box;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    min-height: 2.75rem;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid hsl(5, 53%, 32%);
-    border-radius: 0.625rem;
-    background: hsl(5, 53%, 98%);
-    color: hsl(5, 53%, 28%);
-    font: inherit;
-    font-size: 0.8125rem;
-    font-weight: 600;
-    line-height: 1.25;
-    cursor: pointer;
-    transition:
-      background-color 0.125s,
-      border-color 0.125s;
-  }
-
-  .browse-campus-btn:hover,
-  .browse-campus-btn:focus-visible {
-    background: hsl(5, 53%, 94%);
-    border-color: hsl(5, 53%, 26%);
-  }
-
-  .browse-campus-btn:focus-visible {
-    outline: 2px solid hsl(5, 53%, 32%);
-    outline-offset: 2px;
   }
 
   .alias-hint {

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -213,7 +213,7 @@
 
   .suggestions-toolbar {
     display: flex;
-    justify-content: flex-end;
+    justify-content: flex-start;
     padding: 0 0.5rem 0.25rem;
   }
 

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -11,11 +11,7 @@
     openEphemeralOverlay,
   } from "@lib/overlay-stack";
   import { rafThrottle } from "@lib/layout-css-vars";
-  import {
-    adminAuthStore,
-    mapToolsStore,
-    modalStore,
-  } from "@lib/store.svelte";
+  import { adminAuthStore, mapToolsStore, modalStore } from "@lib/store.svelte";
   import OfflineMaps from "@ui/OfflineMaps.svelte";
   import SyncStatus from "@ui/SyncStatus.svelte";
   import PWAInstallPrompt from "@ui/PWAInstallPrompt.svelte";

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -15,8 +15,6 @@
     adminAuthStore,
     mapToolsStore,
     modalStore,
-    queryStore,
-    sidePanelStore,
   } from "@lib/store.svelte";
   import OfflineMaps from "@ui/OfflineMaps.svelte";
   import SyncStatus from "@ui/SyncStatus.svelte";
@@ -123,20 +121,7 @@
     closePanel();
   }
 
-  function handleNavAction(
-    id: "contributors" | "editor-login" | "browse-classes",
-  ) {
-    if (id === "browse-classes") {
-      queryStore.updateQuery({
-        category: "classes",
-        type: "result",
-        value: "All classes",
-      });
-      queryStore.inputValue = "";
-      sidePanelStore.expand();
-      closePanel();
-      return;
-    }
+  function handleNavAction(id: "contributors" | "editor-login") {
     if (id === "contributors") {
       modalStore.openModal("landing", { landingTab: "campus" });
       closePanel();

--- a/src/components/svelte/status-bar/StatusBarLinkGroups.svelte
+++ b/src/components/svelte/status-bar/StatusBarLinkGroups.svelte
@@ -8,7 +8,7 @@
 
   type Props = {
     groups: StatusBarNavGroup[];
-    onAction: (id: "contributors" | "editor-login" | "browse-classes") => void;
+    onAction: (id: "contributors" | "editor-login") => void;
   };
 
   const { groups, onAction }: Props = $props();
@@ -16,30 +16,104 @@
 
 {#each groups as group (group.id)}
   <div class="status-bar__nav-group" data-status-nav-group={group.id}>
-    {#each group.items as item (item.id)}
-      {#if item.kind === "link"}
-        <a
-          href={item.href}
-          class="map-chrome-ghost-link status-bar__nav-link"
-          target={item.external ? "_blank" : undefined}
-          rel={item.external ? "noopener noreferrer" : undefined}
-        >
-          {#if item.icon === "external"}
-            <ExternalLink size={14} aria-hidden="true" />
-          {:else if item.icon === "discord"}
-            <MessagesSquare size={14} aria-hidden="true" />
-          {:else if item.icon === "messenger"}
-            <MessageCircle size={14} aria-hidden="true" />
-          {:else if item.icon === "version"}
-            <GitFork size={14} aria-hidden="true" />
-          {/if}
-          {item.label}
-        </a>
-      {:else}
-        <MapChromeGhostButton variant="muted" onclick={() => onAction(item.id)}>
-          {item.label}
-        </MapChromeGhostButton>
-      {/if}
-    {/each}
+    {#if group.id === "similar"}
+      <details class="status-bar__similar-dropdown">
+        <summary class="status-bar__similar-summary">Similar maps</summary>
+        <div class="status-bar__similar-links">
+          {#each group.items as item (item.id)}
+            {#if item.kind === "link"}
+              <a
+                href={item.href}
+                class="map-chrome-ghost-link status-bar__nav-link"
+                target={item.external ? "_blank" : undefined}
+                rel={item.external ? "noopener noreferrer" : undefined}
+              >
+                {#if item.icon === "external"}
+                  <ExternalLink size={14} aria-hidden="true" />
+                {/if}
+                {item.label}
+              </a>
+            {/if}
+          {/each}
+        </div>
+      </details>
+    {:else}
+      {#each group.items as item (item.id)}
+        {#if item.kind === "link"}
+          <a
+            href={item.href}
+            class="map-chrome-ghost-link status-bar__nav-link"
+            target={item.external ? "_blank" : undefined}
+            rel={item.external ? "noopener noreferrer" : undefined}
+          >
+            {#if item.icon === "external"}
+              <ExternalLink size={14} aria-hidden="true" />
+            {:else if item.icon === "discord"}
+              <MessagesSquare size={14} aria-hidden="true" />
+            {:else if item.icon === "messenger"}
+              <MessageCircle size={14} aria-hidden="true" />
+            {:else if item.icon === "version"}
+              <GitFork size={14} aria-hidden="true" />
+            {/if}
+            {item.label}
+          </a>
+        {:else}
+          <MapChromeGhostButton variant="muted" onclick={() => onAction(item.id)}>
+            {item.label}
+          </MapChromeGhostButton>
+        {/if}
+      {/each}
+    {/if}
   </div>
 {/each}
+
+<style>
+  .status-bar__similar-dropdown {
+    position: relative;
+  }
+
+  .status-bar__similar-summary {
+    list-style: none;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.375rem;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 28%);
+  }
+
+  .status-bar__similar-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .status-bar__similar-summary::after {
+    content: "▾";
+    font-size: 0.6875rem;
+    color: hsl(0, 0%, 45%);
+  }
+
+  .status-bar__similar-dropdown[open] .status-bar__similar-summary::after {
+    content: "▴";
+  }
+
+  .status-bar__similar-summary:hover,
+  .status-bar__similar-summary:focus-visible {
+    background: hsl(0, 0%, 94%);
+  }
+
+  .status-bar__similar-links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+    padding: 0.375rem;
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 0.5rem;
+    background: white;
+    box-shadow: var(--map-chrome-panel-shadow);
+  }
+</style>

--- a/src/components/svelte/status-bar/StatusBarLinkGroups.svelte
+++ b/src/components/svelte/status-bar/StatusBarLinkGroups.svelte
@@ -58,7 +58,10 @@
             {item.label}
           </a>
         {:else}
-          <MapChromeGhostButton variant="muted" onclick={() => onAction(item.id)}>
+          <MapChromeGhostButton
+            variant="muted"
+            onclick={() => onAction(item.id)}
+          >
             {item.label}
           </MapChromeGhostButton>
         {/if}

--- a/src/constants/status-bar-links.ts
+++ b/src/constants/status-bar-links.ts
@@ -19,7 +19,7 @@ export type StatusBarLinkItem = {
 
 export type StatusBarActionItem = {
   kind: "action";
-  id: "contributors" | "editor-login" | "browse-classes";
+  id: "contributors" | "editor-login";
   label: string;
 };
 
@@ -63,7 +63,6 @@ export const STATUS_BAR_COMMUNITY_GROUP: StatusBarNavGroup = {
 
 /** In-app actions (rendered via StatusBar action handler). */
 export const STATUS_BAR_APP_ACTIONS: StatusBarActionItem[] = [
-  { kind: "action", id: "browse-classes", label: "Browse classes" },
   { kind: "action", id: "contributors", label: "Contributors" },
   { kind: "action", id: "editor-login", label: "Editor sign in" },
 ];
@@ -130,8 +129,7 @@ export function statusBarNavGroups(options: {
 }): StatusBarNavGroup[] {
   const appItems: StatusBarNavItem[] = [
     STATUS_BAR_APP_ACTIONS[0]!,
-    STATUS_BAR_APP_ACTIONS[1]!,
-    ...(options.showEditorLogin ? [STATUS_BAR_APP_ACTIONS[2]!] : []),
+    ...(options.showEditorLogin ? [STATUS_BAR_APP_ACTIONS[1]!] : []),
   ];
 
   return [

--- a/src/lib/browse-campus-shared.ts
+++ b/src/lib/browse-campus-shared.ts
@@ -1,0 +1,15 @@
+export type CampusBrowseTab = "buildings" | "colleges" | "divisions";
+
+type ModalStoreLike = {
+  openModal: (
+    type: "filter",
+    options?: { filterTab?: CampusBrowseTab },
+  ) => void;
+};
+
+export function openCampusBrowseModal(
+  modalStore: ModalStoreLike,
+  tab: CampusBrowseTab = "buildings",
+) {
+  modalStore.openModal("filter", { filterTab: tab });
+}

--- a/src/lib/browse-campus.test.ts
+++ b/src/lib/browse-campus.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { openCampusBrowseModal } from "./browse-campus";
+
+describe("openCampusBrowseModal", () => {
+  it("opens the filter modal with the requested tab", () => {
+    const calls: unknown[] = [];
+    const modalStore = {
+      openModal: (...args: unknown[]) => {
+        calls.push(args);
+      },
+    };
+
+    openCampusBrowseModal(modalStore as never, "colleges");
+
+    expect(calls).toEqual([["filter", { filterTab: "colleges" }]]);
+  });
+});

--- a/src/lib/browse-campus.test.ts
+++ b/src/lib/browse-campus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { openCampusBrowseModal } from "./browse-campus";
+import { openCampusBrowseModal } from "./browse-campus-shared";
 
 describe("openCampusBrowseModal", () => {
   it("opens the filter modal with the requested tab", () => {
@@ -10,7 +10,7 @@ describe("openCampusBrowseModal", () => {
       },
     };
 
-    openCampusBrowseModal(modalStore as never, "colleges");
+    openCampusBrowseModal(modalStore, "colleges");
 
     expect(calls).toEqual([["filter", { filterTab: "colleges" }]]);
   });

--- a/src/lib/browse-campus.ts
+++ b/src/lib/browse-campus.ts
@@ -1,5 +1,9 @@
 import { dismissEphemeralOverlays } from "./overlay-stack.js";
-import type { MainControlsStore, ModalStore, QueryStore } from "./stores/ui-stores.svelte.js";
+import type {
+  MainControlsStore,
+  ModalStore,
+  QueryStore,
+} from "./stores/ui-stores.svelte.js";
 
 export type CampusBrowseTab = "buildings" | "colleges" | "divisions";
 

--- a/src/lib/browse-campus.ts
+++ b/src/lib/browse-campus.ts
@@ -1,0 +1,25 @@
+import { dismissEphemeralOverlays } from "./overlay-stack.js";
+import type { MainControlsStore, ModalStore, QueryStore } from "./stores/ui-stores.svelte.js";
+
+export type CampusBrowseTab = "buildings" | "colleges" | "divisions";
+
+export function openCampusBrowseModal(
+  modalStore: ModalStore,
+  tab: CampusBrowseTab = "buildings",
+) {
+  modalStore.openModal("filter", { filterTab: tab });
+}
+
+export function openBrowseClasses(
+  queryStore: QueryStore,
+  sidePanelStore: MainControlsStore,
+) {
+  dismissEphemeralOverlays();
+  queryStore.updateQuery({
+    category: "classes",
+    type: "result",
+    value: "All classes",
+  });
+  queryStore.inputValue = "";
+  sidePanelStore.expand();
+}

--- a/src/lib/browse-campus.ts
+++ b/src/lib/browse-campus.ts
@@ -1,18 +1,15 @@
 import { dismissEphemeralOverlays } from "./overlay-stack.js";
+import {
+  openCampusBrowseModal,
+  type CampusBrowseTab,
+} from "./browse-campus-shared.js";
 import type {
   MainControlsStore,
-  ModalStore,
   QueryStore,
 } from "./stores/ui-stores.svelte.js";
 
-export type CampusBrowseTab = "buildings" | "colleges" | "divisions";
-
-export function openCampusBrowseModal(
-  modalStore: ModalStore,
-  tab: CampusBrowseTab = "buildings",
-) {
-  modalStore.openModal("filter", { filterTab: tab });
-}
+export type { CampusBrowseTab } from "./browse-campus-shared.js";
+export { openCampusBrowseModal } from "./browse-campus-shared.js";
 
 export function openBrowseClasses(
   queryStore: QueryStore,

--- a/src/lib/stores/store-types.ts
+++ b/src/lib/stores/store-types.ts
@@ -3,11 +3,13 @@ import type { Weekday } from "../schedule-import/day-stops.js";
 import type { ImportedScheduleRow } from "../schedule-import/types.js";
 
 export type LandingModalTab = "welcome" | "campus";
+export type FilterModalTab = "buildings" | "colleges" | "divisions";
 
 export interface ModalStoreState {
   open: boolean;
   type: (typeof modalOptions)[number] | null;
   landingTab?: LandingModalTab;
+  filterTab?: FilterModalTab;
 }
 
 export interface QueryStoreState {

--- a/src/lib/stores/ui-stores.svelte.ts
+++ b/src/lib/stores/ui-stores.svelte.ts
@@ -2,6 +2,7 @@ import { SvelteMap } from "svelte/reactivity";
 import { dismissEphemeralOverlays } from "../overlay-stack.js";
 import type {
   FloatingControlPanel,
+  FilterModalTab,
   LandingModalTab,
   ModalStoreState,
   QueryStoreState,
@@ -17,15 +18,17 @@ export class ModalStore {
   open = $derived(this._modalStore.open);
   type = $derived(this._modalStore.type);
   landingTab = $derived(this._modalStore.landingTab);
+  filterTab = $derived(this._modalStore.filterTab);
 
   openModal = (
     type: ModalStoreState["type"],
-    options?: { landingTab?: LandingModalTab },
+    options?: { landingTab?: LandingModalTab; filterTab?: FilterModalTab },
   ) => {
     dismissEphemeralOverlays();
     this._modalStore.open = true;
     this._modalStore.type = type;
     this._modalStore.landingTab = options?.landingTab;
+    this._modalStore.filterTab = options?.filterTab;
   };
 
   closeModal = () => {


### PR DESCRIPTION
## Summary

Production release for search chrome fixes:

- Fix browse modal (`updateQuery` missing entity value)
- Single search field (no nested box / double clear)
- Browse chips: Buildings | Colleges | Divisions | Classes
- Fix suggestion panel click handling (recent remove, browse)
- Keyboard shortcuts panel stays in viewport
- Similar maps dropdown in app menu

Includes prettier + test isolation fixes for CI.

## Test plan

- [x] CI verify pass on #398
- [ ] Browse chips open filter modal / classes list on prod
- [ ] Shortcuts panel visible when opened from search
- [ ] Recent search remove works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only search chrome, modal, and menu changes; browse/query wiring is localized with a small unit test for modal tab opening.
> 
> **Overview**
> Improves **search chrome** interaction and campus discovery without changing core map or data flows.
> 
> **Browse campus** replaces the single “Browse buildings & rooms” control with **Buildings | Colleges | Divisions | Classes** chips (`CampusBrowseChips`), wired through `openCampusBrowseModal` / `openBrowseClasses` and modal **`filterTab`** so the filter modal opens on the right tab. The browse modal bug is fixed by passing **`value`** (and syncing **`inputValue`**) in `updateQuery` when picking an entity.
> 
> **Suggestion panel clicks** use **`mousedown` + `preventDefault`** on the dropdown and recent-remove control so focus stays in the search field and remove/browse actions work reliably.
> 
> The search field is **`type="text"`** with **`role="searchbox"`** and pill-scoped styles to avoid nested browser search UI / double clear. Chip row layout hides inline browse chips when suggestions are open and adjusts when the shortcuts chip would duplicate the panel.
> 
> **Keyboard shortcuts** popover repositions with **top/above-below flip**, **`max-height`**, scroll/resize listeners, and **`ResizeObserver`** so it stays in the viewport.
> 
> **App menu**: “Browse classes” moves out of status links; **Similar maps** collapses into a **`<details>`** dropdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cad89eca53bddd1ff7243749d46a99c2c97a3f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->