### PR TITLE
Hotfix: dorm detail panel crash

### DIFF
--- a/src/components/svelte/controls/DormResult.svelte
+++ b/src/components/svelte/controls/DormResult.svelte
@@ -33,7 +33,7 @@
   import DormEditorPanel from "@ui/controls/DormEditorPanel.svelte";
   import EntityShareCopyLink from "./EntityShareCopyLink.svelte";
   import { getDormShareUrl } from "@lib/share-links";
-  import { normalizeAmenityList } from "@lib/string-lists";
+  import { normalizeAmenityList, normalizeStringList } from "@lib/string-lists";
   type DormEditableField =
     | "dormName"
     | "shortName"


### PR DESCRIPTION
## Summary
- Fixes `ReferenceError: normalizeStringList is not defined` in `DormResult.svelte`, which blanked dorm side-panel content (meta chips, details, amenity tags).

## Test plan
- [x] `bun test src/lib/string-lists.test.ts`
- [ ] Open any dorm on map → side panel renders name, badges, and details

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single import-line fix with no logic or API changes; restores intended behavior for dorm detail UI.
> 
> **Overview**
> Fixes a runtime **`ReferenceError`** on the dorm map side panel by importing **`normalizeStringList`** from `@lib/string-lists` alongside the existing **`normalizeAmenityList`** import.
> 
> The component already derives **`contactPhones`** with `normalizeStringList(dorm?.contactPhone)`; without the import, opening a dorm crashed rendering and left meta chips, details, and amenity tags blank.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d03ff29e2461da6dafe2fa6d4d4c00a92769c50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->