### PR TITLE
fix(proposals): room adds when building is still pending (#255)

### DIFF
--- a/.cursor/skills/contributor-proposals/SKILL.md
+++ b/.cursor/skills/contributor-proposals/SKILL.md
@@ -62,7 +62,7 @@ Editors use shield menu → review queue:
 
 - `entity_id = 0`, `base_version = 0`.
 - Approved → `applyProposalPatch()` calls `createBuilding`, `createRoom`, etc. in `admin-service.ts`.
-- **Gap:** new building pending → rooms in that building blocked until approve ([#255](https://github.com/uplbtools/room-tba/issues/255)).
+- **Gap (v1 UX):** new building pending → room create form explains the wait and requires a live building picker ([#255](https://github.com/uplbtools/room-tba/issues/255)). Bundled building+rooms and dependency graph are follow-ups.
 
 ## Known edge cases (check before closing issues)
 

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -11,6 +11,8 @@
     resolveSubmitterName,
     publishEntityCreate,
     submitCreateProposal,
+    getStoredPendingCreateProposal,
+    fetchPublicProposalSummary,
     type ProposalCreateType,
   } from "@lib/proposals/client";
   import { validateSubmitterName } from "@constants/proposals";
@@ -83,15 +85,35 @@
   let dormGender = $state("coed");
   let roomCode = $state("");
   let roomDirections = $state("");
+  let roomBuildingDraft = $state("");
   let collegeName = $state("");
   let divisionCollegeDraft = $state("");
   let divisionName = $state("");
   let submitting = $state(false);
   let error = $state<string | null>(null);
   let draftReady = $state(false);
+  let pendingBuildingLabel = $state<string | null>(null);
 
   const appData = getAppData();
   const colleges = $derived(appData().loaded ? appData().colleges : []);
+  const buildings = $derived(
+    appData().loaded
+      ? [...appData().buildings].sort((a, b) =>
+          a.buildingName.localeCompare(b.buildingName),
+        )
+      : [],
+  );
+
+  const roomBuildingNotice = $derived.by(() => {
+    if (kind !== "create_room" || isPublish) return null;
+    if (pendingBuildingLabel) {
+      return `Your building suggestion "${pendingBuildingLabel}" is still waiting for editor review. You can add rooms in that building after it is approved and appears on the map.`;
+    }
+    if (buildings.length === 0) {
+      return "Rooms must belong to a building that is already on the map. Suggest a building first, then come back to add rooms after editors approve it.";
+    }
+    return "Rooms must belong to a building that is already on the map. Pick one below, or open a building in the side panel and use Suggest an edit on an existing room.";
+  });
 
   const needsPin = $derived(
     kind === "create_building" ||
@@ -115,6 +137,7 @@
     dormGender = "coed";
     roomCode = "";
     roomDirections = "";
+    roomBuildingDraft = "";
     collegeName = "";
     divisionCollegeDraft = "";
     divisionName = "";
@@ -136,6 +159,7 @@
       dormGender,
       roomCode,
       roomDirections,
+      roomBuildingDraft,
       collegeName,
       divisionCollegeDraft,
       divisionName,
@@ -159,6 +183,7 @@
     dormGender = saved.dormGender;
     roomCode = saved.roomCode;
     roomDirections = saved.roomDirections;
+    roomBuildingDraft = saved.roomBuildingDraft ?? "";
     collegeName = saved.collegeName;
     divisionCollegeDraft = saved.divisionCollegeDraft;
     divisionName = saved.divisionName;
@@ -167,9 +192,24 @@
     }
   }
 
+  async function refreshPendingBuildingLabel() {
+    pendingBuildingLabel = null;
+    const pending = getStoredPendingCreateProposal("create_building");
+    if (!pending) return;
+    const summary = await fetchPublicProposalSummary(pending.id);
+    pendingBuildingLabel = summary?.entityLabel ?? "New building";
+  }
+
   onMount(() => {
     if (!isPublish) restoreAdditionDraft();
     draftReady = true;
+    void refreshPendingBuildingLabel();
+  });
+
+  $effect(() => {
+    if (kind === "create_room" && !isPublish) {
+      void refreshPendingBuildingLabel();
+    }
   });
 
   $effect(() => {
@@ -187,6 +227,7 @@
     dormGender;
     roomCode;
     roomDirections;
+    roomBuildingDraft;
     collegeName;
     divisionCollegeDraft;
     divisionName;
@@ -301,6 +342,7 @@
         return {
           roomCode: roomCode.trim(),
           directions: roomDirections.trim() || null,
+          buildingId: Number(roomBuildingDraft),
         };
       case "create_college":
         return { collegeName: collegeName.trim() };
@@ -338,6 +380,13 @@
     if (kind === "create_room" && !roomCode.trim()) {
       error = "Room code is required.";
       return;
+    }
+    if (kind === "create_room") {
+      const buildingId = Number(roomBuildingDraft);
+      if (!Number.isInteger(buildingId) || buildingId < 1) {
+        error = "Pick the building this room belongs to.";
+        return;
+      }
     }
     if (kind === "create_dorm" && !dormName.trim()) {
       error = "Dorm name is required.";
@@ -385,7 +434,15 @@
         error = result.error ?? "Could not submit proposal.";
         return;
       }
-      toastStore.show("Thanks. We'll review your suggestion soon.", "success");
+      if (kind === "create_building") {
+        toastStore.show(
+          "Thanks. We will review your building suggestion soon. You can add rooms in that building after editors approve it.",
+          "success",
+        );
+        await refreshPendingBuildingLabel();
+      } else {
+        toastStore.show("Thanks. We'll review your suggestion soon.", "success");
+      }
       clearSuggestAdditionDraft();
       resetFields();
       dismissHost();
@@ -566,6 +623,31 @@
         {/snippet}
       </EntityEditorFormField>
     {:else if kind === "create_room"}
+      {#if roomBuildingNotice}
+        <EntityEditorMessage variant="pending" message={roomBuildingNotice} />
+      {/if}
+      <EntityEditorFormField
+        label="Which building is it in?"
+        inputId="addition-room-building"
+        hint="Only buildings already on the map appear here."
+      >
+        {#snippet control()}
+          <select
+            id="addition-room-building"
+            bind:value={roomBuildingDraft}
+            disabled={buildings.length === 0}
+          >
+            <option value="">
+              {buildings.length === 0
+                ? "No buildings on the map yet"
+                : "Select a building"}
+            </option>
+            {#each buildings as building (building.id)}
+              <option value={String(building.id)}>{building.buildingName}</option>
+            {/each}
+          </select>
+        {/snippet}
+      </EntityEditorFormField>
       <EntityEditorFormField
         label="Room number or code"
         inputId="addition-room-code"

--- a/src/lib/contributor-drafts.ts
+++ b/src/lib/contributor-drafts.ts
@@ -31,6 +31,7 @@ export type SuggestAdditionDraft = {
   dormGender: string;
   roomCode: string;
   roomDirections: string;
+  roomBuildingDraft: string;
   collegeName: string;
   divisionCollegeDraft: string;
   divisionName: string;

--- a/src/lib/proposals/client.test.ts
+++ b/src/lib/proposals/client.test.ts
@@ -1,11 +1,63 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { publishEntityPatch } from "./client";
+import {
+  getStoredPendingCreateProposal,
+  publishEntityPatch,
+  readStoredProposals,
+  rememberProposal,
+} from "./client";
 
 const originalFetch = globalThis.fetch;
+const storage = new Map<string, string>();
+
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storage.set(key, value);
+  },
+  removeItem: (key: string) => {
+    storage.delete(key);
+  },
+  clear: () => {
+    storage.clear();
+  },
+  key: () => null,
+  length: 0,
+} as Storage;
+
+if (typeof globalThis.localStorage === "undefined") {
+  globalThis.localStorage = localStorageMock;
+}
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   mock.restore();
+  storage.clear();
+});
+
+describe("stored proposal refs", () => {
+  test("getStoredPendingCreateProposal finds open create_building", () => {
+    rememberProposal({
+      id: 42,
+      entityType: "create_building",
+      entityId: 0,
+      status: "pending",
+    });
+    rememberProposal({
+      id: 7,
+      entityType: "create_room",
+      entityId: 0,
+      status: "rejected",
+    });
+
+    expect(getStoredPendingCreateProposal("create_building")).toEqual({
+      id: 42,
+      entityType: "create_building",
+      entityId: 0,
+      status: "pending",
+    });
+    expect(getStoredPendingCreateProposal("create_room")).toBeNull();
+    expect(readStoredProposals()).toHaveLength(2);
+  });
 });
 
 describe("publishEntityPatch", () => {

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -44,12 +44,40 @@ export function getStoredProposalForEntity(
   );
 }
 
+export function getStoredPendingCreateProposal(
+  entityType: ProposalCreateType,
+): StoredProposalRef | null {
+  return getStoredProposalForEntity(entityType, 0);
+}
+
+export type PublicProposalSummary = {
+  id: number;
+  entityType: string;
+  entityLabel: string;
+  status: string;
+  adminNote: string | null;
+};
+
+export async function fetchPublicProposalSummary(
+  proposalId: number,
+): Promise<PublicProposalSummary | null> {
+  const res = await fetch(`/api/proposals/${proposalId}`, {
+    credentials: "same-origin",
+  });
+  if (!res.ok) return null;
+  const data = (await res.json().catch(() => ({}))) as {
+    proposal?: PublicProposalSummary;
+  };
+  return data.proposal ?? null;
+}
+
 const FIELD_LABELS: Record<string, string> = {
   buildingName: "Building name",
   directions: "Directions",
   buildingType: "Building type",
   lat: "Latitude",
   lon: "Longitude",
+  buildingId: "Building",
   dormName: "Dorm name",
   shortName: "Short name",
   gender: "Gender",

--- a/src/lib/proposals/create-proposal-validation.test.ts
+++ b/src/lib/proposals/create-proposal-validation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ProposalValidationError,
+  validateCreateProposalPatch,
+} from "@lib/proposals/create-proposal-validation";
+
+describe("validateCreateProposalPatch", () => {
+  test("create_room requires room code and buildingId", () => {
+    expect(() =>
+      validateCreateProposalPatch("create_room", {
+        roomCode: "301",
+      }),
+    ).toThrow(ProposalValidationError);
+
+    expect(() =>
+      validateCreateProposalPatch("create_room", {
+        roomCode: "",
+        buildingId: 1,
+      }),
+    ).toThrow(ProposalValidationError);
+
+    expect(() =>
+      validateCreateProposalPatch("create_room", {
+        roomCode: "301",
+        buildingId: 1,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/lib/proposals/create-proposal-validation.ts
+++ b/src/lib/proposals/create-proposal-validation.ts
@@ -1,0 +1,74 @@
+import type { ProposalCreateType } from "@lib/services/proposal-service";
+
+export class ProposalValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProposalValidationError";
+  }
+}
+
+export function validateCreateProposalPatch(
+  entityType: ProposalCreateType,
+  patch: Record<string, unknown>,
+): void {
+  switch (entityType) {
+    case "create_building": {
+      const name =
+        typeof patch.buildingName === "string" ? patch.buildingName.trim() : "";
+      if (!name)
+        throw new ProposalValidationError("Building name is required.");
+      if (typeof patch.lat !== "number" || typeof patch.lon !== "number") {
+        throw new ProposalValidationError(
+          "Pick a map location for the new building.",
+        );
+      }
+      return;
+    }
+    case "create_event": {
+      const title = typeof patch.title === "string" ? patch.title.trim() : "";
+      if (!title) throw new ProposalValidationError("Event title is required.");
+      if (
+        typeof patch.startsAt !== "string" ||
+        typeof patch.endsAt !== "string"
+      ) {
+        throw new ProposalValidationError("Event start and end are required.");
+      }
+      return;
+    }
+    case "create_dorm": {
+      const name =
+        typeof patch.dormName === "string" ? patch.dormName.trim() : "";
+      const gender =
+        typeof patch.gender === "string" ? patch.gender.trim() : "";
+      if (!name) throw new ProposalValidationError("Dorm name is required.");
+      if (!gender)
+        throw new ProposalValidationError("Dorm gender is required.");
+      return;
+    }
+    case "create_room": {
+      const code =
+        typeof patch.roomCode === "string" ? patch.roomCode.trim() : "";
+      if (!code) throw new ProposalValidationError("Room code is required.");
+      const buildingId = Number(patch.buildingId);
+      if (!Number.isInteger(buildingId) || buildingId < 1) {
+        throw new ProposalValidationError(
+          "Pick the building this room belongs to.",
+        );
+      }
+      return;
+    }
+    case "create_college": {
+      const name =
+        typeof patch.collegeName === "string" ? patch.collegeName.trim() : "";
+      if (!name) throw new ProposalValidationError("College name is required.");
+      return;
+    }
+    case "create_division": {
+      const name =
+        typeof patch.divisionName === "string" ? patch.divisionName.trim() : "";
+      if (!name)
+        throw new ProposalValidationError("Division name is required.");
+      return;
+    }
+  }
+}

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -112,10 +112,24 @@ export async function getEntityLabel(
         return typeof p.dormName === "string" && p.dormName.trim()
           ? `New dorm: ${p.dormName.trim()}`
           : "New dorm";
-      case "create_room":
-        return typeof p.roomCode === "string" && p.roomCode.trim()
-          ? `New room: ${p.roomCode.trim()}`
-          : "New room";
+      case "create_room": {
+        const code =
+          typeof p.roomCode === "string" && p.roomCode.trim()
+            ? p.roomCode.trim()
+            : null;
+        const buildingId = Number(p.buildingId);
+        if (code && Number.isInteger(buildingId) && buildingId >= 1) {
+          const [row] = await db
+            .select({ label: buildingsTable.buildingName })
+            .from(buildingsTable)
+            .where(eq(buildingsTable.id, buildingId))
+            .limit(1);
+          if (row?.label) {
+            return `New room: ${code} (${row.label})`;
+          }
+        }
+        return code ? `New room: ${code}` : "New room";
+      }
       case "create_college":
         return typeof p.collegeName === "string" && p.collegeName.trim()
           ? `New college: ${p.collegeName.trim()}`
@@ -294,66 +308,10 @@ async function withEntityLabel(
   };
 }
 
-function validateCreatePatch(
-  entityType: ProposalCreateType,
-  patch: Record<string, unknown>,
-) {
-  switch (entityType) {
-    case "create_building": {
-      const name =
-        typeof patch.buildingName === "string" ? patch.buildingName.trim() : "";
-      if (!name)
-        throw new ProposalValidationError("Building name is required.");
-      if (typeof patch.lat !== "number" || typeof patch.lon !== "number") {
-        throw new ProposalValidationError(
-          "Pick a map location for the new building.",
-        );
-      }
-      return;
-    }
-    case "create_event": {
-      const title = typeof patch.title === "string" ? patch.title.trim() : "";
-      if (!title) throw new ProposalValidationError("Event title is required.");
-      if (
-        typeof patch.startsAt !== "string" ||
-        typeof patch.endsAt !== "string"
-      ) {
-        throw new ProposalValidationError("Event start and end are required.");
-      }
-      return;
-    }
-    case "create_dorm": {
-      const name =
-        typeof patch.dormName === "string" ? patch.dormName.trim() : "";
-      const gender =
-        typeof patch.gender === "string" ? patch.gender.trim() : "";
-      if (!name) throw new ProposalValidationError("Dorm name is required.");
-      if (!gender)
-        throw new ProposalValidationError("Dorm gender is required.");
-      return;
-    }
-    case "create_room": {
-      const code =
-        typeof patch.roomCode === "string" ? patch.roomCode.trim() : "";
-      if (!code) throw new ProposalValidationError("Room code is required.");
-      return;
-    }
-    case "create_college": {
-      const name =
-        typeof patch.collegeName === "string" ? patch.collegeName.trim() : "";
-      if (!name) throw new ProposalValidationError("College name is required.");
-      return;
-    }
-    case "create_division": {
-      const name =
-        typeof patch.divisionName === "string" ? patch.divisionName.trim() : "";
-      if (!name)
-        throw new ProposalValidationError("Division name is required.");
-      return;
-    }
-  }
-}
-
+import {
+  ProposalValidationError,
+  validateCreateProposalPatch,
+} from "@lib/proposals/create-proposal-validation";
 export async function listPendingProposals(): Promise<EditProposalSummary[]> {
   const rows = await db
     .select()
@@ -431,9 +389,8 @@ export async function submitProposal(
     throw new ProposalValidationError("No changes to submit.");
   }
 
-  if (isCreate) {
-    validateCreatePatch(input.entityType, input.patch);
-  } else if (
+  if (
+    !isCreate &&
     !(await entityExists(
       input.entityType as ProposalUpdateType,
       input.entityId,
@@ -484,6 +441,23 @@ export async function submitProposal(
       }
     : input.patch;
 
+  if (isCreate) {
+    validateCreateProposalPatch(input.entityType, mergedPatch);
+    if (input.entityType === "create_room") {
+      const buildingId = Number(mergedPatch.buildingId);
+      const [row] = await db
+        .select({ id: buildingsTable.id })
+        .from(buildingsTable)
+        .where(eq(buildingsTable.id, buildingId))
+        .limit(1);
+      if (!row) {
+        throw new ProposalValidationError(
+          "That building is not on the map yet. Wait for editors to approve your building suggestion, or pick a building that already exists.",
+        );
+      }
+    }
+  }
+
   if (existing) {
     const [updated] = await db
       .update(editProposalsTable)
@@ -519,12 +493,7 @@ export async function submitProposal(
   return withEntityLabel(created);
 }
 
-export class ProposalValidationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ProposalValidationError";
-  }
-}
+export { ProposalValidationError } from "@lib/proposals/create-proposal-validation";
 
 export class ProposalActionError extends Error {
   status: number;


### PR DESCRIPTION
## Summary

Addresses edge case **#255.1** (new building pending → add rooms):

- **Building picker** on `create_room` in Suggest addition (required `buildingId` in patch)
- **Server validation** rejects room creates without a live building on the map
- **Contextual UX copy** when contributor has a pending `create_building` proposal (from localStorage + `/api/proposals/:id` label)
- **Post-submit toast** on building suggestions explains rooms come after approval
- Extracted `create-proposal-validation.ts` for unit tests

Bundled building+rooms and proposal dependency graph remain follow-ups.

## Test plan

- [x] `bun test src/lib/proposals/create-proposal-validation.test.ts`
- [x] `bun test src/lib/proposals/client.test.ts`
- [ ] CI verify
- [ ] Manual: submit building proposal → open Suggest addition → Room → see pending-building notice
- [ ] Manual: pick live building → room proposal submits with buildingId

Closes gap #255 edge case 1 (interim UX + building picker). Does not close parent #255 (other edge cases remain).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proposal submit validation and `create_room` patch shape (now requires `buildingId`), which can reject previously acceptable submissions; server also checks building existence on merge/revise.
> 
> **Overview**
> **Room suggestions** now tie to a **building already on the map**: the Suggest addition flow adds a required building picker, includes `buildingId` in the patch, and shows contextual copy when the contributor has a pending `create_building` (via `localStorage` + `/api/proposals/:id` for the label). Building-only success toast explains rooms come after approval; contributor drafts persist the selected building.
> 
> **Server-side**, `create_room` validation now requires `buildingId`, runs on the **merged** patch (so revises stay valid), and rejects proposals when that building row is missing. Create-patch rules move to **`create-proposal-validation.ts`** with unit tests; proposal labels for new rooms can include the building name. Client tests cover `getStoredPendingCreateProposal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b33df3f847f31057aaf6749b277694faf4d1a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->