### PR TITLE
feat(notifications): NotificationAdapter and proposal.submitted emit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ R2_SECRET_ACCESS_KEY=
 R2_BUCKET_NAME=
 R2_PUBLIC_URL=
 
+# Notification gateway (Discord bot — optional until bot is deployed)
+# NOTIFICATION_GATEWAY_URL=https://your-bot.herokuapp.com/notifications
+# NOTIFICATION_INGRESS_SECRET=
+
 # AMIS import (scripts/import-amis-classes.ts) — copy bearer token from browser DevTools after AMIS login.
 # Tokens expire in about an hour; paste fresh when running --fetch. Never commit real tokens.
 # Fetch once with --fetch (while token is valid); later imports read data/amis-*-{termId}.json (gitignored).

--- a/.github/workflows/ci-notify-discord.yml
+++ b/.github/workflows/ci-notify-discord.yml
@@ -1,0 +1,23 @@
+name: CI notify Discord
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+jobs:
+  notify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        if: ${{ secrets.DISCORD_CI_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_CI_WEBHOOK_URL: ${{ secrets.DISCORD_CI_WEBHOOK_URL }}
+        run: |
+          payload=$(jq -n \
+            --arg repo "${{ github.repository }}" \
+            --arg branch "${{ github.event.workflow_run.head_branch }}" \
+            --arg url "${{ github.event.workflow_run.html_url }}" \
+            '{embeds:[{title:"CI failed",description:("**"+$repo+"** on `"+$branch+"`"),url:$url,color:15158332}]}')
+          curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_CI_WEBHOOK_URL"

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -166,6 +166,16 @@ export default defineConfig({
         context: "server",
         optional: true,
       }),
+      NOTIFICATION_GATEWAY_URL: envField.string({
+        access: "secret",
+        context: "server",
+        optional: true,
+      }),
+      NOTIFICATION_INGRESS_SECRET: envField.string({
+        access: "secret",
+        context: "server",
+        optional: true,
+      }),
     },
   },
   adapter: vercel({

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,13 @@
+# NotificationEvent contract
+
+Shared with [uplbtools/discord-bot](https://github.com/uplbtools/discord-bot). See `src/lib/notifications/types.ts`.
+
+Producers emit versioned JSON; the Discord bot routes to channels. Room TBA uses `NotificationAdapter` — `HttpNotificationAdapter` when `NOTIFICATION_GATEWAY_URL` + `NOTIFICATION_INGRESS_SECRET` are set, else `NoOpNotificationAdapter`.
+
+## proposal.submitted
+
+Emitted fire-and-forget after successful `POST /api/proposals`.
+
+## Leaderboard API (future)
+
+Discord-only leaderboard UX. Room TBA will expose `GET /api/contributors/leaderboard?window=month|semester|all`. See GitHub issue under #220.

--- a/src/lib/notifications/adapter.ts
+++ b/src/lib/notifications/adapter.ts
@@ -1,0 +1,5 @@
+import type { NotificationEvent } from "./types";
+
+export interface NotificationAdapter {
+  notify(event: NotificationEvent): Promise<void>;
+}

--- a/src/lib/notifications/http-adapter.ts
+++ b/src/lib/notifications/http-adapter.ts
@@ -17,7 +17,9 @@ export class HttpNotificationAdapter implements NotificationAdapter {
       body: JSON.stringify(event),
     });
     if (!res.ok) {
-      throw new Error(`Notification gateway ${res.status}: ${await res.text()}`);
+      throw new Error(
+        `Notification gateway ${res.status}: ${await res.text()}`,
+      );
     }
   }
 }

--- a/src/lib/notifications/http-adapter.ts
+++ b/src/lib/notifications/http-adapter.ts
@@ -1,0 +1,23 @@
+import type { NotificationAdapter } from "./adapter";
+import type { NotificationEvent } from "./types";
+
+export class HttpNotificationAdapter implements NotificationAdapter {
+  constructor(
+    private readonly gatewayUrl: string,
+    private readonly secret: string,
+  ) {}
+
+  async notify(event: NotificationEvent): Promise<void> {
+    const res = await fetch(this.gatewayUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-notification-secret": this.secret,
+      },
+      body: JSON.stringify(event),
+    });
+    if (!res.ok) {
+      throw new Error(`Notification gateway ${res.status}: ${await res.text()}`);
+    }
+  }
+}

--- a/src/lib/notifications/index.ts
+++ b/src/lib/notifications/index.ts
@@ -1,0 +1,25 @@
+import { NoOpNotificationAdapter } from "./noop-adapter";
+import { HttpNotificationAdapter } from "./http-adapter";
+import type { NotificationAdapter } from "./adapter";
+
+let cached: NotificationAdapter | null = null;
+
+export function getNotificationAdapter(): NotificationAdapter {
+  if (cached) return cached;
+
+  const url = process.env.NOTIFICATION_GATEWAY_URL?.trim();
+  const secret = process.env.NOTIFICATION_INGRESS_SECRET?.trim();
+
+  if (url && secret) {
+    cached = new HttpNotificationAdapter(url, secret);
+  } else {
+    cached = new NoOpNotificationAdapter();
+  }
+
+  return cached;
+}
+
+export type { NotificationAdapter } from "./adapter";
+export type { NotificationEvent, ProposalSubmittedPayload } from "./types";
+export { NoOpNotificationAdapter } from "./noop-adapter";
+export { HttpNotificationAdapter } from "./http-adapter";

--- a/src/lib/notifications/noop-adapter.ts
+++ b/src/lib/notifications/noop-adapter.ts
@@ -1,0 +1,8 @@
+import type { NotificationAdapter } from "./adapter";
+import type { NotificationEvent } from "./types";
+
+export class NoOpNotificationAdapter implements NotificationAdapter {
+  async notify(_event: NotificationEvent): Promise<void> {
+    // Local dev / tests — no gateway configured
+  }
+}

--- a/src/lib/notifications/notifications.test.ts
+++ b/src/lib/notifications/notifications.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { NoOpNotificationAdapter } from "./noop-adapter";
+import type { NotificationEvent } from "./types";
+
+describe("NoOpNotificationAdapter", () => {
+  test("notify resolves without error", async () => {
+    const adapter = new NoOpNotificationAdapter();
+    const event: NotificationEvent = {
+      schemaVersion: 1,
+      type: "proposal.submitted",
+      source: "room-tba",
+      occurredAt: new Date().toISOString(),
+      payload: { proposalId: 1 },
+    };
+    await expect(adapter.notify(event)).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -1,0 +1,26 @@
+export type NotificationEventType =
+  | "proposal.submitted"
+  | "proposal.reviewed"
+  | "deploy.succeeded"
+  | "deploy.failed"
+  | "release.published";
+
+export type NotificationSource = "room-tba" | "vercel" | "github";
+
+export type NotificationEvent = {
+  schemaVersion: 1;
+  type: NotificationEventType;
+  source: NotificationSource;
+  occurredAt: string;
+  idempotencyKey?: string;
+  payload: Record<string, unknown>;
+};
+
+export type ProposalSubmittedPayload = {
+  proposalId: number;
+  entityType: string;
+  entityId: number;
+  entityLabel: string;
+  submitterName: string;
+  isAnonymous: boolean;
+};

--- a/src/pages/api/proposals/index.ts
+++ b/src/pages/api/proposals/index.ts
@@ -9,7 +9,9 @@ import { validateSubmitterName } from "@constants/proposals";
 import {
   ProposalValidationError,
   submitProposal,
+  type EditProposalSummary,
 } from "@lib/services/proposal-service";
+import { getNotificationAdapter } from "@lib/notifications";
 
 export const prerender = false;
 
@@ -67,6 +69,11 @@ export const POST: APIRoute = async ({ cookies, request }) => {
       submitterUserId: session?.id && session.id > 0 ? session.id : null,
       proposalId: Number.isInteger(body.proposalId) ? body.proposalId : null,
     });
+
+    void emitProposalSubmitted(proposal, session?.id).catch((err) => {
+      console.error("Notification emit failed:", err);
+    });
+
     return json({ success: true, proposal }, 201);
   } catch (err) {
     if (err instanceof ProposalValidationError) {
@@ -81,5 +88,27 @@ function json(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function emitProposalSubmitted(
+  proposal: EditProposalSummary,
+  sessionUserId: number | undefined,
+): Promise<void> {
+  const notifications = getNotificationAdapter();
+  await notifications.notify({
+    schemaVersion: 1,
+    type: "proposal.submitted",
+    source: "room-tba",
+    occurredAt: new Date().toISOString(),
+    idempotencyKey: `proposal:${proposal.id}:submitted`,
+    payload: {
+      proposalId: proposal.id,
+      entityType: proposal.entityType,
+      entityId: proposal.entityId,
+      entityLabel: proposal.entityLabel,
+      submitterName: proposal.submitterName,
+      isAnonymous: !sessionUserId,
+    },
   });
 }


### PR DESCRIPTION
## Summary
- Adds implementation-agnostic `NotificationAdapter` (`HttpNotificationAdapter` / `NoOpNotificationAdapter`)
- Emits `proposal.submitted` to Discord bot gateway after successful `POST /api/proposals` (fire-and-forget)
- Documents `NotificationEvent` contract in `docs/notifications.md`
- Optional CI→Discord workflow (`DISCORD_CI_WEBHOOK_URL` secret)

## Env (staging/preview)
```
NOTIFICATION_GATEWAY_URL=https://<bot-host>/notifications
NOTIFICATION_INGRESS_SECRET=<shared secret>
```

## Test plan
- [x] `bun test src/lib/notifications/notifications.test.ts`
- [ ] Set gateway URL on staging after discord-bot Heroku deploy
- [ ] Submit test proposal → `#contributors` embed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notifications are async and optional; proposal success is unchanged if the gateway fails, though misconfigured secrets could leak submitter metadata to the wrong endpoint.
> 
> **Overview**
> Adds a **notification pipeline** so Room TBA can POST versioned `NotificationEvent` JSON to an external Discord bot gateway, without blocking API responses.
> 
> **`NotificationAdapter`** is wired via `getNotificationAdapter()`: **`HttpNotificationAdapter`** when `NOTIFICATION_GATEWAY_URL` and `NOTIFICATION_INGRESS_SECRET` are set (shared secret in `x-notification-secret`), otherwise **`NoOpNotificationAdapter`** for local dev/tests. Types and contract are documented in `docs/notifications.md`.
> 
> After a successful **`POST /api/proposals`**, the handler **fire-and-forget** emits **`proposal.submitted`** (idempotency key, entity/submitter payload, anonymous flag); failures are logged only.
> 
> Config/docs/ops: optional env in **`.env.example`** and **`astro.config.mjs`**, plus a **CI workflow** that posts to Discord on non-PR CI failures when `DISCORD_CI_WEBHOOK_URL` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18afa342150d1f5447c9572d175649e1326fa8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->