### PR TITLE
release: prod bootstrap hotfix (#490)

### DIFF
--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -45,6 +45,7 @@
     syncAliasCache,
     syncClasses,
   } from "@lib/local/data/sync";
+  import { getDB, initPGLiteDB } from "@lib/local/data/pgliteDB";
   import { CAMPUS_DATA_REFRESH_EVENT } from "@lib/local/data/invalidate-sync-key";
 
   type MetadataProps = {

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -218,20 +218,20 @@
 <div class="app-layout" class:edit-mode={mapEditStore.enabled}>
   <Map />
   <div class="ui-layer">
-    <div
+    <section
       class="top-right-map-stack"
       aria-label="Map tools"
       bind:this={mapToolsStackEl}
     >
       <MapToolsFlyout />
-      <div class="desktop-camera-controls" aria-label="Map camera">
+      <section class="desktop-camera-controls" aria-label="Map camera">
         <div class="camera-controls-card">
           <MapDimensionToggle embedded />
           <div class="camera-controls-card__divider" aria-hidden="true"></div>
           <MapViewControls variant="camera" embedded />
         </div>
-      </div>
-    </div>
+      </section>
+    </section>
     <div class="inner-layer">
       <MainControls />
       <div class="bottom-band">


### PR DESCRIPTION
## Summary
- Hotfix: restore `getDB` / `initPGLiteDB` import in AppRoot (#490)
- Fixes production map/bootstrap failure (`ReferenceError: getDB is not defined`)

## Test plan
- [x] verify green on #490
- [ ] Prod smoke: no bootstrap console error; campus map loads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line import restore plus non-behavioral HTML element changes; no auth or data-path logic altered beyond fixing the missing import.
> 
> **Overview**
> **Production bootstrap** is fixed by re-adding the missing `getDB` and `initPGLiteDB` import from `@lib/local/data/pgliteDB` in `AppRoot.svelte`, so `onMount` can initialize the local DB before loading cached campus data (avoids `ReferenceError: getDB is not defined`).
> 
> **Map UI markup** in `Entry.svelte` swaps generic `div` wrappers for `section` on the top-right map tools stack and desktop camera controls, keeping the same classes and `aria-label`s for clearer document structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23def61aaf838d6a74f22339d4bcccd3618ba257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->