### PR TITLE
docs(agents): org template note in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 **Human developers and campus volunteers:** start with [CONTRIBUTING.md](CONTRIBUTING.md). You do not need this file.
 
+> **Org template:** Other [uplbtools](https://github.com/uplbtools) repos maintain a shorter `AGENTS.md` adapted from this file for their stack (discord-bot, gradesim, uplbtools.me, punta, iskedyul, laro-tayo, …).
+
 ## Doc map
 
 Read the right doc for the task; do not rely on this file alone for detailed checklists.


### PR DESCRIPTION
Notes that other uplbtools repos adapt AGENTS.md from room-tba.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, auth, or data impact.
> 
> **Overview**
> Adds a short **org template** callout at the top of `AGENTS.md` (right after the pointer to `CONTRIBUTING.md`).
> 
> The note states that other **uplbtools** repositories keep a shorter `AGENTS.md` derived from this one, and names example stacks (discord-bot, gradesim, uplbtools.me, punta, iskedyul, laro-tayo, …). No other sections or behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98982f0bdd673e4435118ca47775d393043d422f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->