### PR TITLE
fix(auth): allow admin login by email address

### DIFF
--- a/integration/services/admin.integration.test.ts
+++ b/integration/services/admin.integration.test.ts
@@ -71,8 +71,9 @@ describeIntegration("admin auth integration", () => {
   });
 
   test("disabled user cannot authenticate", async () => {
-    const { authenticateAdminUser } =
-      await import("@lib/services/admin-user-service");
+    const { authenticateAdminUser } = await import(
+      "@lib/services/admin-user-service"
+    );
     const user = await authenticateAdminUser(
       "e2e-disabled",
       integrationPassword(),
@@ -81,8 +82,9 @@ describeIntegration("admin auth integration", () => {
   });
 
   test("admin user authenticates", async () => {
-    const { authenticateAdminUser } =
-      await import("@lib/services/admin-user-service");
+    const { authenticateAdminUser } = await import(
+      "@lib/services/admin-user-service"
+    );
     const user = await authenticateAdminUser(
       "e2e-admin",
       integrationPassword(),
@@ -100,8 +102,9 @@ describeIntegration("admin auth integration", () => {
     );
 
     try {
-      const { authenticateAdminUser } =
-        await import("@lib/services/admin-user-service");
+      const { authenticateAdminUser } = await import(
+        "@lib/services/admin-user-service"
+      );
       const user = await authenticateAdminUser(
         testEmail,
         integrationPassword(),

--- a/integration/services/admin.integration.test.ts
+++ b/integration/services/admin.integration.test.ts
@@ -47,10 +47,32 @@ describeIntegration("admin building service integration", () => {
 });
 
 describeIntegration("admin auth integration", () => {
-  test("disabled user cannot authenticate", async () => {
-    const { authenticateAdminUser } = await import(
-      "@lib/services/admin-user-service"
+  let client: pg.Client;
+  let hasEmailColumn = false;
+
+  beforeAll(async () => {
+    const url = integrationDatabaseUrl();
+    if (!url) return;
+    client = new pg.Client({ connectionString: url });
+    await client.connect();
+    const { rows } = await client.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'admin_users'
+           AND column_name = 'email'
+       ) AS exists`,
     );
+    hasEmailColumn = rows[0]?.exists ?? false;
+  });
+
+  afterAll(async () => {
+    await client?.end();
+  });
+
+  test("disabled user cannot authenticate", async () => {
+    const { authenticateAdminUser } =
+      await import("@lib/services/admin-user-service");
     const user = await authenticateAdminUser(
       "e2e-disabled",
       integrationPassword(),
@@ -59,13 +81,36 @@ describeIntegration("admin auth integration", () => {
   });
 
   test("admin user authenticates", async () => {
-    const { authenticateAdminUser } = await import(
-      "@lib/services/admin-user-service"
-    );
+    const { authenticateAdminUser } =
+      await import("@lib/services/admin-user-service");
     const user = await authenticateAdminUser(
       "e2e-admin",
       integrationPassword(),
     );
     expect(user?.username).toBe("e2e-admin");
+  });
+
+  test("admin user authenticates by email when email column exists", async () => {
+    if (!hasEmailColumn) return;
+
+    const testEmail = "e2e-admin-login@room-tba.test";
+    await client.query(
+      `UPDATE admin_users SET email = $1 WHERE username = 'e2e-admin'`,
+      [testEmail],
+    );
+
+    try {
+      const { authenticateAdminUser } =
+        await import("@lib/services/admin-user-service");
+      const user = await authenticateAdminUser(
+        testEmail,
+        integrationPassword(),
+      );
+      expect(user?.username).toBe("e2e-admin");
+    } finally {
+      await client.query(
+        `UPDATE admin_users SET email = NULL WHERE username = 'e2e-admin'`,
+      );
+    }
   });
 });

--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -1,5 +1,5 @@
 import bcrypt from "bcrypt";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, or, sql } from "drizzle-orm";
 import { ADMIN_PASSWORD } from "astro:env/server";
 import { adminUsersTable } from "@drizzle/schema";
 import { db } from "@lib/db";
@@ -76,13 +76,16 @@ export async function authenticateAdminUser(
     .from(adminUsersTable)
     .where(
       and(
-        eq(adminUsersTable.username, normalized),
         eq(adminUsersTable.isActive, true),
+        or(
+          eq(adminUsersTable.username, normalized),
+          sql`lower(email) = ${normalized}`,
+        ),
       ),
     )
     .limit(1);
 
-  if (!user) return null;
+  if (!user?.passwordHash) return null;
   const valid = await bcrypt.compare(password, user.passwordHash);
   if (!valid) return null;
 


### PR DESCRIPTION
## Summary
- `authenticateAdminUser` now matches `admin_users` by username **or** `lower(email)`, fixing sign-in when volunteers use their Gmail in the login modal.
- Guards bcrypt compare when `password_hash` is null.
- Integration test covers email login when the `email` column exists (skipped on older DBs).

## Test plan
- [x] `bun run build`
- [x] `bun test src/lib/admin/require-editor.test.ts`
- [ ] CI verify + migrations
- [ ] After deploy: `POST /api/admin/auth` with `semariquit@gmail.com` succeeds on prod

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin authentication lookup logic; scope is limited to password-based `authenticateAdminUser` with existing active-user and bcrypt checks.
> 
> **Overview**
> **Admin password login** now accepts the same normalized identifier as either **username** or **`lower(email)`**, so volunteers can sign in with a Gmail address in the login modal instead of only a username.
> 
> `authenticateAdminUser` also **skips bcrypt** when `password_hash` is missing, avoiding errors for accounts without a local password.
> 
> Integration coverage adds a DB-backed auth suite that **probes for the `email` column** and, when present, temporarily sets an email on `e2e-admin` to assert email-based login, then restores it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1773eefe7d1ce26c689a3f7d7bf643ccb5f4e559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->