### PR TITLE
feat(proposals): contributor withdraw pending suggestions (#255)

### DIFF
--- a/.cursor/skills/contributor-proposals/SKILL.md
+++ b/.cursor/skills/contributor-proposals/SKILL.md
@@ -68,7 +68,7 @@ Editors use shield menu → review queue:
 
 - Revise pending: merge patch if same submitter + open status; anonymous needs same browser/`proposalId`.
 - Multiple pending `create_*` from one logged-in user may collide on `(entity_type, entity_id=0)` — fixed: create merges only via explicit `proposalId` ([#255](https://github.com/uplbtools/room-tba/issues/255) PR pending).
-- No **withdraw** API yet.
+- **Withdraw:** contributor `POST /api/proposals/:id/withdraw` sets status `withdrawn` (pending / needs_changes only).
 - Contributor credit on approve: proposal row only today; ledger is [#450](https://github.com/uplbtools/room-tba/issues/450).
 
 ## Tests (same PR as code)

--- a/drizzle/0017_add_withdrawn_proposal_status.sql
+++ b/drizzle/0017_add_withdrawn_proposal_status.sql
@@ -1,0 +1,5 @@
+DO $$ BEGIN
+  ALTER TYPE "edit_proposal_status" ADD VALUE 'withdrawn';
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -46,6 +46,7 @@ export const editProposalStatusEnum = pgEnum("edit_proposal_status", [
   "approved",
   "rejected",
   "needs_changes",
+  "withdrawn",
 ]);
 
 // Academic terms. `id` mirrors the CRS/SAIS term_id (e.g. 1252) rather than

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -13,8 +13,10 @@
     submitCreateProposal,
     getStoredPendingCreateProposal,
     fetchPublicProposalSummary,
+    withdrawEntityProposal,
     type ProposalCreateType,
   } from "@lib/proposals/client";
+  import { canShowWithdrawProposal } from "@lib/editor/field-action-label";
   import { validateSubmitterName } from "@constants/proposals";
   import { instantToCampusWallString } from "@lib/event-time";
   import { slugifySegment } from "@lib/site";
@@ -93,6 +95,9 @@
   let error = $state<string | null>(null);
   let draftReady = $state(false);
   let pendingBuildingLabel = $state<string | null>(null);
+  let pendingCreateProposalId = $state<number | null>(null);
+  let pendingCreateStatus = $state<string | null>(null);
+  let withdrawingCreate = $state(false);
 
   const appData = getAppData();
   const colleges = $derived(appData().loaded ? appData().colleges : []);
@@ -192,24 +197,62 @@
     }
   }
 
-  async function refreshPendingBuildingLabel() {
+  async function refreshPendingCreateProposal() {
+    pendingCreateProposalId = null;
+    pendingCreateStatus = null;
     pendingBuildingLabel = null;
-    const pending = getStoredPendingCreateProposal("create_building");
-    if (!pending) return;
-    const summary = await fetchPublicProposalSummary(pending.id);
-    pendingBuildingLabel = summary?.entityLabel ?? "New building";
+
+    if (isPublish) return;
+
+    const pendingForKind = getStoredPendingCreateProposal(kind);
+    if (pendingForKind) {
+      pendingCreateProposalId = pendingForKind.id;
+      pendingCreateStatus = pendingForKind.status;
+    }
+
+    if (kind === "create_room") {
+      const pendingBuilding = getStoredPendingCreateProposal("create_building");
+      if (!pendingBuilding) return;
+      const summary = await fetchPublicProposalSummary(pendingBuilding.id);
+      pendingBuildingLabel = summary?.entityLabel ?? "New building";
+    }
+  }
+
+  async function withdrawPendingCreate() {
+    if (!pendingCreateProposalId) return;
+    error = null;
+    withdrawingCreate = true;
+    try {
+      const name = resolveSubmitterName({
+        displayName: adminAuthStore.displayName,
+        username: adminAuthStore.username,
+        draftName: submitterName,
+      });
+      const result = await withdrawEntityProposal({
+        proposalId: pendingCreateProposalId,
+        submitterName: name || undefined,
+      });
+      if (!result.ok) {
+        error = result.error ?? "Could not withdraw suggestion.";
+        return;
+      }
+      toastStore.show("Suggestion withdrawn.", "success");
+      await refreshPendingCreateProposal();
+    } finally {
+      withdrawingCreate = false;
+    }
   }
 
   onMount(() => {
     if (!isPublish) restoreAdditionDraft();
     draftReady = true;
-    void refreshPendingBuildingLabel();
+    void refreshPendingCreateProposal();
   });
 
   $effect(() => {
-    if (kind === "create_room" && !isPublish) {
-      void refreshPendingBuildingLabel();
-    }
+    if (isPublish || !draftReady) return;
+    kind;
+    void refreshPendingCreateProposal();
   });
 
   $effect(() => {
@@ -442,7 +485,7 @@
           "Thanks. We will review your building suggestion soon. You can add rooms in that building after editors approve it.",
           "success",
         );
-        await refreshPendingBuildingLabel();
+        await refreshPendingCreateProposal();
       } else {
         toastStore.show("Thanks. We'll review your suggestion soon.", "success");
       }
@@ -739,6 +782,18 @@
 
   {#if error}
     <EntityEditorMessage variant="error" message={error} />
+  {/if}
+
+  {#if !isPublish && pendingCreateProposalId && canShowWithdrawProposal(pendingCreateStatus)}
+    <div class="entity-editor-form-actions">
+      <EntityEditorSubmitButton
+        label="Withdraw pending suggestion"
+        savingLabel="Withdrawing…"
+        saving={withdrawingCreate}
+        variant="secondary"
+        onclick={withdrawPendingCreate}
+      />
+    </div>
   {/if}
 
   <EntityEditorSubmitButton

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -445,6 +445,11 @@
           submitterNameId="building-submitter-name"
           bind:submitterName={submitterNameDraft}
           {proposalStatus}
+          activeProposalId={activeProposalId}
+          onWithdrawn={() => {
+            activeProposalId = null;
+            proposalStatus = null;
+          }}
           successMessage={savedField
             ? entityEditorSavedMessage({
                 canPublish,

--- a/src/components/svelte/controls/DormEditorPanel.svelte
+++ b/src/components/svelte/controls/DormEditorPanel.svelte
@@ -34,6 +34,8 @@
     savedField: DormEditableField | null;
     fieldError: string | null;
     proposalStatus: string | null;
+    activeProposalId?: number | null;
+    onWithdrawn?: () => void;
     submitterNameDraft?: string;
     nameDraft: string;
     shortNameDraft: string;
@@ -61,6 +63,8 @@
     savedField,
     fieldError,
     proposalStatus,
+    activeProposalId = null,
+    onWithdrawn,
     submitterNameDraft = $bindable(""),
     nameDraft = $bindable(""),
     shortNameDraft = $bindable(""),
@@ -90,6 +94,8 @@
   submitterNameId="dorm-submitter-name"
   bind:submitterName={submitterNameDraft}
   {proposalStatus}
+  {activeProposalId}
+  {onWithdrawn}
   successMessage={savedField
     ? entityEditorSavedMessage({
         canPublish,

--- a/src/components/svelte/controls/DormResult.svelte
+++ b/src/components/svelte/controls/DormResult.svelte
@@ -593,6 +593,11 @@
           {savedField}
           {fieldError}
           {proposalStatus}
+          activeProposalId={activeProposalId}
+          onWithdrawn={() => {
+            activeProposalId = null;
+            proposalStatus = null;
+          }}
           bind:submitterNameDraft
           bind:nameDraft
           bind:shortNameDraft

--- a/src/components/svelte/editor/EntityEditorPanel.svelte
+++ b/src/components/svelte/editor/EntityEditorPanel.svelte
@@ -2,7 +2,13 @@
   import type { Snippet } from "svelte";
   import SubmitterNameField from "@ui/SubmitterNameField.svelte";
   import EntityEditorMessage from "./EntityEditorMessage.svelte";
-  import { proposalStatusMessage } from "@lib/editor/field-action-label";
+  import EntityEditorSubmitButton from "./EntityEditorSubmitButton.svelte";
+  import {
+    canShowWithdrawProposal,
+    proposalStatusMessage,
+  } from "@lib/editor/field-action-label";
+  import { withdrawEntityProposal } from "@lib/proposals/client";
+  import { toastStore } from "@lib/store.svelte";
   import "./entity-editor.css";
 
   type Props = {
@@ -11,6 +17,8 @@
     submitterNameId: string;
     submitterName?: string;
     proposalStatus?: string | null;
+    activeProposalId?: number | null;
+    onWithdrawn?: () => void;
     successMessage?: string | null;
     errorMessage?: string | null;
     children?: Snippet;
@@ -22,10 +30,35 @@
     submitterNameId,
     submitterName = $bindable(""),
     proposalStatus = null,
+    activeProposalId = null,
+    onWithdrawn,
     successMessage = null,
     errorMessage = null,
     children,
   }: Props = $props();
+
+  let withdrawing = $state(false);
+  let withdrawError = $state<string | null>(null);
+
+  async function withdrawSuggestion() {
+    if (!activeProposalId || canPublish) return;
+    withdrawError = null;
+    withdrawing = true;
+    try {
+      const result = await withdrawEntityProposal({
+        proposalId: activeProposalId,
+        submitterName: submitterName.trim() || undefined,
+      });
+      if (!result.ok) {
+        withdrawError = result.error ?? "Could not withdraw suggestion.";
+        return;
+      }
+      toastStore.show("Suggestion withdrawn.", "success");
+      onWithdrawn?.();
+    } finally {
+      withdrawing = false;
+    }
+  }
 </script>
 
 <div class="entity-editor-panel" class:contributor-form={!canPublish}>
@@ -44,7 +77,23 @@
     />
   {/if}
 
+  {#if !canPublish && activeProposalId && canShowWithdrawProposal(proposalStatus)}
+    <div class="entity-editor-form-actions">
+      <EntityEditorSubmitButton
+        label="Withdraw suggestion"
+        savingLabel="Withdrawing…"
+        saving={withdrawing}
+        variant="secondary"
+        onclick={withdrawSuggestion}
+      />
+    </div>
+  {/if}
+
   {@render children?.()}
+
+  {#if withdrawError}
+    <EntityEditorMessage variant="error" message={withdrawError} />
+  {/if}
 
   {#if successMessage}
     <EntityEditorMessage variant="success" message={successMessage} />

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -445,6 +445,11 @@
           submitterNameId="room-submitter-name"
           bind:submitterName={submitterNameDraft}
           {proposalStatus}
+          activeProposalId={activeProposalId}
+          onWithdrawn={() => {
+            activeProposalId = null;
+            proposalStatus = null;
+          }}
           successMessage={savedField
             ? entityEditorSavedMessage({
                 canPublish,

--- a/src/lib/editor/field-action-label.test.ts
+++ b/src/lib/editor/field-action-label.test.ts
@@ -46,7 +46,7 @@ describe("editorToggleLabel", () => {
 describe("proposalStatusMessage", () => {
   test("formats pending statuses", () => {
     expect(proposalStatusMessage("needs_changes")).toBe(
-      "Status: needs changes. Waiting for editor review.",
+      "Status: needs changes. Update your suggestion below or withdraw it.",
     );
   });
 });

--- a/src/lib/editor/field-action-label.ts
+++ b/src/lib/editor/field-action-label.ts
@@ -36,7 +36,9 @@ export function proposalStatusMessage(status: string): string {
   }
 }
 
-export function canShowWithdrawProposal(status: string | null | undefined): boolean {
+export function canShowWithdrawProposal(
+  status: string | null | undefined,
+): boolean {
   return status === "pending" || status === "needs_changes";
 }
 

--- a/src/lib/editor/field-action-label.ts
+++ b/src/lib/editor/field-action-label.ts
@@ -24,7 +24,20 @@ export function editorToggleLabel(options: {
 }
 
 export function proposalStatusMessage(status: string): string {
-  return `Status: ${status.replace("_", " ")}. Waiting for editor review.`;
+  switch (status) {
+    case "pending":
+      return "Status: pending. Waiting for editor review.";
+    case "needs_changes":
+      return "Status: needs changes. Update your suggestion below or withdraw it.";
+    case "withdrawn":
+      return "You withdrew this suggestion.";
+    default:
+      return `Status: ${status.replaceAll("_", " ")}.`;
+  }
+}
+
+export function canShowWithdrawProposal(status: string | null | undefined): boolean {
+  return status === "pending" || status === "needs_changes";
 }
 
 export function entityEditorSavedMessage(options: {

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -30,6 +30,20 @@ export function rememberProposal(ref: StoredProposalRef) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify([ref, ...existing]));
 }
 
+export function removeStoredProposal(id: number) {
+  if (typeof localStorage === "undefined") return;
+  const next = readStoredProposals().filter((item) => item.id !== id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+}
+
+export function updateStoredProposalStatus(id: number, status: string) {
+  const refs = readStoredProposals();
+  const index = refs.findIndex((item) => item.id === id);
+  if (index === -1) return;
+  refs[index] = { ...refs[index]!, status };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(refs));
+}
+
 export function getStoredProposalForEntity(
   entityType: ProposalEntityType,
   entityId: number,
@@ -470,6 +484,26 @@ export async function submitEntityProposal(input: {
     rememberProposal(ref);
     return { ok: true, proposal: ref };
   }
+  return { ok: true };
+}
+
+export async function withdrawEntityProposal(input: {
+  proposalId: number;
+  submitterName?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`/api/proposals/${input.proposalId}/withdraw`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(
+      input.submitterName ? { submitterName: input.submitterName } : {},
+    ),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    return { ok: false, error: (data as { error?: string }).error };
+  }
+  removeStoredProposal(input.proposalId);
   return { ok: true };
 }
 

--- a/src/lib/services/proposal-access.test.ts
+++ b/src/lib/services/proposal-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { canViewProposalSubmitterDetails } from "./proposal-access";
+import { canViewProposalSubmitterDetails, canWithdrawProposal } from "./proposal-access";
 
 describe("canViewProposalSubmitterDetails", () => {
   const proposal = {
@@ -50,6 +50,44 @@ describe("canViewProposalSubmitterDetails", () => {
         },
         proposal,
       ),
+    ).toBe(false);
+  });
+});
+
+describe("canWithdrawProposal", () => {
+  const proposal = {
+    submitterUserId: 5,
+    submitterName: "Ana",
+    status: "pending",
+  };
+
+  test("matching signed-in submitter can withdraw open proposals", () => {
+    expect(
+      canWithdrawProposal(
+        {
+          id: 5,
+          username: "ana",
+          displayName: "Ana",
+          role: "contributor",
+        },
+        proposal,
+      ),
+    ).toBe(true);
+  });
+
+  test("anonymous submitter can withdraw with matching display name", () => {
+    expect(
+      canWithdrawProposal(
+        null,
+        { ...proposal, submitterUserId: null },
+        "Ana",
+      ),
+    ).toBe(true);
+  });
+
+  test("closed proposals cannot be withdrawn", () => {
+    expect(
+      canWithdrawProposal(null, { ...proposal, status: "approved" }, "Ana"),
     ).toBe(false);
   });
 });

--- a/src/lib/services/proposal-access.test.ts
+++ b/src/lib/services/proposal-access.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { canViewProposalSubmitterDetails, canWithdrawProposal } from "./proposal-access";
+import {
+  canViewProposalSubmitterDetails,
+  canWithdrawProposal,
+} from "./proposal-access";
 
 describe("canViewProposalSubmitterDetails", () => {
   const proposal = {
@@ -77,11 +80,7 @@ describe("canWithdrawProposal", () => {
 
   test("anonymous submitter can withdraw with matching display name", () => {
     expect(
-      canWithdrawProposal(
-        null,
-        { ...proposal, submitterUserId: null },
-        "Ana",
-      ),
+      canWithdrawProposal(null, { ...proposal, submitterUserId: null }, "Ana"),
     ).toBe(true);
   });
 

--- a/src/lib/services/proposal-access.ts
+++ b/src/lib/services/proposal-access.ts
@@ -16,3 +16,27 @@ export function canViewProposalSubmitterDetails(
   }
   return false;
 }
+
+type WithdrawProposalRow = ProposalAccessRow & {
+  status: string;
+};
+
+export function canWithdrawProposal(
+  session: SessionUser | null,
+  proposal: WithdrawProposalRow,
+  submitterName?: string,
+): boolean {
+  if (!["pending", "needs_changes"].includes(proposal.status)) return false;
+  if (session && session.id > 0 && proposal.submitterUserId === session.id) {
+    return true;
+  }
+  if (
+    !session &&
+    proposal.submitterUserId == null &&
+    typeof submitterName === "string" &&
+    submitterName.trim() === proposal.submitterName.trim()
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -13,8 +13,14 @@ import { type SessionUser } from "@lib/admin/auth";
 import { validateSubmitterName } from "@constants/proposals";
 import { parseEventImageUrl } from "@lib/r2-upload";
 import { R2_PUBLIC_URL } from "astro:env/server";
-import { canViewProposalSubmitterDetails, canWithdrawProposal } from "./proposal-access";
-export { canViewProposalSubmitterDetails, canWithdrawProposal } from "./proposal-access";
+import {
+  canViewProposalSubmitterDetails,
+  canWithdrawProposal,
+} from "./proposal-access";
+export {
+  canViewProposalSubmitterDetails,
+  canWithdrawProposal,
+} from "./proposal-access";
 import {
   EditConflictError,
   DuplicateSlugError,
@@ -755,7 +761,10 @@ export async function withdrawProposal(
   const proposal = await getProposalById(id);
   if (!proposal) throw new ProposalActionError("Proposal not found.", 404);
   if (!canWithdrawProposal(session, proposal, submitterName)) {
-    throw new ProposalActionError("Not allowed to withdraw this proposal.", 403);
+    throw new ProposalActionError(
+      "Not allowed to withdraw this proposal.",
+      403,
+    );
   }
 
   const withdrawnBy =

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -13,8 +13,8 @@ import { type SessionUser } from "@lib/admin/auth";
 import { validateSubmitterName } from "@constants/proposals";
 import { parseEventImageUrl } from "@lib/r2-upload";
 import { R2_PUBLIC_URL } from "astro:env/server";
-import { canViewProposalSubmitterDetails } from "./proposal-access";
-export { canViewProposalSubmitterDetails } from "./proposal-access";
+import { canViewProposalSubmitterDetails, canWithdrawProposal } from "./proposal-access";
+export { canViewProposalSubmitterDetails, canWithdrawProposal } from "./proposal-access";
 import {
   EditConflictError,
   DuplicateSlugError,
@@ -745,4 +745,44 @@ export async function requestProposalChanges(
   );
   if (!finalized) throw new ProposalActionError("Proposal not found.", 404);
   return withEntityLabel(finalized);
+}
+
+export async function withdrawProposal(
+  id: number,
+  session: SessionUser | null,
+  submitterName?: string,
+) {
+  const proposal = await getProposalById(id);
+  if (!proposal) throw new ProposalActionError("Proposal not found.", 404);
+  if (!canWithdrawProposal(session, proposal, submitterName)) {
+    throw new ProposalActionError("Not allowed to withdraw this proposal.", 403);
+  }
+
+  const withdrawnBy =
+    session?.displayName || session?.username || proposal.submitterName;
+
+  const [updated] = await db
+    .update(editProposalsTable)
+    .set({
+      status: "withdrawn",
+      reviewedBy: withdrawnBy,
+      reviewedAt: sql`now()`,
+      adminNote: null,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(editProposalsTable.id, id),
+        inArray(editProposalsTable.status, [
+          "pending",
+          "needs_changes",
+        ] as const),
+      ),
+    )
+    .returning();
+
+  if (!updated) {
+    throw new ProposalActionError("This proposal is no longer open.", 409);
+  }
+  return withEntityLabel(updated);
 }

--- a/src/pages/api/proposals/[id]/withdraw.ts
+++ b/src/pages/api/proposals/[id]/withdraw.ts
@@ -1,0 +1,54 @@
+import type { APIRoute } from "astro";
+import { getEditorSession } from "@lib/admin/require-editor";
+import { validateSubmitterName } from "@constants/proposals";
+import {
+  ProposalActionError,
+  ProposalValidationError,
+  withdrawProposal,
+} from "@lib/services/proposal-service";
+
+export const prerender = false;
+
+type WithdrawBody = { submitterName?: string };
+
+export const POST: APIRoute = async ({ cookies, params, request }) => {
+  const id = Number(params.id);
+  if (!Number.isInteger(id)) {
+    return json({ error: "Invalid proposal ID" }, 400);
+  }
+
+  const session = getEditorSession(cookies);
+  const body = await request.json().catch(() => ({}) as WithdrawBody);
+  const submitterName =
+    session?.displayName ||
+    session?.username ||
+    (typeof body.submitterName === "string" ? body.submitterName : "");
+
+  if (!session) {
+    const validation = validateSubmitterName(submitterName);
+    if (!validation.ok) {
+      return json({ error: validation.error }, 400);
+    }
+  }
+
+  try {
+    const proposal = await withdrawProposal(id, session, submitterName);
+    return json({ success: true, proposal });
+  } catch (err) {
+    if (err instanceof ProposalValidationError) {
+      return json({ error: err.message }, 400);
+    }
+    if (err instanceof ProposalActionError) {
+      return json({ error: err.message }, err.status);
+    }
+    console.error("Failed to withdraw proposal:", err);
+    return json({ error: "Failed to withdraw proposal" }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Summary

Implements **#255 edge case 3** (withdraw pending proposal):

- Migration `0017_add_withdrawn_proposal_status.sql` adds `withdrawn` enum value
- `POST /api/proposals/:id/withdraw` for submitter (signed-in or anonymous name match)
- **Withdraw suggestion** button in entity editor panels when status is `pending` or `needs_changes`
- Same for open **Suggest addition** create proposals (building, room, etc.)

Withdrawn rows stay out of the admin queue (still lists `pending` / `needs_changes` only).

**Apply migration on Supabase before deploy:** `psql "$DATABASE_URL" -f drizzle/0017_add_withdrawn_proposal_status.sql`

Follows merged #477 (separate create_* rows) and #476 (building→room UX).

## Test plan

- [x] `bun test src/lib/services/proposal-access.test.ts`
- [x] `bun test src/lib/editor/field-action-label.test.ts`
- [ ] CI verify + E2E
- [ ] Manual: submit suggestion → Withdraw → gone from queue + localStorage ref cleared
- [ ] Manual: needs_changes proposal → withdraw works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API mutates proposal state and relies on submitter identity checks; requires DB migration before deploy, but scope is limited to open proposals and does not publish live data.
> 
> **Overview**
> Contributors can **withdraw** their own open suggestions (`pending` or `needs_changes`) instead of waiting on editors to clear them.
> 
> The PR adds a `withdrawn` `edit_proposal_status` value (migration `0017`), `canWithdrawProposal` / `withdrawProposal` in the service layer, and **`POST /api/proposals/:id/withdraw`** for signed-in submitters (by user id) or anonymous ones (matching `submitterName`). Withdrawn rows are not in the editor queue because listing still filters to `pending` / `needs_changes` only.
> 
> On the client, `withdrawEntityProposal` clears the matching `localStorage` ref; **Withdraw suggestion** appears in `EntityEditorPanel` (building, room, dorm flows) and **Withdraw pending suggestion** in `SuggestAdditionPanel` for open create proposals. Status copy now mentions withdraw for `needs_changes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75766b5f7999ee6f52b5d2e6201320f02908d996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->