### PR TITLE
release: messenger redirects and maintainer chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [1.21.0](https://github.com/uplbtools/room-tba/compare/v1.20.0...v1.21.0) (2026-07-03)
+
+
+### Features
+
+* **community:** Messenger role links and brand icons ([#217](https://github.com/uplbtools/room-tba/issues/217), [#406](https://github.com/uplbtools/room-tba/issues/406)) ([8b21958](https://github.com/uplbtools/room-tba/commit/8b21958f7b16851aa994e58eb097414eab0740fa))
+* **notifications:** emit proposal.reviewed on admin approve/reject/changes ([#464](https://github.com/uplbtools/room-tba/issues/464)) ([369a52e](https://github.com/uplbtools/room-tba/commit/369a52e328696a77dacb9588f5038e97ec913856)), closes [#222](https://github.com/uplbtools/room-tba/issues/222)
+
 # [1.17.1](https://github.com/uplbtools/room-tba/compare/v1.17.0...v1.17.1) (2026-06-29)
 
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,6 +42,10 @@ export default defineConfig({
           /^\/privacy(\/|$)/,
           /^\/terms(\/|$)/,
           /^\/changelog(\/|$)/,
+          // Server redirects — must hit network, not offline app shell (#471).
+          /^\/messenger(\/|$)/,
+          /^\/maintain(\/|$)/,
+          /^\/discord(\/|$)/,
         ],
         swDest: `dist/client/sw.js`,
         // Cache third-party map resources at runtime so the campus map works

--- a/e2e/smoke/redirects.spec.ts
+++ b/e2e/smoke/redirects.spec.ts
@@ -16,6 +16,13 @@ test.describe("community redirects", () => {
     expect(res.headers().location).toBe(MESSENGER_CONTRIBUTE_TARGET);
   });
 
+  test("/messenger/contribute navigates to Messenger in browser", async ({
+    page,
+  }) => {
+    await page.goto("/messenger/contribute");
+    await expect(page).toHaveURL(/m\.me\/j\/Aba1V0prvQyLrafZ/);
+  });
+
   test("/messenger/maintain redirects to maintainers Messenger GC", async ({
     request,
   }) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-room",
   "type": "module",
-  "version": "1.17.1",
+  "version": "1.21.0",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
   "engines": {

--- a/scripts/check-pwa-legal-routes.ts
+++ b/scripts/check-pwa-legal-routes.ts
@@ -20,6 +20,9 @@ const requiredDenylist = [
   String.raw`/^\/privacy(\/|$)/`,
   String.raw`/^\/terms(\/|$)/`,
   String.raw`/^\/changelog(\/|$)/`,
+  String.raw`/^\/messenger(\/|$)/`,
+  String.raw`/^\/maintain(\/|$)/`,
+  String.raw`/^\/discord(\/|$)/`,
 ];
 
 let failed = false;

--- a/src/components/svelte/AdminLoginModal.component.test.ts
+++ b/src/components/svelte/AdminLoginModal.component.test.ts
@@ -20,5 +20,8 @@ describe("AdminLoginModal", () => {
     expectNoHorizontalOverflow(frame);
     expect(screen.getByLabelText("Username")).toBeVisible();
     expect(screen.getByLabelText("Password")).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /Message maintainers/i }),
+    ).toHaveAttribute("href", "https://m.me/j/AbZtqMU8UUTiwQfn/");
   });
 });

--- a/src/components/svelte/AdminLoginModal.svelte
+++ b/src/components/svelte/AdminLoginModal.svelte
@@ -11,6 +11,8 @@
   import EntityEditorFormField from "@ui/editor/EntityEditorFormField.svelte";
   import EntityEditorSubmitButton from "@ui/editor/EntityEditorSubmitButton.svelte";
   import EntityEditorMessage from "@ui/editor/EntityEditorMessage.svelte";
+  import CommunityBrandIcon from "@ui/community/CommunityBrandIcon.svelte";
+  import { MESSENGER_MAINTAIN_TARGET } from "@constants/community-links";
   import "./editor/entity-editor.css";
   import { MediaQuery } from "svelte/reactivity";
 
@@ -117,6 +119,18 @@
         saving={adminAuthStore.loading}
       />
     </form>
+    <p class="login-footer">
+      Need editor access?
+      <a
+        href={MESSENGER_MAINTAIN_TARGET}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="login-footer-link"
+      >
+        <CommunityBrandIcon brand="messenger" size={14} />
+        Message maintainers
+      </a>
+    </p>
   </div>
 </div>
 
@@ -169,5 +183,28 @@
   }
   .login-body {
     padding: 1rem;
+  }
+  .login-footer {
+    margin: 0;
+    padding: 0.75rem 1rem 1rem;
+    border-top: 1px solid hsl(0, 0%, 92%);
+    font-size: 0.8125rem;
+    color: hsl(0, 0%, 38%);
+    line-height: 1.5;
+    text-align: center;
+  }
+  .login-footer-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-left: 0.25rem;
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .login-footer-link:hover,
+  .login-footer-link:focus-visible {
+    text-decoration: underline;
+    text-underline-offset: 2px;
   }
 </style>

--- a/src/components/svelte/modal/LandingGuideSteps.svelte
+++ b/src/components/svelte/modal/LandingGuideSteps.svelte
@@ -10,6 +10,7 @@
   import ArrowRight from "@lucide/svelte/icons/arrow-right";
   import Plus from "@lucide/svelte/icons/plus";
   import CommunityBrandIcon from "@ui/community/CommunityBrandIcon.svelte";
+  import { DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@constants/community-links";
 
   const features = [
     { icon: Search, label: "Search rooms", hint: "Room codes and buildings" },
@@ -122,13 +123,13 @@
   <p class="guide-footnote">
     Questions or want to volunteer? Use <strong>Suggest an edit</strong> on the
     map, or reach us on
-    <a href="/discord" target="_blank" rel="noopener noreferrer" class="guide-community-link">
+    <a href={DISCORD_URL} target="_blank" rel="noopener noreferrer" class="guide-community-link">
       <CommunityBrandIcon brand="discord" size={14} />
       Discord
     </a>
     /
     <a
-      href="/messenger/contribute"
+      href={MESSENGER_CONTRIBUTE_TARGET}
       target="_blank"
       rel="noopener noreferrer"
       class="guide-community-link"

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { modalStore } from "@lib/store.svelte";
   import { contributors, designers } from "@constants/contributors";
-  import { UPLB_TOOLS_URL } from "@constants/community-links";
+  import {
+    UPLB_TOOLS_URL,
+    DISCORD_URL,
+    MESSENGER_CONTRIBUTE_TARGET,
+    MESSENGER_MAINTAIN_TARGET,
+  } from "@constants/community-links";
   import CommunityPlatformLink from "@ui/community/CommunityPlatformLink.svelte";
   import {
     fetchGithubContributors,
@@ -211,13 +216,20 @@
               >
             </li>
             <li>
-              <CommunityPlatformLink brand="discord" href="/discord" label="Discord" />
+              <CommunityPlatformLink brand="discord" href={DISCORD_URL} label="Discord" />
             </li>
             <li>
               <CommunityPlatformLink
                 brand="messenger"
-                href="/messenger/contribute"
-                label="Messenger"
+                href={MESSENGER_CONTRIBUTE_TARGET}
+                label="Messenger (contribute)"
+              />
+            </li>
+            <li>
+              <CommunityPlatformLink
+                brand="messenger"
+                href={MESSENGER_MAINTAIN_TARGET}
+                label="Maintainer chat"
               />
             </li>
           </ul>

--- a/src/components/svelte/status-bar/StatusBarLinkGroups.component.test.ts
+++ b/src/components/svelte/status-bar/StatusBarLinkGroups.component.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/svelte";
 import { describe, expect, test } from "vitest";
 import StatusBarLinkGroups from "@ui/status-bar/StatusBarLinkGroups.svelte";
 import { STATUS_BAR_COMMUNITY_GROUP } from "@constants/status-bar-links";
+import { MESSENGER_CONTRIBUTE_TARGET } from "@constants/community-links";
 import { mountAtWidth } from "@test/layout-assertions";
 
 describe("StatusBarLinkGroups", () => {
@@ -20,7 +21,7 @@ describe("StatusBarLinkGroups", () => {
     expect(screen.getByRole("link", { name: /UPLB Tools/i })).toBeVisible();
     expect(screen.getByRole("link", { name: /Messenger/i })).toHaveAttribute(
       "href",
-      "/messenger/contribute",
+      MESSENGER_CONTRIBUTE_TARGET,
     );
   });
 });

--- a/src/constants/community-links.test.ts
+++ b/src/constants/community-links.test.ts
@@ -5,6 +5,7 @@ import {
   MESSENGER_CONTRIBUTE_URL,
   MESSENGER_MAINTAIN_TARGET,
   MESSENGER_MAINTAIN_URL,
+  MESSENGER_SHORT_CONTRIBUTE_URL,
   MESSENGER_URL,
 } from "./community-links.ts";
 
@@ -12,10 +13,13 @@ describe("community-links", () => {
   test("volunteer Messenger defaults to contribute short link", () => {
     expect(MESSENGER_URL).toBe(MESSENGER_CONTRIBUTE_URL);
     expect(MESSENGER_CONTRIBUTE_URL).toBe(
-      "https://messenger.uplbtools.me/contribute",
+      "https://room-tba.uplbtools.me/messenger/contribute",
     );
     expect(MESSENGER_MAINTAIN_URL).toBe(
-      "https://messenger.uplbtools.me/maintain",
+      "https://room-tba.uplbtools.me/messenger/maintain",
+    );
+    expect(MESSENGER_SHORT_CONTRIBUTE_URL).toBe(
+      "https://messenger.uplbtools.me/contribute",
     );
   });
 

--- a/src/constants/community-links.ts
+++ b/src/constants/community-links.ts
@@ -1,16 +1,24 @@
 /** External UPLB Tools community and org links (also wired as short redirects in astro.config). */
 
+/** Canonical production origin — literal so astro.config can import this module. */
+const ROOM_TBA_SITE_URL = "https://room-tba.uplbtools.me";
+
 export const UPLB_TOOLS_URL = "https://uplbtools.me";
 export const DISCORD_URL = "https://discord.uplbtools.me";
 
-/** Facebook Messenger group chat invites (targets for messenger.uplbtools.me redirects). */
+/** Facebook Messenger group chat invites (targets for redirect workers). */
 export const MESSENGER_CONTRIBUTE_TARGET = "https://m.me/j/Aba1V0prvQyLrafZ/";
 export const MESSENGER_MAINTAIN_TARGET = "https://m.me/j/AbZtqMU8UUTiwQfn/";
 
-/** Canonical short URLs (volunteers / maintainers). Host should redirect to *_TARGET. */
-export const MESSENGER_CONTRIBUTE_URL =
+/** Short links on messenger.uplbtools.me (Cloudflare Worker). */
+export const MESSENGER_SHORT_CONTRIBUTE_URL =
   "https://messenger.uplbtools.me/contribute";
-export const MESSENGER_MAINTAIN_URL = "https://messenger.uplbtools.me/maintain";
+export const MESSENGER_SHORT_MAINTAIN_URL =
+  "https://messenger.uplbtools.me/maintain";
+
+/** App-stable redirect URLs on room-tba (avoids messenger subdomain DNS cache misses). */
+export const MESSENGER_CONTRIBUTE_URL = `${ROOM_TBA_SITE_URL}/messenger/contribute`;
+export const MESSENGER_MAINTAIN_URL = `${ROOM_TBA_SITE_URL}/messenger/maintain`;
 
 /** Default volunteer-facing Messenger entry. */
 export const MESSENGER_URL = MESSENGER_CONTRIBUTE_URL;

--- a/src/constants/status-bar-links.ts
+++ b/src/constants/status-bar-links.ts
@@ -1,5 +1,7 @@
 import {
   LEGAL_LINKS,
+  MESSENGER_CONTRIBUTE_TARGET,
+  MESSENGER_MAINTAIN_TARGET,
   UPLB_TOOLS_URL,
   DISCORD_URL,
 } from "@constants/community-links";
@@ -53,7 +55,7 @@ export const STATUS_BAR_COMMUNITY_GROUP: StatusBarNavGroup = {
       kind: "link",
       id: "messenger",
       label: "Messenger",
-      href: "/messenger/contribute",
+      href: MESSENGER_CONTRIBUTE_TARGET,
       external: true,
       icon: "messenger",
     },
@@ -128,7 +130,19 @@ export function statusBarNavGroups(options: {
 }): StatusBarNavGroup[] {
   const appItems: StatusBarNavItem[] = [
     STATUS_BAR_APP_ACTIONS[0]!,
-    ...(options.showEditorLogin ? [STATUS_BAR_APP_ACTIONS[1]!] : []),
+    ...(options.showEditorLogin
+      ? [
+          STATUS_BAR_APP_ACTIONS[1]!,
+          {
+            kind: "link" as const,
+            id: "messenger-maintain",
+            label: "Maintainer chat",
+            href: MESSENGER_MAINTAIN_TARGET,
+            external: true,
+            icon: "messenger" as const,
+          },
+        ]
+      : []),
   ];
 
   return [

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -2,7 +2,7 @@
 export const prerender = true;
 import Layout from "@layouts/Layout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
-import { UPLB_TOOLS_URL } from "@constants/community-links";
+import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@constants/community-links";
 ---
 
 <Layout
@@ -130,11 +130,11 @@ import { UPLB_TOOLS_URL } from "@constants/community-links";
         <h2>Contact</h2>
         <p>
           Questions about privacy? Reach the team via
-          <a href="/messenger/contribute" target="_blank" rel="noopener noreferrer"
+          <a href={MESSENGER_CONTRIBUTE_TARGET} target="_blank" rel="noopener noreferrer"
             >Messenger</a
           >
           or
-          <a href="/discord" target="_blank" rel="noopener noreferrer"
+          <a href={DISCORD_URL} target="_blank" rel="noopener noreferrer"
             >Discord</a
           >.
         </p>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -2,7 +2,7 @@
 export const prerender = true;
 import Layout from "@layouts/Layout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
-import { UPLB_TOOLS_URL } from "@constants/community-links";
+import { UPLB_TOOLS_URL, DISCORD_URL, MESSENGER_CONTRIBUTE_TARGET } from "@constants/community-links";
 ---
 
 <Layout
@@ -124,11 +124,11 @@ import { UPLB_TOOLS_URL } from "@constants/community-links";
         <h2>Contact</h2>
         <p>
           Questions? Reach us on
-          <a href="/discord" target="_blank" rel="noopener noreferrer"
+          <a href={DISCORD_URL} target="_blank" rel="noopener noreferrer"
             >Discord</a
           >
           or
-          <a href="/messenger/contribute" target="_blank" rel="noopener noreferrer"
+          <a href={MESSENGER_CONTRIBUTE_TARGET} target="_blank" rel="noopener noreferrer"
             >Messenger</a
           >, or open an issue on
           <a


### PR DESCRIPTION
## Summary
- Fix PWA service worker swallowing `/messenger/*` server redirects
- Link Discord/Messenger UI directly to `m.me` / discord short URLs
- Add maintainer Messenger GC link in editor login, landing modal, and app menu

## Test plan
- [x] Staging merge #471 — verify + Vercel preview green
- [x] Local `bun run build` on branch
- [ ] E2E on release PR (CI)

## Includes
- #471 fix(community): messenger redirects, maintainer link, PWA denylist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and PWA routing changes only; no auth, data, or API behavior changes beyond redirect/link URLs.
> 
> **Overview**
> **Release 1.21.0** bundles community-link fixes so Messenger and Discord work reliably in the installed PWA and in the UI.
> 
> The **service worker** no longer intercepts `/messenger`, `/maintain`, or `/discord`, so those paths reach **server redirects** to the real destinations instead of the offline app shell (#471). The same patterns are enforced in **`check-pwa-legal-routes`**.
> 
> **`community-links`** now separates **room-tba redirect URLs** (canonical short links) from **`m.me` targets** and legacy **messenger.uplbtools.me** shorts. In-app links (status bar, landing modal/guide, privacy/terms, admin login) point at **`m.me` / discord shorts** where appropriate, with **separate contribute vs maintainer** Messenger GCs and a **“Message maintainers”** footer on the editor login modal. The expanded status bar adds **Maintainer chat** when editor sign-in is shown.
> 
> Tests and E2E cover the new hrefs and a full-browser navigation to Messenger after `/messenger/contribute`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 789c3a2b3a71354f5bea00a0e4320701061d69f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->