### PR TITLE
fix(auth): prod login hardening (hotfix)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,10 +1,11 @@
 /// <reference types="astro/client" />
 
-import type { SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient, User } from "@supabase/supabase-js";
 
 declare namespace App {
   interface Locals {
     supabase?: SupabaseClient;
+    supabaseUser?: User;
     supabaseCacheHeaders?: Record<string, string>;
   }
 }

--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -5,6 +5,30 @@ import { adminUsersTable } from "@drizzle/schema";
 import { db } from "@lib/db";
 import type { SessionUser } from "@lib/admin/auth";
 
+/** Columns safe before migration 0015 (`supabase_user_id`). */
+const adminUserCredentialColumns = {
+  id: adminUsersTable.id,
+  username: adminUsersTable.username,
+  displayName: adminUsersTable.displayName,
+  passwordHash: adminUsersTable.passwordHash,
+  role: adminUsersTable.role,
+  isActive: adminUsersTable.isActive,
+};
+
+function toSessionUser(user: {
+  id: number;
+  username: string;
+  displayName: string | null;
+  role: SessionUser["role"] | null;
+}): SessionUser {
+  return {
+    id: user.id,
+    username: user.username,
+    displayName: user.displayName ?? user.username,
+    role: user.role ?? "editor",
+  };
+}
+
 export async function countAdminUsers(): Promise<number> {
   const rows = await db
     .select({ c: sql<number>`count(*)` })
@@ -15,24 +39,29 @@ export async function countAdminUsers(): Promise<number> {
 export async function getAdminUserBySupabaseId(
   supabaseUserId: string,
 ): Promise<SessionUser | null> {
-  const [user] = await db
-    .select()
-    .from(adminUsersTable)
-    .where(
-      and(
-        eq(adminUsersTable.supabaseUserId, supabaseUserId),
-        eq(adminUsersTable.isActive, true),
-      ),
-    )
-    .limit(1);
+  try {
+    const [user] = await db
+      .select({
+        id: adminUsersTable.id,
+        username: adminUsersTable.username,
+        displayName: adminUsersTable.displayName,
+        role: adminUsersTable.role,
+      })
+      .from(adminUsersTable)
+      .where(
+        and(
+          eq(adminUsersTable.supabaseUserId, supabaseUserId),
+          eq(adminUsersTable.isActive, true),
+        ),
+      )
+      .limit(1);
 
-  if (!user) return null;
-  return {
-    id: user.id,
-    username: user.username,
-    displayName: user.displayName ?? user.username,
-    role: user.role ?? "editor",
-  };
+    if (!user) return null;
+    return toSessionUser(user);
+  } catch (error) {
+    console.error("getAdminUserBySupabaseId failed:", error);
+    return null;
+  }
 }
 
 export async function authenticateAdminUser(
@@ -43,7 +72,7 @@ export async function authenticateAdminUser(
   if (!normalized || password.length === 0) return null;
 
   const [user] = await db
-    .select()
+    .select(adminUserCredentialColumns)
     .from(adminUsersTable)
     .where(
       and(
@@ -57,12 +86,7 @@ export async function authenticateAdminUser(
   const valid = await bcrypt.compare(password, user.passwordHash);
   if (!valid) return null;
 
-  return {
-    id: user.id,
-    username: user.username,
-    displayName: user.displayName ?? user.username,
-    role: user.role ?? "editor",
-  };
+  return toSessionUser(user);
 }
 
 export async function ensureBootstrapAdminUser(): Promise<void> {

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -440,7 +440,16 @@ class AdminAuthStore {
           },
       );
       if (!res.ok) {
-        return data.error ?? `Login failed (${res.status})`;
+        return (
+          data.error ??
+          (res.status === 401
+            ? "Invalid username or password"
+            : res.status === 429
+              ? "Too many attempts. Wait a few minutes and try again."
+              : res.status >= 500
+                ? "Sign-in failed on our side. Try again later."
+                : "Could not sign in. Check your username and password.")
+        );
       }
       this.applySession({
         loggedIn: true,

--- a/src/lib/supabase/session.ts
+++ b/src/lib/supabase/session.ts
@@ -20,9 +20,12 @@ export async function refreshSupabaseSession(
       },
     });
 
-    await supabase.auth.getUser();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
 
     context.locals.supabase = supabase;
+    context.locals.supabaseUser = user ?? undefined;
     context.locals.supabaseCacheHeaders = pendingCacheHeaders;
   } catch (error) {
     console.error("Supabase session refresh failed:", error);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,8 +24,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
   if (!editorUser) {
     const sbUser = context.locals.supabaseUser;
     if (sbUser?.id) {
-      const linked = await getAdminUserBySupabaseId(sbUser.id);
-      if (linked) editorUser = linked;
+      try {
+        const linked = await getAdminUserBySupabaseId(sbUser.id);
+        if (linked) editorUser = linked;
+      } catch (error) {
+        console.error("Supabase editor session lookup failed:", error);
+      }
     }
   }
 

--- a/src/pages/api/admin/auth.ts
+++ b/src/pages/api/admin/auth.ts
@@ -44,86 +44,110 @@ export const GET: APIRoute = async ({ cookies }) => {
 };
 
 export const POST: APIRoute = async ({ request, cookies }) => {
-  const ip = clientIp(request);
-  const ipRate = checkRateLimit(
-    `admin-login:ip:${ip}`,
-    LOGIN_IP_LIMIT.max,
-    LOGIN_IP_LIMIT.windowMs,
-  );
-  if (!ipRate.allowed) {
-    return rateLimitResponse(ipRate.resetAt);
-  }
-
-  const formData = await request.formData();
-  const usernameRaw = formData.get("username");
-  const passwordRaw = formData.get("password");
-  const username = typeof usernameRaw === "string" ? usernameRaw.trim() : "";
-  const password = typeof passwordRaw === "string" ? passwordRaw : "";
-
-  if (username) {
-    const userRate = checkRateLimit(
-      `admin-login:user:${username.toLowerCase()}`,
-      LOGIN_USER_LIMIT.max,
-      LOGIN_USER_LIMIT.windowMs,
-    );
-    if (!userRate.allowed) {
-      return rateLimitResponse(userRate.resetAt);
-    }
-  }
-
-  if (!password) {
-    return json({ error: "Password is required" }, 400);
-  }
-
-  let user: Awaited<ReturnType<typeof authenticateAdminUser>> = null;
-
-  // Try Supabase Auth when configured (#293)
   try {
-    const supabase = createServerSupabaseClient({
-      request,
-      cookies,
-    });
-    const { data, error } = await supabase.auth.signInWithPassword({
-      email: username,
-      password,
-    });
-    if (data.user && !error) {
-      user = await getAdminUserBySupabaseId(data.user.id);
+    const ip = clientIp(request);
+    const ipRate = checkRateLimit(
+      `admin-login:ip:${ip}`,
+      LOGIN_IP_LIMIT.max,
+      LOGIN_IP_LIMIT.windowMs,
+    );
+    if (!ipRate.allowed) {
+      return rateLimitResponse(ipRate.resetAt);
     }
-  } catch {
-    // Supabase not configured or unavailable → fall through to bcrypt
-  }
 
-  if (!user) {
-    user = username ? await authenticateAdminUser(username, password) : null;
-  }
+    const formData = await request.formData();
+    const usernameRaw = formData.get("username");
+    const passwordRaw = formData.get("password");
+    const username = typeof usernameRaw === "string" ? usernameRaw.trim() : "";
+    const password = typeof passwordRaw === "string" ? passwordRaw : "";
 
-  if (!user && !username) {
-    user = await authenticateLegacyAdminPassword(password);
-  }
+    if (username) {
+      const userRate = checkRateLimit(
+        `admin-login:user:${username.toLowerCase()}`,
+        LOGIN_USER_LIMIT.max,
+        LOGIN_USER_LIMIT.windowMs,
+      );
+      if (!userRate.allowed) {
+        return rateLimitResponse(userRate.resetAt);
+      }
+    }
 
-  if (!user) {
-    return json({ error: "Invalid username or password" }, 401);
-  }
+    if (!password) {
+      return json({ error: "Password is required" }, 400);
+    }
 
-  const token = createSessionToken(user);
-  return new Response(
-    JSON.stringify({
-      success: true,
-      username: user.username,
-      displayName: user.displayName,
-      role: user.role,
-      canPublish: canPublishDirectly(user.role),
-      canReview: canReviewProposals(user.role),
-    }),
-    {
-      status: 200,
-      headers: {
-        "Content-Type": "application/json",
-        "Set-Cookie": setSessionCookie(token),
+    let user: Awaited<ReturnType<typeof authenticateAdminUser>> = null;
+
+    // Try Supabase Auth when configured (#293)
+    try {
+      const supabase = createServerSupabaseClient({
+        request,
+        cookies,
+      });
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email: username,
+        password,
+      });
+      if (data.user && !error) {
+        user = await getAdminUserBySupabaseId(data.user.id);
+      }
+    } catch {
+      // Supabase not configured or unavailable → fall through to bcrypt
+    }
+
+    if (!user) {
+      user = username ? await authenticateAdminUser(username, password) : null;
+    }
+
+    if (!user && !username) {
+      user = await authenticateLegacyAdminPassword(password);
+    }
+
+    if (!user) {
+      return json({ error: "Invalid username or password" }, 401);
+    }
+
+    let token: string;
+    try {
+      token = createSessionToken(user);
+    } catch (error) {
+      console.error("Admin session signing misconfigured:", error);
+      return json(
+        {
+          error:
+            "Editor sign-in is not configured on this server. Contact the site maintainer.",
+        },
+        503,
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        username: user.username,
+        displayName: user.displayName,
+        role: user.role,
+        canPublish: canPublishDirectly(user.role),
+        canReview: canReviewProposals(user.role),
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Set-Cookie": setSessionCookie(token),
+        },
       },
-    },
-  );
+    );
+  } catch (error) {
+    console.error("Admin login failed:", error);
+    return json(
+      {
+        error:
+          "Sign-in is temporarily unavailable. Try again in a moment, or contact the site maintainer if this keeps happening.",
+      },
+      503,
+    );
+  }
 };
 
 export const DELETE: APIRoute = async () => {


### PR DESCRIPTION
## Summary

Hotfix for production editor login returning HTTP 500.

- Tolerate missing `supabase_user_id` column on bcrypt login path (explicit column select)
- Wrap Supabase lookup and session signing in try/catch with friendly 401/503 JSON
- Friendlier client login error messages

## Ops

- [x] Applied `drizzle/0015_add_admin_supabase_user_id.sql` to Supabase (agent session)
- [ ] Confirm Vercel **Production** has `ADMIN_PASSWORD` or `ADMIN_SESSION_SECRET`

## Test plan

- [x] `bun test src/lib/admin`
- [ ] Prod smoke: `/?editor=login` → valid credentials → editor session

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication, session resolution, and admin middleware; failures are mostly degraded to 401/503 rather than 500, but login behavior changes if env or DB state is wrong.
> 
> **Overview**
> **Hotfix for production editor login returning HTTP 500** by making auth paths tolerant of partial DB schema and misconfiguration while improving user-facing errors.
> 
> **Admin user DB access** now selects only credential-safe columns on bcrypt login (so a missing `supabase_user_id` column before migration 0015 does not break `SELECT *`), centralizes `SessionUser` mapping in `toSessionUser`, and wraps Supabase ID lookup in try/catch that logs and returns null instead of throwing.
> 
> **Request pipeline** stores the Supabase `User` on `context.locals.supabaseUser` after session refresh, and middleware wraps the Supabase→admin user link lookup in try/catch so a failed lookup does not take down admin routes.
> 
> **`POST /api/admin/auth`** is wrapped in a top-level try/catch that returns **503** with a generic message on unexpected failures; session token creation is isolated so missing **`ADMIN_SESSION_SECRET`** yields **503** with a maintainer-facing message instead of an unhandled error.
> 
> **Client login** falls back to clearer messages for **401**, **429**, and **5xx** when the API omits an `error` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e554f1a8ade82b3979bcd6280e4fb95e1516c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->