### PR TITLE
docs(agents): issue triage labels and parent/sub-issue guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,45 @@ Issues are living specs (paths, schema, acceptance criteria). When coding quickl
 
 Full checklist: [docs/issue-hygiene.md](docs/issue-hygiene.md).
 
+### Creating issues
+
+Whenever an agent (or maintainer) **files a new GitHub issue**, set triage metadata at creation time — not “later.”
+
+| Required | Label(s) | Rule |
+| -------- | -------- | ---- |
+| **Size** | Exactly one of `size/XS` … `size/XL` | Estimate effort for one focused PR (see label descriptions on GitHub). |
+| **Priority** | Exactly one of `priority/high`, `priority/medium`, `priority/low` | `high` = user-visible break or blocker; `medium` = planned improvement; `low` = backlog/nice-to-have. |
+| **Good first issue** | `good first issue` **or omit** | Add only when the task is newcomer-safe: clear AC, small surface, no prod DB/auth/security surprises, paths documented. **Do not** tag epics, migrations, or coordination-heavy work. |
+
+**Optional but common:** `bug`, `enhancement`, `design improvement`, `data`, `qa`, `help wanted` — type labels are separate from size/priority.
+
+**Parent / sub-issue structure**
+
+- **Split** when one request spans multiple PRs, tracks, or owners (e.g. contrast audit → review panel + entity forms + map chrome).
+- **Parent (epic):** `parent issue` + size `M`/`L`/`XL`; body holds shared context, links children, no duplicated child AC.
+- **Child (task):** `sub-issue` + its own size/priority; body starts with `Parent: #NNN` and scoped AC.
+- **Do not** close the parent until all linked sub-issues ship or are explicitly deferred.
+
+**`gh` example**
+
+```sh
+gh issue create \
+  --title "fix(map-chrome): example scoped fix" \
+  --label "bug,size/S,priority/medium" \
+  --body "$(cat <<'EOF'
+Parent: #NNN
+
+## Problem
+…
+
+## Acceptance criteria
+- [ ] …
+EOF
+)"
+```
+
+For a good-first-issue task, add `good first issue` to `--label`. For epics, omit `good first issue` and use `parent issue,size/M,priority/medium` (adjust size/priority to match).
+
 ### Do NOT auto-close issues with human coordination requirements
 
 Some issues cannot be resolved purely through code. Issues that require **external human coordination** must remain open until the human work is complete, even if the technical implementation is merged. Examples include:

--- a/docs/issue-hygiene.md
+++ b/docs/issue-hygiene.md
@@ -12,6 +12,8 @@ Use `gh issue view <n> --repo uplbtools/room-tba` before and after issue-scoped 
 | **Developer**   | `good first issue`, `help wanted`       | Developers           | Dev fills in as they learn the codebase                        |
 | **Spec / epic** | `enhancement`, `parent issue`, `[TASK]` | Maintainers          | Full paths, AC, `Last verified`                                |
 
+**Filing new issues (agents + maintainers):** every new issue gets **one** `size/*`, **one** `priority/*`, and an explicit decision on **`good first issue`** (add the label only when newcomer-safe; otherwise leave it off). Split multi-PR work into a **`parent issue`** epic and **`sub-issue`** children (`Parent: #NNN` in the child body). Details: [AGENTS.md § Creating issues](../AGENTS.md#creating-issues).
+
 **Reporter issues:** problem + verification only. Do not ask reporters to cite `src/` or open PRs.
 
 **Developer issues:** plain acceptance criteria; optional area of app (map, API, etc.).
@@ -26,6 +28,16 @@ When implementing a `data` or `qa` issue on behalf of a reporter:
 2. Append **Implementation pointers** to the issue body if helpful
 3. Open PR to `staging`; `Closes #NNN`
 4. Thank the reporter when merged
+
+---
+
+## Filing a new issue (triage checklist)
+
+1. **Size** — exactly one: `size/XS` | `size/S` | `size/M` | `size/L` | `size/XL`.
+2. **Priority** — exactly one: `priority/high` | `priority/medium` | `priority/low`.
+3. **Good first issue** — add `good first issue` only if scoped, documented, and safe for newcomers; otherwise omit.
+4. **Type** — `bug`, `enhancement`, `design improvement`, `data`, `qa`, etc. as appropriate.
+5. **Epics** — if the work needs multiple PRs, open a **`parent issue`** first, then **`sub-issue`** tasks with `Parent: #NNN` and their own size/priority. Parent body links children; avoid duplicating child AC on the parent.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add **Creating issues** section to `AGENTS.md`: required `size/*` + `priority/*`, when to use `good first issue`, and `parent issue` / `sub-issue` structure.
- Extend `docs/issue-hygiene.md` with a filing checklist and cross-link.

## Test plan
- [x] Docs-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Documents **how agents and maintainers must triage new GitHub issues** — previously only lifecycle updates were spelled out, not creation-time metadata.
> 
> **`AGENTS.md`** gains a **Creating issues** subsection under GitHub issues: required **one** `size/*` and **one** `priority/*` at filing time; rules for when to add **`good first issue`** (and when not to, e.g. epics/migrations); optional type labels; **parent issue** / **sub-issue** splitting with `Parent: #NNN` on children; and a **`gh issue create`** example with labels and body template.
> 
> **`docs/issue-hygiene.md`** adds a one-line pointer in the three-tracks table (cross-link to AGENTS), plus a **Filing a new issue (triage checklist)** section that mirrors the same five steps (size, priority, good first issue, type, epics).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ad0344ee959ee5690b5b36dfcdf425c6479577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->