### PR TITLE
fix(map-chrome): mobile edit dock undo/redo tappable

### DIFF
--- a/docs/map-ui-mode-matrix.md
+++ b/docs/map-ui-mode-matrix.md
@@ -61,7 +61,7 @@ MapLibre attribution is disabled on the map canvas (`attributionControl={false}`
 - `--search-block-height`
 - `--status-bar-block-height` (measured from full `.bottom-chrome` tray)
 - `--side-panel-top-inset` (search block + map padding; desktop fixed drawer top)
-- `--side-panel-bottom-inset` (measured from `.bottom-chrome` top edge + `--side-panel-bottom-gap`; fixed drawer/sheet bottom)
+- `--side-panel-bottom-inset` (measured from `.bottom-chrome` top edge + `--side-panel-bottom-gap`; fixed drawer/sheet bottom; in map edit mode also adds `--edit-bar-height` + `--bottom-fab-gap` so the mobile peek tab clears the edit dock)
 - `--side-panel-bottom-inset-measured` (runtime px distance from viewport bottom to status tray top; set in `Entry.svelte`)
 - `--side-panel-bottom-gap` (extra clearance between drawer and status tray)
 - `--drawer-peek-offset`

--- a/e2e/admin/undo-redo.spec.ts
+++ b/e2e/admin/undo-redo.spec.ts
@@ -13,7 +13,7 @@ test.describe("undo redo", () => {
   test.slow();
   test.describe.configure({ retries: 1 });
 
-  test("undo after pin drag via keyboard", async ({ page }) => {
+  test("undo and redo after pin drag", async ({ page }) => {
     await page.goto("/");
     await waitForAppBoot(page);
     await loginAsAdmin(page);
@@ -28,8 +28,11 @@ test.describe("undo redo", () => {
     );
 
     const undo = page.getByRole("button", { name: /undo last pin move/i });
+    const redo = page.getByRole("button", { name: /redo last pin move/i });
     await expect(undo).toBeEnabled({ timeout: 10_000 });
-    await page.keyboard.press("Control+Z");
+    await undo.click();
+    await expect(redo).toBeEnabled({ timeout: 10_000 });
+    await redo.click();
     await logout(page);
   });
 });

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -357,6 +357,15 @@
     overflow: hidden;
   }
 
+  .app-layout.edit-mode {
+    /* Keep the mobile detail drawer peek above the measured edit dock. */
+    --side-panel-bottom-inset: calc(
+      var(--side-panel-bottom-inset-measured) +
+        var(--side-panel-bottom-gap, 0.375rem) + var(--edit-bar-height, 0rem) +
+        var(--bottom-fab-gap, 0.5rem)
+    );
+  }
+
   .inner-layer {
     display: flex;
     flex-direction: column;

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -2247,9 +2247,405 @@
 
 <svelte:window onkeydown={handleMapEditKeydown} />
 
-<div class="map-container">
+<div class="map-shell">
+  <div class="map-container">
+    {#if eventPlacementStore.active}
+      <EventPlacementImageField />
+    {/if}
+    {#if mapStyle}
+      <MapLibre
+        bind:map={mapStore.mapInstance}
+        style={mapStyle}
+        maxBounds={CAMPUS_MAX_BOUNDS}
+        center={CAMPUS_DEFAULT_CAMERA.center}
+        zoom={17}
+        pitch={CAMPUS_DEFAULT_CAMERA.pitch}
+        bearing={CAMPUS_DEFAULT_CAMERA.bearing}
+        minZoom={13}
+        class="map"
+        attributionControl={false}
+      >
+        {#if locationStore.coords}
+          <Marker lngLat={locationStore.coords}>
+            <div class="user-location-pin"></div>
+          </Marker>
+        {/if}
+        {#if additionProposalStore.draftPin}
+          <Marker
+            lngLat={{
+              lng: additionProposalStore.draftPin.lon,
+              lat: additionProposalStore.draftPin.lat,
+            }}
+          >
+            <div class="addition-draft-pin" aria-hidden="true"></div>
+          </Marker>
+        {/if}
+        {#if loaded}
+          {#if editableEventLocation}
+            {@const editKey = eventLocationEditKey(
+              editableEventLocation.event.id,
+            )}
+            <Marker
+              lngLat={getEventMarkerLngLat(editableEventLocation)}
+              draggable={canDragPin(editKey)}
+              onclick={() =>
+                handleEventMarkerClick(editableEventLocation.event)}
+              ondragstart={() => beginMarkerDrag(editKey)}
+              ondragend={(e) =>
+                handleEventLocationDragEnd(
+                  e,
+                  editableEventLocation.event,
+                  editableEventLocation.location,
+                )}
+            >
+              <div class="event-marker-anchor event-edit-anchor">
+                <span class="event-anchor-dot event-edit-dot" aria-hidden="true"
+                ></span>
+                <div
+                  class="event-edit-pin"
+                  class:editing={selectedEditKey === editKey}
+                  class:hovered={hoveredEditKey === editKey}
+                  class:saving={savingEditKey === editKey}
+                  class:saved={savedEditKey === editKey}
+                  class:failed={failedEditKey === editKey}
+                  title={`Drag to move ${editableEventLocation.event.title}`}
+                  onpointerenter={() => handleEditablePinEnter(editKey)}
+                  onpointerleave={() => handleEditablePinLeave(editKey)}
+                >
+                  <span class="event-edit-icon" aria-hidden="true">
+                    <CalendarDays size={18} />
+                  </span>
+                  <span class="event-edit-copy">
+                    <span>{editableEventLocation.event.title}</span>
+                    {#if savingEditKey === editKey}
+                      <strong>Saving</strong>
+                    {:else if savedEditKey === editKey}
+                      <strong>Saved</strong>
+                    {:else if failedEditKey === editKey}
+                      <strong>Failed</strong>
+                    {:else}
+                      <strong>Drag location</strong>
+                    {/if}
+                  </span>
+                  <span class="event-edit-handle" aria-hidden="true">
+                    <Move size={16} />
+                  </span>
+                </div>
+              </div>
+            </Marker>
+          {/if}
+          {#each eventMarkerGroups as group (`event-group:${group.key}`)}
+            <Marker lngLat={group.lngLat}>
+              <div class="event-marker-anchor" class:anchored={group.anchored}>
+                <span class="event-anchor-connector" aria-hidden="true"></span>
+                <span class="event-anchor-dot" aria-hidden="true"></span>
+                <div class="event-callout" class:anchored={group.anchored}>
+                  {#if group.entries.length === 1}
+                    {@const entry = group.entries[0]}
+                    {#if entry}
+                      {@const image = getEventImage(
+                        entry.event.slug,
+                        entry.event.imageUrl,
+                        entry.event.title,
+                      )}
+                      {@const active = isSelectedEvent(entry.event)}
+                      {@const centralHoverPreview =
+                        shouldShowEntityHoverPreview()}
+                      {@const previewSuppressed =
+                        centralHoverPreview &&
+                        isEventHoverPreview(
+                          entityHoverPreviewStore.entity,
+                          entry.event.slug,
+                        )}
+                      <EventMapPin
+                        {active}
+                        useCentralHoverPreview={centralHoverPreview}
+                        {previewSuppressed}
+                        anchored={group.anchored}
+                        imageSrc={image?.src ?? null}
+                        dateLabel={formatEventMarkerDate(
+                          entry.event.occurrenceStartsAt,
+                        )}
+                        status={entry.event.status}
+                        title={`${entry.event.title}: ${entry.location.resolvedLabel}`}
+                        ariaLabel={`Open event ${entry.event.title} at ${entry.location.resolvedLabel}`}
+                        labelTitle={entry.event.title}
+                        labelMeta={`${getEventStatusLabel(entry.event)} · ${formatEventMarkerDateTime(
+                          entry.event.occurrenceStartsAt,
+                        )}`}
+                        labelVisible={zoomLevel >= 17 || active}
+                        onclick={() => handleEventMarkerClick(entry.event)}
+                        onpointerenter={(event) =>
+                          handleEventPinPointerEnter(entry.event, event)}
+                        onpointerleave={handleEventPinPointerLeave}
+                      />
+                    {/if}
+                  {:else}
+                    {@const primaryEntry = group.entries[0]}
+                    {@const isExpanded = expandedEventGroupKey === group.key}
+                    {#if primaryEntry}
+                      {@const primaryImage = getEventImage(
+                        primaryEntry.event.slug,
+                        primaryEntry.event.imageUrl,
+                        primaryEntry.event.title,
+                      )}
+                      <EventMapPin
+                        variant="group"
+                        anchored={group.anchored}
+                        expanded={isExpanded}
+                        ariaExpanded={isExpanded}
+                        count={group.entries.length}
+                        imageSrc={primaryImage?.src ?? null}
+                        dateLabel={formatEventMarkerDate(
+                          primaryEntry.event.occurrenceStartsAt,
+                        )}
+                        status={primaryEntry.event.status}
+                        title={`${group.entries.length} events at ${group.label}`}
+                        ariaLabel={`${isExpanded ? "Collapse" : "Expand"} ${group.entries.length} events at ${group.label}`}
+                        onclick={() => toggleEventMarkerGroup(group.key)}
+                        onpointerenter={(event) =>
+                          handleEventPinPointerEnter(primaryEntry.event, event)}
+                        onpointerleave={handleEventPinPointerLeave}
+                      />
+                      {#if isExpanded}
+                        <div
+                          class="event-pin-stack"
+                          role="group"
+                          aria-label={`${group.entries.length} events at ${group.label}`}
+                          transition:fade
+                        >
+                          <div class="event-stack-header">
+                            <span class="event-stack-heading">
+                              <strong>{group.entries.length} events</strong>
+                              <span>{group.label}</span>
+                            </span>
+                            <button
+                              class="event-stack-close"
+                              type="button"
+                              aria-label={`Collapse events at ${group.label}`}
+                              onclick={collapseEventMarkerGroup}
+                            >
+                              <X size={14} />
+                            </button>
+                          </div>
+                          <div class="event-stack-list">
+                            {#each group.entries as entry (`event-stack:${entry.event.id}:${entry.location.id}`)}
+                              {@const image = getEventImage(
+                                entry.event.slug,
+                                entry.event.imageUrl,
+                                entry.event.title,
+                              )}
+                              <button
+                                type="button"
+                                class="event-stack-item"
+                                class:active={isSelectedEvent(entry.event)}
+                                class:upcoming={entry.event.status ===
+                                  "upcoming"}
+                                title={`${entry.event.title}: ${entry.location.resolvedLabel}`}
+                                aria-label={`Open event ${entry.event.title} at ${entry.location.resolvedLabel}`}
+                                onclick={() =>
+                                  handleEventMarkerClick(entry.event)}
+                              >
+                                {#if image}
+                                  <img
+                                    class="event-stack-thumb"
+                                    src={image.src}
+                                    alt=""
+                                  />
+                                {:else}
+                                  <span
+                                    class="event-stack-icon"
+                                    aria-hidden="true"
+                                  >
+                                    <CalendarDays size={14} />
+                                  </span>
+                                {/if}
+                                <span class="event-stack-copy">
+                                  <span class="event-stack-title"
+                                    >{entry.event.title}</span
+                                  >
+                                  <span class="event-stack-meta">
+                                    {formatEventMarkerDate(
+                                      entry.event.occurrenceStartsAt,
+                                    )}
+                                    at {formatEventMarkerTime(
+                                      entry.event.occurrenceStartsAt,
+                                    )}
+                                    - {getEventStatusLabel(entry.event)}
+                                  </span>
+                                </span>
+                              </button>
+                            {/each}
+                          </div>
+                        </div>
+                      {/if}
+                    {/if}
+                  {/if}
+                </div>
+              </div>
+            </Marker>
+          {/each}
+          {#each selectedEventRouteStops as stop (`event-stop:${stop.id}`)}
+            <Marker
+              lngLat={[Number(stop.resolvedLon), Number(stop.resolvedLat)]}
+            >
+              <div class="event-route-stop-pin" title={stop.resolvedLabel}>
+                <span>{stop.sortOrder + 1}</span>
+                <span class="event-route-stop-label" transition:fade>
+                  {stop.resolvedLabel}
+                </span>
+              </div>
+            </Marker>
+          {/each}
+        {/if}
+        {#if !mapViewStore.eventsOnly}
+          {#each filteredBuildings as building (`building:${building.id}`)}
+            {#if building.lat && building.lon}
+              {@const editKey = buildingEditKey(building.id)}
+              {@const position = getEditablePosition(editKey, {
+                lat: building.lat,
+                lon: building.lon,
+                version: getLoadedVersion(building.version),
+              })}
+              {@const centralHoverPreview = shouldShowEntityHoverPreview()}
+              {@const previewSuppressed =
+                centralHoverPreview &&
+                isBuildingHoverPreview(
+                  entityHoverPreviewStore.entity,
+                  building.id,
+                )}
+              {#key `${editKey}:${canDragPin(editKey)}`}
+                <Marker
+                  lngLat={[position.lon, position.lat]}
+                  draggable={canDragPin(editKey)}
+                  onclick={() => handleMarkerClick(building.buildingName)}
+                  ondragstart={() => beginMarkerDrag(editKey)}
+                  ondragend={(e) =>
+                    handleBuildingDragEnd(
+                      e,
+                      building.id,
+                      building.buildingName,
+                      position,
+                    )}
+                >
+                  <MapEntityPin
+                    label={building.buildingName}
+                    active={activeBuildingName === building.buildingName}
+                    editable={canDragPin(editKey)}
+                    editing={selectedEditKey === editKey}
+                    dimmed={isBuildingDimmedForEventFocus(building.id)}
+                    eventLinked={isBuildingEventLinked(building.id)}
+                    hovered={hoveredEditKey === editKey}
+                    saveState={savingEditKey === editKey
+                      ? "saving"
+                      : savedEditKey === editKey
+                        ? "saved"
+                        : failedEditKey === editKey
+                          ? "failed"
+                          : "idle"}
+                    labelVisible={zoomLevel >= 17 ||
+                      activeBuildingName === building.buildingName}
+                    useCentralHoverPreview={centralHoverPreview}
+                    {previewSuppressed}
+                    onpointerenter={(event) =>
+                      handleBuildingPinPointerEnter(building, editKey, event)}
+                    onpointerleave={() =>
+                      handleBuildingPinPointerLeave(editKey)}
+                  >
+                    <University size="20" />
+                  </MapEntityPin>
+                </Marker>
+              {/key}
+            {/if}
+          {/each}
+        {/if}
+        {#if activeRouteId}
+          {#each activeRouteStops as stop, i (`${activeRouteId}-${i}-${stop.name}`)}
+            {@const isHovered = jeepneyStore.hoveredStopIndex === i}
+            {@const isSelected = jeepneyStore.selectedStopIndex === i}
+            <Marker lngLat={[stop.lon, stop.lat]}>
+              <button
+                type="button"
+                class="jeepney-stop-pin"
+                class:jeepney-stop-pin--hovered={isHovered}
+                class:jeepney-stop-pin--selected={isSelected}
+                style:--stop-color={activeRouteColor}
+                aria-label={`Jeepney stop ${i + 1}: ${stop.name}`}
+                aria-pressed={isSelected}
+                onclick={(event) => {
+                  event.stopPropagation();
+                  jeepneyStore.openStop(i);
+                }}
+                onmouseenter={() => jeepneyStore.setHoveredStop(i)}
+                onmouseleave={() => jeepneyStore.setHoveredStop(null)}
+                onfocus={() => jeepneyStore.setHoveredStop(i)}
+                onblur={() => jeepneyStore.setHoveredStop(null)}
+              >
+                <span class="stop-index" aria-hidden="true">{i + 1}</span>
+                <span class="stop-label" transition:fade>{stop.name}</span>
+              </button>
+            </Marker>
+          {/each}
+        {/if}
+
+        {#if !mapViewStore.eventsOnly}
+          {#each filteredDorms as dorm (`dorm:${dorm.id}`)}
+            {#if dorm.lat && dorm.lon}
+              {@const editKey = dormEditKey(dorm.id)}
+              {@const position = getEditablePosition(editKey, {
+                lat: dorm.lat,
+                lon: dorm.lon,
+                version: getLoadedVersion(dorm.version),
+              })}
+              {@const centralHoverPreview = shouldShowEntityHoverPreview()}
+              {@const previewSuppressed =
+                centralHoverPreview &&
+                isDormHoverPreview(entityHoverPreviewStore.entity, dorm.id)}
+              {#key `${editKey}:${canDragPin(editKey)}`}
+                <Marker
+                  lngLat={[position.lon, position.lat]}
+                  draggable={canDragPin(editKey)}
+                  onclick={() => handleDormMarkerClick(dorm.dormName)}
+                  ondragstart={() => beginMarkerDrag(editKey)}
+                  ondragend={(e) =>
+                    handleDormDragEnd(e, dorm.id, dorm.dormName, position)}
+                >
+                  <MapEntityPin
+                    label={dorm.dormName}
+                    tone={dorm.isUpManaged ? "dorm" : "privateDorm"}
+                    active={activeDormName === dorm.dormName}
+                    dimmed={isDormDimmedForEventFocus(dorm.id)}
+                    eventLinked={isDormEventLinked(dorm.id)}
+                    editable={canDragPin(editKey)}
+                    editing={selectedEditKey === editKey}
+                    hovered={hoveredEditKey === editKey}
+                    saveState={savingEditKey === editKey
+                      ? "saving"
+                      : savedEditKey === editKey
+                        ? "saved"
+                        : failedEditKey === editKey
+                          ? "failed"
+                          : "idle"}
+                    labelVisible={zoomLevel >= 17 ||
+                      activeDormName === dorm.dormName}
+                    useCentralHoverPreview={centralHoverPreview}
+                    {previewSuppressed}
+                    onpointerenter={(event) =>
+                      handleDormPinPointerEnter(dorm, editKey, event)}
+                    onpointerleave={() => handleDormPinPointerLeave(editKey)}
+                  >
+                    <House size="18" />
+                  </MapEntityPin>
+                </Marker>
+              {/key}
+            {/if}
+          {/each}
+        {/if}
+      </MapLibre>
+    {/if}
+  </div>
+
   {#if eventPlacementStore.active}
-    <EventPlacementImageField />
     {#if md.current}
       <div
         bind:this={editChromeEl}
@@ -2433,384 +2829,16 @@
       </div>
     {/if}
   {/if}
-  {#if mapStyle}
-    <MapLibre
-      bind:map={mapStore.mapInstance}
-      style={mapStyle}
-    maxBounds={CAMPUS_MAX_BOUNDS}
-    center={CAMPUS_DEFAULT_CAMERA.center}
-    zoom={17}
-    pitch={CAMPUS_DEFAULT_CAMERA.pitch}
-    bearing={CAMPUS_DEFAULT_CAMERA.bearing}
-    minZoom={13}
-    class="map"
-    attributionControl={false}
-  >
-    {#if locationStore.coords}
-      <Marker lngLat={locationStore.coords}>
-        <div class="user-location-pin"></div>
-      </Marker>
-    {/if}
-    {#if additionProposalStore.draftPin}
-      <Marker
-        lngLat={{
-          lng: additionProposalStore.draftPin.lon,
-          lat: additionProposalStore.draftPin.lat,
-        }}
-      >
-        <div class="addition-draft-pin" aria-hidden="true"></div>
-      </Marker>
-    {/if}
-    {#if loaded}
-      {#if editableEventLocation}
-        {@const editKey = eventLocationEditKey(editableEventLocation.event.id)}
-        <Marker
-          lngLat={getEventMarkerLngLat(editableEventLocation)}
-          draggable={canDragPin(editKey)}
-          onclick={() => handleEventMarkerClick(editableEventLocation.event)}
-          ondragstart={() => beginMarkerDrag(editKey)}
-          ondragend={(e) =>
-            handleEventLocationDragEnd(
-              e,
-              editableEventLocation.event,
-              editableEventLocation.location,
-            )}
-        >
-          <div class="event-marker-anchor event-edit-anchor">
-            <span class="event-anchor-dot event-edit-dot" aria-hidden="true"
-            ></span>
-            <div
-              class="event-edit-pin"
-              class:editing={selectedEditKey === editKey}
-              class:hovered={hoveredEditKey === editKey}
-              class:saving={savingEditKey === editKey}
-              class:saved={savedEditKey === editKey}
-              class:failed={failedEditKey === editKey}
-              title={`Drag to move ${editableEventLocation.event.title}`}
-              onpointerenter={() => handleEditablePinEnter(editKey)}
-              onpointerleave={() => handleEditablePinLeave(editKey)}
-            >
-              <span class="event-edit-icon" aria-hidden="true">
-                <CalendarDays size={18} />
-              </span>
-              <span class="event-edit-copy">
-                <span>{editableEventLocation.event.title}</span>
-                {#if savingEditKey === editKey}
-                  <strong>Saving</strong>
-                {:else if savedEditKey === editKey}
-                  <strong>Saved</strong>
-                {:else if failedEditKey === editKey}
-                  <strong>Failed</strong>
-                {:else}
-                  <strong>Drag location</strong>
-                {/if}
-              </span>
-              <span class="event-edit-handle" aria-hidden="true">
-                <Move size={16} />
-              </span>
-            </div>
-          </div>
-        </Marker>
-      {/if}
-      {#each eventMarkerGroups as group (`event-group:${group.key}`)}
-        <Marker lngLat={group.lngLat}>
-          <div class="event-marker-anchor" class:anchored={group.anchored}>
-            <span class="event-anchor-connector" aria-hidden="true"></span>
-            <span class="event-anchor-dot" aria-hidden="true"></span>
-            <div class="event-callout" class:anchored={group.anchored}>
-              {#if group.entries.length === 1}
-                {@const entry = group.entries[0]}
-                {#if entry}
-                  {@const image = getEventImage(
-                    entry.event.slug,
-                    entry.event.imageUrl,
-                    entry.event.title,
-                  )}
-                  {@const active = isSelectedEvent(entry.event)}
-                  {@const centralHoverPreview = shouldShowEntityHoverPreview()}
-                  {@const previewSuppressed =
-                    centralHoverPreview &&
-                    isEventHoverPreview(
-                      entityHoverPreviewStore.entity,
-                      entry.event.slug,
-                    )}
-                  <EventMapPin
-                    {active}
-                    useCentralHoverPreview={centralHoverPreview}
-                    {previewSuppressed}
-                    anchored={group.anchored}
-                    imageSrc={image?.src ?? null}
-                    dateLabel={formatEventMarkerDate(
-                      entry.event.occurrenceStartsAt,
-                    )}
-                    status={entry.event.status}
-                    title={`${entry.event.title}: ${entry.location.resolvedLabel}`}
-                    ariaLabel={`Open event ${entry.event.title} at ${entry.location.resolvedLabel}`}
-                    labelTitle={entry.event.title}
-                    labelMeta={`${getEventStatusLabel(entry.event)} · ${formatEventMarkerDateTime(
-                      entry.event.occurrenceStartsAt,
-                    )}`}
-                    labelVisible={zoomLevel >= 17 || active}
-                    onclick={() => handleEventMarkerClick(entry.event)}
-                    onpointerenter={(event) =>
-                      handleEventPinPointerEnter(entry.event, event)}
-                    onpointerleave={handleEventPinPointerLeave}
-                  />
-                {/if}
-              {:else}
-                {@const primaryEntry = group.entries[0]}
-                {@const isExpanded = expandedEventGroupKey === group.key}
-                {#if primaryEntry}
-                  {@const primaryImage = getEventImage(
-                    primaryEntry.event.slug,
-                    primaryEntry.event.imageUrl,
-                    primaryEntry.event.title,
-                  )}
-                  <EventMapPin
-                    variant="group"
-                    anchored={group.anchored}
-                    expanded={isExpanded}
-                    ariaExpanded={isExpanded}
-                    count={group.entries.length}
-                    imageSrc={primaryImage?.src ?? null}
-                    dateLabel={formatEventMarkerDate(
-                      primaryEntry.event.occurrenceStartsAt,
-                    )}
-                    status={primaryEntry.event.status}
-                    title={`${group.entries.length} events at ${group.label}`}
-                    ariaLabel={`${isExpanded ? "Collapse" : "Expand"} ${group.entries.length} events at ${group.label}`}
-                    onclick={() => toggleEventMarkerGroup(group.key)}
-                    onpointerenter={(event) =>
-                      handleEventPinPointerEnter(primaryEntry.event, event)}
-                    onpointerleave={handleEventPinPointerLeave}
-                  />
-                  {#if isExpanded}
-                    <div
-                      class="event-pin-stack"
-                      role="group"
-                      aria-label={`${group.entries.length} events at ${group.label}`}
-                      transition:fade
-                    >
-                      <div class="event-stack-header">
-                        <span class="event-stack-heading">
-                          <strong>{group.entries.length} events</strong>
-                          <span>{group.label}</span>
-                        </span>
-                        <button
-                          class="event-stack-close"
-                          type="button"
-                          aria-label={`Collapse events at ${group.label}`}
-                          onclick={collapseEventMarkerGroup}
-                        >
-                          <X size={14} />
-                        </button>
-                      </div>
-                      <div class="event-stack-list">
-                        {#each group.entries as entry (`event-stack:${entry.event.id}:${entry.location.id}`)}
-                          {@const image = getEventImage(
-                            entry.event.slug,
-                            entry.event.imageUrl,
-                            entry.event.title,
-                          )}
-                          <button
-                            type="button"
-                            class="event-stack-item"
-                            class:active={isSelectedEvent(entry.event)}
-                            class:upcoming={entry.event.status === "upcoming"}
-                            title={`${entry.event.title}: ${entry.location.resolvedLabel}`}
-                            aria-label={`Open event ${entry.event.title} at ${entry.location.resolvedLabel}`}
-                            onclick={() => handleEventMarkerClick(entry.event)}
-                          >
-                            {#if image}
-                              <img
-                                class="event-stack-thumb"
-                                src={image.src}
-                                alt=""
-                              />
-                            {:else}
-                              <span class="event-stack-icon" aria-hidden="true">
-                                <CalendarDays size={14} />
-                              </span>
-                            {/if}
-                            <span class="event-stack-copy">
-                              <span class="event-stack-title"
-                                >{entry.event.title}</span
-                              >
-                              <span class="event-stack-meta">
-                                {formatEventMarkerDate(
-                                  entry.event.occurrenceStartsAt,
-                                )}
-                                at {formatEventMarkerTime(
-                                  entry.event.occurrenceStartsAt,
-                                )}
-                                - {getEventStatusLabel(entry.event)}
-                              </span>
-                            </span>
-                          </button>
-                        {/each}
-                      </div>
-                    </div>
-                  {/if}
-                {/if}
-              {/if}
-            </div>
-          </div>
-        </Marker>
-      {/each}
-      {#each selectedEventRouteStops as stop (`event-stop:${stop.id}`)}
-        <Marker lngLat={[Number(stop.resolvedLon), Number(stop.resolvedLat)]}>
-          <div class="event-route-stop-pin" title={stop.resolvedLabel}>
-            <span>{stop.sortOrder + 1}</span>
-            <span class="event-route-stop-label" transition:fade>
-              {stop.resolvedLabel}
-            </span>
-          </div>
-        </Marker>
-      {/each}
-    {/if}
-    {#if !mapViewStore.eventsOnly}
-      {#each filteredBuildings as building (`building:${building.id}`)}
-        {#if building.lat && building.lon}
-          {@const editKey = buildingEditKey(building.id)}
-          {@const position = getEditablePosition(editKey, {
-            lat: building.lat,
-            lon: building.lon,
-            version: getLoadedVersion(building.version),
-          })}
-          {@const centralHoverPreview = shouldShowEntityHoverPreview()}
-          {@const previewSuppressed =
-            centralHoverPreview &&
-            isBuildingHoverPreview(entityHoverPreviewStore.entity, building.id)}
-          {#key `${editKey}:${canDragPin(editKey)}`}
-            <Marker
-              lngLat={[position.lon, position.lat]}
-              draggable={canDragPin(editKey)}
-              onclick={() => handleMarkerClick(building.buildingName)}
-              ondragstart={() => beginMarkerDrag(editKey)}
-              ondragend={(e) =>
-                handleBuildingDragEnd(
-                  e,
-                  building.id,
-                  building.buildingName,
-                  position,
-                )}
-            >
-              <MapEntityPin
-                label={building.buildingName}
-                active={activeBuildingName === building.buildingName}
-                editable={canDragPin(editKey)}
-                editing={selectedEditKey === editKey}
-                dimmed={isBuildingDimmedForEventFocus(building.id)}
-                eventLinked={isBuildingEventLinked(building.id)}
-                hovered={hoveredEditKey === editKey}
-                saveState={savingEditKey === editKey
-                  ? "saving"
-                  : savedEditKey === editKey
-                    ? "saved"
-                    : failedEditKey === editKey
-                      ? "failed"
-                      : "idle"}
-                labelVisible={zoomLevel >= 17 ||
-                  activeBuildingName === building.buildingName}
-                useCentralHoverPreview={centralHoverPreview}
-                {previewSuppressed}
-                onpointerenter={(event) =>
-                  handleBuildingPinPointerEnter(building, editKey, event)}
-                onpointerleave={() => handleBuildingPinPointerLeave(editKey)}
-              >
-                <University size="20" />
-              </MapEntityPin>
-            </Marker>
-          {/key}
-        {/if}
-      {/each}
-    {/if}
-    {#if activeRouteId}
-      {#each activeRouteStops as stop, i (`${activeRouteId}-${i}-${stop.name}`)}
-        {@const isHovered = jeepneyStore.hoveredStopIndex === i}
-        {@const isSelected = jeepneyStore.selectedStopIndex === i}
-        <Marker lngLat={[stop.lon, stop.lat]}>
-          <button
-            type="button"
-            class="jeepney-stop-pin"
-            class:jeepney-stop-pin--hovered={isHovered}
-            class:jeepney-stop-pin--selected={isSelected}
-            style:--stop-color={activeRouteColor}
-            aria-label={`Jeepney stop ${i + 1}: ${stop.name}`}
-            aria-pressed={isSelected}
-            onclick={(event) => {
-              event.stopPropagation();
-              jeepneyStore.openStop(i);
-            }}
-            onmouseenter={() => jeepneyStore.setHoveredStop(i)}
-            onmouseleave={() => jeepneyStore.setHoveredStop(null)}
-            onfocus={() => jeepneyStore.setHoveredStop(i)}
-            onblur={() => jeepneyStore.setHoveredStop(null)}
-          >
-            <span class="stop-index" aria-hidden="true">{i + 1}</span>
-            <span class="stop-label" transition:fade>{stop.name}</span>
-          </button>
-        </Marker>
-      {/each}
-    {/if}
-
-    {#if !mapViewStore.eventsOnly}
-      {#each filteredDorms as dorm (`dorm:${dorm.id}`)}
-        {#if dorm.lat && dorm.lon}
-          {@const editKey = dormEditKey(dorm.id)}
-          {@const position = getEditablePosition(editKey, {
-            lat: dorm.lat,
-            lon: dorm.lon,
-            version: getLoadedVersion(dorm.version),
-          })}
-          {@const centralHoverPreview = shouldShowEntityHoverPreview()}
-          {@const previewSuppressed =
-            centralHoverPreview &&
-            isDormHoverPreview(entityHoverPreviewStore.entity, dorm.id)}
-          {#key `${editKey}:${canDragPin(editKey)}`}
-            <Marker
-              lngLat={[position.lon, position.lat]}
-              draggable={canDragPin(editKey)}
-              onclick={() => handleDormMarkerClick(dorm.dormName)}
-              ondragstart={() => beginMarkerDrag(editKey)}
-              ondragend={(e) =>
-                handleDormDragEnd(e, dorm.id, dorm.dormName, position)}
-            >
-              <MapEntityPin
-                label={dorm.dormName}
-                tone={dorm.isUpManaged ? "dorm" : "privateDorm"}
-                active={activeDormName === dorm.dormName}
-                dimmed={isDormDimmedForEventFocus(dorm.id)}
-                eventLinked={isDormEventLinked(dorm.id)}
-                editable={canDragPin(editKey)}
-                editing={selectedEditKey === editKey}
-                hovered={hoveredEditKey === editKey}
-                saveState={savingEditKey === editKey
-                  ? "saving"
-                  : savedEditKey === editKey
-                    ? "saved"
-                    : failedEditKey === editKey
-                      ? "failed"
-                      : "idle"}
-                labelVisible={zoomLevel >= 17 || activeDormName === dorm.dormName}
-                useCentralHoverPreview={centralHoverPreview}
-                {previewSuppressed}
-                onpointerenter={(event) =>
-                  handleDormPinPointerEnter(dorm, editKey, event)}
-                onpointerleave={() => handleDormPinPointerLeave(editKey)}
-              >
-                <House size="18" />
-              </MapEntityPin>
-            </Marker>
-          {/key}
-        {/if}
-      {/each}
-    {/if}
-  </MapLibre>
-  {/if}
 </div>
 
 <style>
+  .map-shell {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+  }
+
   .map-container {
     position: fixed;
     top: 0;
@@ -2818,6 +2846,14 @@
     width: 100%;
     height: 100%;
     z-index: 0;
+    pointer-events: auto;
+  }
+
+  .map-shell :global(.edit-dock),
+  .map-shell :global(.map-edit-toolbar),
+  .map-shell :global(.event-placement-toolbar) {
+    pointer-events: auto;
+    z-index: 18;
   }
 
   .map-edit-toolbar {


### PR DESCRIPTION
## Summary
- Lift the mobile detail drawer when map edit is active so the peek tab no longer overlaps the edit dock (`--edit-bar-height` + `--bottom-fab-gap` in `.app-layout.edit-mode`).
- Move edit chrome outside `.map-container` so the dock stacks at z-index 18 above the UI layer and receives taps.
- Restore E2E undo/redo coverage via tap (not keyboard-only workaround).

## Test plan
- [x] `bun run build`
- [x] Prettier on edited files
- [ ] Blocking E2E (run/e2e label)
- [ ] Manual: mobile 320px — open building, enable map edit, drag pin, tap Undo then Redo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile layout tokens, z-index, and pointer-events across map shell and edit mode; low data/security risk but could regress overlay hit-testing or drawer positioning on small viewports.
> 
> **Overview**
> Fixes mobile map edit so **Undo/Redo on the edit dock receive taps** and no longer sit under overlapping UI.
> 
> **`Map.svelte`** wraps the canvas in a **`map-shell`**: the map stays in **`map-container`** with pointer events, while **edit docks/toolbars are siblings outside the container** with **`pointer-events: auto`** and **z-index 18**, so they are not trapped under the **`ui-layer`** stacking context.
> 
> **`Entry.svelte`** adds **`.app-layout.edit-mode`**, bumping **`--side-panel-bottom-inset`** by measured **`--edit-bar-height`** plus **`--bottom-fab-gap`** so the mobile detail sheet peek clears the edit dock.
> 
> Docs note the inset behavior; **E2E** exercises **tap Undo then Redo** after a pin drag instead of keyboard-only undo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2fa21e5d27480f8dae1e913e4929287e2a93f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->