### PR TITLE
fix(auth): allow admin login by email address (prod hotfix)

### DIFF
--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -64,25 +64,50 @@ export async function getAdminUserBySupabaseId(
   }
 }
 
-export async function authenticateAdminUser(
-  username: string,
-  password: string,
-): Promise<SessionUser | null> {
-  const normalized = username.trim().toLowerCase();
-  if (!normalized || password.length === 0) return null;
+async function findUserByLogin(login: string) {
+  const normalized = login.trim().toLowerCase();
+  if (!normalized) return null;
 
-  const [user] = await db
+  const [byUsername] = await db
     .select(adminUserCredentialColumns)
     .from(adminUsersTable)
     .where(
       and(
-        eq(adminUsersTable.username, normalized),
         eq(adminUsersTable.isActive, true),
+        eq(adminUsersTable.username, normalized),
       ),
     )
     .limit(1);
+  if (byUsername) return byUsername;
 
-  if (!user) return null;
+  if (!normalized.includes("@")) return null;
+
+  try {
+    const [byEmail] = await db
+      .select(adminUserCredentialColumns)
+      .from(adminUsersTable)
+      .where(
+        and(
+          eq(adminUsersTable.isActive, true),
+          sql`lower(email) = ${normalized}`,
+        ),
+      )
+      .limit(1);
+    return byEmail ?? null;
+  } catch {
+    // `admin_users.email` added in drizzle/0018; skip until migrated.
+    return null;
+  }
+}
+
+export async function authenticateAdminUser(
+  login: string,
+  password: string,
+): Promise<SessionUser | null> {
+  if (!login.trim() || password.length === 0) return null;
+
+  const user = await findUserByLogin(login);
+  if (!user?.passwordHash) return null;
   const valid = await bcrypt.compare(password, user.passwordHash);
   if (!valid) return null;
 


### PR DESCRIPTION
## Summary
- Production login modal says “Email or username” but `authenticateAdminUser` only matched `username`.
- Now tries username first, then `lower(email)` when login contains `@`.
- Email query is try/catch so unmigrated DBs (E2E) still work.

## Test plan
- [x] `bun run build`
- [ ] After merge: `POST /api/admin/auth` with `semariquit@gmail.com` on prod

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin authentication credential lookup; behavior is additive for username logins but email matching depends on migrated schema and stored email values.
> 
> **Overview**
> Aligns password-based admin login with the UI that accepts **email or username** by resolving the user through a new `findUserByLogin` helper instead of matching only `username`.
> 
> Lookup is **username first** (normalized trim/lowercase), then **`lower(email)`** when the login string contains `@`. The email query runs inside **try/catch** so environments without the `admin_users.email` column (pre–migration 0018 / E2E) still authenticate by username only. `authenticateAdminUser` now rejects missing `passwordHash` before `bcrypt.compare`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 555646af3a1fee06d49407ac404b2ca06d81d13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->