### PR TITLE
feat(notifications): Discord notify when admin reviews proposals

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -18,6 +18,20 @@ See [docs/e2e-discord-handoff.md](e2e-discord-handoff.md).
 
 Emitted fire-and-forget after successful `POST /api/proposals`.
 
+## proposal.reviewed
+
+Emitted fire-and-forget after successful admin review:
+
+- `POST /api/admin/proposals/[id]/approve` → `outcome: approved`
+- `POST /api/admin/proposals/[id]/reject` → `outcome: rejected`
+- `POST /api/admin/proposals/[id]/request-changes` → `outcome: needs_changes`
+
+Not emitted when approve fails with `409` (publish conflict — proposal stays pending).
+
+Payload: `proposalId`, `outcome`, `entityType`, `entityId`, `entityLabel`, `submitterName`, `reviewedBy`, `adminNote`.
+
+Discord bot posts to `#contributors` (see discord-bot repo).
+
 ## Leaderboard API (future)
 
 Discord-only leaderboard UX. Room TBA will expose `GET /api/contributors/leaderboard?window=month|semester|all`. See GitHub issue under #220.

--- a/src/lib/notifications/proposal-events.test.ts
+++ b/src/lib/notifications/proposal-events.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import type { EditProposalSummary } from "@lib/services/proposal-service";
+import { emitProposalReviewed, emitProposalSubmitted } from "./proposal-events";
+
+const sampleProposal = {
+  id: 42,
+  entityType: "room",
+  entityId: 230,
+  entityLabel: "CEM 203",
+  submitterName: "Yeyel",
+  submitterUserId: null,
+  status: "approved",
+  proposedPatch: {},
+  baseVersion: 1,
+  adminNote: null,
+  reviewedBy: "Stimmie",
+  reviewedAt: "2026-07-03T00:00:00.000Z",
+  createdAt: "2026-07-02T00:00:00.000Z",
+  updatedAt: "2026-07-03T00:00:00.000Z",
+} satisfies EditProposalSummary;
+
+describe("proposal notification events", () => {
+  test("emitProposalSubmitted uses NoOp adapter without error", async () => {
+    await expect(
+      emitProposalSubmitted(sampleProposal, undefined),
+    ).resolves.toBeUndefined();
+  });
+
+  test("emitProposalReviewed uses NoOp adapter without error", async () => {
+    await expect(
+      emitProposalReviewed(sampleProposal, "approved"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/notifications/proposal-events.ts
+++ b/src/lib/notifications/proposal-events.ts
@@ -1,0 +1,54 @@
+import { getNotificationAdapter } from "./index";
+import type { EditProposalSummary } from "@lib/services/proposal-service";
+
+export type ProposalReviewOutcome = "approved" | "rejected" | "needs_changes";
+
+export async function emitProposalSubmitted(
+  proposal: EditProposalSummary,
+  sessionUserId: number | undefined,
+): Promise<void> {
+  const notifications = getNotificationAdapter();
+  await notifications.notify({
+    schemaVersion: 1,
+    type: "proposal.submitted",
+    source: "room-tba",
+    occurredAt: new Date().toISOString(),
+    idempotencyKey: `proposal:${proposal.id}:submitted`,
+    payload: {
+      proposalId: proposal.id,
+      entityType: proposal.entityType,
+      entityId: proposal.entityId,
+      entityLabel: proposal.entityLabel,
+      submitterName: proposal.submitterName,
+      isAnonymous: !sessionUserId,
+    },
+  });
+}
+
+export async function emitProposalReviewed(
+  proposal: EditProposalSummary,
+  outcome: ProposalReviewOutcome,
+): Promise<void> {
+  const notifications = getNotificationAdapter();
+  await notifications.notify({
+    schemaVersion: 1,
+    type: "proposal.reviewed",
+    source: "room-tba",
+    occurredAt: new Date().toISOString(),
+    idempotencyKey: `proposal:${proposal.id}:reviewed:${outcome}`,
+    payload: {
+      proposalId: proposal.id,
+      outcome,
+      entityType: proposal.entityType,
+      entityId: proposal.entityId,
+      entityLabel: proposal.entityLabel,
+      submitterName: proposal.submitterName,
+      reviewedBy: proposal.reviewedBy ?? "Unknown",
+      adminNote: proposal.adminNote,
+    },
+  });
+}
+
+export function logNotificationEmitFailure(context: string, err: unknown) {
+  console.error(`${context}:`, err);
+}

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -29,3 +29,16 @@ export type ProposalSubmittedPayload = {
   submitterName: string;
   isAnonymous: boolean;
 };
+
+export type ProposalReviewOutcome = "approved" | "rejected" | "needs_changes";
+
+export type ProposalReviewedPayload = {
+  proposalId: number;
+  outcome: ProposalReviewOutcome;
+  entityType: string;
+  entityId: number;
+  entityLabel: string;
+  submitterName: string;
+  reviewedBy: string;
+  adminNote: string | null;
+};

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -751,7 +751,8 @@ export async function rejectProposal(
     reviewer.displayName || reviewer.username,
     note,
   );
-  return finalized;
+  if (!finalized) throw new ProposalActionError("Proposal not found.", 404);
+  return withEntityLabel(finalized);
 }
 
 export async function requestProposalChanges(
@@ -775,5 +776,6 @@ export async function requestProposalChanges(
     reviewer.displayName || reviewer.username,
     note,
   );
-  return finalized;
+  if (!finalized) throw new ProposalActionError("Proposal not found.", 404);
+  return withEntityLabel(finalized);
 }

--- a/src/pages/api/admin/proposals/[id]/approve.ts
+++ b/src/pages/api/admin/proposals/[id]/approve.ts
@@ -4,6 +4,10 @@ import {
   approveProposal,
   ProposalActionError,
 } from "@lib/services/proposal-service";
+import {
+  emitProposalReviewed,
+  logNotificationEmitFailure,
+} from "@lib/notifications/proposal-events";
 
 export const prerender = false;
 
@@ -16,6 +20,9 @@ export const POST: APIRoute = async ({ cookies, params }) => {
 
   try {
     const result = await approveProposal(id, auth.session);
+    void emitProposalReviewed(result.proposal, "approved").catch((err) => {
+      logNotificationEmitFailure("Proposal reviewed notification failed", err);
+    });
     return json({ success: true, ...result });
   } catch (err) {
     if (err instanceof ProposalActionError) {

--- a/src/pages/api/admin/proposals/[id]/reject.ts
+++ b/src/pages/api/admin/proposals/[id]/reject.ts
@@ -4,6 +4,10 @@ import {
   ProposalActionError,
   rejectProposal,
 } from "@lib/services/proposal-service";
+import {
+  emitProposalReviewed,
+  logNotificationEmitFailure,
+} from "@lib/notifications/proposal-events";
 
 export const prerender = false;
 
@@ -20,6 +24,14 @@ export const POST: APIRoute = async ({ cookies, params, request }) => {
 
   try {
     const proposal = await rejectProposal(id, auth.session, body.note);
+    if (proposal) {
+      void emitProposalReviewed(proposal, "rejected").catch((err) => {
+        logNotificationEmitFailure(
+          "Proposal reviewed notification failed",
+          err,
+        );
+      });
+    }
     return json({ success: true, proposal });
   } catch (err) {
     if (err instanceof ProposalActionError) {

--- a/src/pages/api/admin/proposals/[id]/request-changes.ts
+++ b/src/pages/api/admin/proposals/[id]/request-changes.ts
@@ -5,6 +5,10 @@ import {
   ProposalValidationError,
   requestProposalChanges,
 } from "@lib/services/proposal-service";
+import {
+  emitProposalReviewed,
+  logNotificationEmitFailure,
+} from "@lib/notifications/proposal-events";
 
 export const prerender = false;
 
@@ -21,6 +25,14 @@ export const POST: APIRoute = async ({ cookies, params, request }) => {
 
   try {
     const proposal = await requestProposalChanges(id, auth.session, body.note);
+    if (proposal) {
+      void emitProposalReviewed(proposal, "needs_changes").catch((err) => {
+        logNotificationEmitFailure(
+          "Proposal reviewed notification failed",
+          err,
+        );
+      });
+    }
     return json({ success: true, proposal });
   } catch (err) {
     if (err instanceof ProposalValidationError) {

--- a/src/pages/api/proposals/index.ts
+++ b/src/pages/api/proposals/index.ts
@@ -9,9 +9,11 @@ import { validateSubmitterName } from "@constants/proposals";
 import {
   ProposalValidationError,
   submitProposal,
-  type EditProposalSummary,
 } from "@lib/services/proposal-service";
-import { getNotificationAdapter } from "@lib/notifications";
+import {
+  emitProposalSubmitted,
+  logNotificationEmitFailure,
+} from "@lib/notifications/proposal-events";
 
 export const prerender = false;
 
@@ -71,7 +73,7 @@ export const POST: APIRoute = async ({ cookies, request }) => {
     });
 
     void emitProposalSubmitted(proposal, session?.id).catch((err) => {
-      console.error("Notification emit failed:", err);
+      logNotificationEmitFailure("Notification emit failed", err);
     });
 
     return json({ success: true, proposal }, 201);
@@ -88,27 +90,5 @@ function json(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
-  });
-}
-
-async function emitProposalSubmitted(
-  proposal: EditProposalSummary,
-  sessionUserId: number | undefined,
-): Promise<void> {
-  const notifications = getNotificationAdapter();
-  await notifications.notify({
-    schemaVersion: 1,
-    type: "proposal.submitted",
-    source: "room-tba",
-    occurredAt: new Date().toISOString(),
-    idempotencyKey: `proposal:${proposal.id}:submitted`,
-    payload: {
-      proposalId: proposal.id,
-      entityType: proposal.entityType,
-      entityId: proposal.entityId,
-      entityLabel: proposal.entityLabel,
-      submitterName: proposal.submitterName,
-      isAnonymous: !sessionUserId,
-    },
   });
 }


### PR DESCRIPTION
## Summary
- Emit `proposal.reviewed` from admin approve / reject / request-changes routes
- Shared `proposal-events.ts` helpers + unit tests
- Return `entityLabel` on reject and needs-changes for notification payload

## Test plan
- [x] `bun test src/lib/notifications/`
- [ ] Merge bot PR + deploy Heroku first (or same time)
- [ ] Approve a proposal on staging → green embed in `#contributors`

Closes #222
Pairs with uplbtools/discord-bot#4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Fire-and-forget notifications and a small service return-shape change; no change to auth or publish logic beyond existing approve rollback behavior.
> 
> **Overview**
> Adds **`proposal.reviewed`** notifications so contributors get Discord updates when an admin finishes review (approve, reject, or request changes).
> 
> Proposal submit/review emits are centralized in **`proposal-events.ts`** (`emitProposalSubmitted`, `emitProposalReviewed`, shared failure logging). Admin routes fire **`emitProposalReviewed`** fire-and-forget after a successful action; approve still skips notify on **409** publish conflicts. **`rejectProposal`** and **`requestProposalChanges`** now return summaries with **`entityLabel`** for the notification payload. Types and docs describe the new event and payload fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e322e58d435b200104455bdd9299a061f142c919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->