### PR TITLE
release: staging → main (Vercel ISR build-time fix)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ ADMIN_PASSWORD=
 # Preferred signing secret for admin_session cookies (falls back to ADMIN_PASSWORD if unset).
 ADMIN_SESSION_SECRET=
 
+# Vercel ISR on-demand revalidation (32+ chars). Set in Production + Preview; optional locally.
+# Must match bypassToken in astro.config.mjs. Admin writes send x-prerender-revalidate.
+ISR_BYPASS_TOKEN=
+
 # Supabase JS client (Settings → API). Used for Auth/Realtime/Storage — not Drizzle queries.
 PUBLIC_SUPABASE_URL=
 PUBLIC_SUPABASE_PUBLISHABLE_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,11 +134,11 @@ Full checklist: [docs/issue-hygiene.md](docs/issue-hygiene.md).
 
 Whenever an agent (or maintainer) **files a new GitHub issue**, set triage metadata at creation time — not “later.”
 
-| Required | Label(s) | Rule |
-| -------- | -------- | ---- |
-| **Size** | Exactly one of `size/XS` … `size/XL` | Estimate effort for one focused PR (see label descriptions on GitHub). |
-| **Priority** | Exactly one of `priority/high`, `priority/medium`, `priority/low` | `high` = user-visible break or blocker; `medium` = planned improvement; `low` = backlog/nice-to-have. |
-| **Good first issue** | `good first issue` **or omit** | Add only when the task is newcomer-safe: clear AC, small surface, no prod DB/auth/security surprises, paths documented. **Do not** tag epics, migrations, or coordination-heavy work. |
+| Required             | Label(s)                                                          | Rule                                                                                                                                                                                  |
+| -------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Size**             | Exactly one of `size/XS` … `size/XL`                              | Estimate effort for one focused PR (see label descriptions on GitHub).                                                                                                                |
+| **Priority**         | Exactly one of `priority/high`, `priority/medium`, `priority/low` | `high` = user-visible break or blocker; `medium` = planned improvement; `low` = backlog/nice-to-have.                                                                                 |
+| **Good first issue** | `good first issue` **or omit**                                    | Add only when the task is newcomer-safe: clear AC, small surface, no prod DB/auth/security surprises, paths documented. **Do not** tag epics, migrations, or coordination-heavy work. |
 
 **Optional but common:** `bug`, `enhancement`, `design improvement`, `data`, `qa`, `help wanted` — type labels are separate from size/priority.
 
@@ -207,13 +207,13 @@ Do not run full build after every small edit. See the workflow skill for session
 
 When the agent session has **browser automation** (Cursor agentic browser, Playwright MCP, or headless Playwright in the shell), **use it** for UI verification instead of skipping straight to “needs manual QA.”
 
-| Use agentic browser for | Still human-only |
-| ----------------------- | ---------------- |
-| Open entity side panels (building, dorm, room, event) | Drag/drop pin polish, animation feel |
-| Map chrome at 320px / 768px viewport | Subjective visual design judgment |
-| Capture `pageerror` / console errors after navigation | Long editor save/conflict sessions |
-| Dismiss landing modal, wait for bootstrap (`campus-browse-chips`, map canvas) | Production account-specific data |
-| Staging or prod smoke after deploy (`room-tba.uplbtools.me`) | |
+| Use agentic browser for                                                       | Still human-only                     |
+| ----------------------------------------------------------------------------- | ------------------------------------ |
+| Open entity side panels (building, dorm, room, event)                         | Drag/drop pin polish, animation feel |
+| Map chrome at 320px / 768px viewport                                          | Subjective visual design judgment    |
+| Capture `pageerror` / console errors after navigation                         | Long editor save/conflict sessions   |
+| Dismiss landing modal, wait for bootstrap (`campus-browse-chips`, map canvas) | Production account-specific data     |
+| Staging or prod smoke after deploy (`room-tba.uplbtools.me`)                  |                                      |
 
 **Practices:**
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Contributor notes: [AGENTS.md](AGENTS.md)
 - [Bun](https://bun.sh) 1.3+
 - A **Supabase** Postgres URL (`DATABASE_URL`); session pooler recommended for dev
 - `ADMIN_PASSWORD` if you want editor login locally
+- `ISR_BYPASS_TOKEN` (optional locally; **required on Vercel** for on-demand SEO page revalidation after editor publishes)
 
 ### Setup
 
@@ -123,17 +124,17 @@ Open **http://localhost:4321**. Without `DATABASE_URL`, the dev server starts bu
 
 ### Commands worth knowing
 
-| Command                       | Does what                                                                                    |
-| ----------------------------- | -------------------------------------------------------------------------------------------- |
-| `bun dev`                     | Dev server                                                                                   |
-| `bun run build`               | Production build (**needs** `DATABASE_URL`)                                                  |
-| `bun test src`                | Unit tests (no DB required)                                                                  |
-| `bun run lint`                | Prettier + ESLint                                                                            |
-| `bun run format`              | Prettier write                                                                               |
-| `bunx drizzle-kit studio`     | Browse/edit Postgres visually                                                                |
-| `bun run seed:aliases`        | Seed building aliases from `public/room_info.json`                                           |
-| `bun run import:amis-classes` | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`)                                     |
-| `bun run import:final-exams`  | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`) |
+| Command                       | Does what                                                                                                          |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `bun dev`                     | Dev server                                                                                                         |
+| `bun run build`               | Production build (**needs** `DATABASE_URL`; entity SEO pages render on first request via Vercel ISR, not at build) |
+| `bun test src`                | Unit tests (no DB required)                                                                                        |
+| `bun run lint`                | Prettier + ESLint                                                                                                  |
+| `bun run format`              | Prettier write                                                                                                     |
+| `bunx drizzle-kit studio`     | Browse/edit Postgres visually                                                                                      |
+| `bun run seed:aliases`        | Seed building aliases from `public/room_info.json`                                                                 |
+| `bun run import:amis-classes` | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`)                                                           |
+| `bun run import:final-exams`  | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`)                       |
 
 Legacy **`data/info.db`** SQLite is only for old seed/export scripts (`bun:sqlite`, not runtime). Production uses Supabase Postgres via `DATABASE_URL`. Archived SQLite migrations live in `drizzle-migrations/` — do not edit; active schema is `drizzle/`.
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -168,5 +168,13 @@ export default defineConfig({
       }),
     },
   },
-  adapter: vercel(),
+  adapter: vercel({
+    // Entity SEO pages use prerender=false and render on first request; Vercel
+    // caches HTML at the edge (ISR). Admin writes revalidate via ISR_BYPASS_TOKEN.
+    isr: {
+      expiration: 60 * 60 * 24,
+      bypassToken: process.env.ISR_BYPASS_TOKEN,
+      exclude: [/^\/api\//],
+    },
+  }),
 });

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -11,7 +11,7 @@
   import LandingGuideSteps from "./LandingGuideSteps.svelte";
   import ContributorProgressPanel from "@ui/status-bar/ContributorProgressPanel.svelte";
   import Download from "@lucide/svelte/icons/download";
-import { untrack } from "svelte";
+  import { untrack } from "svelte";
 
   type LandingTab = "welcome" | "campus";
 

--- a/src/lib/isr-revalidate.ts
+++ b/src/lib/isr-revalidate.ts
@@ -1,0 +1,74 @@
+/**
+ * On-demand ISR revalidation for Vercel (x-prerender-revalidate).
+ *
+ * Requires ISR_BYPASS_TOKEN in Vercel env and matching bypassToken in astro.config.
+ * No-op when the token is unset (local dev, previews without ISR configured).
+ */
+
+import {
+  getBuildingSlug,
+  getCollegeSlug,
+  getDivisionSlug,
+  getDormRouteSlug,
+  getRoomRouteSlug,
+} from "@lib/app-data";
+import { SITE_URL } from "@lib/site";
+import type {
+  BuildingData,
+  CollegeData,
+  DivisionData,
+  DormData,
+  RoomData,
+} from "@lib/types";
+
+const SITEMAP_PATH = "/sitemap.xml";
+
+export function roomIsrPath(room: Pick<RoomData, "id" | "code">): string {
+  return `/room/${getRoomRouteSlug(room)}/`;
+}
+
+export function buildingIsrPath(
+  building: Pick<BuildingData, "buildingName">,
+): string {
+  return `/building/${getBuildingSlug(building)}/`;
+}
+
+export function collegeIsrPath(
+  college: Pick<CollegeData, "collegeName">,
+): string {
+  return `/college/${getCollegeSlug(college)}/`;
+}
+
+export function divisionIsrPath(
+  division: Pick<DivisionData, "divisionName">,
+): string {
+  return `/division/${getDivisionSlug(division)}/`;
+}
+
+export function dormIsrPath(dorm: Pick<DormData, "id" | "dormName">): string {
+  return `/dorm/${getDormRouteSlug(dorm)}/`;
+}
+
+export function eventIsrPath(slug: string): string {
+  return `/event/${slug}/`;
+}
+
+/** Fire-and-forget ISR revalidation; always includes sitemap when paths are provided. */
+export function revalidateIsrPaths(paths: string[] | undefined): void {
+  if (!paths?.length) return;
+
+  const token = process.env.ISR_BYPASS_TOKEN?.trim();
+  if (!token) return;
+
+  const unique = [...new Set([...paths, SITEMAP_PATH])];
+  const base = SITE_URL.replace(/\/$/, "");
+
+  void Promise.allSettled(
+    unique.map((path) =>
+      fetch(`${base}${path}`, {
+        method: "HEAD",
+        headers: { "x-prerender-revalidate": token },
+      }),
+    ),
+  );
+}

--- a/src/lib/route-slugs.test.ts
+++ b/src/lib/route-slugs.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { parseIdRouteSlug } from "./route-slugs";
+
+describe("parseIdRouteSlug", () => {
+  test("parses numeric suffix from room route slugs", () => {
+    expect(parseIdRouteSlug("pslh-a-42")).toBe(42);
+    expect(parseIdRouteSlug("melchor-hall-1001")).toBe(1001);
+  });
+
+  test("returns null for invalid slugs", () => {
+    expect(parseIdRouteSlug("no-id-here")).toBeNull();
+    expect(parseIdRouteSlug("bad-0")).toBeNull();
+    expect(parseIdRouteSlug("")).toBeNull();
+  });
+});

--- a/src/lib/route-slugs.ts
+++ b/src/lib/route-slugs.ts
@@ -8,3 +8,11 @@ export function getRoomRouteSlug(room: Pick<RoomData, "id" | "code">) {
 export function getDormRouteSlug(dorm: Pick<DormData, "id" | "dormName">) {
   return `${slugifySegment(dorm.dormName)}-${dorm.id}`;
 }
+
+/** Parse numeric id suffix from room/dorm route slugs (`code-123` → 123). */
+export function parseIdRouteSlug(slug: string): number | null {
+  const match = slug.match(/-(\d+)$/);
+  if (!match) return null;
+  const id = Number(match[1]);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}

--- a/src/lib/services/admin-service.ts
+++ b/src/lib/services/admin-service.ts
@@ -16,6 +16,15 @@ import {
 } from "@drizzle/schema";
 import { normalizeEntityName } from "@lib/entity-names";
 import { db } from "@lib/db";
+import {
+  buildingIsrPath,
+  collegeIsrPath,
+  divisionIsrPath,
+  dormIsrPath,
+  eventIsrPath,
+  revalidateIsrPaths,
+  roomIsrPath,
+} from "@lib/isr-revalidate";
 import { getEventById } from "./event-service";
 import type { EventData, RoomData } from "@lib/types";
 import { EditConflictError } from "./edit-conflict-error";
@@ -56,11 +65,15 @@ export class DuplicateNameError<TCandidate = unknown> extends Error {
 }
 
 /** Refresh the sync key for a table so viewers detect the change and re-sync. */
-export async function refreshSyncKey(tableName: string): Promise<void> {
+export async function refreshSyncKey(
+  tableName: string,
+  revalidatePaths?: string[],
+): Promise<void> {
   await db
     .update(updateTable)
     .set({ syncKey: randomUUID() })
     .where(eq(updateTable.tableName, tableName));
+  revalidateIsrPaths(revalidatePaths);
 }
 
 type EditorHistoryInput = {
@@ -333,7 +346,12 @@ export async function updateRoom(
       });
     }
 
-    await refreshSyncKey("rooms");
+    const revalidatePaths = ["/room/"];
+    if (after) revalidatePaths.push(roomIsrPath(after));
+    if (before && after && before.code !== after.code) {
+      revalidatePaths.push(roomIsrPath(before));
+    }
+    await refreshSyncKey("rooms", revalidatePaths);
     return after ?? (await getRoomById(id));
   }
 
@@ -377,7 +395,10 @@ export async function createRoom(
       editedBy,
     });
   }
-  await refreshSyncKey("rooms");
+  await refreshSyncKey(
+    "rooms",
+    after ? [roomIsrPath(after), "/room/"] : ["/room/"],
+  );
   return after;
 }
 
@@ -445,7 +466,11 @@ export async function upsertRoomPosition(
       roomId,
     });
   }
-  await refreshSyncKey("rooms");
+  const room = await getRoomById(roomId);
+  await refreshSyncKey(
+    "rooms",
+    room ? [roomIsrPath(room), "/room/"] : ["/room/"],
+  );
 }
 
 export async function updateRoomPosition(
@@ -533,7 +558,10 @@ export async function updateRoomPosition(
     });
   }
 
-  await refreshSyncKey("rooms");
+  await refreshSyncKey(
+    "rooms",
+    after ? [roomIsrPath(after), "/room/"] : ["/room/"],
+  );
   return after;
 }
 
@@ -625,7 +653,12 @@ export async function updateBuilding(
       });
     }
 
-    await refreshSyncKey("buildings");
+    const revalidatePaths = ["/building/"];
+    if (updated) revalidatePaths.push(buildingIsrPath(updated));
+    if (before && updated && before.buildingName !== updated.buildingName) {
+      revalidatePaths.push(buildingIsrPath(before));
+    }
+    await refreshSyncKey("buildings", revalidatePaths);
     return updated ?? (await getBuildingById(id));
   }
 
@@ -666,7 +699,7 @@ export async function createBuilding(
     versionAfter: inserted.version,
     editedBy,
   });
-  await refreshSyncKey("buildings");
+  await refreshSyncKey("buildings", [buildingIsrPath(inserted), "/building/"]);
   return inserted;
 }
 
@@ -733,7 +766,10 @@ export async function updateCollege(
     });
   }
 
-  await refreshSyncKey("colleges");
+  await refreshSyncKey("colleges", [
+    collegeIsrPath(updated ?? before),
+    "/college/",
+  ]);
   return updated ?? (await getCollegeById(id));
 }
 
@@ -758,7 +794,7 @@ export async function createCollege(
     versionAfter: inserted.version,
     editedBy,
   });
-  await refreshSyncKey("colleges");
+  await refreshSyncKey("colleges", [collegeIsrPath(inserted), "/college/"]);
   return inserted;
 }
 
@@ -846,7 +882,10 @@ export async function updateDivision(
     });
   }
 
-  await refreshSyncKey("divisions");
+  await refreshSyncKey("divisions", [
+    divisionIsrPath(updated ?? before),
+    "/division/",
+  ]);
   return updated ?? (await getDivisionById(id));
 }
 
@@ -886,7 +925,7 @@ export async function createDivision(
     versionAfter: inserted.version,
     editedBy,
   });
-  await refreshSyncKey("divisions");
+  await refreshSyncKey("divisions", [divisionIsrPath(inserted), "/division/"]);
   return inserted;
 }
 
@@ -975,7 +1014,7 @@ export async function updateDorm(
       });
     }
 
-    await refreshSyncKey("dorms");
+    await refreshSyncKey("dorms", [dormIsrPath(updated ?? before), "/dorm/"]);
     return updated ?? (await getDormById(id));
   }
 
@@ -1023,7 +1062,7 @@ export async function createDorm(
     versionAfter: inserted.version,
     editedBy,
   });
-  await refreshSyncKey("dorms");
+  await refreshSyncKey("dorms", [dormIsrPath(inserted), "/dorm/"]);
   return inserted;
 }
 
@@ -1084,10 +1123,11 @@ const EVENT_SYNC_TABLES = [
   "event_route_stops",
 ];
 
-async function refreshEventSyncKeys() {
+async function refreshEventSyncKeys(revalidatePaths?: string[]) {
   await Promise.all(
     EVENT_SYNC_TABLES.map((tableName) => refreshSyncKey(tableName)),
   );
+  revalidateIsrPaths(revalidatePaths);
 }
 
 function getEventUpdates(input: EventWriteInput) {
@@ -1158,7 +1198,9 @@ export async function createEvent(
       editedBy,
     });
   }
-  await refreshEventSyncKeys();
+  await refreshEventSyncKeys(
+    after?.slug ? [eventIsrPath(after.slug), "/event/"] : ["/event/"],
+  );
   return after;
 }
 
@@ -1217,7 +1259,10 @@ export async function updateEvent(
       editedBy,
     });
   }
-  await refreshEventSyncKeys();
+  const eventPaths = ["/event/"];
+  if (after?.slug) eventPaths.push(eventIsrPath(after.slug));
+  if (before.slug !== after?.slug) eventPaths.push(eventIsrPath(before.slug));
+  await refreshEventSyncKeys(eventPaths);
   return after;
 }
 
@@ -1273,7 +1318,9 @@ export async function updateEventLocations(
       editedBy,
     });
   }
-  await refreshEventSyncKeys();
+  await refreshEventSyncKeys(
+    after?.slug ? [eventIsrPath(after.slug), "/event/"] : ["/event/"],
+  );
   return after;
 }
 

--- a/src/lib/services/ssg-service.ts
+++ b/src/lib/services/ssg-service.ts
@@ -7,9 +7,45 @@ import {
   dormsTable,
   roomsTable,
 } from "@drizzle/schema";
+import {
+  getBuildingSlug,
+  getCollegeSlug,
+  getDivisionSlug,
+} from "@lib/app-data";
 import { db } from "@lib/db";
 import { getEventBySlug } from "./event-service";
 import { getDefaultTerm } from "./term-service";
+
+export async function resolveBuildingNameFromSlug(
+  slug: string,
+): Promise<string | null> {
+  const rows = await db
+    .select({ buildingName: buildingsTable.buildingName })
+    .from(buildingsTable);
+  return (
+    rows.find((row) => getBuildingSlug(row) === slug)?.buildingName ?? null
+  );
+}
+
+export async function resolveCollegeNameFromSlug(
+  slug: string,
+): Promise<string | null> {
+  const rows = await db
+    .select({ collegeName: collegesTable.collegeName })
+    .from(collegesTable);
+  return rows.find((row) => getCollegeSlug(row) === slug)?.collegeName ?? null;
+}
+
+export async function resolveDivisionNameFromSlug(
+  slug: string,
+): Promise<string | null> {
+  const rows = await db
+    .select({ divisionName: divisionsTable.divisionName })
+    .from(divisionsTable);
+  return (
+    rows.find((row) => getDivisionSlug(row) === slug)?.divisionName ?? null
+  );
+}
 
 export async function getBuildingPageData(buildingName: string) {
   const defaultTerm = await getDefaultTerm();

--- a/src/lib/stores/store-types.ts
+++ b/src/lib/stores/store-types.ts
@@ -1,5 +1,8 @@
 import { modalOptions } from "@constants/modal-states";
-import type { ImportedScheduleRow, Weekday } from "@lib/schedule-import/types.js";
+import type {
+  ImportedScheduleRow,
+  Weekday,
+} from "@lib/schedule-import/types.js";
 
 export type LandingModalTab = "welcome" | "campus";
 

--- a/src/pages/building/[slug].astro
+++ b/src/pages/building/[slug].astro
@@ -1,8 +1,12 @@
 ---
+export const prerender = false;
+
 import EntityPage from "@seo/EntityPage.astro";
 import { getBuildingSlug } from "@lib/app-data";
-import { getAllBuildingsCached } from "@lib/services/map-data-service";
-import { getBuildingPageData } from "@lib/services/ssg-service";
+import {
+  getBuildingPageData,
+  resolveBuildingNameFromSlug,
+} from "@lib/services/ssg-service";
 import {
   absoluteUrl,
   breadcrumbSchema,
@@ -11,20 +15,20 @@ import {
   webpageSchema,
 } from "@lib/site";
 
-export async function getStaticPaths() {
-  const buildings = await getAllBuildingsCached();
-
-  return buildings.map((building) => ({
-    params: { slug: getBuildingSlug(building) },
-    props: { buildingName: building.buildingName },
-  }));
+const slug = Astro.params.slug;
+if (!slug) {
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 
-const { buildingName } = Astro.props;
+const buildingName = await resolveBuildingNameFromSlug(slug);
+if (!buildingName) {
+  return new Response(null, { status: 404, statusText: "Not Found" });
+}
+
 const appData = await getBuildingPageData(buildingName);
 
 if (appData === null) {
-  throw new Error(`Building not found for slug: ${buildingName}`);
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 const { building, roomCount, classCount, termLabel } = appData;
 const termPhrase = termLabel ? ` for ${termLabel}` : "";

--- a/src/pages/building/index.astro
+++ b/src/pages/building/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import EntityIndexPage from "@seo/EntityIndexPage.astro";
 import { getBuildingSlug, loadAppData } from "@lib/app-data";
 import { getDefaultTerm } from "@lib/services/term-service";

--- a/src/pages/college/[slug].astro
+++ b/src/pages/college/[slug].astro
@@ -1,8 +1,12 @@
 ---
+export const prerender = false;
+
 import EntityPage from "@seo/EntityPage.astro";
 import { getCollegeSlug } from "@lib/app-data";
-import { getAllCollegesCached } from "@lib/services/map-data-service";
-import { getCollegePageData } from "@lib/services/ssg-service";
+import {
+  getCollegePageData,
+  resolveCollegeNameFromSlug,
+} from "@lib/services/ssg-service";
 import {
   absoluteUrl,
   breadcrumbSchema,
@@ -11,20 +15,20 @@ import {
   webpageSchema,
 } from "@lib/site";
 
-export async function getStaticPaths() {
-  const colleges = await getAllCollegesCached();
-
-  return colleges.map((college) => ({
-    params: { slug: getCollegeSlug(college) },
-    props: { collegeName: college.collegeName },
-  }));
+const slug = Astro.params.slug;
+if (!slug) {
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 
-const { collegeName } = Astro.props;
+const collegeName = await resolveCollegeNameFromSlug(slug);
+if (!collegeName) {
+  return new Response(null, { status: 404, statusText: "Not Found" });
+}
+
 const appData = await getCollegePageData(collegeName);
 
 if (appData === null) {
-  throw new Error(`College not found for slug: ${collegeName}`);
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 
 const { college, roomCount } = appData;

--- a/src/pages/college/index.astro
+++ b/src/pages/college/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import EntityIndexPage from "@seo/EntityIndexPage.astro";
 import { getCollegeSlug, loadAppData } from "@lib/app-data";
 import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";

--- a/src/pages/division/[slug].astro
+++ b/src/pages/division/[slug].astro
@@ -1,8 +1,12 @@
 ---
+export const prerender = false;
+
 import EntityPage from "@seo/EntityPage.astro";
 import { getDivisionSlug } from "@lib/app-data";
-import { getDivisionPageData } from "@lib/services/ssg-service";
-import { getAllDivisionsCached } from "@lib/services/map-data-service";
+import {
+  getDivisionPageData,
+  resolveDivisionNameFromSlug,
+} from "@lib/services/ssg-service";
 import {
   absoluteUrl,
   breadcrumbSchema,
@@ -11,20 +15,20 @@ import {
   webpageSchema,
 } from "@lib/site";
 
-export async function getStaticPaths() {
-  const divisions = await getAllDivisionsCached();
-
-  return divisions.map((division) => ({
-    params: { slug: getDivisionSlug(division) },
-    props: { divisionName: division.divisionName },
-  }));
+const slug = Astro.params.slug;
+if (!slug) {
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 
-const { divisionName } = Astro.props;
+const divisionName = await resolveDivisionNameFromSlug(slug);
+if (!divisionName) {
+  return new Response(null, { status: 404, statusText: "Not Found" });
+}
+
 const appData = await getDivisionPageData(divisionName);
 
 if (appData === null) {
-  throw new Error(`Division not found for slug: ${divisionName}`);
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 const { division, roomCount } = appData;
 

--- a/src/pages/division/index.astro
+++ b/src/pages/division/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import EntityIndexPage from "@seo/EntityIndexPage.astro";
 import { getDivisionSlug, loadAppData } from "@lib/app-data";
 import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";

--- a/src/pages/dorm/[slug].astro
+++ b/src/pages/dorm/[slug].astro
@@ -1,7 +1,9 @@
 ---
+export const prerender = false;
+
 import EntityPage from "@seo/EntityPage.astro";
 import { getDormRouteSlug } from "@lib/app-data";
-import { getAllDormsCached } from "@lib/services/map-data-service";
+import { parseIdRouteSlug } from "@lib/route-slugs";
 import { getDormPageData } from "@lib/services/ssg-service";
 import {
   absoluteUrl,
@@ -11,20 +13,16 @@ import {
   webpageSchema,
 } from "@lib/site";
 
-export async function getStaticPaths() {
-  const dorms = await getAllDormsCached();
-
-  return dorms.map((dorm) => ({
-    params: { slug: getDormRouteSlug(dorm) },
-    props: { dormId: dorm.id },
-  }));
+const slug = Astro.params.slug;
+const dormId = slug ? parseIdRouteSlug(slug) : null;
+if (!dormId) {
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 
-const { dormId } = Astro.props;
 const appData = await getDormPageData(dormId);
 
 if (appData === null) {
-  throw new Error(`Dorm not found for slug: ${dormId}`);
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 const { dorm } = appData;
 

--- a/src/pages/dorm/index.astro
+++ b/src/pages/dorm/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import EntityIndexPage from "@seo/EntityIndexPage.astro";
 import { getDormRouteSlug } from "@lib/app-data";
 import { getAllDorms } from "@lib/services/map-data-service";

--- a/src/pages/event/[slug].astro
+++ b/src/pages/event/[slug].astro
@@ -1,9 +1,10 @@
 ---
+export const prerender = false;
+
 import AppRoot from "@ui/AppRoot.svelte";
 import Layout from "@layouts/Layout.astro";
 import { getEventImage } from "@lib/event-images";
 import { formatCampusDateTime } from "@lib/event-time";
-import { getSeoEvents } from "@lib/services/event-service";
 import { getEventPageData } from "@lib/services/ssg-service";
 import {
   absoluteUrl,
@@ -11,20 +12,16 @@ import {
   jsonLd,
   webpageSchema,
 } from "@lib/site";
-import { getSeoEventsCached } from "@lib/services/event-service";
-
-export async function getStaticPaths() {
-  const events = await getSeoEventsCached();
-  return events.map((event) => ({
-    params: { slug: event.slug },
-  }));
-}
 
 const { slug } = Astro.params;
-const appData = slug ? await getEventPageData(slug) : null;
+if (!slug) {
+  return new Response(null, { status: 404, statusText: "Not Found" });
+}
+
+const appData = await getEventPageData(slug);
 
 if (appData === null) {
-  throw new Error(`Event not found for slug: ${slug}`);
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 
 const { event } = appData;

--- a/src/pages/event/index.astro
+++ b/src/pages/event/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import EntityIndexPage from "@seo/EntityIndexPage.astro";
 import { formatCampusDateLong } from "@lib/event-time";
 import { getSeoEvents } from "@lib/services/event-service";

--- a/src/pages/room/[slug].astro
+++ b/src/pages/room/[slug].astro
@@ -1,7 +1,9 @@
 ---
+export const prerender = false;
+
 import EntityPage from "@seo/EntityPage.astro";
 import { getRoomRouteSlug } from "@lib/app-data";
-import { getAllRoomsCached } from "@lib/services/map-data-service";
+import { parseIdRouteSlug } from "@lib/route-slugs";
 import { getRoomPageData } from "@lib/services/ssg-service";
 import {
   absoluteUrl,
@@ -11,20 +13,16 @@ import {
   webpageSchema,
 } from "@lib/site";
 
-export async function getStaticPaths() {
-  const rooms = await getAllRoomsCached();
-
-  return rooms.map((room) => ({
-    params: { slug: getRoomRouteSlug(room) },
-    props: { roomId: room.id },
-  }));
+const slug = Astro.params.slug;
+const roomId = slug ? parseIdRouteSlug(slug) : null;
+if (!roomId) {
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 
-const { roomId } = Astro.props;
 const appData = await getRoomPageData(roomId);
 
 if (appData === null) {
-  throw new Error(`Room not found for slug: ${roomId}`);
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 
 const { room, classCount, termLabel } = appData;

--- a/src/pages/room/index.astro
+++ b/src/pages/room/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import EntityIndexPage from "@seo/EntityIndexPage.astro";
 import { getRoomRouteSlug, loadAppData } from "@lib/app-data";
 import { getDefaultTerm } from "@lib/services/term-service";

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,5 +1,7 @@
 // src/pages/sitemap.xml.ts
 
+export const prerender = false;
+
 import type { APIRoute } from "astro";
 import {
   getBuildingSlug,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "astro/tsconfigs/base",
-  "include": [".astro/types.d.ts", "src/**/*.ts", "src/**/*.astro", "src/**/*.svelte"],
+  "include": [
+    ".astro/types.d.ts",
+    "src/**/*.ts",
+    "src/**/*.astro",
+    "src/**/*.svelte"
+  ],
   "exclude": ["dist"],
   "compilerOptions": {
     "baseUrl": ".",


### PR DESCRIPTION
## Summary

Release **staging → main** with the Vercel ISR build-time fix ([#444](https://github.com/uplbtools/room-tba/pull/444), refs #331).

- Entity SEO pages (`/room/*`, `/building/*`, etc.) use `prerender = false` + Vercel ISR instead of ~650 build-time SSG pages.
- Build prerender phase drops to static shell only (~670ms vs ~3.5min before).
- Admin publishes revalidate cached SEO HTML via `ISR_BYPASS_TOKEN` (already set on Vercel Production + Preview staging).

Also includes Prettier formatting fixes on files that were blocking CI.

## Test plan

- [x] PR #444 merged to `staging`; CI + Vercel preview green
- [x] Local `bun run build` on `staging`
- [ ] Vercel production-bound checks green on this release PR
- [ ] Post-deploy smoke on prod: room entity page HTML + sitemap.xml

## Ops

- `ISR_BYPASS_TOKEN` must remain set on Vercel **Production** (configured before #444).

Closes #331

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes production caching and deploy/build behavior for all public SEO URLs; stale HTML is possible if `ISR_BYPASS_TOKEN` is missing or revalidation fails, and first-request slug resolution loads full building/college/division tables per lookup.
> 
> **Overview**
> Entity SEO routes (`/room`, `/building`, `/college`, `/division`, `/dorm`, `/event`, indexes, and `sitemap.xml`) **no longer pre-render at build time**. They set `prerender = false`, resolve slugs at request time (including new `parseIdRouteSlug` for room/dorm and DB slug resolvers for building/college/division), and return proper **404** responses instead of build-time throws.
> 
> The **Vercel adapter** gains **ISR** (24h TTL, `/api` excluded) keyed on **`ISR_BYPASS_TOKEN`**. New **`revalidateIsrPaths`** sends `x-prerender-revalidate` HEAD requests after admin writes; **`refreshSyncKey`** now accepts paths so publishes invalidate affected entity URLs, list pages, old slugs on renames, and the sitemap.
> 
> Docs/env: **`.env.example`**, **README**, and minor formatting elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c52df8fe1b445928da8dac1d812353f9f88f04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->