### PR TITLE
release: building panel refresh after approve (#486)

### DIFF
--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -48,7 +48,10 @@ const E2E_MIGRATION_FILES = [
 
 async function applyE2eMigrations(client: pg.Client) {
   for (const file of E2E_MIGRATION_FILES) {
-    const sql = readFileSync(join(import.meta.dir, "..", "drizzle", file), "utf8");
+    const sql = readFileSync(
+      join(import.meta.dir, "..", "drizzle", file),
+      "utf8",
+    );
     await client.query(sql);
   }
 }

--- a/src/components/svelte/ProposalReviewPanel.svelte
+++ b/src/components/svelte/ProposalReviewPanel.svelte
@@ -6,13 +6,15 @@
   } from "@lib/store.svelte";
   import { summarizeProposalPatch } from "@lib/proposals/client";
   import { afterProposalPublished } from "@lib/proposals/apply-published-entity";
-  import { getAppActions } from "@lib/context";
+  import { syncOpenEntityQueryAfterPublish } from "@lib/proposals/sync-open-entity-query";
+  import { getAppActions, getAppData } from "@lib/context";
   import type { ProposalEntityType } from "@lib/services/proposal-service";
   import { parseBundledRooms } from "@lib/proposals/create-proposal-validation";
   import EntityEditorFormField from "@ui/editor/EntityEditorFormField.svelte";
   import EntityReviewActions from "@ui/editor/EntityReviewActions.svelte";
 
   const appActions = getAppActions();
+  const appData = getAppData();
 
   function bundledRoomsSummary(
     entityType: ProposalEntityType,
@@ -56,6 +58,12 @@
         if (entityType) {
           afterProposalPublished(
             appActions,
+            appData,
+            entityType as ProposalEntityType,
+            published,
+          );
+          syncOpenEntityQueryAfterPublish(
+            appData,
             entityType as ProposalEntityType,
             published,
           );

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -51,11 +51,23 @@
   const appActions = getAppActions();
   const { buildings, loaded } = $derived(appData());
 
-  const building = $derived(
-    loaded
-      ? buildings.find((b) => b.buildingName === queryStore.queryValue)
-      : null,
-  );
+  let pinnedBuildingId = $state<number | null>(null);
+
+  const building = $derived.by(() => {
+    if (!loaded) return null;
+    const byName = buildings.find(
+      (b) => b.buildingName === queryStore.queryValue,
+    );
+    if (byName) return byName;
+    if (queryStore.category === "building" && pinnedBuildingId !== null) {
+      return buildings.find((b) => b.id === pinnedBuildingId) ?? null;
+    }
+    return null;
+  });
+
+  $effect(() => {
+    if (building?.id) pinnedBuildingId = building.id;
+  });
   const buildingShareUrl = $derived(
     building ? getBuildingShareUrl(building.buildingName) : "",
   );

--- a/src/lib/proposals/apply-published-entity.test.ts
+++ b/src/lib/proposals/apply-published-entity.test.ts
@@ -3,20 +3,51 @@ import {
   applyPublishedEntity,
   syncTablesForEntityType,
 } from "@lib/proposals/apply-published-entity";
-import type { AppActions } from "@lib/context";
+import type { AppActions, AppContextData } from "@lib/context";
 
 function mockActions() {
   const calls: string[] = [];
+  let lastBuilding: unknown;
   const actions: AppActions = {
     replaceEvent: () => calls.push("event"),
     removeEvent: () => {},
-    upsertBuilding: () => calls.push("building"),
+    upsertBuilding: (row) => {
+      calls.push("building");
+      lastBuilding = row;
+    },
     upsertDorm: () => {},
     upsertCollege: () => {},
     upsertDivision: () => {},
   };
-  return { actions, calls };
+  return {
+    actions,
+    calls,
+    getLastBuilding: () => lastBuilding,
+  };
 }
+
+const loadedData = (): AppContextData => ({
+  loaded: true,
+  buildings: [
+    {
+      id: 1,
+      buildingName: "Old Hall",
+      lat: 14.1,
+      lon: 121.1,
+      buildingType: "non-admin",
+      directions: "Old directions",
+      version: 1,
+      updatedAt: "2026-01-01",
+      osmLink: null,
+    },
+  ],
+  colleges: [],
+  divisions: [],
+  dorms: [],
+  events: [],
+  totalRooms: 1,
+  directionCount: 1,
+});
 
 describe("applyPublishedEntity", () => {
   test("upserts building on building approve", () => {
@@ -27,6 +58,27 @@ describe("applyPublishedEntity", () => {
     });
     expect(ok).toBe(true);
     expect(calls).toEqual(["building"]);
+  });
+
+  test("merges published patch into existing building row", () => {
+    const { actions, getLastBuilding } = mockActions();
+    applyPublishedEntity(
+      actions,
+      "building",
+      { id: 1, directions: "New directions", version: 2 },
+      loadedData,
+    );
+    expect(getLastBuilding()).toEqual({
+      id: 1,
+      buildingName: "Old Hall",
+      lat: 14.1,
+      lon: 121.1,
+      buildingType: "non-admin",
+      directions: "New directions",
+      version: 2,
+      updatedAt: "2026-01-01",
+      osmLink: null,
+    });
   });
 
   test("maps entity types to sync tables", () => {

--- a/src/lib/proposals/apply-published-entity.ts
+++ b/src/lib/proposals/apply-published-entity.ts
@@ -1,4 +1,4 @@
-import type { AppActions } from "@lib/context";
+import type { AppActions, AppContextData } from "@lib/context";
 import type {
   BuildingData,
   CollegeData,
@@ -34,31 +34,69 @@ export function syncTablesForEntityType(
   return ENTITY_SYNC_TABLES[entityType] ?? [];
 }
 
+function mergePublishedRow<T extends { id: number }>(
+  getData: (() => AppContextData) | undefined,
+  list: T[] | null | undefined,
+  published: T,
+): T {
+  if (!getData) return published;
+  const data = getData();
+  if (!data.loaded || !list) return published;
+  const existing = list.find((row) => row.id === published.id);
+  return existing ? { ...existing, ...published } : published;
+}
+
 /** Apply approve/publish API payload to in-memory campus data immediately. */
 export function applyPublishedEntity(
   actions: AppActions,
   entityType: ProposalEntityType,
   published: unknown,
+  getData?: () => AppContextData,
 ): boolean {
   if (!published || typeof published !== "object") return false;
+  const data = getData?.();
 
   switch (entityType) {
     case "building":
-    case "create_building":
-      actions.upsertBuilding(published as BuildingData);
+    case "create_building": {
+      const row = mergePublishedRow(
+        getData,
+        data?.loaded ? data.buildings : undefined,
+        published as BuildingData,
+      );
+      actions.upsertBuilding(row);
       return true;
+    }
     case "dorm":
-    case "create_dorm":
-      actions.upsertDorm(published as DormData);
+    case "create_dorm": {
+      const row = mergePublishedRow(
+        getData,
+        data?.loaded ? data.dorms : undefined,
+        published as DormData,
+      );
+      actions.upsertDorm(row);
       return true;
+    }
     case "college":
-    case "create_college":
-      actions.upsertCollege(published as CollegeData);
+    case "create_college": {
+      const row = mergePublishedRow(
+        getData,
+        data?.loaded ? data.colleges : undefined,
+        published as CollegeData,
+      );
+      actions.upsertCollege(row);
       return true;
+    }
     case "division":
-    case "create_division":
-      actions.upsertDivision(published as DivisionData);
+    case "create_division": {
+      const row = mergePublishedRow(
+        getData,
+        data?.loaded ? data.divisions : undefined,
+        published as DivisionData,
+      );
+      actions.upsertDivision(row);
       return true;
+    }
     case "event":
     case "create_event":
       actions.replaceEvent(published as EventData);
@@ -74,15 +112,21 @@ export function applyPublishedEntity(
 
 export function afterProposalPublished(
   actions: AppActions,
+  getData: () => AppContextData,
   entityType: ProposalEntityType,
   published: unknown,
 ): void {
-  const applied = applyPublishedEntity(actions, entityType, published);
+  const applied = applyPublishedEntity(actions, entityType, published, getData);
   const tables = syncTablesForEntityType(entityType);
   if (tables.length > 0) {
     invalidateLocalSyncKeys(tables);
   }
-  if (applied || tables.length > 0) {
+  if (applied) {
+    // In-memory upsert is authoritative for the open panel. A full campus
+    // refresh can race PGlite and overwrite with stale rows (#481 prod).
+    return;
+  }
+  if (tables.length > 0) {
     requestCampusDataRefresh();
   }
 }

--- a/src/lib/proposals/sync-open-entity-query.ts
+++ b/src/lib/proposals/sync-open-entity-query.ts
@@ -1,0 +1,121 @@
+import { queryStore } from "@lib/store.svelte";
+import type { AppContextData } from "@lib/context";
+import type { ProposalEntityType } from "@lib/services/proposal-service";
+import type {
+  BuildingData,
+  CollegeData,
+  DivisionData,
+  DormData,
+  EventData,
+} from "@lib/types";
+
+type PublishedRow = { id: number };
+
+function openEntityId(
+  data: AppContextData,
+  category: typeof queryStore.category,
+  queryValue: string,
+): number | null {
+  if (!data.loaded || !category || !queryValue) return null;
+
+  switch (category) {
+    case "building": {
+      const row = data.buildings.find((b) => b.buildingName === queryValue);
+      return row?.id ?? null;
+    }
+    case "dorm": {
+      const row = data.dorms.find((d) => d.dormName === queryValue);
+      return row?.id ?? null;
+    }
+    case "college": {
+      const row = data.colleges.find((c) => c.collegeName === queryValue);
+      return row?.id ?? null;
+    }
+    case "division": {
+      const row = data.divisions.find((d) => d.divisionName === queryValue);
+      return row?.id ?? null;
+    }
+    case "event": {
+      const row = data.events.find(
+        (e) =>
+          e.title === queryValue || e.slug === queryStore.selectedEventSlug,
+      );
+      return row?.id ?? null;
+    }
+    default:
+      return null;
+  }
+}
+
+/** Keep the open side panel pointed at the entity after approve renames it. */
+export function syncOpenEntityQueryAfterPublish(
+  getData: () => AppContextData,
+  entityType: ProposalEntityType,
+  published: unknown,
+): void {
+  if (!published || typeof published !== "object" || !("id" in published)) {
+    return;
+  }
+  const publishedId = Number((published as PublishedRow).id);
+  if (!Number.isInteger(publishedId)) return;
+
+  const data = getData();
+  const openId = openEntityId(data, queryStore.category, queryStore.queryValue);
+  if (openId !== publishedId) return;
+
+  switch (entityType) {
+    case "building":
+    case "create_building": {
+      const row = published as BuildingData;
+      queryStore.hydrateQuery({
+        type: "result",
+        category: "building",
+        value: row.buildingName,
+      });
+      return;
+    }
+    case "dorm":
+    case "create_dorm": {
+      const row = published as DormData;
+      queryStore.hydrateQuery({
+        type: "result",
+        category: "dorm",
+        value: row.dormName,
+      });
+      return;
+    }
+    case "college":
+    case "create_college": {
+      const row = published as CollegeData;
+      queryStore.hydrateQuery({
+        type: "result",
+        category: "college",
+        value: row.collegeName,
+      });
+      return;
+    }
+    case "division":
+    case "create_division": {
+      const row = published as DivisionData;
+      queryStore.hydrateQuery({
+        type: "result",
+        category: "division",
+        value: row.divisionName,
+      });
+      return;
+    }
+    case "event":
+    case "create_event": {
+      const row = published as EventData;
+      queryStore.hydrateQuery({
+        type: "result",
+        category: "event",
+        value: row.title,
+        eventSlug: row.slug,
+      });
+      return;
+    }
+    default:
+      return;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes building side panel staying stale after admin approves a building proposal (#486)
- Skips immediate full campus refresh when in-memory upsert succeeded (avoids stale PGlite overwrite)
- Pins open building panel by `id` after renames; syncs `queryStore` via `syncOpenEntityQueryAfterPublish`

## Test plan
- [x] Unit: `apply-published-entity.test.ts`
- [x] CI verify green on #486
- [ ] Manual: open building → approve proposal → panel updates without hard refresh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-approve client data flow and deliberately skips full campus refresh when upsert succeeds; wrong merge or skip logic could leave panels or other views briefly inconsistent.
> 
> **Overview**
> Fixes the **building side panel staying stale** after an admin approves a building (or related) proposal, without requiring a hard refresh.
> 
> **In-memory publish path:** `applyPublishedEntity` now **merges** the API `published` payload into the matching row already in app context (so partial patches don’t wipe fields). `afterProposalPublished` takes `getData`, still invalidates local sync keys, but **skips `requestCampusDataRefresh`** when the in-memory upsert succeeded—avoiding a race where PGlite refresh overwrote fresh data (#481).
> 
> **Open panel / renames:** New `syncOpenEntityQueryAfterPublish` re-hydrates `queryStore` when the approved entity is the one currently open (e.g. updated name). `BuildingResult` **pins** the open building by `id` when lookup by name fails after a rename. `ProposalReviewPanel` calls both helpers on approve.
> 
> Minor formatting-only change in `e2e-reset-db.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6baee23d1b8765b70d1b95a1ec61d45e99920f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->