### PR TITLE
fix(side-panel): mobile collapsed peek pill border radius

### DIFF
--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -334,8 +334,8 @@
 
     .drawer.is-collapsed .drawer-sheet {
       flex: 0 0 auto;
-      border-radius: var(--map-chrome-radius, 1rem)
-        var(--map-chrome-radius, 1rem) 0 0;
+      border-radius: var(--map-chrome-radius, 1rem);
+      border-bottom: 1px solid var(--map-chrome-border, hsl(5 10% 68%));
     }
 
     .drawer-peek {


### PR DESCRIPTION
## Summary
- Mobile collapsed drawer peek (building/dorm/etc. retracted) now uses full `--map-chrome-radius` on all four corners instead of top-only rounding.
- Restores bottom border so the pill reads as a complete chip above the status bar.

## Test plan
- [ ] 320px: open building detail → collapse → peek pill has rounded bottom corners

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile CSS for the collapsed drawer peek only; no logic or data-path changes.
> 
> **Overview**
> On mobile, when the details drawer is **collapsed**, the peek “chip” (`.drawer.is-collapsed .drawer-sheet`) now uses **full** `--map-chrome-radius` on all corners instead of rounding only the top edge.
> 
> A **bottom border** is added in that collapsed state so the peek reads as a complete pill above the status bar, matching the open sheet’s chrome border token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0acb4d446f7152c4127e9589ab7c2b600e4164fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->