### PR TITLE
fix(ui): review contrast, map hover labels, landing pitch (#425 #423 #421)

### DIFF
--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -35,7 +35,7 @@
   import { observeBlockHeight } from "@lib/layout-css-vars";
   import * as mapGl from "maplibre-gl";
   import type { FeatureCollection, LineString } from "geojson";
-  import type { BuildingData, EventData } from "@lib/types";
+  import type { BuildingData, DormData, EventData } from "@lib/types";
   import {
     JEEPNEY_ROUTES,
     type JeepneyRoute,
@@ -78,9 +78,11 @@
   } from "@lib/map-edit/errors";
   import {
     buildingPreviewFromRow,
+    dormPreviewFromRow,
     entityHoverPreviewStore,
     eventPreviewFromRow,
     isBuildingHoverPreview,
+    isDormHoverPreview,
     isEventHoverPreview,
   } from "@lib/entity-hover-preview.svelte";
   import { patchEventLocations, patchPosition } from "@lib/map-edit/patch-api";
@@ -787,6 +789,25 @@
   }
 
   function handleBuildingPinPointerLeave(editKey: string) {
+    handleEditablePinLeave(editKey);
+    if (!shouldShowEntityHoverPreview() || canDragPin(editKey)) return;
+    entityHoverPreviewStore.scheduleHide();
+  }
+
+  function handleDormPinPointerEnter(
+    dorm: DormData,
+    editKey: string,
+    event: PointerEvent,
+  ) {
+    handleEditablePinEnter(editKey);
+    if (!shouldShowEntityHoverPreview() || canDragPin(editKey)) return;
+    entityHoverPreviewStore.show(dormPreviewFromRow(dorm), {
+      x: event.clientX,
+      y: event.clientY,
+    });
+  }
+
+  function handleDormPinPointerLeave(editKey: string) {
     handleEditablePinLeave(editKey);
     if (!shouldShowEntityHoverPreview() || canDragPin(editKey)) return;
     entityHoverPreviewStore.scheduleHide();
@@ -2488,9 +2509,16 @@
                   )}
                   {@const active = isSelectedEvent(entry.event)}
                   {@const centralHoverPreview = shouldShowEntityHoverPreview()}
+                  {@const previewSuppressed =
+                    centralHoverPreview &&
+                    isEventHoverPreview(
+                      entityHoverPreviewStore.entity,
+                      entry.event.slug,
+                    )}
                   <EventMapPin
                     {active}
                     useCentralHoverPreview={centralHoverPreview}
+                    {previewSuppressed}
                     anchored={group.anchored}
                     imageSrc={image?.src ?? null}
                     dateLabel={formatEventMarkerDate(
@@ -2503,6 +2531,7 @@
                     labelMeta={`${getEventStatusLabel(entry.event)} · ${formatEventMarkerDateTime(
                       entry.event.occurrenceStartsAt,
                     )}`}
+                    labelVisible={zoomLevel >= 17 || active}
                     onclick={() => handleEventMarkerClick(entry.event)}
                     onpointerenter={(event) =>
                       handleEventPinPointerEnter(entry.event, event)}
@@ -2661,8 +2690,8 @@
                   : failedEditKey === editKey
                     ? "failed"
                     : "idle"}
-              labelVisible={!centralHoverPreview &&
-                (zoomLevel >= 17 || hoveredEditKey === editKey)}
+              labelVisible={zoomLevel >= 17 ||
+                activeBuildingName === building.buildingName}
               useCentralHoverPreview={centralHoverPreview}
               {previewSuppressed}
               onpointerenter={(event) =>
@@ -2713,6 +2742,10 @@
             lon: dorm.lon,
             version: getLoadedVersion(dorm.version),
           })}
+          {@const centralHoverPreview = shouldShowEntityHoverPreview()}
+          {@const previewSuppressed =
+            centralHoverPreview &&
+            isDormHoverPreview(entityHoverPreviewStore.entity, dorm.id)}
           <Marker
             lngLat={[position.lon, position.lat]}
             draggable={canDragPin(editKey)}
@@ -2737,9 +2770,12 @@
                   : failedEditKey === editKey
                     ? "failed"
                     : "idle"}
-              labelVisible={zoomLevel >= 17 || hoveredEditKey === editKey}
-              onpointerenter={(event) => handleEditablePinEnter(editKey)}
-              onpointerleave={() => handleEditablePinLeave(editKey)}
+              labelVisible={zoomLevel >= 17 || activeDormName === dorm.dormName}
+              useCentralHoverPreview={centralHoverPreview}
+              {previewSuppressed}
+              onpointerenter={(event) =>
+                handleDormPinPointerEnter(dorm, editKey, event)}
+              onpointerleave={() => handleDormPinPointerLeave(editKey)}
             >
               <House size="18" />
             </MapEntityPin>

--- a/src/components/svelte/editor/review-panel.css
+++ b/src/components/svelte/editor/review-panel.css
@@ -11,20 +11,21 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 0.5rem;
-  font-size: 0.8125rem;
-  color: hsl(5, 53%, 32%);
+  font-size: 0.875rem;
+  color: hsl(5, 53%, 28%);
 }
 
 .entity-review-count {
-  color: hsl(0, 0%, 42%);
-  font-size: 0.75rem;
+  color: hsl(0, 0%, 32%);
+  font-size: 0.8125rem;
   font-weight: 600;
 }
 
 .entity-review-empty {
   margin: 0;
-  color: hsl(0, 0%, 45%);
-  font-size: 0.75rem;
+  color: hsl(0, 0%, 35%);
+  font-size: 0.8125rem;
+  line-height: 1.4;
 }
 
 .entity-review-list {
@@ -41,7 +42,7 @@
 .entity-review-item {
   border: 1px solid hsl(0, 0%, 90%);
   border-radius: 0.625rem;
-  padding: 0.375rem;
+  padding: 0.4375rem;
   background: hsl(0, 0%, 99%);
 }
 
@@ -53,9 +54,9 @@
 }
 
 .entity-review-entity {
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   font-weight: 700;
-  color: hsl(0, 0%, 18%);
+  color: hsl(0, 0%, 12%);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -63,25 +64,28 @@
 
 .entity-review-entity small {
   font-weight: 600;
-  color: hsl(0, 0%, 45%);
+  color: hsl(0, 0%, 35%);
 }
 
 .entity-review-submitter {
-  font-size: 0.75rem;
-  color: hsl(0, 0%, 42%);
+  font-size: 0.8125rem;
+  color: hsl(0, 0%, 32%);
+  line-height: 1.35;
 }
 
 .entity-review-changes {
   margin: 0.375rem 0 0;
   padding-left: 1rem;
-  color: hsl(0, 0%, 28%);
-  font-size: 0.75rem;
+  color: hsl(0, 0%, 18%);
+  font-size: 0.8125rem;
+  line-height: 1.4;
 }
 
 .entity-review-note {
   margin: 0.375rem 0 0;
-  font-size: 0.75rem;
-  color: hsl(35, 80%, 28%);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: hsl(35, 80%, 24%);
 }
 
 .entity-review-actions {
@@ -92,28 +96,43 @@
 }
 
 .entity-review-actions button {
-  border: 1px solid hsl(0, 0%, 85%);
+  border: 1px solid hsl(0, 0%, 80%);
   border-radius: 0.5rem;
   background: white;
-  color: hsl(0, 0%, 22%);
+  color: hsl(0, 0%, 16%);
   cursor: pointer;
   font: inherit;
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   font-weight: 700;
-  padding: 0.25rem 0.4375rem;
+  line-height: 1.25;
+  padding: 0.3125rem 0.5rem;
 }
 
 .entity-review-actions button.approve {
-  border-color: hsl(160, 84%, 34%);
-  color: hsl(160, 84%, 22%);
+  border-color: hsl(160, 84%, 30%);
+  color: hsl(160, 84%, 18%);
 }
 
 .entity-review-actions button.reject {
-  border-color: hsl(0, 70%, 82%);
-  color: hsl(0, 70%, 38%);
+  border-color: hsl(0, 70%, 78%);
+  color: hsl(0, 70%, 32%);
 }
 
 .entity-review-actions button:disabled {
-  opacity: 0.55;
+  opacity: 0.65;
+  color: hsl(0, 0%, 38%);
   cursor: not-allowed;
+}
+
+.entity-review-panel :global(.editor-field label) {
+  font-size: 0.8125rem;
+  color: hsl(0, 0%, 22%);
+}
+
+.entity-review-panel :global(.editor-control-row textarea) {
+  font-size: 0.875rem;
+}
+
+.entity-review-panel :global(.editor-control-row textarea::placeholder) {
+  color: hsl(0, 0%, 38%);
 }

--- a/src/components/svelte/map/EntityHoverPreview.svelte
+++ b/src/components/svelte/map/EntityHoverPreview.svelte
@@ -21,6 +21,14 @@
           : null
       : null,
   );
+
+  const dormBadge = $derived(
+    preview?.kind === "dorm"
+      ? preview.isUpManaged
+        ? "UP-managed dorm"
+        : "Private dorm"
+      : null,
+  );
 </script>
 
 {#if preview && anchor}
@@ -35,14 +43,22 @@
     {/if}
     <div class="entity-hover-preview__body">
       <p class="entity-hover-preview__title">
-        {preview.kind === "building" ? preview.name : preview.title}
+        {preview.kind === "event" ? preview.title : preview.name}
       </p>
       {#if preview.kind === "building" && buildingBadge}
         <p class="entity-hover-preview__meta">{buildingBadge}</p>
+      {:else if preview.kind === "dorm" && dormBadge}
+        <p class="entity-hover-preview__meta">{dormBadge}</p>
       {:else if preview.kind === "event" && preview.category}
         <p class="entity-hover-preview__meta">{preview.category}</p>
       {/if}
       {#if preview.kind === "building" && preview.directions}
+        <p class="entity-hover-preview__hint">
+          {preview.directions.slice(0, 120)}{preview.directions.length > 120
+            ? "…"
+            : ""}
+        </p>
+      {:else if preview.kind === "dorm" && preview.directions}
         <p class="entity-hover-preview__hint">
           {preview.directions.slice(0, 120)}{preview.directions.length > 120
             ? "…"

--- a/src/components/svelte/map/EventMapPin.svelte
+++ b/src/components/svelte/map/EventMapPin.svelte
@@ -16,9 +16,11 @@
     imageSrc?: string | null;
     labelMeta?: string;
     labelTitle?: string;
+    labelVisible?: boolean;
     onclick: () => void;
     onpointerenter?: (event: PointerEvent) => void;
     onpointerleave?: (event: PointerEvent) => void;
+    previewSuppressed?: boolean;
     status?: string;
     title?: string;
     variant?: EventPinVariant;
@@ -37,9 +39,11 @@
     imageSrc = null,
     labelMeta,
     labelTitle,
+    labelVisible = false,
     onclick,
     onpointerenter,
     onpointerleave,
+    previewSuppressed = false,
     status = "active",
     title,
     variant = "single",
@@ -47,6 +51,10 @@
   }: Props = $props();
 
   const isGroup = $derived(variant === "group");
+  const showInlineLabel = $derived(
+    !isGroup && labelTitle && (labelVisible || active) && !previewSuppressed,
+  );
+  const showInlineMeta = $derived(!useCentralHoverPreview || active);
 </script>
 
 <button
@@ -56,6 +64,7 @@
   class:anchored
   class:expanded
   class:group={isGroup}
+  class:preview-suppressed={previewSuppressed}
   class:past={status === "past"}
   class:upcoming={status === "upcoming"}
   title={useCentralHoverPreview ? undefined : title}
@@ -79,15 +88,18 @@
     <span class="event-pin-chevron" aria-hidden="true">
       <ChevronDown size={12} />
     </span>
-  {:else if labelTitle && labelMeta && !useCentralHoverPreview}
+  {:else if showInlineLabel}
     <span
       class="event-pin-label"
       class:active
+      class:title-only={useCentralHoverPreview && labelVisible && !active}
       transition:fade
       aria-hidden="true"
     >
       <span class="event-pin-title">{labelTitle}</span>
-      <span class="event-pin-meta">{labelMeta}</span>
+      {#if showInlineMeta && labelMeta}
+        <span class="event-pin-meta">{labelMeta}</span>
+      {/if}
     </span>
   {/if}
 </button>
@@ -280,6 +292,14 @@
   .event-map-pin:hover .event-pin-label,
   .event-map-pin:focus-visible .event-pin-label,
   .event-pin-label.active {
+    opacity: 1;
+  }
+
+  .event-map-pin.preview-suppressed .event-pin-label {
+    opacity: 0;
+  }
+
+  .event-pin-label.title-only {
     opacity: 1;
   }
 

--- a/src/components/svelte/map/MapEntityPin.svelte
+++ b/src/components/svelte/map/MapEntityPin.svelte
@@ -43,12 +43,7 @@
     useCentralHoverPreview = false,
   }: Props = $props();
 
-  /** With central hover preview, only the selected pin keeps an inline label. */
-  const showPinLabel = $derived(
-    useCentralHoverPreview
-      ? active && !previewSuppressed
-      : (labelVisible || active) && !previewSuppressed,
-  );
+  const showPinLabel = $derived((labelVisible || active) && !previewSuppressed);
 
   const statusLabel = $derived(
     saveState === "saving"
@@ -78,6 +73,7 @@
   class:dimmed
   class:event-linked={eventLinked}
   class:hovered
+  class:preview-suppressed={previewSuppressed}
   class:saving={saveState === "saving"}
   class:saved={saveState === "saved"}
   class:failed={saveState === "failed"}
@@ -215,12 +211,8 @@
     opacity: 1;
   }
 
-  .map-entity-pin.central-hover-preview .pin-label {
+  .map-entity-pin.preview-suppressed .pin-label {
     opacity: 0;
-  }
-
-  .map-entity-pin.central-hover-preview.active .pin-label.active {
-    opacity: 1;
   }
 
   .map-entity-pin.event-linked {
@@ -292,9 +284,9 @@
     color: white;
   }
 
-  .map-entity-pin:not(.central-hover-preview):hover .pin-label,
-  .map-entity-pin:not(.central-hover-preview) .pin-label.active,
-  .map-entity-pin:not(.central-hover-preview) .pin-label.persistent {
+  .map-entity-pin:not(.preview-suppressed):hover .pin-label,
+  .map-entity-pin .pin-label.active,
+  .map-entity-pin .pin-label.persistent {
     opacity: 1;
   }
 

--- a/src/components/svelte/modal/LandingGuideSteps.svelte
+++ b/src/components/svelte/modal/LandingGuideSteps.svelte
@@ -5,6 +5,8 @@
   import PencilLine from "@lucide/svelte/icons/pencil-line";
   import ClipboardCheck from "@lucide/svelte/icons/clipboard-check";
   import CircleCheck from "@lucide/svelte/icons/circle-check";
+  import UserRound from "@lucide/svelte/icons/user-round";
+  import WifiOff from "@lucide/svelte/icons/wifi-off";
   import ArrowRight from "@lucide/svelte/icons/arrow-right";
   import Plus from "@lucide/svelte/icons/plus";
 
@@ -12,7 +14,21 @@
     { icon: Search, label: "Search rooms", hint: "Room codes and buildings" },
     { icon: Map, label: "Explore the map", hint: "Buildings, dorms, and pins" },
     { icon: CalendarDays, label: "Events", hint: "Where things happen" },
-    { icon: PencilLine, label: "Suggest fixes", hint: "Keep the map accurate" },
+    {
+      icon: UserRound,
+      label: "Browse freely",
+      hint: "No sign-in required",
+    },
+    {
+      icon: WifiOff,
+      label: "Offline-friendly",
+      hint: "Cache after your first visit",
+    },
+    {
+      icon: PencilLine,
+      label: "Suggest fixes",
+      hint: "Optional login to edit",
+    },
   ] as const;
 
   const steps = [
@@ -134,7 +150,7 @@
     margin: 0;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 0.375rem;
   }
 

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -121,6 +121,13 @@
         <p class="hero-tagline">
           Find rooms, explore the map, and discover campus events at UPLB.
         </p>
+        <ul class="hero-pitches">
+          <li>No account needed — search and browse right away.</li>
+          <li>
+            Works on spotty campus Wi‑Fi — data saves locally after your first
+            visit.
+          </li>
+        </ul>
       </div>
     </div>
 
@@ -333,6 +340,24 @@
     font-weight: 500;
     max-width: 24rem;
     line-height: 1.35;
+  }
+
+  .hero-pitches {
+    list-style: none;
+    margin: 0.375rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    max-width: 24rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1.35;
+    color: hsl(5, 35%, 92%);
+  }
+
+  .hero-pitches li {
+    margin: 0;
   }
 
   .tab-bar {

--- a/src/lib/entity-hover-preview.svelte.ts
+++ b/src/lib/entity-hover-preview.svelte.ts
@@ -1,4 +1,4 @@
-import type { BuildingData, EventData } from "@lib/types";
+import type { BuildingData, DormData, EventData } from "@lib/types";
 
 export type EntityHoverPreview =
   | {
@@ -6,6 +6,13 @@ export type EntityHoverPreview =
       id: number;
       name: string;
       buildingType: string | null;
+      directions: string | null;
+    }
+  | {
+      kind: "dorm";
+      id: number;
+      name: string;
+      isUpManaged: boolean;
       directions: string | null;
     }
   | {
@@ -66,6 +73,16 @@ export function buildingPreviewFromRow(
   };
 }
 
+export function dormPreviewFromRow(dorm: DormData): EntityHoverPreview {
+  return {
+    kind: "dorm",
+    id: dorm.id,
+    name: dorm.dormName,
+    isUpManaged: dorm.isUpManaged,
+    directions: dorm.directions ?? null,
+  };
+}
+
 export function eventPreviewFromRow(event: EventData): EntityHoverPreview {
   return {
     kind: "event",
@@ -81,6 +98,13 @@ export function isBuildingHoverPreview(
   buildingId: number,
 ): boolean {
   return entity?.kind === "building" && entity.id === buildingId;
+}
+
+export function isDormHoverPreview(
+  entity: EntityHoverPreview | null,
+  dormId: number,
+): boolean {
+  return entity?.kind === "dorm" && entity.id === dormId;
 }
 
 export function isEventHoverPreview(

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ import {
 const title =
   "Room TBA | Find Rooms, Dorms, Buildings, Colleges, and Divisions at UPLB";
 const description =
-  "Search rooms, dorms, buildings, colleges, and divisions around UPLB with Room TBA.";
+  "Search rooms, dorms, and buildings at UPLB — no account needed. Campus data caches locally for spotty Wi‑Fi.";
 const structuredData = jsonLd(
   websiteSchema(),
   webpageSchema({ title, description, path: "/" }),


### PR DESCRIPTION
## Summary
- **#425** — Increase font sizes and contrast in the suggested-edits review panel (`review-panel.css`): change list, submitter, action buttons, and “Note to contributor” field.
- **#423** — Restore zoom ≥ 17 name/title pills on building, dorm, and event pins; hide inline label while `EntityHoverPreview` is active; add dorm preview kind + handlers.
- **#421** — Welcome modal hero pitches for no-account browse and offline-friendly caching; two new guide feature cards; index meta description aligned.

## Test plan
- [x] `bun run build`
- [x] `bun run check:readme`
- [ ] Manual: pending proposal in editor shelf — readable at 320px
- [ ] Manual: zoom 17+ building/dorm/event pins show names; hover shows preview only
- [ ] Manual: landing modal hero lines wrap at 320px / 768px

Fixes #425, #423, #421

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CSS and map UI presentation; no auth, API, or data-model changes beyond new dorm hover preview types.
> 
> **Overview**
> Improves **editor review readability** by bumping type sizes and contrast in `review-panel.css` (headings, list copy, approve/reject actions, and contributor note fields).
> 
> **Map read mode** gets coordinated pin labels and hover previews: building/dorm/event pins show name/title pills at zoom ≥ 17 or when selected; while `EntityHoverPreview` is active for that entity, inline labels are suppressed via `previewSuppressed`. Dorms now participate in the shared hover flow (`dorm` preview kind, pointer handlers, UP-managed vs private badge and directions snippet).
> 
> **Onboarding copy** adds welcome hero bullets and two guide feature cards (no sign-in browse, offline-friendly caching), reframes “Suggest fixes” as optional login, switches the feature grid to three columns, and aligns the home page meta description with that messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b7b2c6176cfca5223eb99d6f5a08aad0dbfd982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->