### PR TITLE
fix(proposals): separate pending create_* proposals (#255)

### DIFF
--- a/.cursor/skills/contributor-proposals/SKILL.md
+++ b/.cursor/skills/contributor-proposals/SKILL.md
@@ -67,7 +67,7 @@ Editors use shield menu → review queue:
 ## Known edge cases (check before closing issues)
 
 - Revise pending: merge patch if same submitter + open status; anonymous needs same browser/`proposalId`.
-- Multiple pending `create_*` from one logged-in user may collide on `(entity_type, entity_id=0)`.
+- Multiple pending `create_*` from one logged-in user may collide on `(entity_type, entity_id=0)` — fixed: create merges only via explicit `proposalId` ([#255](https://github.com/uplbtools/room-tba/issues/255) PR pending).
 - No **withdraw** API yet.
 - Contributor credit on approve: proposal row only today; ledger is [#450](https://github.com/uplbtools/room-tba/issues/450).
 

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -425,10 +425,13 @@
         username: adminAuthStore.username,
         draftName: submitterName,
       })!;
+      const pendingCreate = getStoredPendingCreateProposal(kind);
       const result = await submitCreateProposal({
         entityType: kind,
         patch,
         submitterName: name,
+        proposalId:
+          pendingCreate?.status === "needs_changes" ? pendingCreate.id : null,
       });
       if (!result.ok) {
         error = result.error ?? "Could not submit proposal.";

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -420,6 +420,7 @@ export async function submitCreateProposal(input: {
   entityType: ProposalCreateType;
   patch: Record<string, unknown>;
   submitterName?: string;
+  proposalId?: number | null;
 }): Promise<{ ok: boolean; error?: string; proposal?: StoredProposalRef }> {
   return submitEntityProposal({
     entityType: input.entityType,
@@ -427,6 +428,7 @@ export async function submitCreateProposal(input: {
     baseVersion: 0,
     patch: input.patch,
     submitterName: input.submitterName,
+    proposalId: input.proposalId,
   });
 }
 

--- a/src/lib/proposals/proposal-merge-policy.test.ts
+++ b/src/lib/proposals/proposal-merge-policy.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { allowEntityScopedProposalMerge } from "@lib/proposals/proposal-merge-policy";
+
+describe("allowEntityScopedProposalMerge", () => {
+  test("create proposals only merge when proposalId is sent explicitly", () => {
+    expect(allowEntityScopedProposalMerge(true, 42)).toBe(false);
+    expect(allowEntityScopedProposalMerge(true, null)).toBe(false);
+  });
+
+  test("update proposals still merge for signed-in submitters", () => {
+    expect(allowEntityScopedProposalMerge(false, 42)).toBe(true);
+    expect(allowEntityScopedProposalMerge(false, null)).toBe(false);
+  });
+});

--- a/src/lib/proposals/proposal-merge-policy.ts
+++ b/src/lib/proposals/proposal-merge-policy.ts
@@ -1,0 +1,7 @@
+/** Whether submitProposal may merge into an open row by entity + submitter (updates only). */
+export function allowEntityScopedProposalMerge(
+  isCreate: boolean,
+  submitterUserId: number | null | undefined,
+): boolean {
+  return Boolean(submitterUserId && !isCreate);
+}

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -41,6 +41,8 @@ import {
   type RoomCreateInput,
   type RoomUpdateInput,
 } from "./admin-service";
+import { allowEntityScopedProposalMerge } from "@lib/proposals/proposal-merge-policy";
+import { validateCreateProposalPatch } from "@lib/proposals/create-proposal-validation";
 
 export const PROPOSAL_UPDATE_TYPES = [
   "building",
@@ -308,10 +310,6 @@ async function withEntityLabel(
   };
 }
 
-import {
-  ProposalValidationError,
-  validateCreateProposalPatch,
-} from "@lib/proposals/create-proposal-validation";
 export async function listPendingProposals(): Promise<EditProposalSummary[]> {
   const rows = await db
     .select()
@@ -416,7 +414,7 @@ export async function submitProposal(
     ) {
       existing = undefined;
     }
-  } else if (input.submitterUserId) {
+  } else if (allowEntityScopedProposalMerge(isCreate, input.submitterUserId)) {
     [existing] = await db
       .select()
       .from(editProposalsTable)


### PR DESCRIPTION
## Summary

Fixes **#255 edge case 2** (multiple pending `create_*` overwriting each other):

- `submitProposal` no longer auto-merges **create** rows by `(entity_type, entity_id=0, submitter_user_id)`
- **Update** proposals still merge for signed-in users (unchanged)
- **Create** revisions merge only when client sends explicit `proposalId` (wired for `needs_changes` resubmit in `SuggestAdditionPanel`)

Follows merged #476 (building→room UX).

## Test plan

- [x] `bun test src/lib/proposals/proposal-merge-policy.test.ts`
- [x] Related proposal unit tests pass
- [ ] CI verify + E2E
- [ ] Manual: signed-in user submits two different `create_building` → two queue rows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core proposal submit/merge behavior for all create_* flows; low blast radius for updates (policy preserves prior merge rules) but queue duplication and resubmit wiring need correct client proposalId handling.
> 
> **Overview**
> Fixes **#255**: signed-in users submitting multiple `create_*` suggestions no longer overwrite a single open row keyed by `(entity_type, entity_id=0, submitter)`.
> 
> **`submitProposal`** now uses **`allowEntityScopedProposalMerge`**: entity-scoped auto-merge runs only for **update** proposals with a logged-in submitter. **Create** proposals get a new queue row unless the client sends an explicit **`proposalId`** (existing merge-by-id path unchanged).
> 
> **`SuggestAdditionPanel`** passes **`proposalId`** from stored pending create refs when status is **`needs_changes`**, so resubmits after “request changes” still merge into the right row. **`submitCreateProposal`** forwards **`proposalId`** to the API.
> 
> Adds **`proposal-merge-policy.ts`** + unit tests; contributor-proposals skill doc notes the edge case as fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4edea3b2696d6828c73eb2c77be39eb269d6b24b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->