### PR TITLE
feat(proposals): before/after field diffs in review queue

### DIFF
--- a/src/components/svelte/ProposalReviewPanel.component.test.ts
+++ b/src/components/svelte/ProposalReviewPanel.component.test.ts
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test } from "vitest";
+import ProposalReviewPanelHost from "@test/components/ProposalReviewPanelHost.svelte";
+import { adminAuthStore, proposalsStore } from "@lib/store.svelte";
+import { mountAtWidth } from "@test/layout-assertions";
+
+function baseProposal() {
+  return {
+    id: 7,
+    entityType: "building",
+    entityId: 12,
+    entityLabel: "Old Hall",
+    status: "pending",
+    submitterName: "Yeyel",
+    proposedPatch: { directions: "Enter from the east gate" },
+    adminNote: null,
+    createdAt: new Date().toISOString(),
+    baseVersion: 3,
+    currentValues: { directions: "Enter from the west gate" },
+    currentVersion: 3,
+  };
+}
+
+describe("ProposalReviewPanel diffs", () => {
+  beforeEach(() => {
+    adminAuthStore.isLoggedIn = true;
+    adminAuthStore.canReview = true;
+    proposalsStore.loading = false;
+    proposalsStore.pendingCount = 1;
+  });
+
+  test("renders before and after for a changed field at 320px", () => {
+    mountAtWidth(320);
+    proposalsStore.proposals = [baseProposal()];
+    render(ProposalReviewPanelHost);
+    expect(screen.getByText("Directions")).toBeVisible();
+    expect(screen.getByText("Enter from the west gate")).toBeVisible();
+    expect(screen.getByText("Enter from the east gate")).toBeVisible();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  test("shows stale banner when published version moved past baseVersion", () => {
+    proposalsStore.proposals = [{ ...baseProposal(), currentVersion: 5 }];
+    render(ProposalReviewPanelHost);
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /published data changed/i,
+    );
+  });
+
+  test("create proposals show New entry as the before value", () => {
+    proposalsStore.proposals = [
+      {
+        ...baseProposal(),
+        entityType: "create_room",
+        entityId: 0,
+        baseVersion: 0,
+        proposedPatch: { roomCode: "CEM 203" },
+        currentValues: null,
+        currentVersion: null,
+      },
+    ];
+    render(ProposalReviewPanelHost);
+    expect(screen.getByText("New entry")).toBeVisible();
+    expect(screen.getByText("CEM 203")).toBeVisible();
+  });
+});

--- a/src/components/svelte/ProposalReviewPanel.svelte
+++ b/src/components/svelte/ProposalReviewPanel.svelte
@@ -4,7 +4,7 @@
     proposalsStore,
     toastStore,
   } from "@lib/store.svelte";
-  import { summarizeProposalPatch } from "@lib/proposals/client";
+  import { buildFieldDiffs } from "@lib/proposals/diff";
   import { afterProposalPublished } from "@lib/proposals/apply-published-entity";
   import { syncOpenEntityQueryAfterPublish } from "@lib/proposals/sync-open-entity-query";
   import { getAppActions, getAppData } from "@lib/context";
@@ -113,9 +113,31 @@
                 >{proposal.submitterName}</span
               >
             </div>
+            {#if proposal.currentVersion != null && proposal.currentVersion !== proposal.baseVersion}
+              <p class="entity-review-stale" role="alert">
+                Published data changed since this was submitted. Compare
+                carefully — approving may conflict.
+              </p>
+            {/if}
             <ul class="entity-review-changes">
-              {#each summarizeProposalPatch(proposal.proposedPatch, proposal.entityType as ProposalEntityType) as line}
-                <li>{line}</li>
+              {#each buildFieldDiffs(proposal.currentValues ?? null, proposal.proposedPatch) as diff (diff.field)}
+                <li class="entity-review-diff">
+                  <span class="entity-review-diff-label">{diff.label}</span>
+                  <span class="entity-review-diff-values">
+                    <span
+                      class="entity-review-diff-old"
+                      class:entity-review-diff-before={diff.before != null}
+                      >{proposal.currentValues == null &&
+                      proposal.entityType.startsWith("create_")
+                        ? "New entry"
+                        : (diff.before ?? "—")}</span
+                    >
+                    <span aria-hidden="true">→</span>
+                    <span class="entity-review-diff-after"
+                      >{diff.after ?? "—"}</span
+                    >
+                  </span>
+                </li>
               {/each}
             </ul>
             {#if bundledRoomsSummary(proposal.entityType as ProposalEntityType, proposal.proposedPatch as Record<string, unknown>)}
@@ -166,5 +188,49 @@
     font-size: 0.85rem;
     font-weight: 600;
     line-height: 1.35;
+  }
+
+  .entity-review-stale {
+    margin: 0.35rem 0;
+    padding: 0.35rem 0.5rem;
+    border-radius: 6px;
+    background: hsl(40 90% 92%);
+    border: 1px solid hsl(40 70% 70%);
+    color: hsl(30 60% 25%);
+    font-size: 0.8rem;
+    line-height: 1.35;
+  }
+
+  .entity-review-diff {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.15rem 0.5rem;
+    font-size: 0.85rem;
+    line-height: 1.4;
+  }
+
+  .entity-review-diff-label {
+    font-weight: 600;
+  }
+
+  .entity-review-diff-values {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  .entity-review-diff-old {
+    color: hsl(0 0% 45%);
+    overflow-wrap: anywhere;
+  }
+
+  .entity-review-diff-before {
+    text-decoration: line-through;
+  }
+
+  .entity-review-diff-after {
+    font-weight: 600;
+    overflow-wrap: anywhere;
   }
 </style>

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -2,6 +2,7 @@ import type {
   ProposalCreateType,
   ProposalEntityType,
 } from "@lib/services/proposal-service";
+import { FIELD_LABELS } from "./diff";
 import { validateSubmitterName } from "@constants/proposals";
 import type { RoomData } from "@lib/types";
 import {
@@ -143,35 +144,6 @@ export async function loadOpenPendingProposals(options?: {
   );
   return rows.filter((row) => isOpenProposalStatus(row.status));
 }
-
-const FIELD_LABELS: Record<string, string> = {
-  buildingName: "Building name",
-  directions: "Directions",
-  buildingType: "Building type",
-  lat: "Latitude",
-  lon: "Longitude",
-  buildingId: "Building",
-  dormName: "Dorm name",
-  shortName: "Short name",
-  gender: "Gender",
-  capacity: "Capacity",
-  roomCode: "Room code",
-  collegeName: "College name",
-  collegeId: "Parent college",
-  divisionName: "Division name",
-  description: "Description",
-  managingOffice: "Managing office",
-  contactEmail: "Contact email",
-  isUpManaged: "UP managed",
-  title: "Title",
-  category: "Category",
-  startsAt: "Starts",
-  endsAt: "Ends",
-  sourceUrl: "Source URL",
-  imageUrl: "Image",
-  recurrence: "Recurrence",
-  rooms: "Bundled rooms",
-};
 
 export function summarizeProposalPatch(
   patch: Record<string, unknown>,

--- a/src/lib/proposals/diff.test.ts
+++ b/src/lib/proposals/diff.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { buildFieldDiffs } from "./diff";
+
+describe("buildFieldDiffs", () => {
+  test("shows before and after for a changed string field", () => {
+    const diffs = buildFieldDiffs(
+      { buildingName: "Old Hall", version: 3 },
+      { buildingName: "New Hall" },
+    );
+    expect(diffs).toEqual([
+      {
+        field: "buildingName",
+        label: "Building name",
+        before: "Old Hall",
+        after: "New Hall",
+      },
+    ]);
+  });
+
+  test("omits fields where the value is unchanged", () => {
+    const diffs = buildFieldDiffs(
+      { directions: "Same", capacity: 10 },
+      { directions: "Same", capacity: 12 },
+    );
+    expect(diffs.map((d) => d.field)).toEqual(["capacity"]);
+  });
+
+  test("formats booleans, nulls, and arrays", () => {
+    const diffs = buildFieldDiffs(
+      { isUpManaged: false, contactEmail: null, amenities: ["wifi"] },
+      { isUpManaged: true, contactEmail: "a@b.ph", amenities: ["wifi", "gym"] },
+    );
+    expect(diffs).toEqual([
+      { field: "isUpManaged", label: "UP managed", before: "No", after: "Yes" },
+      {
+        field: "contactEmail",
+        label: "Contact email",
+        before: null,
+        after: "a@b.ph",
+      },
+      {
+        field: "amenities",
+        label: "amenities",
+        before: "wifi",
+        after: "wifi, gym",
+      },
+    ]);
+  });
+
+  test("create proposals (null current) list every patch field with null before", () => {
+    const diffs = buildFieldDiffs(null, { roomCode: "CEM 203", lat: 14.16 });
+    expect(diffs).toEqual([
+      { field: "roomCode", label: "Room code", before: null, after: "CEM 203" },
+      { field: "lat", label: "Latitude", before: null, after: "14.16" },
+    ]);
+  });
+
+  test("skips bundled rooms and event locations keys", () => {
+    const diffs = buildFieldDiffs(null, {
+      rooms: [{ roomCode: "A" }],
+      locations: [{ label: "gate" }],
+      title: "Fair",
+    });
+    expect(diffs.map((d) => d.field)).toEqual(["title"]);
+  });
+
+  test("treats empty strings as unset", () => {
+    const diffs = buildFieldDiffs(
+      { description: "" },
+      { description: "Now filled" },
+    );
+    expect(diffs[0]).toEqual({
+      field: "description",
+      label: "Description",
+      before: null,
+      after: "Now filled",
+    });
+  });
+});

--- a/src/lib/proposals/diff.ts
+++ b/src/lib/proposals/diff.ts
@@ -1,0 +1,76 @@
+export const FIELD_LABELS: Record<string, string> = {
+  buildingName: "Building name",
+  directions: "Directions",
+  buildingType: "Building type",
+  lat: "Latitude",
+  lon: "Longitude",
+  buildingId: "Building",
+  dormName: "Dorm name",
+  shortName: "Short name",
+  gender: "Gender",
+  capacity: "Capacity",
+  roomCode: "Room code",
+  collegeName: "College name",
+  collegeId: "Parent college",
+  divisionName: "Division name",
+  description: "Description",
+  managingOffice: "Managing office",
+  contactEmail: "Contact email",
+  isUpManaged: "UP managed",
+  title: "Title",
+  category: "Category",
+  startsAt: "Starts",
+  endsAt: "Ends",
+  sourceUrl: "Source URL",
+  imageUrl: "Image",
+  recurrence: "Recurrence",
+  rooms: "Bundled rooms",
+};
+
+export type FieldDiff = {
+  field: string;
+  label: string;
+  /** null = empty / not set (render as em dash) */
+  before: string | null;
+  after: string | null;
+};
+
+// Keys with their own review summaries (bundled rooms, event locations).
+const SKIPPED_KEYS = new Set(["rooms", "locations"]);
+
+function formatValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value.trim() === "" ? null : value;
+  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (Array.isArray(value)) {
+    const items = value.filter((item) => item !== null && item !== undefined);
+    return items.length === 0 ? null : items.map(String).join(", ");
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * Before/after rows for a proposal patch against the currently published
+ * entity. `current` is null for create_* proposals (before renders as new).
+ * Unchanged fields are omitted so reviewers only see real differences.
+ */
+export function buildFieldDiffs(
+  current: Record<string, unknown> | null,
+  patch: Record<string, unknown>,
+): FieldDiff[] {
+  const diffs: FieldDiff[] = [];
+  for (const [field, proposed] of Object.entries(patch)) {
+    if (SKIPPED_KEYS.has(field)) continue;
+    const before = current ? formatValue(current[field]) : null;
+    const after = formatValue(proposed);
+    if (current && before === after) continue;
+    diffs.push({
+      field,
+      label: FIELD_LABELS[field] ?? field,
+      before,
+      after,
+    });
+  }
+  return diffs;
+}

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -339,6 +339,101 @@ export async function listPendingProposals(): Promise<EditProposalSummary[]> {
   return Promise.all(rows.map(withEntityLabel));
 }
 
+export async function getCurrentEntityValues(
+  entityType: ProposalUpdateType,
+  entityId: number,
+): Promise<Record<string, unknown> | null> {
+  switch (entityType) {
+    case "building": {
+      const [row] = await db
+        .select()
+        .from(buildingsTable)
+        .where(eq(buildingsTable.id, entityId))
+        .limit(1);
+      return row ?? null;
+    }
+    case "dorm": {
+      const [row] = await db
+        .select()
+        .from(dormsTable)
+        .where(eq(dormsTable.id, entityId))
+        .limit(1);
+      return row ?? null;
+    }
+    case "room": {
+      const [row] = await db
+        .select()
+        .from(roomsTable)
+        .where(eq(roomsTable.id, entityId))
+        .limit(1);
+      return row ?? null;
+    }
+    case "college": {
+      const [row] = await db
+        .select()
+        .from(collegesTable)
+        .where(eq(collegesTable.id, entityId))
+        .limit(1);
+      return row ?? null;
+    }
+    case "division": {
+      const [row] = await db
+        .select()
+        .from(divisionsTable)
+        .where(eq(divisionsTable.id, entityId))
+        .limit(1);
+      return row ?? null;
+    }
+    case "event":
+    case "event_locations": {
+      const [row] = await db
+        .select()
+        .from(eventsTable)
+        .where(eq(eventsTable.id, entityId))
+        .limit(1);
+      return row ?? null;
+    }
+  }
+}
+
+export type ReviewProposalSummary = EditProposalSummary & {
+  /** Published values for the patched fields; null for create_* or deleted entities. */
+  currentValues: Record<string, unknown> | null;
+  currentVersion: number | null;
+};
+
+export async function listPendingProposalsForReview(): Promise<
+  ReviewProposalSummary[]
+> {
+  const rows = await listPendingProposals();
+  return Promise.all(
+    rows.map(async (row) => {
+      if (isCreateProposalType(row.entityType)) {
+        return { ...row, currentValues: null, currentVersion: null };
+      }
+      const current = await getCurrentEntityValues(
+        row.entityType as ProposalUpdateType,
+        row.entityId,
+      );
+      if (!current) {
+        return { ...row, currentValues: null, currentVersion: null };
+      }
+      const patch = row.proposedPatch as Record<string, unknown>;
+      const currentValues = Object.fromEntries(
+        Object.keys(patch)
+          .filter((key) => key in current)
+          .map((key) => [key, current[key]]),
+      );
+      const version = current.version;
+      return {
+        ...row,
+        currentValues,
+        currentVersion: typeof version === "number" ? version : null,
+      };
+    }),
+  );
+}
+
 export async function countPendingProposals(): Promise<number> {
   const rows = await db
     .select({ c: sql<number>`count(*)` })

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -594,6 +594,9 @@ class ProposalsStore {
       proposedPatch: Record<string, unknown>;
       adminNote?: string | null;
       createdAt: string;
+      baseVersion: number;
+      currentValues?: Record<string, unknown> | null;
+      currentVersion?: number | null;
     }>
   >([]);
 

--- a/src/pages/api/admin/proposals/index.ts
+++ b/src/pages/api/admin/proposals/index.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
 import {
   countPendingProposals,
-  listPendingProposals,
+  listPendingProposalsForReview,
 } from "@lib/services/proposal-service";
 
 export const prerender = false;
@@ -12,7 +12,7 @@ export const GET: APIRoute = async ({ cookies }) => {
   if (auth instanceof Response) return auth;
 
   const [proposals, pendingCount] = await Promise.all([
-    listPendingProposals(),
+    listPendingProposalsForReview(),
     countPendingProposals(),
   ]);
 

--- a/src/test/components/ProposalReviewPanelHost.svelte
+++ b/src/test/components/ProposalReviewPanelHost.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import ProposalReviewPanel from "@ui/ProposalReviewPanel.svelte";
+  import AppContextTestShell from "@test/AppContextTestShell.svelte";
+  import { loadedAppContext } from "@test/fixtures/app-context";
+</script>
+
+<AppContextTestShell data={loadedAppContext()}>
+  <ProposalReviewPanel />
+</AppContextTestShell>


### PR DESCRIPTION
## Summary
- Admin proposals list API now includes `currentValues` (published values for the patched fields only) and `currentVersion` per proposal
- New shared `src/lib/proposals/diff.ts`: `buildFieldDiffs(current, patch)` + `FIELD_LABELS` (moved out of client.ts) — reused by upcoming version-history UI (#202)
- `ProposalReviewPanel` renders per-field **before → after** rows (strikethrough old value), a stale-`baseVersion` warning banner when the published row moved on, and **New entry** for create_* proposals
- Stacks cleanly at 320px

## Test plan
- [x] `bun test src/lib` — 174 pass (6 new diff unit tests)
- [x] `bunx vitest run ProposalReviewPanel.component.test.ts` — 3 pass (diff @320px, stale banner, create proposal)
- [x] `bun run build` green

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Review API now does extra DB reads per pending update proposal and exposes published field values to reviewers; approval behavior is unchanged but reviewers rely on new version/stale signaling.
> 
> **Overview**
> The admin proposals review flow now loads **published baseline data** alongside each pending edit. `GET /api/admin/proposals` uses `listPendingProposalsForReview()` to attach `currentValues` (live values for patched fields only) and `currentVersion`; create proposals and missing entities get nulls.
> 
> **`ProposalReviewPanel`** stops listing one-line patch summaries and instead renders per-field **before → after** rows via new shared `buildFieldDiffs()` in `src/lib/proposals/diff.ts` (with `FIELD_LABELS` moved out of `client.ts`). Unchanged fields are hidden; create_* proposals show **New entry** as the before side. When `currentVersion !== baseVersion`, a **stale** alert warns that approval may conflict.
> 
> Unit and component tests cover diff formatting, stale banner, narrow layout, and create proposals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae887ca1b9490a63a80367f088d1e7effa786713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->