### PR TITLE
Hotfix: dorm detail panel crash (prod)

### DIFF
--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -92,7 +92,7 @@
     colleges = data.colleges;
     directionCount = data.directionCount;
     divisions = data.divisions;
-    dorms = data.dorms;
+    dorms = data.dorms.map(normalizeDormListFields);
     events = data.events;
     totalRooms = data.totalRooms;
   }

--- a/src/components/svelte/controls/DormResult.svelte
+++ b/src/components/svelte/controls/DormResult.svelte
@@ -33,7 +33,6 @@
   import DormEditorPanel from "@ui/controls/DormEditorPanel.svelte";
   import EntityShareCopyLink from "./EntityShareCopyLink.svelte";
   import { getDormShareUrl } from "@lib/share-links";
-  import { normalizeAmenityList, normalizeStringList } from "@lib/string-lists";
   type DormEditableField =
     | "dormName"
     | "shortName"
@@ -111,8 +110,8 @@
     osmLink: "OpenStreetMap link",
   };
 
-  const amenities = $derived(normalizeAmenityList(dorm?.amenities));
-  const contactPhones = $derived(normalizeStringList(dorm?.contactPhone));
+  const amenities = $derived(dorm?.amenities ?? []);
+  const contactPhones = $derived(dorm?.contactPhone ?? []);
   const showDormDetails = $derived(
     Boolean(
       dorm &&


### PR DESCRIPTION
## Summary
- **Root cause:** `DormResult` called `normalizeStringList()` at render time; production bundle still threw `ReferenceError: normalizeStringList is not defined`, blanking the dorm side panel.
- **Fix:** Normalize dorm `amenities` / `contactPhone` once in `AppRoot.applyData()` via `normalizeDormListFields()`, and read arrays directly in `DormResult`.

## Verification
- Playwright on local dev: search → Men's Residence Hall → side panel shows title, badges, details, amenities (no normalize errors)
- `bun test src/lib/string-lists.test.ts`
- `bun run build`

## Test plan
- [ ] Prod: search/open any dorm → panel renders (not blank / Astro error)
- [ ] Amenities and contact phone display correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted hotfix moving normalization earlier in the data path; no auth or API changes, low blast radius beyond dorm display.
> 
> **Overview**
> Fixes a **production crash** that blanked the dorm side panel when opening a dorm from search.
> 
> **`DormResult`** no longer calls `normalizeStringList` / `normalizeAmenityList` at render time (the prod bundle threw `ReferenceError: normalizeStringList is not defined`). It now reads **`amenities`** and **`contactPhone`** as arrays with `?? []`.
> 
> **`AppRoot.applyData`** normalizes every dorm once with **`normalizeDormListFields`** when campus data is applied, aligning with existing **`replaceDorm`** normalization so list fields stay consistent app-wide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bcb4bc56dd8b7912d14cfaa07e1ca2997d59cb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->