### PR TITLE
fix(auth): email login backcompat for unmigrated DBs

### DIFF
--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -1,5 +1,5 @@
 import bcrypt from "bcrypt";
-import { and, eq, or, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { ADMIN_PASSWORD } from "astro:env/server";
 import { adminUsersTable } from "@drizzle/schema";
 import { db } from "@lib/db";
@@ -64,27 +64,49 @@ export async function getAdminUserBySupabaseId(
   }
 }
 
-export async function authenticateAdminUser(
-  username: string,
-  password: string,
-): Promise<SessionUser | null> {
-  const normalized = username.trim().toLowerCase();
-  if (!normalized || password.length === 0) return null;
+async function findUserByLogin(login: string) {
+  const normalized = login.trim().toLowerCase();
+  if (!normalized) return null;
 
-  const [user] = await db
+  const [byUsername] = await db
     .select(adminUserCredentialColumns)
     .from(adminUsersTable)
     .where(
       and(
         eq(adminUsersTable.isActive, true),
-        or(
-          eq(adminUsersTable.username, normalized),
-          sql`lower(email) = ${normalized}`,
-        ),
+        eq(adminUsersTable.username, normalized),
       ),
     )
     .limit(1);
+  if (byUsername) return byUsername;
 
+  if (!normalized.includes("@")) return null;
+
+  try {
+    const [byEmail] = await db
+      .select(adminUserCredentialColumns)
+      .from(adminUsersTable)
+      .where(
+        and(
+          eq(adminUsersTable.isActive, true),
+          sql`lower(email) = ${normalized}`,
+        ),
+      )
+      .limit(1);
+    return byEmail ?? null;
+  } catch {
+    // `admin_users.email` added in drizzle/0018; skip until migrated.
+    return null;
+  }
+}
+
+export async function authenticateAdminUser(
+  login: string,
+  password: string,
+): Promise<SessionUser | null> {
+  if (!login.trim() || password.length === 0) return null;
+
+  const user = await findUserByLogin(login);
   if (!user?.passwordHash) return null;
   const valid = await bcrypt.compare(password, user.passwordHash);
   if (!valid) return null;


### PR DESCRIPTION
## Summary
- Follow-up to #458: username lookup first, email lookup only when login contains `@`
- Catches missing `admin_users.email` column so CI/E2E DBs do not 500 on every login

## Test plan
- [x] `bun test src/lib/admin/require-editor.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication lookup paths; behavior change is intentional for backward compatibility but login resolution order differs from the prior single-query OR.
> 
> **Overview**
> Refactors admin bcrypt login in `admin-user-service` so **username is resolved first**, and **email lookup runs only when the login string contains `@`**.
> 
> Email matching is isolated in a **try/catch** so databases that have not applied migration **0018** (`admin_users.email`) no longer throw on every login attempt—CI/E2E environments get a failed auth instead of a **500**. The combined `OR` username/email query is removed in favor of `findUserByLogin`; `authenticateAdminUser` now takes a `login` parameter with the same password check behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58b311733c93978b4e05625432efd498a401587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->