### PR TITLE
chore(skills): add domain agent skills

### DIFF
--- a/.cursor/skills/amis-term-import/SKILL.md
+++ b/.cursor/skills/amis-term-import/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: amis-term-import
+description: Imports and triages AMIS/CRS class schedules into Room TBA by term_id. Use when wrong term bugs, AMIS fetch/import, term labels, skipped rows, import:amis-classes, or data issues about schedules and term_id 1251/1252/1253.
+---
+
+# AMIS term import
+
+Full policy: [AGENTS.md § AMIS class imports](../../AGENTS.md#amis-class-imports). Never commit tokens or unsanitized AMIS JSON.
+
+## CRS term IDs (source of truth)
+
+Chronological within the academic year. **`terms.id` must equal the CRS id** passed to `--term-id`.
+
+| CRS id | Period | Typical dates (AY 2025–2026) |
+| --- | --- | --- |
+| **1251** | 1st semester | Aug–Dec |
+| **1252** | 2nd semester | Jan–May |
+| **1253** | Midyear | Jun–Jul |
+
+Fix labels/dates in the `terms` row. **Never move class rows between ids** to fix a naming mix-up.
+
+## Commands
+
+```sh
+# Fetch once (needs fresh AMIS_BEARER_TOKEN ~1h TTL)
+bun run import:amis-classes -- --term-id 1252 --fetch
+
+# Re-import from cached JSON (no token)
+bun run import:amis-classes -- --term-id 1252 --replace
+
+# Scrub PII from local exports
+bun run import:amis-classes -- --scrub-exports
+```
+
+Cached files: `data/amis-*-<term_id>.json` (gitignored).
+
+## Import filter (by design)
+
+AMIS returns all section types; Room TBA imports **LEC/LAB with a matched room** only.
+
+- 12k fetch → ~3k import (2nd sem) can be normal.
+- Midyear ~120 rows can be normal.
+
+## Two skip buckets (do not conflate)
+
+| Bucket | Cause | Action |
+| --- | --- | --- |
+| **By design** | THE, SPR, PRA, DSR, IND, etc. no `facility_id` | Expected; room panel explains |
+| **Data gap (#300)** | LEC/LAB with facility string that does not match `rooms.room_code` | Alias/typo work, not term surgery |
+
+## Triage checklist (wrong term reports)
+
+1. Sample `classes.schedule` per `term_id` (midyear = intensive daily blocks; 2nd sem = weekly TTH/MWF).
+2. Confirm `/api/terms` labels match CRS table above.
+3. Re-import **correct CRS id** with `--replace` if data is wrong.
+4. **Do not** re-apply `drizzle/0012_reassign_second_sem_classes.sql` or copy 0009/0010 label assumptions.
+
+## PII rules
+
+- `sanitizeAmisRow()` strips instructor fields before JSON is written.
+- DB stores course, section, schedule, room, term only.
+- Never commit `data/amis-*.json` or paste `AMIS_BEARER_TOKEN` in issues/chat.
+
+## Verification
+
+```sh
+bun test src/lib/amis/   # fixture tests only in CI; never live --fetch in CI
+```
+
+After import: spot-check row counts and schedule patterns; update issue with term id and sample schedules.

--- a/.cursor/skills/contributor-proposals/SKILL.md
+++ b/.cursor/skills/contributor-proposals/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: contributor-proposals
+description: Implements and debugs Room TBA contributor edit proposals (suggest an edit, review queue, approve/reject, create proposals). Use when working on edit_proposals, proposal-service, Suggest an edit UI, admin review routes, proposal edge cases, or issue #208/#255/#222.
+---
+
+# Contributor proposals
+
+Policy and architecture: [AGENTS.md](../../AGENTS.md). Edge cases: [docs/issue-test-matrix.md](../../docs/issue-test-matrix.md) and GitHub [#255](https://github.com/uplbtools/room-tba/issues/255).
+
+## Mental model
+
+```text
+Contributor edits in map app → pending edit_proposals row → editor review → approve publishes live data
+```
+
+- **Suggest** never writes published entity rows until **approve**.
+- **Direct publish** is editor/admin only (session + `/api/admin/*`).
+- No separate admin dashboard; review lives in the main app (shield menu).
+
+## Key paths
+
+| Layer | Path |
+| --- | --- |
+| Service | `src/lib/services/proposal-service.ts` |
+| Public API | `src/pages/api/proposals/index.ts` |
+| Admin review | `src/pages/api/admin/proposals/` |
+| Client helpers | `src/lib/proposals/client.ts` |
+| UI | `RoomResult.svelte`, `BuildingResult.svelte`, `SuggestAdditionPanel.svelte`, `ProposalReviewPanel.svelte` |
+| Schema | `drizzle/schema.ts` (`edit_proposals`), `drizzle/0005_add_edit_proposals.sql` |
+| Notifications | `src/lib/notifications/proposal-events.ts` (see [discord-notifications](../discord-notifications/SKILL.md)) |
+
+## Proposal statuses
+
+| Status | Meaning |
+| --- | --- |
+| `pending` | Awaiting editor |
+| `needs_changes` | Editor sent back with note; contributor may revise |
+| `approved` | Published (or failed publish rolled back to prior status) |
+| `rejected` | Closed |
+
+## Submit flow
+
+1. Contributor opens entity panel → **Suggest an edit** (or **Suggest addition** for `create_*` types).
+2. `POST /api/proposals` → `submitProposal()` creates or **merges** an open proposal (same entity + submitter).
+3. Fire-and-forget `proposal.submitted` → Discord `#contributors`.
+
+Anonymous: requires `submitterName`; tracks proposal via `localStorage` (`room-tba-proposal-refs`).
+
+## Review flow
+
+Editors use shield menu → review queue:
+
+| Action | API | On success |
+| --- | --- | --- |
+| Approve | `POST /api/admin/proposals/[id]/approve` | Atomic publish + `editor_history` + sync key bump + `proposal.reviewed` |
+| Reject | `.../reject` | Status rejected + optional note + `proposal.reviewed` |
+| Request changes | `.../request-changes` | Status needs_changes + **required** note + `proposal.reviewed` |
+
+**409 on approve:** live data changed; proposal stays open; **no** `proposal.reviewed` event.
+
+## Create proposals (`create_building`, `create_room`, …)
+
+- `entity_id = 0`, `base_version = 0`.
+- Approved → `applyProposalPatch()` calls `createBuilding`, `createRoom`, etc. in `admin-service.ts`.
+- **Gap:** new building pending → rooms in that building blocked until approve ([#255](https://github.com/uplbtools/room-tba/issues/255)).
+
+## Known edge cases (check before closing issues)
+
+- Revise pending: merge patch if same submitter + open status; anonymous needs same browser/`proposalId`.
+- Multiple pending `create_*` from one logged-in user may collide on `(entity_type, entity_id=0)`.
+- No **withdraw** API yet.
+- Contributor credit on approve: proposal row only today; ledger is [#450](https://github.com/uplbtools/room-tba/issues/450).
+
+## Tests (same PR as code)
+
+| Change | Test |
+| --- | --- |
+| Service logic | `integration/services/proposals.integration.test.ts` |
+| Approve 409 | integration stale-version test |
+| UI flow | `e2e/admin/proposals.spec.ts` (partial; expand when stable) |
+| Notifications | `src/lib/notifications/proposal-events.test.ts` |
+
+## Verification
+
+```sh
+bun test src/lib/notifications/proposal-events.test.ts
+bun run test:integration   # when proposal-service or admin routes change
+```
+
+Manual: suggest edit on staging → pending in queue → approve → live map updates; Discord submit + reviewed embeds in `#contributors`.

--- a/.cursor/skills/discord-notifications/SKILL.md
+++ b/.cursor/skills/discord-notifications/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: discord-notifications
+description: Wires and debugs Room TBA NotificationEvent delivery to uplbtools/discord-bot (proposal.submitted, proposal.reviewed, CI E2E, test inventory). Use when Discord notifications fail, NOTIFICATION_* env vars, Heroku bot deploy, or cross-repo changes with discord-bot.
+---
+
+# Discord notifications (room-tba ↔ discord-bot)
+
+Contract: [docs/notifications.md](../../docs/notifications.md). Bot repo: `uplbtools/discord-bot` (Heroku). Handoff: [docs/e2e-discord-handoff.md](../../docs/e2e-discord-handoff.md).
+
+## Two repos
+
+| Repo | Role |
+| --- | --- |
+| **room-tba** | **Producer** — emits JSON via `NotificationAdapter` |
+| **discord-bot** | **Consumer** — `POST /notifications` → Discord channels |
+
+Always check **both** when notifications are silent.
+
+## room-tba producer
+
+```text
+getNotificationAdapter()
+  → HttpNotificationAdapter if NOTIFICATION_GATEWAY_URL + NOTIFICATION_INGRESS_SECRET set
+  → NoOpNotificationAdapter otherwise (silent!)
+```
+
+| Event | Emitted from |
+| --- | --- |
+| `proposal.submitted` | `src/pages/api/proposals/index.ts` |
+| `proposal.reviewed` | `src/pages/api/admin/proposals/[id]/approve|reject|request-changes.ts` |
+| `ci.e2e.*` | GitHub Actions → `scripts/ci-notify-discord-e2e.sh` (not Astro runtime) |
+| `ci.test_inventory.updated` | `.github/workflows/discord-test-inventory.yml` |
+
+Shared helpers: `src/lib/notifications/proposal-events.ts`.
+
+## discord-bot consumer
+
+- Ingress: `POST https://uplbtools-discord-bot-*.herokuapp.com/notifications`
+- Header: `x-notification-secret: NOTIFICATION_INGRESS_SECRET`
+- Delivery: `src/notifications/delivery/discord.ts`
+
+| Event | Channel |
+| --- | --- |
+| `proposal.submitted`, `proposal.reviewed` | `#contributors` (`CHANNEL_CONTRIBUTORS_ID`) |
+| `ci.e2e.failed`, blocking E2E | `#development` |
+| `ci.staging-smoke.failed` | `#deploys` |
+| `ci.test_inventory.updated` | `#test-suite` |
+
+## Vercel env (room-tba runtime)
+
+Required on **Production** and **Preview (staging)** at minimum:
+
+```sh
+NOTIFICATION_GATEWAY_URL=https://uplbtools-discord-bot-5eb468fac572.herokuapp.com/notifications
+NOTIFICATION_INGRESS_SECRET=<same as Heroku NOTIFICATION_INGRESS_SECRET>
+```
+
+**Pitfall:** vars can exist but be **empty strings** — app no-ops silently. `vercel env pull` often omits encrypted values; verify with a successful notify or Vercel UI.
+
+```sh
+vercel env ls | rg NOTIFICATION
+vercel env add NOTIFICATION_GATEWAY_URL production --value "$GATEWAY" --yes --force
+```
+
+**Redeploy** after env fix; existing deployments do not pick up new vars.
+
+## Heroku (discord-bot)
+
+```sh
+heroku config:get NOTIFICATION_INGRESS_SECRET -a uplbtools-discord-bot
+git push heroku main   # from discord-bot checkout on main
+```
+
+## Manual verify (curl)
+
+```sh
+SECRET=$(heroku config:get NOTIFICATION_INGRESS_SECRET -a uplbtools-discord-bot)
+curl -sS -X POST "https://uplbtools-discord-bot-5eb468fac572.herokuapp.com/notifications" \
+  -H "Content-Type: application/json" \
+  -H "x-notification-secret: $SECRET" \
+  -d '{"schemaVersion":1,"type":"proposal.reviewed","source":"room-tba","occurredAt":"'$(date -Iseconds)'","idempotencyKey":"test:manual","payload":{"proposalId":1,"outcome":"approved","entityType":"room","entityId":1,"entityLabel":"Test","submitterName":"Test","reviewedBy":"Editor","adminNote":null}}'
+```
+
+Expect `{"ok":true}` and embed in `#contributors`.
+
+## Ship order (new event type)
+
+1. Add type + Zod schema in **both** repos.
+2. Bot handler + deploy Heroku.
+3. room-tba emitter + Vercel env check.
+4. Manual curl, then end-to-end on staging/prod.
+
+## Paired issues
+
+- room-tba [#222](https://github.com/uplbtools/room-tba/issues/222) — proposal reviewed
+- discord-bot [#4](https://github.com/uplbtools/discord-bot/issues/4) — bot embed handler
+
+Comment on both issues when shipping cross-repo work.

--- a/.cursor/skills/playwright-e2e-ci/SKILL.md
+++ b/.cursor/skills/playwright-e2e-ci/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: playwright-e2e-ci
+description: Runs and debugs Room TBA Playwright E2E, integration tests in CI, workflow gating, E2E database, and staging smoke. Use when e2e fails in GitHub Actions, EMAXCONNSESSION pool errors, run/e2e label, e2e-reusable.yml, or test:integration:live locally.
+---
+
+# Playwright + E2E CI
+
+Full doc: [docs/testing.md](../../docs/testing.md). Handoff: [docs/e2e-discord-handoff.md](../../docs/e2e-discord-handoff.md).
+
+## Commands
+
+| Command | Use |
+| --- | --- |
+| `bun run test:integration:live` | Local CI parity: build:e2e → preview → integration + HTTP |
+| `bun run e2e:reset-db` | Truncate + seed E2E Supabase |
+| `bun run e2e` | Playwright blocking (~16 min local) |
+| `bun run e2e:advisory` | Non-blocking suite |
+| `bun run e2e:staging` | Live staging smoke (read-only) |
+| `SKIP_E2E_BUILD=1 bun run e2e` | Re-run after first build:e2e |
+
+`test:integration` **without preview** runs service tests only; HTTP suites fail fast.
+
+## Databases
+
+| DB | Automation |
+| --- | --- |
+| **E2E** (`yhzinxlakcewqjaqbbaj`) | CI integration + Playwright; **mutating** |
+| **Staging** | `e2e:staging` smoke; read-only |
+| **Production** | **Never** automated writes |
+
+Env: `E2E_DATABASE_URL`, `E2E_ADMIN_PASSWORD`, `E2E_ADMIN_SESSION_SECRET` in GitHub Actions secrets.
+
+## PR CI gating
+
+| Trigger | Runs |
+| --- | --- |
+| Every push (incl. draft) | `verify` + `migrations` only (~6–9 min) |
+| **Ready for review** | Blocking E2E (integration + Playwright) + advisory + bundle |
+| **`run/e2e` label** | Re-run heavy stack after fixes |
+| Push to **`staging`** | Full blocking E2E + staging-smoke (non-blocking) |
+
+```sh
+gh pr ready <number>
+gh pr edit <number> --add-label run/e2e
+gh pr checks <number> --repo uplbtools/room-tba
+```
+
+Ordinary pushes after ready **do not** re-trigger E2E; add label again.
+
+## Blocking job order (e2e-reusable.yml)
+
+1. `bun run e2e:reset-db`
+2. `bun run build:e2e`
+3. Start preview (`bun run preview:e2e`)
+4. **`bun run test:integration`** (with `PREVIEW_BASE_URL`)
+5. **`bun run e2e`** (`PLAYWRIGHT_SKIP_WEBSERVER=1`)
+
+Wall clock ~28–35 min in CI.
+
+## Workflows
+
+| File | Name |
+| --- | --- |
+| `.github/workflows/ci.yml` | verify, migrations |
+| `.github/workflows/e2e.yml` | E2E (PR blocking) |
+| `.github/workflows/e2e-advisory.yml` | E2E advisory |
+| `.github/workflows/e2e-staging.yml` | E2E staging + nightly |
+| `.github/workflows/staging-smoke.yml` | Live staging smoke |
+
+## Common CI failures
+
+| Error | Likely cause | Mitigation |
+| --- | --- | --- |
+| `EMAXCONNSESSION max clients reached` | Too many parallel PG connections in integration job | Serialize tests, lower concurrency, or pooler limits |
+| Preview failed to start | build:e2e or port conflict | Read job log before Playwright step |
+| staging-smoke `/admin` redirect | Staging deploy lag vs test expectation | Wait for Vercel staging deploy; check live URL |
+| Integration pass locally, fail CI | Missing preview or wrong `PREVIEW_BASE_URL` | Use `test:integration:live` |
+
+## Before marking PR ready
+
+```sh
+bun run lint && bun test src
+bun run test:integration:live   # API/service changes
+bun run e2e                     # UI/map/proposal flows
+bun run build                   # substantive changes
+```
+
+## Spec locations
+
+- `e2e/smoke/`, `e2e/browse/`, `e2e/admin/`
+- Inventory: [docs/test-inventory.md](../../docs/test-inventory.md)
+
+## Release PR note
+
+`staging → main` runs E2E + staging-smoke. If only notification/API changes, verify + migrations may suffice for feature PR; release PR still hits full stack. Admin merge only when failures are known infra flakes, not regressions.

--- a/.cursor/skills/room-tba-agent-workflow/SKILL.md
+++ b/.cursor/skills/room-tba-agent-workflow/SKILL.md
@@ -7,6 +7,8 @@ description: Guides agentic coding workflow in Room TBA, including scoped edits,
 
 Policy (commits, verification tiers, architecture, product rules) lives in [AGENTS.md](../../AGENTS.md). This skill covers **session execution**.
 
+Domain skills (read when the task matches): [contributor-proposals](../contributor-proposals/SKILL.md), [discord-notifications](../discord-notifications/SKILL.md), [amis-term-import](../amis-term-import/SKILL.md), [vercel-supabase-ops](../vercel-supabase-ops/SKILL.md), [playwright-e2e-ci](../playwright-e2e-ci/SKILL.md).
+
 ## Coding practices
 
 - Read the relevant existing code paths and local conventions before editing.

--- a/.cursor/skills/vercel-supabase-ops/SKILL.md
+++ b/.cursor/skills/vercel-supabase-ops/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: vercel-supabase-ops
+description: Operates Room TBA Vercel deploys and Supabase Postgres (DATABASE_URL, env vars, preview/production, migrations). Use when builds fail on Vercel, missing DATABASE_URL, env pull empty strings, staging preview, or applying drizzle migrations before deploy.
+---
+
+# Vercel + Supabase ops
+
+Canonical reference: [AGENTS.md § Vercel CLI and environment ops](../../AGENTS.md#vercel-cli-and-environment-ops). Human setup: [docs/developer-guide.md](../../docs/developer-guide.md).
+
+## Project
+
+- Vercel: `stimmie/saan-ang-room` (`.vercel/project.json`)
+- Production: `room-tba.uplbtools.me` ← **`main` only**
+- Staging preview: `staging.room-tba.uplbtools.me` ← **`staging` branch**
+- GitHub org: `uplbtools/room-tba`
+
+Use **`gh`** and **`vercel`** CLI by default; do not send maintainers to dashboards when CLI works.
+
+## Required env vars
+
+| Var | Where | Notes |
+| --- | --- | --- |
+| `DATABASE_URL` | Production + all Preview | **Mandatory** for `bun run build` (SSG prerender) |
+| `NOTIFICATION_GATEWAY_URL` | Production + Preview staging | See [discord-notifications](../discord-notifications/SKILL.md) |
+| `NOTIFICATION_INGRESS_SECRET` | Production + Preview staging | Same |
+| `ADMIN_PASSWORD` | Dev/local | Editor login |
+| `ISR_BYPASS_TOKEN` | Vercel | On-demand SEO revalidation after publish |
+
+Runtime code uses **`DATABASE_URL` only** (not `NEON_CONNECTION_STRING`).
+
+## Common pitfalls
+
+| Symptom | Fix |
+| --- | --- |
+| `vercel env pull` shows `DATABASE_URL=""` | Encrypted omit; copy from Supabase/Vercel UI |
+| Var listed but build fails missing DATABASE_URL | Value may be empty string; re-add with `--force` |
+| Preview branch build fails | `DATABASE_URL` must exist for **all** preview targets, not only `staging` |
+| Prod deploy from wrong branch | `check-production-branch.sh` blocks non-`main` on production builds |
+
+## CLI cheat sheet
+
+```sh
+vercel whoami
+vercel env ls
+vercel env add DATABASE_URL preview staging --value "$DATABASE_URL" --yes --force
+vercel env pull .env.vercel --environment=preview --yes
+vercel ls
+vercel redeploy <latest-production-deployment-url>
+gh pr checks <n> --repo uplbtools/room-tba
+```
+
+**Never** `vercel deploy --prod` except from `main` matching `origin/main`. Ship prod via **`staging → main`** release PR.
+
+## Supabase migrations
+
+- SQL in `drizzle/`; apply **before** deploy that depends on new columns.
+- Apply: `psql "$DATABASE_URL" -f drizzle/NNNN_name.sql` or Supabase SQL editor.
+- Local check: `bun run check:migrations` (CI uses E2E DB).
+
+## Local dev
+
+```sh
+# Prefer session pooler (*.pooler.supabase.com)
+cp .env.example .env.local
+vercel env pull .env.vercel --environment=development --yes
+# Merge DATABASE_URL into .env.local
+bun dev
+```
+
+PGlite in browser is **offline cache only**, not a server DB fallback.
+
+## Build guards
+
+- `scripts/check-vercel-env.sh` — fails missing `DATABASE_URL`
+- `scripts/check-production-branch.sh` — prod builds only on `main`
+
+```sh
+bun run check:vercel-env
+bun run check:prod-branch   # set VERCEL_ENV=production to test branch guard
+bun run build               # local pre-merge gate
+```
+
+## Branch → deploy
+
+| Branch | Target |
+| --- | --- |
+| `main` | Production |
+| `staging` | Staging preview |
+| feature | Ephemeral preview |
+
+After env fix on Vercel: **redeploy**; failed deploys are not auto-retried.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,11 @@ Read the right doc for the task; do not rely on this file alone for detailed che
 | Human volunteers, developers (default)           | [CONTRIBUTING.md](CONTRIBUTING.md)                                                                                                             |
 | Developer setup detail                           | [docs/developer-guide.md](docs/developer-guide.md)                                                                                             |
 | Starting a coding session, commit, or PR         | [.cursor/skills/room-tba-agent-workflow/SKILL.md](.cursor/skills/room-tba-agent-workflow/SKILL.md)                                             |
+| Contributor proposals, review queue, suggest edit | [.cursor/skills/contributor-proposals/SKILL.md](.cursor/skills/contributor-proposals/SKILL.md)                                                  |
+| Discord notifications (room-tba + discord-bot)   | [.cursor/skills/discord-notifications/SKILL.md](.cursor/skills/discord-notifications/SKILL.md)                                                 |
+| AMIS class import, term_id triage                | [.cursor/skills/amis-term-import/SKILL.md](.cursor/skills/amis-term-import/SKILL.md)                                                           |
+| Vercel env, deploy guards, Supabase migrations   | [.cursor/skills/vercel-supabase-ops/SKILL.md](.cursor/skills/vercel-supabase-ops/SKILL.md)                                                   |
+| Playwright E2E, integration CI, `run/e2e` label  | [.cursor/skills/playwright-e2e-ci/SKILL.md](.cursor/skills/playwright-e2e-ci/SKILL.md)                                                         |
 | Worktrees, multiple agents, push to `staging`    | [AGENTS.md § Worktrees and multiple agents](#worktrees-and-multiple-agents)                                                                    |
 | Map chrome, Entry zones, flyouts, 320/768 layout | [.cursor/rules/map-layout.mdc](.cursor/rules/map-layout.mdc) + [docs/map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md)                        |
 | Side panel / entity detail views                 | [.cursor/rules/side-panel.mdc](.cursor/rules/side-panel.mdc)                                                                                   |


### PR DESCRIPTION
## Summary
- Add 5 Cursor project skills: contributor-proposals, discord-notifications, amis-term-import, vercel-supabase-ops, playwright-e2e-ci
- Link from AGENTS.md doc map and room-tba-agent-workflow

## Test plan
- [x] Docs/skills only, no runtime change
- [ ] Reload Cursor to pick up new skills

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only under `.cursor/skills/` and `AGENTS.md`; no runtime, database, or deployment code changes.
> 
> **Overview**
> Adds **five Cursor project skills** under `.cursor/skills/` so agents can load focused runbooks instead of only the long `AGENTS.md` sections: **contributor-proposals**, **discord-notifications**, **amis-term-import**, **vercel-supabase-ops**, and **playwright-e2e-ci**.
> 
> Each skill summarizes commands, key paths, triage checklists, and verification steps for its domain (with cross-links between skills where relevant).
> 
> **AGENTS.md** doc map gains rows pointing at those skills. **room-tba-agent-workflow** now lists them as domain skills to read when the task matches. No application or CI behavior changes—documentation and agent tooling only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e88f12311946cb7f4d6afe5c3cbd437b768ec99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->