### PR TITLE
feat(testing): Discord #test-suite tier embeds (no markdown attachment)

### DIFF
--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -7,38 +7,39 @@ bun run generate:test-inventory
 ```
 
 **Last generated:** 2026-07-03  
-**Total spec files:** 104
+**Total spec files:** 106
 
 See [testing.md](testing.md) for commands, CI gates, and databases. Issue-linked expectations: [issue-test-matrix.md](issue-test-matrix.md).
 
 ## Summary by tier
 
-| Command                    | Config / runner                         | Files    |
-| -------------------------- | --------------------------------------- | -------- |
-| `bun test src`             | Bun — unit (`src/lib`, `src/constants`) | 42       |
-| `bun run test:components`  | Vitest — stores + Svelte @320px         | 17       |
-| `bun run test:integration` | Bun — HTTP + services (E2E DB)          | 5        |
-| `bun run e2e`              | Playwright blocking — local preview     | 26       |
-| `bun run e2e:advisory`     | Playwright advisory — non-blocking CI   | 11       |
-| `bun run e2e:staging`      | Playwright — live staging URL           | 3        |
-| `bun run check:migrations` | Schema table guard (not a spec file)    | 1 script |
+| Command | Config / runner | Files |
+| ------- | ---------------- | ----- |
+| `bun test src` | Bun — unit (`src/lib`, `src/constants`) | 43 |
+| `bun run test:components` | Vitest — stores + Svelte @320px | 17 |
+| `bun run test:integration` | Bun — HTTP + services (E2E DB) | 5 |
+| `bun run e2e` | Playwright blocking — local preview | 26 |
+| `bun run e2e:advisory` | Playwright advisory — non-blocking CI | 11 |
+| `bun run e2e:staging` | Playwright — live staging URL | 3 |
+| `bun run check:migrations` | Schema table guard (not a spec file) | 1 script |
+
 
 ## CI mapping
 
-| Workflow                                                                      | What runs                                                |
-| ----------------------------------------------------------------------------- | -------------------------------------------------------- |
-| [ci.yml](../.github/workflows/ci.yml)                                         | `bun test src`, `test:components`, lint, prod build      |
-| [ci.yml](../.github/workflows/ci.yml) migrations job                          | `check:migrations` on E2E DB                             |
-| [e2e.yml](../.github/workflows/e2e.yml)                                       | reset DB → build:e2e → integration → Playwright blocking |
-| [e2e-advisory.yml](../.github/workflows/e2e-advisory.yml)                     | Playwright advisory                                      |
-| [e2e-staging.yml](../.github/workflows/e2e-staging.yml)                       | Same blocking stack on `staging` branch + nightly        |
-| [staging-smoke.yml](../.github/workflows/staging-smoke.yml)                   | Read-only staging Playwright (subset)                    |
-| [bundle-advisory.yml](../.github/workflows/bundle-advisory.yml)               | JS bundle budget                                         |
-| [discord-test-inventory.yml](../.github/workflows/discord-test-inventory.yml) | Refresh #test-suite on Discord                           |
+| Workflow | What runs |
+| -------- | --------- |
+| [ci.yml](../.github/workflows/ci.yml) | `bun test src`, `test:components`, lint, prod build |
+| [ci.yml](../.github/workflows/ci.yml) migrations job | `check:migrations` on E2E DB |
+| [e2e.yml](../.github/workflows/e2e.yml) | reset DB → build:e2e → integration → Playwright blocking |
+| [e2e-advisory.yml](../.github/workflows/e2e-advisory.yml) | Playwright advisory |
+| [e2e-staging.yml](../.github/workflows/e2e-staging.yml) | Same blocking stack on `staging` branch + nightly |
+| [staging-smoke.yml](../.github/workflows/staging-smoke.yml) | Read-only staging Playwright (subset) |
+| [bundle-advisory.yml](../.github/workflows/bundle-advisory.yml) | JS bundle budget |
+| [discord-test-inventory.yml](../.github/workflows/discord-test-inventory.yml) | Refresh #test-suite on Discord |
 
 Playwright **blocking** uses [playwright.config.ts](../playwright.config.ts) (`testDir: e2e`, ignores `advisory/` + `staging/`). Projects: **desktop-chrome**, **mobile-chrome** (skips `@desktop-only`).
 
-## Unit tests (Bun) — 42 files
+## Unit tests (Bun) — 43 files
 
 `bun test src/lib src/constants` (excludes `*.store.test.ts`).
 
@@ -69,6 +70,7 @@ Playwright **blocking** uses [playwright.config.ts](../playwright.config.ts) (`t
 - `src/lib/landing-modal-auto-open.test.ts`
 - `src/lib/map-chrome.test.ts`
 - `src/lib/notifications/notifications.test.ts`
+- `src/lib/notifications/proposal-events.test.ts`
 - `src/lib/proposals/client.test.ts`
 - `src/lib/r2-upload.test.ts`
 - `src/lib/route-slugs.test.ts`
@@ -85,6 +87,7 @@ Playwright **blocking** uses [playwright.config.ts](../playwright.config.ts) (`t
 - `src/lib/term-calendar.test.ts`
 - `src/lib/term-url.test.ts`
 
+
 ## Store tests (Vitest) — 7 files
 
 Included in `bun run test:components`.
@@ -96,6 +99,7 @@ Included in `bun run test:components`.
 - `src/lib/stores/map-stores.store.test.ts`
 - `src/lib/stores/schedule-route.store.test.ts`
 - `src/lib/stores/sync-stores.store.test.ts`
+
 
 ## Component tests (Vitest) — 10 files
 
@@ -112,6 +116,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `src/components/svelte/status-bar/StatusBarLinkGroups.component.test.ts`
 - `src/test/map-chrome-layout.component.test.ts`
 
+
 ## Integration tests — 5 files
 
 `bun run test:integration` (E2E Supabase; HTTP suites need preview — use `test:integration:live`).
@@ -121,6 +126,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `integration/services/admin.integration.test.ts`
 - `integration/services/merge.integration.test.ts`
 - `integration/services/proposals.integration.test.ts`
+
 
 ## E2E blocking (Playwright) — 26 files
 
@@ -133,6 +139,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/smoke/redirects.spec.ts`
 - `e2e/smoke/term-classes.spec.ts`
 
+
 ### Browse (9)
 
 - `e2e/browse/building-filters.spec.ts`
@@ -144,6 +151,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/browse/search-collapse.spec.ts`
 - `e2e/browse/search-flow.spec.ts`
 - `e2e/browse/side-panel.spec.ts`
+
 
 ### Admin / editor (13)
 
@@ -161,6 +169,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/admin/room-edit.spec.ts`
 - `e2e/admin/undo-redo.spec.ts`
 
+
 ## E2E advisory (Playwright) — 11 files
 
 `bun run e2e:advisory` — a11y, offline, touch, cross-browser, etc.
@@ -177,6 +186,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/advisory/schedule-import.spec.ts`
 - `e2e/advisory/transit-jeepney.spec.ts`
 
+
 ## E2E staging (Playwright) — 3 files
 
 `bun run e2e:staging` — read-only against `staging.room-tba.uplbtools.me`.
@@ -185,14 +195,15 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/staging/live-boot.spec.ts`
 - `e2e/staging/live-browse.spec.ts`
 
+
 ## Other checks
 
-| Script                     | Purpose                        |
-| -------------------------- | ------------------------------ |
+| Script | Purpose |
+| ------ | ------- |
 | `bun run check:migrations` | Required Postgres tables exist |
-| `bun run check:readme`     | README onboarding facts        |
-| `bun run check:pwa-legal`  | PWA legal routes               |
-| `bun run check:bundle`     | Client JS budget (advisory CI) |
+| `bun run check:readme` | README onboarding facts |
+| `bun run check:pwa-legal` | PWA legal routes |
+| `bun run check:bundle` | Client JS budget (advisory CI) |
 
 ## Manual only (not in this list)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -110,6 +110,6 @@ bun run generate:issue-test-matrix
 bun run generate:test-inventory
 ```
 
-**Discord `#test-suite`:** CI posts a pinned, auto-updated inventory (embed + `test-inventory.md` attachment) via [discord-test-inventory.yml](../.github/workflows/discord-test-inventory.yml). Local dry-run: `GATEWAY_URL=… SECRET=… bun run post:test-inventory-discord`.
+**Discord `#test-suite`:** CI posts a pinned, auto-updated inventory (summary embed + tier embeds with full file lists) via [discord-test-inventory.yml](../.github/workflows/discord-test-inventory.yml). Local dry-run: `GATEWAY_URL=… SECRET=… bun run post:test-inventory-discord`.
 
 Agent policy: [AGENTS.md § Tests with GitHub issues](../AGENTS.md#tests-with-github-issues).

--- a/scripts/lib/test-inventory.test.ts
+++ b/scripts/lib/test-inventory.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type TestInventory,
+  testInventoryDiscordTiers,
+} from "./test-inventory.ts";
+
+function sampleInventory(
+  overrides: Partial<TestInventory> = {},
+): TestInventory {
+  return {
+    generated: "2026-07-03",
+    total: 6,
+    unit: ["src/lib/foo.test.ts"],
+    store: ["src/lib/bar.store.test.ts"],
+    component: ["src/test/layout.component.test.ts"],
+    integration: ["integration/http/public.integration.test.ts"],
+    e2eBlocking: [
+      "e2e/smoke/boot.spec.ts",
+      "e2e/browse/search-flow.spec.ts",
+      "e2e/admin/auth.spec.ts",
+      "e2e/helpers/db.ts",
+    ],
+    e2eAdvisory: ["e2e/advisory/a11y.spec.ts"],
+    e2eStaging: ["e2e/staging/live-boot.spec.ts"],
+    ...overrides,
+  };
+}
+
+describe("testInventoryDiscordTiers", () => {
+  test("splits blocking E2E by smoke, browse, and admin folders", () => {
+    const tiers = testInventoryDiscordTiers(sampleInventory());
+
+    expect(tiers.unit).toEqual(["src/lib/foo.test.ts"]);
+    expect(tiers.store).toEqual(["src/lib/bar.store.test.ts"]);
+    expect(tiers.component).toEqual(["src/test/layout.component.test.ts"]);
+    expect(tiers.integration).toEqual([
+      "integration/http/public.integration.test.ts",
+    ]);
+    expect(tiers.e2eBlockingSmoke).toEqual(["e2e/smoke/boot.spec.ts"]);
+    expect(tiers.e2eBlockingBrowse).toEqual(["e2e/browse/search-flow.spec.ts"]);
+    expect(tiers.e2eBlockingAdmin).toEqual([
+      "e2e/admin/auth.spec.ts",
+      "e2e/helpers/db.ts",
+    ]);
+    expect(tiers.e2eAdvisory).toEqual(["e2e/advisory/a11y.spec.ts"]);
+    expect(tiers.e2eStaging).toEqual(["e2e/staging/live-boot.spec.ts"]);
+  });
+
+  test("returns empty arrays when a tier has no files", () => {
+    const tiers = testInventoryDiscordTiers(
+      sampleInventory({
+        store: [],
+        component: [],
+        e2eAdvisory: [],
+        e2eStaging: [],
+      }),
+    );
+
+    expect(tiers.store).toEqual([]);
+    expect(tiers.component).toEqual([]);
+    expect(tiers.e2eAdvisory).toEqual([]);
+    expect(tiers.e2eStaging).toEqual([]);
+  });
+});

--- a/scripts/lib/test-inventory.ts
+++ b/scripts/lib/test-inventory.ts
@@ -63,6 +63,44 @@ export async function scanTestInventory(root: string): Promise<TestInventory> {
   };
 }
 
+export type TestInventoryDiscordTiers = {
+  unit: string[];
+  store: string[];
+  component: string[];
+  integration: string[];
+  e2eBlockingSmoke: string[];
+  e2eBlockingBrowse: string[];
+  e2eBlockingAdmin: string[];
+  e2eAdvisory: string[];
+  e2eStaging: string[];
+};
+
+/** File lists per tier for Discord embed payloads. */
+export function testInventoryDiscordTiers(
+  inv: TestInventory,
+): TestInventoryDiscordTiers {
+  const smoke: string[] = [];
+  const browse: string[] = [];
+  const admin: string[] = [];
+  for (const f of inv.e2eBlocking) {
+    if (f.includes("/smoke/")) smoke.push(f);
+    else if (f.includes("/browse/")) browse.push(f);
+    else if (f.includes("/admin/")) admin.push(f);
+    else admin.push(f);
+  }
+  return {
+    unit: inv.unit,
+    store: inv.store,
+    component: inv.component,
+    integration: inv.integration,
+    e2eBlockingSmoke: smoke,
+    e2eBlockingBrowse: browse,
+    e2eBlockingAdmin: admin,
+    e2eAdvisory: inv.e2eAdvisory,
+    e2eStaging: inv.e2eStaging,
+  };
+}
+
 function mdList(files: string[]): string {
   if (files.length === 0) return "_None_\n";
   return files.map((f) => `- \`${f}\``).join("\n") + "\n";

--- a/scripts/post-test-inventory-discord.ts
+++ b/scripts/post-test-inventory-discord.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import {
   renderTestInventoryMarkdown,
   scanTestInventory,
+  testInventoryDiscordTiers,
 } from "./lib/test-inventory.ts";
 
 const ROOT = path.join(import.meta.dir, "..");
@@ -22,6 +23,7 @@ async function main() {
 
   const inv = await scanTestInventory(ROOT);
   const markdown = renderTestInventoryMarkdown(inv);
+  const tiers = testInventoryDiscordTiers(inv);
   writeFileSync(OUT, markdown);
 
   const repo = process.env.GITHUB_REPOSITORY ?? "uplbtools/room-tba";
@@ -58,7 +60,7 @@ async function main() {
       e2eBlocking: inv.e2eBlocking.length,
       e2eAdvisory: inv.e2eAdvisory.length,
       e2eStaging: inv.e2eStaging.length,
-      markdown,
+      tiers,
     },
   };
 


### PR DESCRIPTION
## Summary

- Room TBA CI now sends structured `tiers` file lists in `ci.test_inventory.updated` instead of a full markdown attachment
- Matches discord-bot tier embed renderer (already on main / Heroku v23+)
- Adds `testInventoryDiscordTiers()` with unit tests for smoke/browse/admin E2E splitting
- Regenerates `docs/test-inventory.md` (106 spec files)

Follow-up to #463.

## Test plan

- [x] `bun test scripts/lib/test-inventory.test.ts` (2 pass)
- [x] Biome format on touched TS files
- [ ] CI verify (Biome + unit tests)
- [ ] After merge: trigger **Discord test inventory** workflow on `staging` or wait for next spec change
- [ ] Confirm `#test-suite` pinned message shows summary + tier embeds (no `.md` attachment)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/docs and Discord notification payload shape only; no app runtime or auth paths. Bot must already expect `tiers` instead of `markdown`.
> 
> **Overview**
> Discord test-inventory notifications now send **structured `tiers` file lists** on `ci.test_inventory.updated` instead of embedding the full `test-inventory.md` body, aligning with the discord-bot tier embed renderer.
> 
> Adds **`testInventoryDiscordTiers()`** in `scripts/lib/test-inventory.ts` to map scanned inventory into per-tier paths, including splitting blocking Playwright specs into **smoke / browse / admin** (anything outside those folders falls under admin). **`post-test-inventory-discord.ts`** wires that into the gateway payload; **`scripts/lib/test-inventory.test.ts`** covers the split and empty-tier cases.
> 
> Docs are refreshed: **`testing.md`** describes summary + tier embeds (no `.md` attachment), and **`docs/test-inventory.md`** is regenerated (106 specs, +1 Bun unit file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f30269934a102b27a2be72fd5091a0b57eebe54e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->