### PR TITLE
release: MapTiler basemap tile fix (#492)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ ISR_BYPASS_TOKEN=
 PUBLIC_SUPABASE_URL=
 PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 
+# MapTiler vector/terrain tiles (Settings → API keys; restrict to your domains).
+PUBLIC_MAPTILER_KEY=
+
 # Cloudflare R2 image uploads (optional until /api/admin/upload is needed)
 R2_ACCOUNT_ID=
 R2_ACCESS_KEY_ID=

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -145,6 +145,11 @@ export default defineConfig({
         context: "client",
         optional: true,
       }),
+      PUBLIC_MAPTILER_KEY: envField.string({
+        access: "public",
+        context: "client",
+        optional: true,
+      }),
       ADMIN_PASSWORD: envField.string({
         access: "secret",
         context: "server",

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -19,6 +19,7 @@
     terrainStore,
   } from "@lib/store.svelte";
   import { untrack } from "svelte";
+  import { onMount } from "svelte";
   import { fade } from "svelte/transition";
   import MapLibreGlDirections from "@maplibre/maplibre-gl-directions";
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
@@ -33,6 +34,7 @@
   import MapEntityPin from "./map/MapEntityPin.svelte";
   import { MediaQuery } from "svelte/reactivity";
   import { observeBlockHeight } from "@lib/layout-css-vars";
+  import type { StyleSpecification } from "maplibre-gl";
   import * as mapGl from "maplibre-gl";
   import type { FeatureCollection, LineString } from "geojson";
   import type { BuildingData, DormData, EventData } from "@lib/types";
@@ -51,10 +53,11 @@
     TERRAIN_HILLSHADE_LAYER_ID,
     TERRAIN_SOURCE_ID,
     TERRAIN_TILE_FAILURE_MESSAGE,
-    TERRAIN_TILEJSON_URL,
     TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE,
+    getTerrainTileJsonUrl,
   } from "@constants/map-terrain";
   import { applyBasemapPalette } from "@lib/map-basemap-palette";
+  import { loadCampusMapStyle } from "@lib/maptiler-key";
   import { isMap2DPitch } from "@constants/map-dimension";
   import { syncBuildingLayersForDimension } from "@lib/map-dimension-layers";
   import {
@@ -123,6 +126,21 @@
     );
   }
   let directions: MapLibreGlDirections | undefined = $state.raw();
+  let mapStyle = $state<StyleSpecification | null>(null);
+
+  onMount(() => {
+    void loadCampusMapStyle<StyleSpecification>()
+      .then((style) => {
+        mapStyle = style;
+      })
+      .catch((error) => {
+        console.error("Failed to load campus map style", error);
+        toastStore.show(
+          "Campus map tiles could not load. Check MapTiler configuration.",
+          "error",
+        );
+      });
+  });
 
   const JEEPNEY_ROUTE_SOURCE_ID = "jeepney-route-line";
   const JEEPNEY_ROUTE_LAYER_ID = "jeepney-route-line";
@@ -536,7 +554,7 @@
     if (!map.getSource(TERRAIN_SOURCE_ID)) {
       map.addSource(TERRAIN_SOURCE_ID, {
         type: "raster-dem",
-        url: TERRAIN_TILEJSON_URL,
+        url: getTerrainTileJsonUrl(),
         bounds: MAKILING_TERRAIN_SOURCE_BOUNDS,
         maxzoom: 14,
         tileSize: 512,
@@ -2415,9 +2433,10 @@
       </div>
     {/if}
   {/if}
-  <MapLibre
-    bind:map={mapStore.mapInstance}
-    style="/liberty-customized.json"
+  {#if mapStyle}
+    <MapLibre
+      bind:map={mapStore.mapInstance}
+      style={mapStyle}
     maxBounds={CAMPUS_MAX_BOUNDS}
     center={CAMPUS_DEFAULT_CAMERA.center}
     zoom={17}
@@ -2784,6 +2803,7 @@
       {/each}
     {/if}
   </MapLibre>
+  {/if}
 </div>
 
 <style>

--- a/src/constants/map-terrain.ts
+++ b/src/constants/map-terrain.ts
@@ -1,9 +1,14 @@
-const MAPTILER_KEY = "__MAPTILER_KEY__";
+import { MAPTILER_KEY_PLACEHOLDER, withMaptilerKey } from "@lib/maptiler-key";
 
 export const TERRAIN_SOURCE_ID = "makiling-terrain-dem";
 export const TERRAIN_HILLSHADE_LAYER_ID = "makiling-terrain-hillshade";
 export const TERRAIN_HILLSHADE_BEFORE_LAYER_ID = "road_area_pattern";
-export const TERRAIN_TILEJSON_URL = `https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=${MAPTILER_KEY}`;
+
+const TERRAIN_TILEJSON_URL_TEMPLATE = `https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=${MAPTILER_KEY_PLACEHOLDER}`;
+
+export function getTerrainTileJsonUrl(): string {
+  return withMaptilerKey(TERRAIN_TILEJSON_URL_TEMPLATE);
+}
 
 export const TERRAIN_EXAGGERATION_OPTIONS = [1, 1.5, 2] as const;
 export const DEFAULT_TERRAIN_EXAGGERATION = 1.5;

--- a/src/lib/local/offline-maps.ts
+++ b/src/lib/local/offline-maps.ts
@@ -3,6 +3,7 @@
 // service worker's `map-tiles` runtime cache stores them (see astro.config.mjs).
 
 import { CAMPUS_BOUNDS } from "@constants/map-terrain";
+import { CAMPUS_MAP_STYLE_URL, injectMaptilerKey } from "@lib/maptiler-key";
 
 // Campus bounds — mirrors `CAMPUS_MAX_BOUNDS` in src/constants/map-terrain.ts.
 const CAMPUS_BOUNDS_LON_LAT = {
@@ -70,7 +71,9 @@ let cachedSource: TileSource | null = null;
 export async function getTileTemplate(): Promise<TileSource | null> {
   if (cachedSource) return cachedSource;
   try {
-    const style = await (await fetch("/liberty-customized.json")).json();
+    const style = injectMaptilerKey(
+      await (await fetch(CAMPUS_MAP_STYLE_URL)).json(),
+    );
     const src = style?.sources?.openmaptiles;
     if (!src) return null;
 

--- a/src/lib/maptiler-key.test.ts
+++ b/src/lib/maptiler-key.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyMaptilerKeyToText,
+  MAPTILER_KEY_PLACEHOLDER,
+} from "@lib/maptiler-key";
+
+describe("maptiler-key", () => {
+  test("replaces placeholder in tile URLs", () => {
+    const url = `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${MAPTILER_KEY_PLACEHOLDER}`;
+    expect(applyMaptilerKeyToText(url, "test-key")).toBe(
+      "https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=test-key",
+    );
+  });
+
+  test("replaces every placeholder in serialized style JSON", () => {
+    const json = JSON.stringify({
+      sources: {
+        openmaptiles: {
+          url: `https://api.maptiler.com/example?key=${MAPTILER_KEY_PLACEHOLDER}`,
+        },
+      },
+    });
+    const out = applyMaptilerKeyToText(json, "abc123");
+    expect(out).not.toContain(MAPTILER_KEY_PLACEHOLDER);
+    expect(out).toContain("abc123");
+  });
+});

--- a/src/lib/maptiler-key.ts
+++ b/src/lib/maptiler-key.ts
@@ -1,0 +1,36 @@
+/** Placeholder in committed map assets — replaced at runtime with PUBLIC_MAPTILER_KEY. */
+export const MAPTILER_KEY_PLACEHOLDER = "__MAPTILER_KEY__";
+
+/** MapTiler client key — set PUBLIC_MAPTILER_KEY in .env (domain-restricted on MapTiler). */
+export function getMaptilerKey(): string {
+  const key = import.meta.env.PUBLIC_MAPTILER_KEY;
+  if (!key) {
+    throw new Error("PUBLIC_MAPTILER_KEY is not set");
+  }
+  return key;
+}
+
+export function applyMaptilerKeyToText(text: string, key: string): string {
+  return text.replaceAll(MAPTILER_KEY_PLACEHOLDER, key);
+}
+
+/** Inject the runtime key into URLs or style JSON that use __MAPTILER_KEY__ placeholders. */
+export function withMaptilerKey(value: string): string {
+  return applyMaptilerKeyToText(value, getMaptilerKey());
+}
+
+/** Inject the runtime key into a map style JSON that uses __MAPTILER_KEY__ placeholders. */
+export function injectMaptilerKey<T>(style: T): T {
+  return JSON.parse(withMaptilerKey(JSON.stringify(style))) as T;
+}
+
+export const CAMPUS_MAP_STYLE_URL = "/liberty-customized.json";
+
+/** Load the campus MapLibre style with the runtime MapTiler key applied. */
+export async function loadCampusMapStyle<T>(): Promise<T> {
+  const res = await fetch(CAMPUS_MAP_STYLE_URL);
+  if (!res.ok) {
+    throw new Error(`Failed to load map style (${res.status})`);
+  }
+  return injectMaptilerKey((await res.json()) as T);
+}

--- a/src/lib/osm-basemap.ts
+++ b/src/lib/osm-basemap.ts
@@ -9,12 +9,12 @@
  * contributors + MapTiler).
  */
 
-/**
- *
- API key */
-const MAPTILER_KEY = "__MAPTILER_KEY__";
+import { MAPTILER_KEY_PLACEHOLDER, withMaptilerKey } from "@lib/maptiler-key";
+
 const TILE_URL = (z: number, x: number, y: number) =>
-  `https://api.maptiler.com/maps/streets-v2/256/${z}/${x}/${y}.png?key=${MAPTILER_KEY}`;
+  withMaptilerKey(
+    `https://api.maptiler.com/maps/streets-v2/256/${z}/${x}/${y}.png?key=${MAPTILER_KEY_PLACEHOLDER}`,
+  );
 
 const TILE_SIZE = 256;
 const METERS_PER_DEGREE_LAT = 111_320;


### PR DESCRIPTION
## Summary
- Runtime injection of `PUBLIC_MAPTILER_KEY` for campus MapLibre style, terrain, 3D basemap, and offline prefetch
- Fixes grey map / MapTiler 403 on `__MAPTILER_KEY__` placeholder

## Test plan
- [x] verify green on #492
- [ ] Prod: basemap tiles render after redeploy (env already on Vercel production)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The campus map, terrain, offline prefetch, and 3D basemap all depend on PUBLIC_MAPTILER_KEY at runtime; a missing or misconfigured deploy env breaks tiles but does not affect auth or data.
> 
> **Overview**
> Fixes grey basemaps and MapTiler **403** responses caused by committed `__MAPTILER_KEY__` placeholders never being replaced in production.
> 
> Introduces **`PUBLIC_MAPTILER_KEY`** (documented in `.env.example`, registered in Astro’s env schema) and a shared **`@lib/maptiler-key`** helper that substitutes the placeholder in URLs and style JSON at runtime. The main map now **fetches** `liberty-customized.json`, injects the key, and only then mounts MapLibre; load failures surface an error toast. **Terrain** TileJSON, **offline tile prefetch**, and **3D OSM raster basemap** URLs use the same injection path instead of hardcoded placeholders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b552c578ddb9d7a0a82ce90a5ce349894c9d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->