### PR TITLE
fix(auth): shorten login rate-limit window to 30 seconds

### DIFF
--- a/src/lib/api/rate-limit.ts
+++ b/src/lib/api/rate-limit.ts
@@ -46,11 +46,14 @@ export function clientIp(request: Request): string {
   return "unknown";
 }
 
-export function rateLimitResponse(resetAt: number) {
+export function rateLimitResponse(
+  resetAt: number,
+  message = "Too many requests. Wait a few minutes and try again.",
+) {
   const retryAfter = Math.max(1, Math.ceil((resetAt - Date.now()) / 1000));
   return new Response(
     JSON.stringify({
-      error: "Too many requests. Wait a few minutes and try again.",
+      error: message,
     }),
     {
       status: 429,

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -445,7 +445,7 @@ class AdminAuthStore {
           (res.status === 401
             ? "Invalid username or password"
             : res.status === 429
-              ? "Too many attempts. Wait a few minutes and try again."
+              ? "Too many sign-in attempts. Wait about 30 seconds and try again."
               : res.status >= 500
                 ? "Sign-in failed on our side. Try again later."
                 : "Could not sign in. Check your username and password.")

--- a/src/pages/api/admin/auth.ts
+++ b/src/pages/api/admin/auth.ts
@@ -21,8 +21,11 @@ import { createServerSupabaseClient } from "@lib/supabase/server";
 
 export const prerender = false;
 
-const LOGIN_IP_LIMIT = { max: 12, windowMs: 15 * 60 * 1000 };
-const LOGIN_USER_LIMIT = { max: 8, windowMs: 15 * 60 * 1000 };
+const LOGIN_RATE_LIMIT_WINDOW_MS = 30 * 1000;
+const LOGIN_IP_LIMIT = { max: 12, windowMs: LOGIN_RATE_LIMIT_WINDOW_MS };
+const LOGIN_USER_LIMIT = { max: 8, windowMs: LOGIN_RATE_LIMIT_WINDOW_MS };
+const LOGIN_RATE_LIMIT_MESSAGE =
+  "Too many sign-in attempts. Wait about 30 seconds and try again.";
 
 export const GET: APIRoute = async ({ cookies }) => {
   const session = getEditorSession(cookies);
@@ -55,7 +58,7 @@ export const POST: APIRoute = async ({ request, cookies }) => {
         LOGIN_IP_LIMIT.windowMs,
       );
       if (!ipRate.allowed) {
-        return rateLimitResponse(ipRate.resetAt);
+        return rateLimitResponse(ipRate.resetAt, LOGIN_RATE_LIMIT_MESSAGE);
       }
     }
 
@@ -72,7 +75,7 @@ export const POST: APIRoute = async ({ request, cookies }) => {
         LOGIN_USER_LIMIT.windowMs,
       );
       if (!userRate.allowed) {
-        return rateLimitResponse(userRate.resetAt);
+        return rateLimitResponse(userRate.resetAt, LOGIN_RATE_LIMIT_MESSAGE);
       }
     }
 


### PR DESCRIPTION
## Summary
- Admin login rate limit window: **15 min → 30 sec** (still 8 tries/user, 12/IP per window)
- Updated API + modal copy to match

## Test plan
- [x] `bun test src/lib/api/rate-limit.test.ts`
- [x] `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rate-limit behavior on the admin login endpoint (security-sensitive), though attempt limits are unchanged and the window is shorter rather than removed.
> 
> **Overview**
> Shortens the **admin login** rate-limit window from **15 minutes to 30 seconds** while keeping the same caps (**12 attempts per IP**, **8 per username** per window).
> 
> `rateLimitResponse` now accepts an optional **custom error message**; the admin auth route passes a login-specific 429 body and the sign-in store uses matching fallback copy when the API returns 429 without a message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4743fff4bce35c8b385cd55b5d31ba985a9b6a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->