### PR TITLE
fix(ci): cap Postgres pool and Playwright workers in E2E

### DIFF
--- a/.cursor/skills/playwright-e2e-ci/SKILL.md
+++ b/.cursor/skills/playwright-e2e-ci/SKILL.md
@@ -71,7 +71,7 @@ Wall clock ~28–35 min in CI.
 
 | Error | Likely cause | Mitigation |
 | --- | --- | --- |
-| `EMAXCONNSESSION max clients reached` | Too many parallel PG connections in integration job | Serialize tests, lower concurrency, or pooler limits |
+| `EMAXCONNSESSION max clients reached` | Too many parallel PG connections in integration job | CI sets `PLAYWRIGHT_WORKERS=1` and `DATABASE_POOL_MAX=4`; integration runs with `--concurrency 1` |
 | Preview failed to start | build:e2e or port conflict | Read job log before Playwright step |
 | staging-smoke `/admin` redirect | Staging deploy lag vs test expectation | Wait for Vercel staging deploy; check live URL |
 | Integration pass locally, fail CI | Missing preview or wrong `PREVIEW_BASE_URL` | Use `test:integration:live` |

--- a/.github/workflows/e2e-advisory.yml
+++ b/.github/workflows/e2e-advisory.yml
@@ -11,7 +11,7 @@ on:
       - ".cursor/**"
 
 concurrency:
-  group: e2e-stack-${{ github.event.pull_request.number }}
+  group: e2e-advisory-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -20,6 +20,8 @@ jobs:
       ADMIN_SESSION_SECRET: ${{ secrets.E2E_ADMIN_SESSION_SECRET }}
       CI: true
       SKIP_E2E_BUILD: "1"
+      DATABASE_POOL_MAX: "4"
+      PLAYWRIGHT_WORKERS: "1"
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ on:
       - ".cursor/**"
 
 concurrency:
-  group: e2e-stack-${{ github.event.pull_request.number }}
+  group: e2e-blocking-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,7 +26,7 @@ bun run e2e                     # Playwright starts its own preview (~16 min fir
 
 `bun run test:integration` alone runs **service/DB tests** only when preview is offline; **HTTP suites fail fast** with instructions. Do not treat a green `test:integration` without preview as full coverage.
 
-E2E runs `serve:e2e`, which rebuilds with `@astrojs/node` because `@astrojs/vercel` does not support `astro preview`. After the first `build:e2e`, speed up reruns with `SKIP_E2E_BUILD=1 bun run e2e`. For fast iteration on an already-running preview, set `PLAYWRIGHT_REUSE_SERVER=1`. Default Playwright workers are **2** (override with `PLAYWRIGHT_WORKERS`); the full suite is heavy on one preview server (~16 min locally; ~25 min wall clock in CI).
+E2E runs `serve:e2e`, which rebuilds with `@astrojs/node` because `@astrojs/vercel` does not support `astro preview`. After the first `build:e2e`, speed up reruns with `SKIP_E2E_BUILD=1 bun run e2e`. For fast iteration on an already-running preview, set `PLAYWRIGHT_REUSE_SERVER=1`. Default Playwright workers are **2** locally (**1** in CI via `PLAYWRIGHT_WORKERS`; override either way); the full suite is heavy on one preview server (~16 min locally; ~25 min wall clock in CI).
 
 ## CI (every PR push, including drafts)
 

--- a/e2e/smoke/redirects.spec.ts
+++ b/e2e/smoke/redirects.spec.ts
@@ -20,7 +20,8 @@ test.describe("community redirects", () => {
     page,
   }) => {
     await page.goto("/messenger/contribute");
-    await expect(page).toHaveURL(/m\.me\/j\/Aba1V0prvQyLrafZ/);
+    // m.me redirects to www.messenger.com in real browsers.
+    await expect(page).toHaveURL(/\/j\/Aba1V0prvQyLrafZ/);
   });
 
   test("/messenger/maintain redirects to maintainers Messenger GC", async ({

--- a/playwright.advisory.config.ts
+++ b/playwright.advisory.config.ts
@@ -4,12 +4,18 @@ import { loadEnv } from "./scripts/load-env";
 loadEnv();
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:4321";
+const workers = process.env.PLAYWRIGHT_WORKERS
+  ? Number(process.env.PLAYWRIGHT_WORKERS)
+  : process.env.CI
+    ? 1
+    : undefined;
 
 export default defineConfig({
   testDir: "e2e/advisory",
   timeout: 60_000,
-  fullyParallel: true,
+  fullyParallel: !process.env.CI,
   retries: 0,
+  workers,
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,9 @@ loadEnv();
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:4321";
 const workers = process.env.PLAYWRIGHT_WORKERS
   ? Number(process.env.PLAYWRIGHT_WORKERS)
-  : 2;
+  : process.env.CI
+    ? 1
+    : 2;
 
 export default defineConfig({
   testDir: "e2e",

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,16 @@
 import { DATABASE_URL } from "astro:env/server";
 import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
 
-export const db = drizzle(DATABASE_URL);
+/** Cap pool size in CI so Playwright + preview stay under Supabase session pooler limits. */
+const poolMax = Number(
+  process.env.DATABASE_POOL_MAX ?? (process.env.CI ? "4" : "10"),
+);
+
+const pool = new Pool({
+  connectionString: DATABASE_URL,
+  max: Number.isFinite(poolMax) && poolMax > 0 ? poolMax : 10,
+  idleTimeoutMillis: 10_000,
+});
+
+export const db = drizzle(pool);


### PR DESCRIPTION
## Summary
- **Not fixed before this PR:** advisory E2E runs on recent messenger PRs were **cancelled** (superseded); blocking/staging E2E failed with **`EMAXCONNSESSION`** (Supabase session pooler limit 15).
- Cap Drizzle `pg` pool via explicit `Pool` (`DATABASE_POOL_MAX=4` in CI)
- Run Playwright with **1 worker** in CI (blocking + advisory)
- Advisory suite: `fullyParallel: false` in CI

## Test plan
- [ ] CI verify + migrations (auto)
- [ ] E2E blocking + E2E advisory green on this PR
- [ ] Staging push E2E green after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global DB connection pooling (CI defaults to max 4) and E2E parallelism; misconfiguration could affect integration/E2E stability or local dev if env vars are wrong.
> 
> **Overview**
> Addresses **`EMAXCONNSESSION`** (Supabase session pooler) failures during blocking/advisory E2E by **reducing parallel DB and browser load** in CI.
> 
> **Runtime:** `src/lib/db.ts` now uses an explicit `pg` `Pool` with **`DATABASE_POOL_MAX`** (default **4** when `CI`, **10** locally). `e2e-reusable.yml` sets `DATABASE_POOL_MAX=4` and `PLAYWRIGHT_WORKERS=1`. Blocking and advisory Playwright configs default to **1 worker** in CI; advisory also disables **`fullyParallel`** in CI.
> 
> **Workflows:** Separate GitHub Actions concurrency groups for **`e2e-blocking`** vs **`e2e-advisory`** so one suite re-run does not cancel the other.
> 
> **Tests/docs:** Messenger contribute browser E2E now asserts the join path after **`m.me` → messenger.com** redirect (not `m.me` hostname). Testing skill/docs updated to describe the CI mitigations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0fd5dedcc41c481343bb4b5764393686d9cef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->