### PR TITLE
[FIX] back-link chip styling and inline link spacing on legal pages

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -2,7 +2,11 @@
 export const prerender = true;
 import Layout from "@layouts/Layout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
-import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@constants/community-links";
+import {
+  UPLB_TOOLS_URL,
+  DISCORD_URL,
+  MESSENGER_CONTRIBUTE_TARGET,
+} from "@constants/community-links";
 ---
 
 <Layout
@@ -12,15 +16,18 @@ import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@const
   showAppLoadingShell={false}
 >
   <main class="legal-page">
-    <a href="/" class="back-link">Back to Room TBA</a>
+    <a href="/" class="back-link">
+      <span aria-hidden="true">←</span> Back to Room TBA
+    </a>
 
     <header class="hero">
       <p class="eyebrow">Legal</p>
       <h1>Privacy Policy</h1>
       <p class="lede">
-        Last updated: June 29, 2026. Room TBA is operated by
-        <a href={UPLB_TOOLS_URL} target="_blank" rel="noopener noreferrer"
-          >UPLB Tools</a
+        Last updated: June 29, 2026. Room TBA is operated by <a
+          href={UPLB_TOOLS_URL}
+          target="_blank"
+          rel="noopener noreferrer">UPLB Tools</a
         > volunteers. This policy explains what we collect and why.
       </p>
     </header>
@@ -129,12 +136,11 @@ import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@const
       <section>
         <h2>Contact</h2>
         <p>
-          Questions about privacy? Reach the team via
-          <a href={MESSENGER_CONTRIBUTE_TARGET} target="_blank" rel="noopener noreferrer"
-            >Messenger</a
-          >
-          or
-          <a href={DISCORD_URL} target="_blank" rel="noopener noreferrer"
+          Questions about privacy? Reach the team via <a
+            href={MESSENGER_CONTRIBUTE_TARGET}
+            target="_blank"
+            rel="noopener noreferrer">Messenger</a
+          > or <a href={DISCORD_URL} target="_blank" rel="noopener noreferrer"
             >Discord</a
           >.
         </p>
@@ -154,10 +160,25 @@ import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@const
 
   .back-link {
     display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
     margin-bottom: 1.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    background: hsl(5 53% 32% / 0.08);
+    border: 1px solid hsl(5 53% 32% / 0.25);
     text-decoration: none;
     color: hsl(5, 53%, 32%);
     font-weight: 600;
+    font-size: 0.9375rem;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .back-link:hover {
+    background: hsl(5 53% 32% / 0.14);
+    border-color: hsl(5 53% 32% / 0.4);
   }
 
   .hero {

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -2,7 +2,11 @@
 export const prerender = true;
 import Layout from "@layouts/Layout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
-import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@constants/community-links";
+import {
+  UPLB_TOOLS_URL,
+  DISCORD_URL,
+  MESSENGER_CONTRIBUTE_TARGET,
+} from "@constants/community-links";
 ---
 
 <Layout
@@ -12,16 +16,19 @@ import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@const
   showAppLoadingShell={false}
 >
   <main class="legal-page">
-    <a href="/" class="back-link">Back to Room TBA</a>
+    <a href="/" class="back-link">
+      <span aria-hidden="true">←</span> Back to Room TBA
+    </a>
 
     <header class="hero">
       <p class="eyebrow">Legal</p>
       <h1>Terms of Service</h1>
       <p class="lede">
         Last updated: June 29, 2026. By using Room TBA you agree to these terms.
-        The service is provided by
-        <a href={UPLB_TOOLS_URL} target="_blank" rel="noopener noreferrer"
-          >UPLB Tools</a
+        The service is provided by <a
+          href={UPLB_TOOLS_URL}
+          target="_blank"
+          rel="noopener noreferrer">UPLB Tools</a
         > volunteers.
       </p>
     </header>
@@ -123,15 +130,15 @@ import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@const
       <section>
         <h2>Contact</h2>
         <p>
-          Questions? Reach us on
-          <a href={DISCORD_URL} target="_blank" rel="noopener noreferrer"
-            >Discord</a
-          >
-          or
-          <a href={MESSENGER_CONTRIBUTE_TARGET} target="_blank" rel="noopener noreferrer"
-            >Messenger</a
-          >, or open an issue on
-          <a
+          Questions? Reach us on <a
+            href={DISCORD_URL}
+            target="_blank"
+            rel="noopener noreferrer">Discord</a
+          > or <a
+            href={MESSENGER_CONTRIBUTE_TARGET}
+            target="_blank"
+            rel="noopener noreferrer">Messenger</a
+          >, or open an issue on <a
             href="https://github.com/uplbtools/room-tba"
             target="_blank"
             rel="noopener noreferrer">GitHub</a
@@ -153,10 +160,25 @@ import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@const
 
   .back-link {
     display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
     margin-bottom: 1.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    background: hsl(5 53% 32% / 0.08);
+    border: 1px solid hsl(5 53% 32% / 0.25);
     text-decoration: none;
     color: hsl(5, 53%, 32%);
     font-weight: 600;
+    font-size: 0.9375rem;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .back-link:hover {
+    background: hsl(5 53% 32% / 0.14);
+    border-color: hsl(5 53% 32% / 0.4);
   }
 
   .hero {


### PR DESCRIPTION
## Who are you?
- [ ] **Campus / data / QA only:** no code in this PR? Comment on the issue and skip the rest.
- [x] **Developer:** code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.

## Summary
Fixed the back-link on legal pages so it renders as a styled chip/button instead of plain text, and fixed missing whitespace around inline links in the Contact sections (and lede paragraphs) of `terms.astro` and `privacy.astro` by flattening multi-line anchor markup onto single lines.

**Linked issues:** Closes #405

## Developer checklist
- [x] `bun test src`
- [x] `bun run lint` (or Prettier on touched files)
- [x] Linked issue commented with this PR URL

## QA Summary (code changes)
Automated:
- [x] Prettier passed: `bunx prettier --check .` (PR CI)
- [x] Unit tests passed: `bun test src` (PR CI)
- [x] Full lint passed (local): `bun run lint`
- [x] Build passed (local): `bun run build` (needs `DATABASE_URL`; not run in PR CI)

If auth, routing, or schema changed:
- [ ] Admin redirects verified: `/admin`, `/admin/login`
- [ ] Migration applied on Supabase (if `drizzle/` changed)

If map chrome, editor, or side panel changed:
- [ ] Verified at 320px and/or 768px per [map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md)
- [ ] Editor/login/drag-save flows (see [editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md))

Known gaps:
- No unit tests added — this is a styling/markup-only fix on static legal pages, not covered by existing test suite.

Follow-up:
- None anticipated; flag if other pages use the same multi-line inline-link pattern and show the same spacing bug.

## Issues updated (maintainers / detailed specs)
- [ ] Linked issue(s) commented with this PR
- [ ] Acceptance criteria / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
- [x] `Last verified against staging:` date set on linked issues

## Test plan
1. Run `npm run dev` (or `bun run dev`)
2. Visit `/terms` and `/privacy`
3. Confirm the "Back to Room TBA" link renders as a pill/chip with visible background and border, not plain text
4. Confirm body copy reads with normal spacing — no "onDiscord"/"orMessenger" run-together text in the Contact sections
5. Confirm the lede paragraph ("...provided by UPLB Tools volunteers.") has correct spacing around the link