### PR TITLE
fix(map-chrome): anchor shortcuts help in map column (#429)

### DIFF
--- a/src/components/svelte/map-chrome/KeyboardShortcutsChip.svelte
+++ b/src/components/svelte/map-chrome/KeyboardShortcutsChip.svelte
@@ -6,7 +6,13 @@
     modifierLabel,
   } from "@lib/keyboard-shortcuts";
   import { trapFocus } from "@lib/focus-trap";
+  import { rafThrottle } from "@lib/layout-css-vars";
   import { portal } from "@lib/portal";
+  import {
+    computeShortcutsPanelLayout,
+    formatShortcutsPanelStyle,
+    measureOpenSidePanelBounds,
+  } from "@lib/shortcuts-panel-position";
   import { mapToolsStore } from "@lib/store.svelte";
   import {
     registerEphemeralOverlayDismisser,
@@ -39,47 +45,21 @@
     };
   });
 
-  const PANEL_MAX_HEIGHT = 20 * 16;
-  const VIEWPORT_MARGIN = 8;
-  const TRIGGER_GAP = 6;
-
   function updatePanelPosition() {
     if (!open || !triggerEl) return;
-    const rect = triggerEl.getBoundingClientRect();
-    const width = Math.min(18 * 16, window.innerWidth - VIEWPORT_MARGIN * 2);
-    const left = Math.min(
-      Math.max(VIEWPORT_MARGIN, rect.left),
-      window.innerWidth - width - VIEWPORT_MARGIN,
-    );
-
-    const measuredHeight = panelEl?.offsetHeight ?? PANEL_MAX_HEIGHT;
-    const maxHeight = Math.min(
-      PANEL_MAX_HEIGHT,
-      window.innerHeight - VIEWPORT_MARGIN * 2,
-    );
-    const spaceBelow =
-      window.innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN;
-    const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN;
-    const preferredHeight = Math.min(maxHeight, measuredHeight);
-
-    let top: number;
-    let heightCap: number;
-
-    if (spaceBelow >= preferredHeight || spaceBelow >= spaceAbove) {
-      top = rect.bottom + TRIGGER_GAP;
-      heightCap = Math.max(0, Math.min(maxHeight, spaceBelow));
-    } else {
-      heightCap = Math.max(0, Math.min(maxHeight, spaceAbove));
-      top = Math.max(VIEWPORT_MARGIN, rect.top - TRIGGER_GAP - heightCap);
-    }
-
-    panelStyle = `left: ${left}px; top: ${top}px; width: ${width}px; max-height: ${heightCap}px;`;
+    const layout = computeShortcutsPanelLayout({
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      triggerRect: triggerEl.getBoundingClientRect(),
+      sidePanel: measureOpenSidePanelBounds(),
+    });
+    panelStyle = formatShortcutsPanelStyle(layout);
   }
 
   $effect(() => {
     if (!open) return;
     updatePanelPosition();
-    const handleLayout = () => updatePanelPosition();
+    const handleLayout = rafThrottle(updatePanelPosition);
     window.addEventListener("resize", handleLayout);
     window.addEventListener("scroll", handleLayout, true);
     return () => {

--- a/src/lib/shortcuts-panel-position.test.ts
+++ b/src/lib/shortcuts-panel-position.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import {
+  computeShortcutsPanelLayout,
+  formatShortcutsPanelStyle,
+} from "./shortcuts-panel-position";
+
+describe("computeShortcutsPanelLayout", () => {
+  test("anchors above trigger with bottom positioning when drawer is closed", () => {
+    const layout = computeShortcutsPanelLayout({
+      viewportWidth: 1280,
+      viewportHeight: 800,
+      triggerRect: { left: 8, top: 760, right: 40, bottom: 784 },
+      sidePanel: null,
+    });
+
+    expect(layout.bottom).toBe(48);
+    expect(layout.left).toBe(8);
+    expect(layout.width).toBe(288);
+    expect(layout.maxHeight).toBeGreaterThan(0);
+    expect(formatShortcutsPanelStyle(layout)).toContain("bottom: 48px");
+  });
+
+  test("centers in map column when side panel is open", () => {
+    const layout = computeShortcutsPanelLayout({
+      viewportWidth: 1280,
+      viewportHeight: 800,
+      triggerRect: { left: 8, top: 760, right: 40, bottom: 784 },
+      sidePanel: { left: 8, top: 72, right: 520 },
+    });
+
+    const mapLeft = 520 + 8;
+    const mapWidth = 1280 - 8 - mapLeft;
+    const expectedLeft = mapLeft + (mapWidth - layout.width) / 2;
+
+    expect(layout.left).toBeCloseTo(expectedLeft, 5);
+    expect(layout.left).toBeGreaterThan(520);
+    expect(layout.maxHeight).toBeLessThanOrEqual(760 - 8 - 72);
+  });
+
+  test("keeps panel within viewport on narrow mobile widths", () => {
+    const layout = computeShortcutsPanelLayout({
+      viewportWidth: 320,
+      viewportHeight: 640,
+      triggerRect: { left: 8, top: 600, right: 36, bottom: 624 },
+      sidePanel: { left: 8, top: 120, right: 304 },
+    });
+
+    expect(layout.left + layout.width).toBeLessThanOrEqual(320 - 8);
+    expect(layout.bottom).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/src/lib/shortcuts-panel-position.ts
+++ b/src/lib/shortcuts-panel-position.ts
@@ -1,0 +1,123 @@
+export type ShortcutsPanelBounds = {
+  left: number;
+  top: number;
+  right: number;
+};
+
+export type ShortcutsPanelLayoutInput = {
+  viewportWidth: number;
+  viewportHeight: number;
+  triggerRect:
+    | DOMRectReadOnly
+    | { left: number; top: number; right: number; bottom: number };
+  sidePanel: ShortcutsPanelBounds | null;
+  margin?: number;
+  triggerGap?: number;
+  maxPanelWidth?: number;
+  maxPanelHeight?: number;
+};
+
+export type ShortcutsPanelLayout = {
+  left: number;
+  bottom: number;
+  width: number;
+  maxHeight: number;
+};
+
+const DEFAULT_MARGIN = 8;
+const DEFAULT_TRIGGER_GAP = 8;
+const DEFAULT_MAX_WIDTH = 18 * 16;
+const DEFAULT_MAX_HEIGHT = 20 * 16;
+
+/** Anchor shortcuts help above the status bar; stay in the map column when the drawer is open. */
+export function computeShortcutsPanelLayout(
+  input: ShortcutsPanelLayoutInput,
+): ShortcutsPanelLayout {
+  const margin = input.margin ?? DEFAULT_MARGIN;
+  const triggerGap = input.triggerGap ?? DEFAULT_TRIGGER_GAP;
+  const maxPanelWidth = input.maxPanelWidth ?? DEFAULT_MAX_WIDTH;
+  const maxPanelHeight = input.maxPanelHeight ?? DEFAULT_MAX_HEIGHT;
+  const { viewportWidth, viewportHeight, triggerRect, sidePanel } = input;
+
+  const bottom = Math.max(
+    margin,
+    viewportHeight - triggerRect.top + triggerGap,
+  );
+
+  let left: number;
+  let width: number;
+
+  if (sidePanel) {
+    const mapLeft = sidePanel.right + margin;
+    const mapRight = viewportWidth - margin;
+    const mapWidth = Math.max(0, mapRight - mapLeft);
+    if (mapWidth >= 12 * 16) {
+      width = Math.min(maxPanelWidth, mapWidth);
+      left =
+        mapWidth > width
+          ? mapLeft + (mapWidth - width) / 2
+          : Math.min(mapLeft, Math.max(margin, mapRight - width));
+    } else {
+      width = Math.min(maxPanelWidth, viewportWidth - margin * 2);
+      left = Math.max(margin, (viewportWidth - width) / 2);
+    }
+  } else {
+    width = Math.min(maxPanelWidth, viewportWidth - margin * 2);
+    left = Math.min(
+      Math.max(margin, triggerRect.left),
+      viewportWidth - width - margin,
+    );
+  }
+
+  const contentTop = sidePanel?.top ?? margin;
+  let maxHeight = Math.min(
+    maxPanelHeight,
+    viewportHeight - bottom - margin,
+    Math.max(0, triggerRect.top - triggerGap - contentTop),
+  );
+
+  if (sidePanel) {
+    const mapLeft = sidePanel.right + margin;
+    const mapRight = viewportWidth - margin;
+    const mapWidth = Math.max(0, mapRight - mapLeft);
+    if (mapWidth < 12 * 16) {
+      const mapBandHeight = Math.max(
+        0,
+        triggerRect.top - triggerGap - sidePanel.top,
+      );
+      maxHeight = Math.min(maxHeight, mapBandHeight);
+    }
+  }
+
+  return { left, bottom, width, maxHeight };
+}
+
+export function formatShortcutsPanelStyle(
+  layout: ShortcutsPanelLayout,
+): string {
+  return `left: ${layout.left}px; bottom: ${layout.bottom}px; width: ${layout.width}px; max-height: ${layout.maxHeight}px;`;
+}
+
+/** Measure open side-panel chrome so the shortcuts sheet can avoid covering it. */
+export function measureOpenSidePanelBounds(): ShortcutsPanelBounds | null {
+  if (typeof document === "undefined") return null;
+
+  const drawer = document.querySelector(".drawer:not(.is-collapsed)");
+  if (!(drawer instanceof HTMLElement)) return null;
+
+  const details = drawer.querySelector("#side-panel-details");
+  if (details?.getAttribute("aria-hidden") === "true") return null;
+
+  const drawerRect = drawer.getBoundingClientRect();
+  if (drawerRect.width <= 0 || drawerRect.height <= 0) return null;
+
+  const handle = drawer.querySelector(".drawer-handle");
+  const handleRect =
+    handle instanceof HTMLElement ? handle.getBoundingClientRect() : drawerRect;
+
+  return {
+    left: drawerRect.left,
+    top: drawerRect.top,
+    right: Math.max(drawerRect.right, handleRect.right),
+  };
+}


### PR DESCRIPTION
## Summary
- Extract `computeShortcutsPanelLayout()` so shortcuts help uses **bottom-anchored** placement (same pattern as AppMenu) instead of top + flip logic.
- When the side drawer is open, measure drawer + handle bounds and **center the panel in the map column** to the right — avoids covering the collapse handle and entity list.
- On narrow mobile sheets, center horizontally above the status bar with height capped to the map band.

Fixes #429

## Review notes
- Pure layout helper is unit-tested; DOM measurement isolated in `measureOpenSidePanelBounds()`.
- Focus trap, Escape dismiss, and outside-click behavior unchanged.
- Playwright smoke (1280px, building browse open): panel left edge clears drawer right edge (~763px vs ~504px).

## Test plan
- [x] `bun test src/lib/shortcuts-panel-position.test.ts`
- [x] Prettier on changed files
- [x] `bun run build`
- [x] Playwright: desktop with drawer open — panel in map column
- [x] Playwright: 320px — centered above status bar
- [ ] Manual: open `?` with building room list visible — confirm list + handle stay readable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout refactor with isolated DOM measurement and unit tests; no auth, data, or API changes.
> 
> **Overview**
> Moves keyboard shortcuts panel positioning out of `KeyboardShortcutsChip` into **`shortcuts-panel-position`**, switching from **top + flip** logic to **bottom-anchored** placement above the status bar (aligned with other map chrome popovers).
> 
> When the **side drawer is open**, `measureOpenSidePanelBounds()` reads drawer/handle geometry so the panel **centers in the map column** instead of sitting over the entity list and collapse handle; on **narrow viewports** it centers horizontally and caps height to the map band.
> 
> Resize/scroll listeners now use **`rafThrottle`** for layout updates. Focus trap, dismiss behavior, and overlay stacking are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 019461c29cf77dedc73cb4c7a313cb4385e2c128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->