### PR TITLE
release: Lighthouse a11y fix and audit doc

### DIFF
--- a/.cursor/skills/contributor-proposals/SKILL.md
+++ b/.cursor/skills/contributor-proposals/SKILL.md
@@ -62,7 +62,7 @@ Editors use shield menu → review queue:
 
 - `entity_id = 0`, `base_version = 0`.
 - Approved → `applyProposalPatch()` calls `createBuilding`, `createRoom`, etc. in `admin-service.ts`.
-- **Gap:** new building pending → rooms in that building blocked until approve ([#255](https://github.com/uplbtools/room-tba/issues/255)).
+- **Gap (v1 UX):** new building pending → room create form explains the wait and requires a live building picker ([#255](https://github.com/uplbtools/room-tba/issues/255)). Bundled building+rooms and dependency graph are follow-ups.
 
 ## Known edge cases (check before closing issues)
 

--- a/.cursor/skills/contributor-proposals/SKILL.md
+++ b/.cursor/skills/contributor-proposals/SKILL.md
@@ -67,7 +67,7 @@ Editors use shield menu → review queue:
 ## Known edge cases (check before closing issues)
 
 - Revise pending: merge patch if same submitter + open status; anonymous needs same browser/`proposalId`.
-- Multiple pending `create_*` from one logged-in user may collide on `(entity_type, entity_id=0)`.
+- Multiple pending `create_*` from one logged-in user may collide on `(entity_type, entity_id=0)` — fixed: create merges only via explicit `proposalId` ([#255](https://github.com/uplbtools/room-tba/issues/255) PR pending).
 - No **withdraw** API yet.
 - Contributor credit on approve: proposal row only today; ledger is [#450](https://github.com/uplbtools/room-tba/issues/450).
 

--- a/.cursor/skills/contributor-proposals/SKILL.md
+++ b/.cursor/skills/contributor-proposals/SKILL.md
@@ -68,7 +68,7 @@ Editors use shield menu → review queue:
 
 - Revise pending: merge patch if same submitter + open status; anonymous needs same browser/`proposalId`.
 - Multiple pending `create_*` from one logged-in user may collide on `(entity_type, entity_id=0)` — fixed: create merges only via explicit `proposalId` ([#255](https://github.com/uplbtools/room-tba/issues/255) PR pending).
-- No **withdraw** API yet.
+- **Withdraw:** contributor `POST /api/proposals/:id/withdraw` sets status `withdrawn` (pending / needs_changes only).
 - Contributor credit on approve: proposal row only today; ledger is [#450](https://github.com/uplbtools/room-tba/issues/450).
 
 ## Tests (same PR as code)

--- a/docs/lighthouse-audit-2026-07-04.md
+++ b/docs/lighthouse-audit-2026-07-04.md
@@ -1,0 +1,53 @@
+# Lighthouse audit — top 10 Vercel apps (2026-07-04)
+
+Audit of the ten most recently updated production Vercel projects under `stimmie`, ranked by deployment recency. Raw Lighthouse JSON was captured to `/tmp/lighthouse-audits/` during the agent session.
+
+## Baseline scores (production, pre-fix)
+
+| Project | URL | Perf | A11y | BP | SEO |
+| --- | --- | ---: | ---: | ---: | ---: |
+| room-tba | room-tba.uplbtools.me | 32 | 90 | 96 | 100 |
+| uplbtools-me | www.uplbtools.me | 65 | 93 | 100 | 100 |
+| web-mobile | web.stimmie.dev | 71 | 100 | 96 | 100 |
+| stimmie-dev | www.stimmie.dev | 79 | 96 | 96 | 100 |
+| crib | crib.stimmie.dev | 74 | 98 | 100 | 100 |
+| hearthcraft | www.hearthcraft.net | 75 | 98 | 100 | 100 |
+| tutorial | tutor.stimmie.dev | 85 | 92 | 96 | 100 |
+| portal | portal-five-drab.vercel.app | 84 | 94 | 100 | 100 |
+| math-mock | math-mock-one.vercel.app | 89 | 94 | 100 | 100 |
+| freshie-guide | guide.stimmie.dev | 91 | 96 | 100 | 100 |
+
+## Shipped in this pass (2026-07-04)
+
+| Repo | Commit scope | Production path |
+| --- | --- | --- |
+| uplbtools/room-tba | Search ARIA (`aria-haspopup` vs invalid `aria-expanded` on `searchbox`) | `staging` → `main` |
+| uplbtools/uplbtools.me | Contrast, heading order, hero image dimensions | `main` |
+| smmariquit/web-mobile | Image dimensions, prerender `/projects/*` routes | `main` |
+| smmariquit/stimmie.dev | UTC marquee dates, divider contrast, scrapbook CLS reserve | `main` |
+| smmariquit/the-crib | `<main>` landmark | `main` |
+| smmariquit/hearthcraft | `<main>` landmark in root layout | `main` |
+| smmariquit/tutorials | `<main>` landmark, remove broken insights script, headings/contrast | `main` |
+| smmariquit/freshie-guide | Heading order (`h2` guide titles) | `main` |
+| smmariquit/math-mock | `<main>` landmark, contrast | `main` |
+| smmariquit/curriculum | `<main>` landmark, footer link underline | `main` |
+
+## Deferred — tracked as GitHub issues
+
+| Area | Issue |
+| --- | --- |
+| room-tba map/PGlite TBT & perf score | [#482](https://github.com/uplbtools/room-tba/issues/482) |
+| LCP & image delivery | [uplbtools.me#3](https://github.com/uplbtools/uplbtools.me/issues/3), [the-crib#2](https://github.com/smmariquit/the-crib/issues/2), [hearthcraft#8](https://github.com/smmariquit/hearthcraft/issues/8) |
+| Render-blocking CSS / unused JS | [web-mobile#2](https://github.com/smmariquit/web-mobile/issues/2), [stimmie.dev#20](https://github.com/smmariquit/stimmie.dev/issues/20), [tutorials#6](https://github.com/smmariquit/tutorials/issues/6) |
+
+Re-run after deploy:
+
+```sh
+npx lighthouse https://room-tba.uplbtools.me --view
+```
+
+## Notes
+
+- **room-tba perf (32)** in headless Lighthouse is partly environmental: WebGL init fails without GPU; real-user perf still needs bundle/code-split work ([#482](https://github.com/uplbtools/room-tba/issues/482)).
+- **web-mobile** `_payload.json` 404 on prefetched project routes required explicit Nitro prerender routes for `/projects/:slug`.
+- **tutorial** hard-coded `/_vercel/insights/script.js` 404s when Web Analytics is not enabled on the Vercel project; removed in favor of optional `@vercel/analytics` if needed later.

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -7,38 +7,39 @@ bun run generate:test-inventory
 ```
 
 **Last generated:** 2026-07-03  
-**Total spec files:** 104
+**Total spec files:** 106
 
 See [testing.md](testing.md) for commands, CI gates, and databases. Issue-linked expectations: [issue-test-matrix.md](issue-test-matrix.md).
 
 ## Summary by tier
 
-| Command                    | Config / runner                         | Files    |
-| -------------------------- | --------------------------------------- | -------- |
-| `bun test src`             | Bun — unit (`src/lib`, `src/constants`) | 42       |
-| `bun run test:components`  | Vitest — stores + Svelte @320px         | 17       |
-| `bun run test:integration` | Bun — HTTP + services (E2E DB)          | 5        |
-| `bun run e2e`              | Playwright blocking — local preview     | 26       |
-| `bun run e2e:advisory`     | Playwright advisory — non-blocking CI   | 11       |
-| `bun run e2e:staging`      | Playwright — live staging URL           | 3        |
-| `bun run check:migrations` | Schema table guard (not a spec file)    | 1 script |
+| Command | Config / runner | Files |
+| ------- | ---------------- | ----- |
+| `bun test src` | Bun — unit (`src/lib`, `src/constants`) | 43 |
+| `bun run test:components` | Vitest — stores + Svelte @320px | 17 |
+| `bun run test:integration` | Bun — HTTP + services (E2E DB) | 5 |
+| `bun run e2e` | Playwright blocking — local preview | 26 |
+| `bun run e2e:advisory` | Playwright advisory — non-blocking CI | 11 |
+| `bun run e2e:staging` | Playwright — live staging URL | 3 |
+| `bun run check:migrations` | Schema table guard (not a spec file) | 1 script |
+
 
 ## CI mapping
 
-| Workflow                                                                      | What runs                                                |
-| ----------------------------------------------------------------------------- | -------------------------------------------------------- |
-| [ci.yml](../.github/workflows/ci.yml)                                         | `bun test src`, `test:components`, lint, prod build      |
-| [ci.yml](../.github/workflows/ci.yml) migrations job                          | `check:migrations` on E2E DB                             |
-| [e2e.yml](../.github/workflows/e2e.yml)                                       | reset DB → build:e2e → integration → Playwright blocking |
-| [e2e-advisory.yml](../.github/workflows/e2e-advisory.yml)                     | Playwright advisory                                      |
-| [e2e-staging.yml](../.github/workflows/e2e-staging.yml)                       | Same blocking stack on `staging` branch + nightly        |
-| [staging-smoke.yml](../.github/workflows/staging-smoke.yml)                   | Read-only staging Playwright (subset)                    |
-| [bundle-advisory.yml](../.github/workflows/bundle-advisory.yml)               | JS bundle budget                                         |
-| [discord-test-inventory.yml](../.github/workflows/discord-test-inventory.yml) | Refresh #test-suite on Discord                           |
+| Workflow | What runs |
+| -------- | --------- |
+| [ci.yml](../.github/workflows/ci.yml) | `bun test src`, `test:components`, lint, prod build |
+| [ci.yml](../.github/workflows/ci.yml) migrations job | `check:migrations` on E2E DB |
+| [e2e.yml](../.github/workflows/e2e.yml) | reset DB → build:e2e → integration → Playwright blocking |
+| [e2e-advisory.yml](../.github/workflows/e2e-advisory.yml) | Playwright advisory |
+| [e2e-staging.yml](../.github/workflows/e2e-staging.yml) | Same blocking stack on `staging` branch + nightly |
+| [staging-smoke.yml](../.github/workflows/staging-smoke.yml) | Read-only staging Playwright (subset) |
+| [bundle-advisory.yml](../.github/workflows/bundle-advisory.yml) | JS bundle budget |
+| [discord-test-inventory.yml](../.github/workflows/discord-test-inventory.yml) | Refresh #test-suite on Discord |
 
 Playwright **blocking** uses [playwright.config.ts](../playwright.config.ts) (`testDir: e2e`, ignores `advisory/` + `staging/`). Projects: **desktop-chrome**, **mobile-chrome** (skips `@desktop-only`).
 
-## Unit tests (Bun) — 42 files
+## Unit tests (Bun) — 43 files
 
 `bun test src/lib src/constants` (excludes `*.store.test.ts`).
 
@@ -69,6 +70,7 @@ Playwright **blocking** uses [playwright.config.ts](../playwright.config.ts) (`t
 - `src/lib/landing-modal-auto-open.test.ts`
 - `src/lib/map-chrome.test.ts`
 - `src/lib/notifications/notifications.test.ts`
+- `src/lib/notifications/proposal-events.test.ts`
 - `src/lib/proposals/client.test.ts`
 - `src/lib/r2-upload.test.ts`
 - `src/lib/route-slugs.test.ts`
@@ -85,6 +87,7 @@ Playwright **blocking** uses [playwright.config.ts](../playwright.config.ts) (`t
 - `src/lib/term-calendar.test.ts`
 - `src/lib/term-url.test.ts`
 
+
 ## Store tests (Vitest) — 7 files
 
 Included in `bun run test:components`.
@@ -96,6 +99,7 @@ Included in `bun run test:components`.
 - `src/lib/stores/map-stores.store.test.ts`
 - `src/lib/stores/schedule-route.store.test.ts`
 - `src/lib/stores/sync-stores.store.test.ts`
+
 
 ## Component tests (Vitest) — 10 files
 
@@ -112,6 +116,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `src/components/svelte/status-bar/StatusBarLinkGroups.component.test.ts`
 - `src/test/map-chrome-layout.component.test.ts`
 
+
 ## Integration tests — 5 files
 
 `bun run test:integration` (E2E Supabase; HTTP suites need preview — use `test:integration:live`).
@@ -121,6 +126,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `integration/services/admin.integration.test.ts`
 - `integration/services/merge.integration.test.ts`
 - `integration/services/proposals.integration.test.ts`
+
 
 ## E2E blocking (Playwright) — 26 files
 
@@ -133,6 +139,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/smoke/redirects.spec.ts`
 - `e2e/smoke/term-classes.spec.ts`
 
+
 ### Browse (9)
 
 - `e2e/browse/building-filters.spec.ts`
@@ -144,6 +151,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/browse/search-collapse.spec.ts`
 - `e2e/browse/search-flow.spec.ts`
 - `e2e/browse/side-panel.spec.ts`
+
 
 ### Admin / editor (13)
 
@@ -161,6 +169,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/admin/room-edit.spec.ts`
 - `e2e/admin/undo-redo.spec.ts`
 
+
 ## E2E advisory (Playwright) — 11 files
 
 `bun run e2e:advisory` — a11y, offline, touch, cross-browser, etc.
@@ -177,6 +186,7 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/advisory/schedule-import.spec.ts`
 - `e2e/advisory/transit-jeepney.spec.ts`
 
+
 ## E2E staging (Playwright) — 3 files
 
 `bun run e2e:staging` — read-only against `staging.room-tba.uplbtools.me`.
@@ -185,14 +195,15 @@ Layout guards at 320px / 768px where noted. Included in `bun run test:components
 - `e2e/staging/live-boot.spec.ts`
 - `e2e/staging/live-browse.spec.ts`
 
+
 ## Other checks
 
-| Script                     | Purpose                        |
-| -------------------------- | ------------------------------ |
+| Script | Purpose |
+| ------ | ------- |
 | `bun run check:migrations` | Required Postgres tables exist |
-| `bun run check:readme`     | README onboarding facts        |
-| `bun run check:pwa-legal`  | PWA legal routes               |
-| `bun run check:bundle`     | Client JS budget (advisory CI) |
+| `bun run check:readme` | README onboarding facts |
+| `bun run check:pwa-legal` | PWA legal routes |
+| `bun run check:bundle` | Client JS budget (advisory CI) |
 
 ## Manual only (not in this list)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -110,6 +110,6 @@ bun run generate:issue-test-matrix
 bun run generate:test-inventory
 ```
 
-**Discord `#test-suite`:** CI posts a pinned, auto-updated inventory (embed + `test-inventory.md` attachment) via [discord-test-inventory.yml](../.github/workflows/discord-test-inventory.yml). Local dry-run: `GATEWAY_URL=… SECRET=… bun run post:test-inventory-discord`.
+**Discord `#test-suite`:** CI posts a pinned, auto-updated inventory (summary embed + tier embeds with full file lists) via [discord-test-inventory.yml](../.github/workflows/discord-test-inventory.yml). Local dry-run: `GATEWAY_URL=… SECRET=… bun run post:test-inventory-discord`.
 
 Agent policy: [AGENTS.md § Tests with GitHub issues](../AGENTS.md#tests-with-github-issues).

--- a/drizzle/0017_add_withdrawn_proposal_status.sql
+++ b/drizzle/0017_add_withdrawn_proposal_status.sql
@@ -1,0 +1,5 @@
+DO $$ BEGIN
+  ALTER TYPE "edit_proposal_status" ADD VALUE 'withdrawn';
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -46,6 +46,7 @@ export const editProposalStatusEnum = pgEnum("edit_proposal_status", [
   "approved",
   "rejected",
   "needs_changes",
+  "withdrawn",
 ]);
 
 // Academic terms. `id` mirrors the CRS/SAIS term_id (e.g. 1252) rather than

--- a/scripts/lib/test-inventory.test.ts
+++ b/scripts/lib/test-inventory.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type TestInventory,
+  testInventoryDiscordTiers,
+} from "./test-inventory.ts";
+
+function sampleInventory(
+  overrides: Partial<TestInventory> = {},
+): TestInventory {
+  return {
+    generated: "2026-07-03",
+    total: 6,
+    unit: ["src/lib/foo.test.ts"],
+    store: ["src/lib/bar.store.test.ts"],
+    component: ["src/test/layout.component.test.ts"],
+    integration: ["integration/http/public.integration.test.ts"],
+    e2eBlocking: [
+      "e2e/smoke/boot.spec.ts",
+      "e2e/browse/search-flow.spec.ts",
+      "e2e/admin/auth.spec.ts",
+      "e2e/helpers/db.ts",
+    ],
+    e2eAdvisory: ["e2e/advisory/a11y.spec.ts"],
+    e2eStaging: ["e2e/staging/live-boot.spec.ts"],
+    ...overrides,
+  };
+}
+
+describe("testInventoryDiscordTiers", () => {
+  test("splits blocking E2E by smoke, browse, and admin folders", () => {
+    const tiers = testInventoryDiscordTiers(sampleInventory());
+
+    expect(tiers.unit).toEqual(["src/lib/foo.test.ts"]);
+    expect(tiers.store).toEqual(["src/lib/bar.store.test.ts"]);
+    expect(tiers.component).toEqual(["src/test/layout.component.test.ts"]);
+    expect(tiers.integration).toEqual([
+      "integration/http/public.integration.test.ts",
+    ]);
+    expect(tiers.e2eBlockingSmoke).toEqual(["e2e/smoke/boot.spec.ts"]);
+    expect(tiers.e2eBlockingBrowse).toEqual(["e2e/browse/search-flow.spec.ts"]);
+    expect(tiers.e2eBlockingAdmin).toEqual([
+      "e2e/admin/auth.spec.ts",
+      "e2e/helpers/db.ts",
+    ]);
+    expect(tiers.e2eAdvisory).toEqual(["e2e/advisory/a11y.spec.ts"]);
+    expect(tiers.e2eStaging).toEqual(["e2e/staging/live-boot.spec.ts"]);
+  });
+
+  test("returns empty arrays when a tier has no files", () => {
+    const tiers = testInventoryDiscordTiers(
+      sampleInventory({
+        store: [],
+        component: [],
+        e2eAdvisory: [],
+        e2eStaging: [],
+      }),
+    );
+
+    expect(tiers.store).toEqual([]);
+    expect(tiers.component).toEqual([]);
+    expect(tiers.e2eAdvisory).toEqual([]);
+    expect(tiers.e2eStaging).toEqual([]);
+  });
+});

--- a/scripts/lib/test-inventory.ts
+++ b/scripts/lib/test-inventory.ts
@@ -63,6 +63,44 @@ export async function scanTestInventory(root: string): Promise<TestInventory> {
   };
 }
 
+export type TestInventoryDiscordTiers = {
+  unit: string[];
+  store: string[];
+  component: string[];
+  integration: string[];
+  e2eBlockingSmoke: string[];
+  e2eBlockingBrowse: string[];
+  e2eBlockingAdmin: string[];
+  e2eAdvisory: string[];
+  e2eStaging: string[];
+};
+
+/** File lists per tier for Discord embed payloads. */
+export function testInventoryDiscordTiers(
+  inv: TestInventory,
+): TestInventoryDiscordTiers {
+  const smoke: string[] = [];
+  const browse: string[] = [];
+  const admin: string[] = [];
+  for (const f of inv.e2eBlocking) {
+    if (f.includes("/smoke/")) smoke.push(f);
+    else if (f.includes("/browse/")) browse.push(f);
+    else if (f.includes("/admin/")) admin.push(f);
+    else admin.push(f);
+  }
+  return {
+    unit: inv.unit,
+    store: inv.store,
+    component: inv.component,
+    integration: inv.integration,
+    e2eBlockingSmoke: smoke,
+    e2eBlockingBrowse: browse,
+    e2eBlockingAdmin: admin,
+    e2eAdvisory: inv.e2eAdvisory,
+    e2eStaging: inv.e2eStaging,
+  };
+}
+
 function mdList(files: string[]): string {
   if (files.length === 0) return "_None_\n";
   return files.map((f) => `- \`${f}\``).join("\n") + "\n";

--- a/scripts/post-test-inventory-discord.ts
+++ b/scripts/post-test-inventory-discord.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import {
   renderTestInventoryMarkdown,
   scanTestInventory,
+  testInventoryDiscordTiers,
 } from "./lib/test-inventory.ts";
 
 const ROOT = path.join(import.meta.dir, "..");
@@ -22,6 +23,7 @@ async function main() {
 
   const inv = await scanTestInventory(ROOT);
   const markdown = renderTestInventoryMarkdown(inv);
+  const tiers = testInventoryDiscordTiers(inv);
   writeFileSync(OUT, markdown);
 
   const repo = process.env.GITHUB_REPOSITORY ?? "uplbtools/room-tba";
@@ -58,7 +60,7 @@ async function main() {
       e2eBlocking: inv.e2eBlocking.length,
       e2eAdvisory: inv.e2eAdvisory.length,
       e2eStaging: inv.e2eStaging.length,
-      markdown,
+      tiers,
     },
   };
 

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -11,6 +11,8 @@
     resolveSubmitterName,
     publishEntityCreate,
     submitCreateProposal,
+    getStoredPendingCreateProposal,
+    fetchPublicProposalSummary,
     type ProposalCreateType,
   } from "@lib/proposals/client";
   import { validateSubmitterName } from "@constants/proposals";
@@ -83,15 +85,35 @@
   let dormGender = $state("coed");
   let roomCode = $state("");
   let roomDirections = $state("");
+  let roomBuildingDraft = $state("");
   let collegeName = $state("");
   let divisionCollegeDraft = $state("");
   let divisionName = $state("");
   let submitting = $state(false);
   let error = $state<string | null>(null);
   let draftReady = $state(false);
+  let pendingBuildingLabel = $state<string | null>(null);
 
   const appData = getAppData();
   const colleges = $derived(appData().loaded ? appData().colleges : []);
+  const buildings = $derived(
+    appData().loaded
+      ? [...appData().buildings].sort((a, b) =>
+          a.buildingName.localeCompare(b.buildingName),
+        )
+      : [],
+  );
+
+  const roomBuildingNotice = $derived.by(() => {
+    if (kind !== "create_room" || isPublish) return null;
+    if (pendingBuildingLabel) {
+      return `Your building suggestion "${pendingBuildingLabel}" is still waiting for editor review. You can add rooms in that building after it is approved and appears on the map.`;
+    }
+    if (buildings.length === 0) {
+      return "Rooms must belong to a building that is already on the map. Suggest a building first, then come back to add rooms after editors approve it.";
+    }
+    return "Rooms must belong to a building that is already on the map. Pick one below, or open a building in the side panel and use Suggest an edit on an existing room.";
+  });
 
   const needsPin = $derived(
     kind === "create_building" ||
@@ -115,6 +137,7 @@
     dormGender = "coed";
     roomCode = "";
     roomDirections = "";
+    roomBuildingDraft = "";
     collegeName = "";
     divisionCollegeDraft = "";
     divisionName = "";
@@ -136,6 +159,7 @@
       dormGender,
       roomCode,
       roomDirections,
+      roomBuildingDraft,
       collegeName,
       divisionCollegeDraft,
       divisionName,
@@ -159,6 +183,7 @@
     dormGender = saved.dormGender;
     roomCode = saved.roomCode;
     roomDirections = saved.roomDirections;
+    roomBuildingDraft = saved.roomBuildingDraft ?? "";
     collegeName = saved.collegeName;
     divisionCollegeDraft = saved.divisionCollegeDraft;
     divisionName = saved.divisionName;
@@ -167,9 +192,24 @@
     }
   }
 
+  async function refreshPendingBuildingLabel() {
+    pendingBuildingLabel = null;
+    const pending = getStoredPendingCreateProposal("create_building");
+    if (!pending) return;
+    const summary = await fetchPublicProposalSummary(pending.id);
+    pendingBuildingLabel = summary?.entityLabel ?? "New building";
+  }
+
   onMount(() => {
     if (!isPublish) restoreAdditionDraft();
     draftReady = true;
+    void refreshPendingBuildingLabel();
+  });
+
+  $effect(() => {
+    if (kind === "create_room" && !isPublish) {
+      void refreshPendingBuildingLabel();
+    }
   });
 
   $effect(() => {
@@ -187,6 +227,7 @@
     dormGender;
     roomCode;
     roomDirections;
+    roomBuildingDraft;
     collegeName;
     divisionCollegeDraft;
     divisionName;
@@ -301,6 +342,7 @@
         return {
           roomCode: roomCode.trim(),
           directions: roomDirections.trim() || null,
+          buildingId: Number(roomBuildingDraft),
         };
       case "create_college":
         return { collegeName: collegeName.trim() };
@@ -338,6 +380,13 @@
     if (kind === "create_room" && !roomCode.trim()) {
       error = "Room code is required.";
       return;
+    }
+    if (kind === "create_room") {
+      const buildingId = Number(roomBuildingDraft);
+      if (!Number.isInteger(buildingId) || buildingId < 1) {
+        error = "Pick the building this room belongs to.";
+        return;
+      }
     }
     if (kind === "create_dorm" && !dormName.trim()) {
       error = "Dorm name is required.";
@@ -385,7 +434,15 @@
         error = result.error ?? "Could not submit proposal.";
         return;
       }
-      toastStore.show("Thanks. We'll review your suggestion soon.", "success");
+      if (kind === "create_building") {
+        toastStore.show(
+          "Thanks. We will review your building suggestion soon. You can add rooms in that building after editors approve it.",
+          "success",
+        );
+        await refreshPendingBuildingLabel();
+      } else {
+        toastStore.show("Thanks. We'll review your suggestion soon.", "success");
+      }
       clearSuggestAdditionDraft();
       resetFields();
       dismissHost();
@@ -566,6 +623,31 @@
         {/snippet}
       </EntityEditorFormField>
     {:else if kind === "create_room"}
+      {#if roomBuildingNotice}
+        <EntityEditorMessage variant="pending" message={roomBuildingNotice} />
+      {/if}
+      <EntityEditorFormField
+        label="Which building is it in?"
+        inputId="addition-room-building"
+        hint="Only buildings already on the map appear here."
+      >
+        {#snippet control()}
+          <select
+            id="addition-room-building"
+            bind:value={roomBuildingDraft}
+            disabled={buildings.length === 0}
+          >
+            <option value="">
+              {buildings.length === 0
+                ? "No buildings on the map yet"
+                : "Select a building"}
+            </option>
+            {#each buildings as building (building.id)}
+              <option value={String(building.id)}>{building.buildingName}</option>
+            {/each}
+          </select>
+        {/snippet}
+      </EntityEditorFormField>
       <EntityEditorFormField
         label="Room number or code"
         inputId="addition-room-code"

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -13,8 +13,10 @@
     submitCreateProposal,
     getStoredPendingCreateProposal,
     fetchPublicProposalSummary,
+    withdrawEntityProposal,
     type ProposalCreateType,
   } from "@lib/proposals/client";
+  import { canShowWithdrawProposal } from "@lib/editor/field-action-label";
   import { validateSubmitterName } from "@constants/proposals";
   import { instantToCampusWallString } from "@lib/event-time";
   import { slugifySegment } from "@lib/site";
@@ -93,6 +95,9 @@
   let error = $state<string | null>(null);
   let draftReady = $state(false);
   let pendingBuildingLabel = $state<string | null>(null);
+  let pendingCreateProposalId = $state<number | null>(null);
+  let pendingCreateStatus = $state<string | null>(null);
+  let withdrawingCreate = $state(false);
 
   const appData = getAppData();
   const colleges = $derived(appData().loaded ? appData().colleges : []);
@@ -192,24 +197,62 @@
     }
   }
 
-  async function refreshPendingBuildingLabel() {
+  async function refreshPendingCreateProposal() {
+    pendingCreateProposalId = null;
+    pendingCreateStatus = null;
     pendingBuildingLabel = null;
-    const pending = getStoredPendingCreateProposal("create_building");
-    if (!pending) return;
-    const summary = await fetchPublicProposalSummary(pending.id);
-    pendingBuildingLabel = summary?.entityLabel ?? "New building";
+
+    if (isPublish) return;
+
+    const pendingForKind = getStoredPendingCreateProposal(kind);
+    if (pendingForKind) {
+      pendingCreateProposalId = pendingForKind.id;
+      pendingCreateStatus = pendingForKind.status;
+    }
+
+    if (kind === "create_room") {
+      const pendingBuilding = getStoredPendingCreateProposal("create_building");
+      if (!pendingBuilding) return;
+      const summary = await fetchPublicProposalSummary(pendingBuilding.id);
+      pendingBuildingLabel = summary?.entityLabel ?? "New building";
+    }
+  }
+
+  async function withdrawPendingCreate() {
+    if (!pendingCreateProposalId) return;
+    error = null;
+    withdrawingCreate = true;
+    try {
+      const name = resolveSubmitterName({
+        displayName: adminAuthStore.displayName,
+        username: adminAuthStore.username,
+        draftName: submitterName,
+      });
+      const result = await withdrawEntityProposal({
+        proposalId: pendingCreateProposalId,
+        submitterName: name || undefined,
+      });
+      if (!result.ok) {
+        error = result.error ?? "Could not withdraw suggestion.";
+        return;
+      }
+      toastStore.show("Suggestion withdrawn.", "success");
+      await refreshPendingCreateProposal();
+    } finally {
+      withdrawingCreate = false;
+    }
   }
 
   onMount(() => {
     if (!isPublish) restoreAdditionDraft();
     draftReady = true;
-    void refreshPendingBuildingLabel();
+    void refreshPendingCreateProposal();
   });
 
   $effect(() => {
-    if (kind === "create_room" && !isPublish) {
-      void refreshPendingBuildingLabel();
-    }
+    if (isPublish || !draftReady) return;
+    kind;
+    void refreshPendingCreateProposal();
   });
 
   $effect(() => {
@@ -442,7 +485,7 @@
           "Thanks. We will review your building suggestion soon. You can add rooms in that building after editors approve it.",
           "success",
         );
-        await refreshPendingBuildingLabel();
+        await refreshPendingCreateProposal();
       } else {
         toastStore.show("Thanks. We'll review your suggestion soon.", "success");
       }
@@ -739,6 +782,18 @@
 
   {#if error}
     <EntityEditorMessage variant="error" message={error} />
+  {/if}
+
+  {#if !isPublish && pendingCreateProposalId && canShowWithdrawProposal(pendingCreateStatus)}
+    <div class="entity-editor-form-actions">
+      <EntityEditorSubmitButton
+        label="Withdraw pending suggestion"
+        savingLabel="Withdrawing…"
+        saving={withdrawingCreate}
+        variant="secondary"
+        onclick={withdrawPendingCreate}
+      />
+    </div>
   {/if}
 
   <EntityEditorSubmitButton

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -425,10 +425,13 @@
         username: adminAuthStore.username,
         draftName: submitterName,
       })!;
+      const pendingCreate = getStoredPendingCreateProposal(kind);
       const result = await submitCreateProposal({
         entityType: kind,
         patch,
         submitterName: name,
+        proposalId:
+          pendingCreate?.status === "needs_changes" ? pendingCreate.id : null,
       });
       if (!result.ok) {
         error = result.error ?? "Could not submit proposal.";

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -445,6 +445,11 @@
           submitterNameId="building-submitter-name"
           bind:submitterName={submitterNameDraft}
           {proposalStatus}
+          activeProposalId={activeProposalId}
+          onWithdrawn={() => {
+            activeProposalId = null;
+            proposalStatus = null;
+          }}
           successMessage={savedField
             ? entityEditorSavedMessage({
                 canPublish,

--- a/src/components/svelte/controls/DormEditorPanel.svelte
+++ b/src/components/svelte/controls/DormEditorPanel.svelte
@@ -34,6 +34,8 @@
     savedField: DormEditableField | null;
     fieldError: string | null;
     proposalStatus: string | null;
+    activeProposalId?: number | null;
+    onWithdrawn?: () => void;
     submitterNameDraft?: string;
     nameDraft: string;
     shortNameDraft: string;
@@ -61,6 +63,8 @@
     savedField,
     fieldError,
     proposalStatus,
+    activeProposalId = null,
+    onWithdrawn,
     submitterNameDraft = $bindable(""),
     nameDraft = $bindable(""),
     shortNameDraft = $bindable(""),
@@ -90,6 +94,8 @@
   submitterNameId="dorm-submitter-name"
   bind:submitterName={submitterNameDraft}
   {proposalStatus}
+  {activeProposalId}
+  {onWithdrawn}
   successMessage={savedField
     ? entityEditorSavedMessage({
         canPublish,

--- a/src/components/svelte/controls/DormResult.svelte
+++ b/src/components/svelte/controls/DormResult.svelte
@@ -593,6 +593,11 @@
           {savedField}
           {fieldError}
           {proposalStatus}
+          activeProposalId={activeProposalId}
+          onWithdrawn={() => {
+            activeProposalId = null;
+            proposalStatus = null;
+          }}
           bind:submitterNameDraft
           bind:nameDraft
           bind:shortNameDraft

--- a/src/components/svelte/editor/EntityEditorPanel.svelte
+++ b/src/components/svelte/editor/EntityEditorPanel.svelte
@@ -2,7 +2,13 @@
   import type { Snippet } from "svelte";
   import SubmitterNameField from "@ui/SubmitterNameField.svelte";
   import EntityEditorMessage from "./EntityEditorMessage.svelte";
-  import { proposalStatusMessage } from "@lib/editor/field-action-label";
+  import EntityEditorSubmitButton from "./EntityEditorSubmitButton.svelte";
+  import {
+    canShowWithdrawProposal,
+    proposalStatusMessage,
+  } from "@lib/editor/field-action-label";
+  import { withdrawEntityProposal } from "@lib/proposals/client";
+  import { toastStore } from "@lib/store.svelte";
   import "./entity-editor.css";
 
   type Props = {
@@ -11,6 +17,8 @@
     submitterNameId: string;
     submitterName?: string;
     proposalStatus?: string | null;
+    activeProposalId?: number | null;
+    onWithdrawn?: () => void;
     successMessage?: string | null;
     errorMessage?: string | null;
     children?: Snippet;
@@ -22,10 +30,35 @@
     submitterNameId,
     submitterName = $bindable(""),
     proposalStatus = null,
+    activeProposalId = null,
+    onWithdrawn,
     successMessage = null,
     errorMessage = null,
     children,
   }: Props = $props();
+
+  let withdrawing = $state(false);
+  let withdrawError = $state<string | null>(null);
+
+  async function withdrawSuggestion() {
+    if (!activeProposalId || canPublish) return;
+    withdrawError = null;
+    withdrawing = true;
+    try {
+      const result = await withdrawEntityProposal({
+        proposalId: activeProposalId,
+        submitterName: submitterName.trim() || undefined,
+      });
+      if (!result.ok) {
+        withdrawError = result.error ?? "Could not withdraw suggestion.";
+        return;
+      }
+      toastStore.show("Suggestion withdrawn.", "success");
+      onWithdrawn?.();
+    } finally {
+      withdrawing = false;
+    }
+  }
 </script>
 
 <div class="entity-editor-panel" class:contributor-form={!canPublish}>
@@ -44,7 +77,23 @@
     />
   {/if}
 
+  {#if !canPublish && activeProposalId && canShowWithdrawProposal(proposalStatus)}
+    <div class="entity-editor-form-actions">
+      <EntityEditorSubmitButton
+        label="Withdraw suggestion"
+        savingLabel="Withdrawing…"
+        saving={withdrawing}
+        variant="secondary"
+        onclick={withdrawSuggestion}
+      />
+    </div>
+  {/if}
+
   {@render children?.()}
+
+  {#if withdrawError}
+    <EntityEditorMessage variant="error" message={withdrawError} />
+  {/if}
 
   {#if successMessage}
     <EntityEditorMessage variant="success" message={successMessage} />

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -445,6 +445,11 @@
           submitterNameId="room-submitter-name"
           bind:submitterName={submitterNameDraft}
           {proposalStatus}
+          activeProposalId={activeProposalId}
+          onWithdrawn={() => {
+            activeProposalId = null;
+            proposalStatus = null;
+          }}
           successMessage={savedField
             ? entityEditorSavedMessage({
                 canPublish,

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -297,9 +297,9 @@
                 onblur={() => {
                   searchFocused = false;
                 }}
-                aria-expanded={showSearchDropdown}
                 aria-controls="search-suggestions"
                 aria-autocomplete="list"
+                aria-haspopup="listbox"
                 placeholder="Search room, building, dorm, event, division..."
               />
               {#if draftInput !== "" || queryStore.category !== null}

--- a/src/lib/contributor-drafts.ts
+++ b/src/lib/contributor-drafts.ts
@@ -31,6 +31,7 @@ export type SuggestAdditionDraft = {
   dormGender: string;
   roomCode: string;
   roomDirections: string;
+  roomBuildingDraft: string;
   collegeName: string;
   divisionCollegeDraft: string;
   divisionName: string;

--- a/src/lib/editor/field-action-label.test.ts
+++ b/src/lib/editor/field-action-label.test.ts
@@ -46,7 +46,7 @@ describe("editorToggleLabel", () => {
 describe("proposalStatusMessage", () => {
   test("formats pending statuses", () => {
     expect(proposalStatusMessage("needs_changes")).toBe(
-      "Status: needs changes. Waiting for editor review.",
+      "Status: needs changes. Update your suggestion below or withdraw it.",
     );
   });
 });

--- a/src/lib/editor/field-action-label.ts
+++ b/src/lib/editor/field-action-label.ts
@@ -24,7 +24,22 @@ export function editorToggleLabel(options: {
 }
 
 export function proposalStatusMessage(status: string): string {
-  return `Status: ${status.replace("_", " ")}. Waiting for editor review.`;
+  switch (status) {
+    case "pending":
+      return "Status: pending. Waiting for editor review.";
+    case "needs_changes":
+      return "Status: needs changes. Update your suggestion below or withdraw it.";
+    case "withdrawn":
+      return "You withdrew this suggestion.";
+    default:
+      return `Status: ${status.replaceAll("_", " ")}.`;
+  }
+}
+
+export function canShowWithdrawProposal(
+  status: string | null | undefined,
+): boolean {
+  return status === "pending" || status === "needs_changes";
 }
 
 export function entityEditorSavedMessage(options: {

--- a/src/lib/proposals/client.test.ts
+++ b/src/lib/proposals/client.test.ts
@@ -1,11 +1,63 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { publishEntityPatch } from "./client";
+import {
+  getStoredPendingCreateProposal,
+  publishEntityPatch,
+  readStoredProposals,
+  rememberProposal,
+} from "./client";
 
 const originalFetch = globalThis.fetch;
+const storage = new Map<string, string>();
+
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storage.set(key, value);
+  },
+  removeItem: (key: string) => {
+    storage.delete(key);
+  },
+  clear: () => {
+    storage.clear();
+  },
+  key: () => null,
+  length: 0,
+} as Storage;
+
+if (typeof globalThis.localStorage === "undefined") {
+  globalThis.localStorage = localStorageMock;
+}
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   mock.restore();
+  storage.clear();
+});
+
+describe("stored proposal refs", () => {
+  test("getStoredPendingCreateProposal finds open create_building", () => {
+    rememberProposal({
+      id: 42,
+      entityType: "create_building",
+      entityId: 0,
+      status: "pending",
+    });
+    rememberProposal({
+      id: 7,
+      entityType: "create_room",
+      entityId: 0,
+      status: "rejected",
+    });
+
+    expect(getStoredPendingCreateProposal("create_building")).toEqual({
+      id: 42,
+      entityType: "create_building",
+      entityId: 0,
+      status: "pending",
+    });
+    expect(getStoredPendingCreateProposal("create_room")).toBeNull();
+    expect(readStoredProposals()).toHaveLength(2);
+  });
 });
 
 describe("publishEntityPatch", () => {

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -30,6 +30,20 @@ export function rememberProposal(ref: StoredProposalRef) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify([ref, ...existing]));
 }
 
+export function removeStoredProposal(id: number) {
+  if (typeof localStorage === "undefined") return;
+  const next = readStoredProposals().filter((item) => item.id !== id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+}
+
+export function updateStoredProposalStatus(id: number, status: string) {
+  const refs = readStoredProposals();
+  const index = refs.findIndex((item) => item.id === id);
+  if (index === -1) return;
+  refs[index] = { ...refs[index]!, status };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(refs));
+}
+
 export function getStoredProposalForEntity(
   entityType: ProposalEntityType,
   entityId: number,
@@ -470,6 +484,26 @@ export async function submitEntityProposal(input: {
     rememberProposal(ref);
     return { ok: true, proposal: ref };
   }
+  return { ok: true };
+}
+
+export async function withdrawEntityProposal(input: {
+  proposalId: number;
+  submitterName?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`/api/proposals/${input.proposalId}/withdraw`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(
+      input.submitterName ? { submitterName: input.submitterName } : {},
+    ),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    return { ok: false, error: (data as { error?: string }).error };
+  }
+  removeStoredProposal(input.proposalId);
   return { ok: true };
 }
 

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -44,12 +44,40 @@ export function getStoredProposalForEntity(
   );
 }
 
+export function getStoredPendingCreateProposal(
+  entityType: ProposalCreateType,
+): StoredProposalRef | null {
+  return getStoredProposalForEntity(entityType, 0);
+}
+
+export type PublicProposalSummary = {
+  id: number;
+  entityType: string;
+  entityLabel: string;
+  status: string;
+  adminNote: string | null;
+};
+
+export async function fetchPublicProposalSummary(
+  proposalId: number,
+): Promise<PublicProposalSummary | null> {
+  const res = await fetch(`/api/proposals/${proposalId}`, {
+    credentials: "same-origin",
+  });
+  if (!res.ok) return null;
+  const data = (await res.json().catch(() => ({}))) as {
+    proposal?: PublicProposalSummary;
+  };
+  return data.proposal ?? null;
+}
+
 const FIELD_LABELS: Record<string, string> = {
   buildingName: "Building name",
   directions: "Directions",
   buildingType: "Building type",
   lat: "Latitude",
   lon: "Longitude",
+  buildingId: "Building",
   dormName: "Dorm name",
   shortName: "Short name",
   gender: "Gender",

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -420,6 +420,7 @@ export async function submitCreateProposal(input: {
   entityType: ProposalCreateType;
   patch: Record<string, unknown>;
   submitterName?: string;
+  proposalId?: number | null;
 }): Promise<{ ok: boolean; error?: string; proposal?: StoredProposalRef }> {
   return submitEntityProposal({
     entityType: input.entityType,
@@ -427,6 +428,7 @@ export async function submitCreateProposal(input: {
     baseVersion: 0,
     patch: input.patch,
     submitterName: input.submitterName,
+    proposalId: input.proposalId,
   });
 }
 

--- a/src/lib/proposals/create-proposal-validation.test.ts
+++ b/src/lib/proposals/create-proposal-validation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ProposalValidationError,
+  validateCreateProposalPatch,
+} from "@lib/proposals/create-proposal-validation";
+
+describe("validateCreateProposalPatch", () => {
+  test("create_room requires room code and buildingId", () => {
+    expect(() =>
+      validateCreateProposalPatch("create_room", {
+        roomCode: "301",
+      }),
+    ).toThrow(ProposalValidationError);
+
+    expect(() =>
+      validateCreateProposalPatch("create_room", {
+        roomCode: "",
+        buildingId: 1,
+      }),
+    ).toThrow(ProposalValidationError);
+
+    expect(() =>
+      validateCreateProposalPatch("create_room", {
+        roomCode: "301",
+        buildingId: 1,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/lib/proposals/create-proposal-validation.ts
+++ b/src/lib/proposals/create-proposal-validation.ts
@@ -1,0 +1,74 @@
+import type { ProposalCreateType } from "@lib/services/proposal-service";
+
+export class ProposalValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProposalValidationError";
+  }
+}
+
+export function validateCreateProposalPatch(
+  entityType: ProposalCreateType,
+  patch: Record<string, unknown>,
+): void {
+  switch (entityType) {
+    case "create_building": {
+      const name =
+        typeof patch.buildingName === "string" ? patch.buildingName.trim() : "";
+      if (!name)
+        throw new ProposalValidationError("Building name is required.");
+      if (typeof patch.lat !== "number" || typeof patch.lon !== "number") {
+        throw new ProposalValidationError(
+          "Pick a map location for the new building.",
+        );
+      }
+      return;
+    }
+    case "create_event": {
+      const title = typeof patch.title === "string" ? patch.title.trim() : "";
+      if (!title) throw new ProposalValidationError("Event title is required.");
+      if (
+        typeof patch.startsAt !== "string" ||
+        typeof patch.endsAt !== "string"
+      ) {
+        throw new ProposalValidationError("Event start and end are required.");
+      }
+      return;
+    }
+    case "create_dorm": {
+      const name =
+        typeof patch.dormName === "string" ? patch.dormName.trim() : "";
+      const gender =
+        typeof patch.gender === "string" ? patch.gender.trim() : "";
+      if (!name) throw new ProposalValidationError("Dorm name is required.");
+      if (!gender)
+        throw new ProposalValidationError("Dorm gender is required.");
+      return;
+    }
+    case "create_room": {
+      const code =
+        typeof patch.roomCode === "string" ? patch.roomCode.trim() : "";
+      if (!code) throw new ProposalValidationError("Room code is required.");
+      const buildingId = Number(patch.buildingId);
+      if (!Number.isInteger(buildingId) || buildingId < 1) {
+        throw new ProposalValidationError(
+          "Pick the building this room belongs to.",
+        );
+      }
+      return;
+    }
+    case "create_college": {
+      const name =
+        typeof patch.collegeName === "string" ? patch.collegeName.trim() : "";
+      if (!name) throw new ProposalValidationError("College name is required.");
+      return;
+    }
+    case "create_division": {
+      const name =
+        typeof patch.divisionName === "string" ? patch.divisionName.trim() : "";
+      if (!name)
+        throw new ProposalValidationError("Division name is required.");
+      return;
+    }
+  }
+}

--- a/src/lib/proposals/proposal-merge-policy.test.ts
+++ b/src/lib/proposals/proposal-merge-policy.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { allowEntityScopedProposalMerge } from "@lib/proposals/proposal-merge-policy";
+
+describe("allowEntityScopedProposalMerge", () => {
+  test("create proposals only merge when proposalId is sent explicitly", () => {
+    expect(allowEntityScopedProposalMerge(true, 42)).toBe(false);
+    expect(allowEntityScopedProposalMerge(true, null)).toBe(false);
+  });
+
+  test("update proposals still merge for signed-in submitters", () => {
+    expect(allowEntityScopedProposalMerge(false, 42)).toBe(true);
+    expect(allowEntityScopedProposalMerge(false, null)).toBe(false);
+  });
+});

--- a/src/lib/proposals/proposal-merge-policy.ts
+++ b/src/lib/proposals/proposal-merge-policy.ts
@@ -1,0 +1,7 @@
+/** Whether submitProposal may merge into an open row by entity + submitter (updates only). */
+export function allowEntityScopedProposalMerge(
+  isCreate: boolean,
+  submitterUserId: number | null | undefined,
+): boolean {
+  return Boolean(submitterUserId && !isCreate);
+}

--- a/src/lib/services/proposal-access.test.ts
+++ b/src/lib/services/proposal-access.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { canViewProposalSubmitterDetails } from "./proposal-access";
+import {
+  canViewProposalSubmitterDetails,
+  canWithdrawProposal,
+} from "./proposal-access";
 
 describe("canViewProposalSubmitterDetails", () => {
   const proposal = {
@@ -50,6 +53,40 @@ describe("canViewProposalSubmitterDetails", () => {
         },
         proposal,
       ),
+    ).toBe(false);
+  });
+});
+
+describe("canWithdrawProposal", () => {
+  const proposal = {
+    submitterUserId: 5,
+    submitterName: "Ana",
+    status: "pending",
+  };
+
+  test("matching signed-in submitter can withdraw open proposals", () => {
+    expect(
+      canWithdrawProposal(
+        {
+          id: 5,
+          username: "ana",
+          displayName: "Ana",
+          role: "contributor",
+        },
+        proposal,
+      ),
+    ).toBe(true);
+  });
+
+  test("anonymous submitter can withdraw with matching display name", () => {
+    expect(
+      canWithdrawProposal(null, { ...proposal, submitterUserId: null }, "Ana"),
+    ).toBe(true);
+  });
+
+  test("closed proposals cannot be withdrawn", () => {
+    expect(
+      canWithdrawProposal(null, { ...proposal, status: "approved" }, "Ana"),
     ).toBe(false);
   });
 });

--- a/src/lib/services/proposal-access.ts
+++ b/src/lib/services/proposal-access.ts
@@ -16,3 +16,27 @@ export function canViewProposalSubmitterDetails(
   }
   return false;
 }
+
+type WithdrawProposalRow = ProposalAccessRow & {
+  status: string;
+};
+
+export function canWithdrawProposal(
+  session: SessionUser | null,
+  proposal: WithdrawProposalRow,
+  submitterName?: string,
+): boolean {
+  if (!["pending", "needs_changes"].includes(proposal.status)) return false;
+  if (session && session.id > 0 && proposal.submitterUserId === session.id) {
+    return true;
+  }
+  if (
+    !session &&
+    proposal.submitterUserId == null &&
+    typeof submitterName === "string" &&
+    submitterName.trim() === proposal.submitterName.trim()
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -112,10 +112,24 @@ export async function getEntityLabel(
         return typeof p.dormName === "string" && p.dormName.trim()
           ? `New dorm: ${p.dormName.trim()}`
           : "New dorm";
-      case "create_room":
-        return typeof p.roomCode === "string" && p.roomCode.trim()
-          ? `New room: ${p.roomCode.trim()}`
-          : "New room";
+      case "create_room": {
+        const code =
+          typeof p.roomCode === "string" && p.roomCode.trim()
+            ? p.roomCode.trim()
+            : null;
+        const buildingId = Number(p.buildingId);
+        if (code && Number.isInteger(buildingId) && buildingId >= 1) {
+          const [row] = await db
+            .select({ label: buildingsTable.buildingName })
+            .from(buildingsTable)
+            .where(eq(buildingsTable.id, buildingId))
+            .limit(1);
+          if (row?.label) {
+            return `New room: ${code} (${row.label})`;
+          }
+        }
+        return code ? `New room: ${code}` : "New room";
+      }
       case "create_college":
         return typeof p.collegeName === "string" && p.collegeName.trim()
           ? `New college: ${p.collegeName.trim()}`
@@ -294,66 +308,10 @@ async function withEntityLabel(
   };
 }
 
-function validateCreatePatch(
-  entityType: ProposalCreateType,
-  patch: Record<string, unknown>,
-) {
-  switch (entityType) {
-    case "create_building": {
-      const name =
-        typeof patch.buildingName === "string" ? patch.buildingName.trim() : "";
-      if (!name)
-        throw new ProposalValidationError("Building name is required.");
-      if (typeof patch.lat !== "number" || typeof patch.lon !== "number") {
-        throw new ProposalValidationError(
-          "Pick a map location for the new building.",
-        );
-      }
-      return;
-    }
-    case "create_event": {
-      const title = typeof patch.title === "string" ? patch.title.trim() : "";
-      if (!title) throw new ProposalValidationError("Event title is required.");
-      if (
-        typeof patch.startsAt !== "string" ||
-        typeof patch.endsAt !== "string"
-      ) {
-        throw new ProposalValidationError("Event start and end are required.");
-      }
-      return;
-    }
-    case "create_dorm": {
-      const name =
-        typeof patch.dormName === "string" ? patch.dormName.trim() : "";
-      const gender =
-        typeof patch.gender === "string" ? patch.gender.trim() : "";
-      if (!name) throw new ProposalValidationError("Dorm name is required.");
-      if (!gender)
-        throw new ProposalValidationError("Dorm gender is required.");
-      return;
-    }
-    case "create_room": {
-      const code =
-        typeof patch.roomCode === "string" ? patch.roomCode.trim() : "";
-      if (!code) throw new ProposalValidationError("Room code is required.");
-      return;
-    }
-    case "create_college": {
-      const name =
-        typeof patch.collegeName === "string" ? patch.collegeName.trim() : "";
-      if (!name) throw new ProposalValidationError("College name is required.");
-      return;
-    }
-    case "create_division": {
-      const name =
-        typeof patch.divisionName === "string" ? patch.divisionName.trim() : "";
-      if (!name)
-        throw new ProposalValidationError("Division name is required.");
-      return;
-    }
-  }
-}
-
+import {
+  ProposalValidationError,
+  validateCreateProposalPatch,
+} from "@lib/proposals/create-proposal-validation";
 export async function listPendingProposals(): Promise<EditProposalSummary[]> {
   const rows = await db
     .select()
@@ -431,9 +389,8 @@ export async function submitProposal(
     throw new ProposalValidationError("No changes to submit.");
   }
 
-  if (isCreate) {
-    validateCreatePatch(input.entityType, input.patch);
-  } else if (
+  if (
+    !isCreate &&
     !(await entityExists(
       input.entityType as ProposalUpdateType,
       input.entityId,
@@ -484,6 +441,23 @@ export async function submitProposal(
       }
     : input.patch;
 
+  if (isCreate) {
+    validateCreateProposalPatch(input.entityType, mergedPatch);
+    if (input.entityType === "create_room") {
+      const buildingId = Number(mergedPatch.buildingId);
+      const [row] = await db
+        .select({ id: buildingsTable.id })
+        .from(buildingsTable)
+        .where(eq(buildingsTable.id, buildingId))
+        .limit(1);
+      if (!row) {
+        throw new ProposalValidationError(
+          "That building is not on the map yet. Wait for editors to approve your building suggestion, or pick a building that already exists.",
+        );
+      }
+    }
+  }
+
   if (existing) {
     const [updated] = await db
       .update(editProposalsTable)
@@ -519,12 +493,7 @@ export async function submitProposal(
   return withEntityLabel(created);
 }
 
-export class ProposalValidationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ProposalValidationError";
-  }
-}
+export { ProposalValidationError } from "@lib/proposals/create-proposal-validation";
 
 export class ProposalActionError extends Error {
   status: number;

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -41,6 +41,8 @@ import {
   type RoomCreateInput,
   type RoomUpdateInput,
 } from "./admin-service";
+import { allowEntityScopedProposalMerge } from "@lib/proposals/proposal-merge-policy";
+import { validateCreateProposalPatch } from "@lib/proposals/create-proposal-validation";
 
 export const PROPOSAL_UPDATE_TYPES = [
   "building",
@@ -308,10 +310,6 @@ async function withEntityLabel(
   };
 }
 
-import {
-  ProposalValidationError,
-  validateCreateProposalPatch,
-} from "@lib/proposals/create-proposal-validation";
 export async function listPendingProposals(): Promise<EditProposalSummary[]> {
   const rows = await db
     .select()
@@ -416,7 +414,7 @@ export async function submitProposal(
     ) {
       existing = undefined;
     }
-  } else if (input.submitterUserId) {
+  } else if (allowEntityScopedProposalMerge(isCreate, input.submitterUserId)) {
     [existing] = await db
       .select()
       .from(editProposalsTable)

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -13,8 +13,14 @@ import { type SessionUser } from "@lib/admin/auth";
 import { validateSubmitterName } from "@constants/proposals";
 import { parseEventImageUrl } from "@lib/r2-upload";
 import { R2_PUBLIC_URL } from "astro:env/server";
-import { canViewProposalSubmitterDetails } from "./proposal-access";
-export { canViewProposalSubmitterDetails } from "./proposal-access";
+import {
+  canViewProposalSubmitterDetails,
+  canWithdrawProposal,
+} from "./proposal-access";
+export {
+  canViewProposalSubmitterDetails,
+  canWithdrawProposal,
+} from "./proposal-access";
 import {
   EditConflictError,
   DuplicateSlugError,
@@ -745,4 +751,47 @@ export async function requestProposalChanges(
   );
   if (!finalized) throw new ProposalActionError("Proposal not found.", 404);
   return withEntityLabel(finalized);
+}
+
+export async function withdrawProposal(
+  id: number,
+  session: SessionUser | null,
+  submitterName?: string,
+) {
+  const proposal = await getProposalById(id);
+  if (!proposal) throw new ProposalActionError("Proposal not found.", 404);
+  if (!canWithdrawProposal(session, proposal, submitterName)) {
+    throw new ProposalActionError(
+      "Not allowed to withdraw this proposal.",
+      403,
+    );
+  }
+
+  const withdrawnBy =
+    session?.displayName || session?.username || proposal.submitterName;
+
+  const [updated] = await db
+    .update(editProposalsTable)
+    .set({
+      status: "withdrawn",
+      reviewedBy: withdrawnBy,
+      reviewedAt: sql`now()`,
+      adminNote: null,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(editProposalsTable.id, id),
+        inArray(editProposalsTable.status, [
+          "pending",
+          "needs_changes",
+        ] as const),
+      ),
+    )
+    .returning();
+
+  if (!updated) {
+    throw new ProposalActionError("This proposal is no longer open.", 409);
+  }
+  return withEntityLabel(updated);
 }

--- a/src/pages/api/proposals/[id]/withdraw.ts
+++ b/src/pages/api/proposals/[id]/withdraw.ts
@@ -1,0 +1,54 @@
+import type { APIRoute } from "astro";
+import { getEditorSession } from "@lib/admin/require-editor";
+import { validateSubmitterName } from "@constants/proposals";
+import {
+  ProposalActionError,
+  ProposalValidationError,
+  withdrawProposal,
+} from "@lib/services/proposal-service";
+
+export const prerender = false;
+
+type WithdrawBody = { submitterName?: string };
+
+export const POST: APIRoute = async ({ cookies, params, request }) => {
+  const id = Number(params.id);
+  if (!Number.isInteger(id)) {
+    return json({ error: "Invalid proposal ID" }, 400);
+  }
+
+  const session = getEditorSession(cookies);
+  const body = await request.json().catch(() => ({}) as WithdrawBody);
+  const submitterName =
+    session?.displayName ||
+    session?.username ||
+    (typeof body.submitterName === "string" ? body.submitterName : "");
+
+  if (!session) {
+    const validation = validateSubmitterName(submitterName);
+    if (!validation.ok) {
+      return json({ error: validation.error }, 400);
+    }
+  }
+
+  try {
+    const proposal = await withdrawProposal(id, session, submitterName);
+    return json({ success: true, proposal });
+  } catch (err) {
+    if (err instanceof ProposalValidationError) {
+      return json({ error: err.message }, 400);
+    }
+    if (err instanceof ProposalActionError) {
+      return json({ error: err.message }, err.status);
+    }
+    console.error("Failed to withdraw proposal:", err);
+    return json({ error: "Failed to withdraw proposal" }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Summary

- fix(a11y): search `role=searchbox` — use `aria-haspopup=listbox` instead of invalid `aria-expanded`
- docs: `docs/lighthouse-audit-2026-07-04.md` — baseline scores for top 10 Vercel apps + follow-up issue links

Part of 2026-07-04 Lighthouse remediation. Perf work tracked in #482.

## Test plan

- [x] Signed commit on `staging`
- [ ] Vercel staging preview green
- [ ] Production deploy after merge to `main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proposal submit/merge rules, a new DB enum value, and public withdraw API—behavioral changes to contributor flows; search and Discord payload changes are low risk.
> 
> **Overview**
> **Contributor proposals (#255):** Adds **`withdrawn`** status (migration `0017`), **`POST /api/proposals/:id/withdraw`** with `canWithdrawProposal` checks, and **Withdraw** actions in `EntityEditorPanel`, `SuggestAdditionPanel`, and entity edit panels. **Create proposals** no longer auto-merge on `(entity_type, entity_id=0)` for signed-in users—only when **`proposalId`** is sent; **`create_room`** now requires a live **`buildingId`** (server validation + DB existence check) and the addition form adds a building picker, pending-building messaging, and revise-via-`proposalId` for `needs_changes`.
> 
> **A11y & docs:** Search input uses **`aria-haspopup="listbox"`** instead of **`aria-expanded`** on the searchbox. New **`docs/lighthouse-audit-2026-07-04.md`** records baseline Lighthouse scores and shipped/deferred fixes.
> 
> **CI/Docs:** Discord test-inventory posts **tier file lists** via `testInventoryDiscordTiers` (not a single markdown attachment); inventory docs and contributor-proposals skill updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ebc841eebde5fe5fc728f2423511abfae38759b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->