### PR TITLE
chore(release): 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [1.21.0](https://github.com/uplbtools/room-tba/compare/v1.20.0...v1.21.0) (2026-07-03)
+
+
+### Features
+
+* **community:** Messenger role links and brand icons ([#217](https://github.com/uplbtools/room-tba/issues/217), [#406](https://github.com/uplbtools/room-tba/issues/406)) ([8b21958](https://github.com/uplbtools/room-tba/commit/8b21958f7b16851aa994e58eb097414eab0740fa))
+* **notifications:** emit proposal.reviewed on admin approve/reject/changes ([#464](https://github.com/uplbtools/room-tba/issues/464)) ([369a52e](https://github.com/uplbtools/room-tba/commit/369a52e328696a77dacb9588f5038e97ec913856)), closes [#222](https://github.com/uplbtools/room-tba/issues/222)
+
 # [1.17.1](https://github.com/uplbtools/room-tba/compare/v1.17.0...v1.17.1) (2026-06-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-room",
   "type": "module",
-  "version": "1.17.1",
+  "version": "1.21.0",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Sync `package.json` and `CHANGELOG.md` after semantic-release published v1.21.0.

The release workflow could not open this PR automatically (org blocks Actions from creating PRs). Without this merge, prod still shows **v1.17.1** in the status bar even though GitHub Releases is at v1.21.0.

Includes `[skip ci]` — does not re-run semantic-release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version string only; no application or infrastructure code changes.
> 
> **Overview**
> Manual **post-release sync** after semantic-release published **v1.21.0** on GitHub: bumps `package.json` from **1.17.1** to **1.21.0** so the in-app status bar (`APP_VERSION` from `package.json`) matches the release tag.
> 
> Prepends a **1.21.0** block to `CHANGELOG.md` documenting that release’s shipped features (community Messenger role links/brand icons; `proposal.reviewed` notifications on admin approve/reject/changes). No runtime or build logic changes beyond version metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6fda95af0daa382b2e4dc6c636709bb921e9030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->