### PR TITLE
feat(editor): entity images, Google sign-in, editor email digest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,13 @@ R2_PUBLIC_URL=
 # NOTIFICATION_GATEWAY_URL=https://your-bot.herokuapp.com/notifications
 # NOTIFICATION_INGRESS_SECRET=
 
+# Resend — daily editor digest of pending proposals (#272). Optional; digest
+# is skipped when unset. Vercel injects CRON_SECRET automatically in prod;
+# set locally only to test /api/cron/proposal-digest by hand.
+# RESEND_API_KEY=
+# RESEND_FROM_EMAIL="Room TBA <digest@uplbtools.me>"
+# CRON_SECRET=
+
 # AMIS import (scripts/import-amis-classes.ts) — copy bearer token from browser DevTools after AMIS login.
 # Tokens expire in about an hour; paste fresh when running --fetch. Never commit real tokens.
 # Fetch once with --fetch (while token is valid); later imports read data/amis-*-{termId}.json (gitignored).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -197,6 +197,24 @@ export default defineConfig({
         context: "server",
         optional: true,
       }),
+      // Resend (editor email digests, #272). Digest is skipped when unset.
+      RESEND_API_KEY: envField.string({
+        access: "secret",
+        context: "server",
+        optional: true,
+      }),
+      // From address, e.g. "Room TBA <digest@uplbtools.me>".
+      RESEND_FROM_EMAIL: envField.string({
+        access: "secret",
+        context: "server",
+        optional: true,
+      }),
+      // Vercel injects CRON_SECRET; /api/cron/* requires it as a Bearer token.
+      CRON_SECRET: envField.string({
+        access: "secret",
+        context: "server",
+        optional: true,
+      }),
     },
   },
   adapter: e2eNodeAdapter

--- a/drizzle/0019_add_entity_image_url.sql
+++ b/drizzle/0019_add_entity_image_url.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "image_url" text;
+ALTER TABLE "rooms" ADD COLUMN IF NOT EXISTS "image_url" text;
+ALTER TABLE "dorms" ADD COLUMN IF NOT EXISTS "image_url" text;

--- a/drizzle/0020_add_admin_user_email.sql
+++ b/drizzle/0020_add_admin_user_email.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "admin_users" ADD COLUMN IF NOT EXISTS "email" text;
+CREATE UNIQUE INDEX IF NOT EXISTS "admin_users_email_unique"
+  ON "admin_users" (lower("email"))
+  WHERE "email" IS NOT NULL;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -101,6 +101,7 @@ export const dormsTable = pgTable("dorms", {
   priceRange: text("price_range"),
   contactPhone: varchar("contact_phone", { length: 20 }).array(),
   facebookLink: text("facebook_link"),
+  imageUrl: text("image_url"),
   version: integer().default(1).notNull(),
   updatedAt: timestamp("updated_at", { mode: "string" }).defaultNow().notNull(),
 });
@@ -204,6 +205,7 @@ export const buildingsTable = pgTable("buildings", {
   buildingType: buildingEnum("type").default("non-admin").notNull(),
   lat: doublePrecision().notNull(),
   directions: text().notNull(),
+  imageUrl: text("image_url"),
   version: integer().default(1).notNull(),
   updatedAt: timestamp("updated_at", { mode: "string" }).defaultNow().notNull(),
 });
@@ -277,6 +279,7 @@ export const roomsTable = pgTable(
     buildingId: integer("building_id"),
     collegeId: integer("college_id"),
     divisionId: integer("division_id"),
+    imageUrl: text("image_url"),
     version: integer().default(1).notNull(),
     updatedAt: timestamp("updated_at", { mode: "string" })
       .defaultNow()
@@ -326,6 +329,7 @@ export const adminUsersTable = pgTable(
     displayName: varchar("display_name", { length: 100 }),
     passwordHash: text("password_hash").notNull(),
     role: adminRoleEnum().default("editor").notNull(),
+    email: text(),
     isActive: boolean("is_active").default(true).notNull(),
     supabaseUserId: uuid("supabase_user_id"),
     createdAt: timestamp("created_at", { mode: "string" })

--- a/integration/services/contributor-link.integration.test.ts
+++ b/integration/services/contributor-link.integration.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import pg from "pg";
+import { integrationDatabaseUrl, skipWithoutE2eDb } from "../helpers/env";
+
+const describeIntegration = skipWithoutE2eDb() ? describe.skip : describe;
+
+const SUPABASE_ID_NEW = "00000000-0000-4000-8000-00000000e2e1";
+const SUPABASE_ID_LINK = "00000000-0000-4000-8000-00000000e2e2";
+const EMAIL_NEW = "e2e-google-new@example.com";
+const EMAIL_LINK = "e2e-google-link@example.com";
+
+describeIntegration("linkOrCreateContributorFromSupabase (#456)", () => {
+  let client: pg.Client;
+
+  const cleanup = async () => {
+    await client.query(
+      `DELETE FROM admin_users WHERE email IN ($1, $2) OR supabase_user_id IN ($3, $4)`,
+      [EMAIL_NEW, EMAIL_LINK, SUPABASE_ID_NEW, SUPABASE_ID_LINK],
+    );
+  };
+
+  beforeAll(async () => {
+    const url = integrationDatabaseUrl();
+    if (!url) return;
+    client = new pg.Client({ connectionString: url });
+    await client.connect();
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await client?.end();
+  });
+
+  test("creates a contributor account for a new Google user", async () => {
+    const { linkOrCreateContributorFromSupabase } = await import(
+      "@lib/services/admin-user-service"
+    );
+    const user = await linkOrCreateContributorFromSupabase({
+      id: SUPABASE_ID_NEW,
+      email: EMAIL_NEW,
+      name: "E2E Google User",
+    });
+    expect(user).not.toBeNull();
+    expect(user?.role).toBe("contributor");
+    expect(user?.displayName).toBe("E2E Google User");
+
+    const { rows } = await client.query(
+      `SELECT role, email, supabase_user_id FROM admin_users WHERE supabase_user_id = $1`,
+      [SUPABASE_ID_NEW],
+    );
+    expect(rows[0]?.role).toBe("contributor");
+    expect(rows[0]?.email).toBe(EMAIL_NEW);
+  });
+
+  test("returning Google user resolves to the same account", async () => {
+    const { linkOrCreateContributorFromSupabase } = await import(
+      "@lib/services/admin-user-service"
+    );
+    const first = await linkOrCreateContributorFromSupabase({
+      id: SUPABASE_ID_NEW,
+      email: EMAIL_NEW,
+    });
+    const second = await linkOrCreateContributorFromSupabase({
+      id: SUPABASE_ID_NEW,
+      email: EMAIL_NEW,
+    });
+    expect(second?.id).toBe(first?.id ?? -1);
+  });
+
+  test("links an existing account by email without a supabase id", async () => {
+    await client.query(
+      `INSERT INTO admin_users (username, display_name, password_hash, role, email, is_active)
+       VALUES ('e2e-google-link', 'Link Me', 'x', 'editor', $1, true)`,
+      [EMAIL_LINK],
+    );
+    const { linkOrCreateContributorFromSupabase } = await import(
+      "@lib/services/admin-user-service"
+    );
+    const user = await linkOrCreateContributorFromSupabase({
+      id: SUPABASE_ID_LINK,
+      email: EMAIL_LINK.toUpperCase(),
+    });
+    expect(user?.username).toBe("e2e-google-link");
+    expect(user?.role).toBe("editor");
+
+    const { rows } = await client.query(
+      `SELECT supabase_user_id FROM admin_users WHERE email = $1`,
+      [EMAIL_LINK],
+    );
+    expect(rows[0]?.supabase_user_id).toBe(SUPABASE_ID_LINK);
+  });
+});

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -44,6 +44,8 @@ function assertE2eDatabase(url: string) {
 const E2E_MIGRATION_FILES = [
   "0017_add_withdrawn_proposal_status.sql",
   "0018_contributions_ledger.sql",
+  "0019_add_entity_image_url.sql",
+  "0020_add_admin_user_email.sql",
 ] as const;
 
 async function applyE2eMigrations(client: pg.Client) {

--- a/src/components/svelte/AdminLoginModal.svelte
+++ b/src/components/svelte/AdminLoginModal.svelte
@@ -16,13 +16,44 @@
   import "./editor/entity-editor.css";
   import { MediaQuery } from "svelte/reactivity";
 
+  import { isSupabaseConfigured } from "@lib/supabase/env";
+
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
   const loginErrorId = "admin-login-error";
+  const googleEnabled = isSupabaseConfigured();
+
+  const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+    missing_code: "Google sign-in was cancelled or incomplete. Try again.",
+    oauth_failed: "Google sign-in failed. Try again.",
+    account_unavailable:
+      "This Google account cannot be used to sign in. Contact the maintainers.",
+  };
 
   let loginFrameEl = $state<HTMLDivElement | null>(null);
   let username = $state("admin");
   let password = $state("");
   let error: string | null = $state(null);
+  let googleLoading = $state(false);
+
+  $effect(() => {
+    const code = adminAuthStore.oauthError;
+    if (code) {
+      error =
+        OAUTH_ERROR_MESSAGES[code] ?? "Google sign-in failed. Try again.";
+    }
+  });
+
+  async function signInWithGoogle() {
+    error = null;
+    adminAuthStore.oauthError = null;
+    googleLoading = true;
+    const err = await adminAuthStore.loginWithGoogle();
+    if (err) {
+      error = err;
+      googleLoading = false;
+    }
+    // On success the browser navigates away to Google.
+  }
 
   async function submit(e: Event) {
     e.preventDefault();
@@ -118,6 +149,35 @@
         savingLabel="Signing in…"
         saving={adminAuthStore.loading}
       />
+      {#if googleEnabled}
+        <div class="login-divider" aria-hidden="true">or</div>
+        <button
+          type="button"
+          class="google-login-btn"
+          onclick={signInWithGoogle}
+          disabled={googleLoading || adminAuthStore.loading}
+        >
+          <svg viewBox="0 0 48 48" width="16" height="16" aria-hidden="true">
+            <path
+              fill="#EA4335"
+              d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+            />
+            <path
+              fill="#4285F4"
+              d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+            />
+            <path
+              fill="#FBBC05"
+              d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+            />
+            <path
+              fill="#34A853"
+              d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+            />
+          </svg>
+          {googleLoading ? "Redirecting…" : "Continue with Google"}
+        </button>
+      {/if}
     </form>
     <p class="login-footer">
       Need editor access?
@@ -206,5 +266,44 @@
   .login-footer-link:focus-visible {
     text-decoration: underline;
     text-underline-offset: 2px;
+  }
+  .login-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: hsl(0, 0%, 55%);
+    font-size: 0.75rem;
+    margin: 0.25rem 0;
+  }
+  .login-divider::before,
+  .login-divider::after {
+    content: "";
+    flex: 1;
+    border-top: 1px solid hsl(0, 0%, 90%);
+  }
+  .google-login-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid hsl(0, 0%, 82%);
+    border-radius: 0.5rem;
+    background: white;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 25%);
+    cursor: pointer;
+  }
+  .google-login-btn:hover:not(:disabled),
+  .google-login-btn:focus-visible {
+    background: hsl(0, 0%, 97%);
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 1px;
+  }
+  .google-login-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 </style>

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -78,6 +78,13 @@
       window.history.replaceState({}, "", window.location.pathname);
     }
 
+    const authError = urlParams.get("auth_error");
+    if (authError) {
+      adminAuthStore.oauthError = authError;
+      adminAuthStore.openLogin();
+      window.history.replaceState({}, "", window.location.pathname);
+    }
+
     if (urlParams.get("contribute") === "1") {
       floatingControlPanelStore.openPanel = "suggest-addition";
       window.history.replaceState({}, "", window.location.pathname);

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -21,6 +21,8 @@
   import EntityEditorPanel from "@ui/editor/EntityEditorPanel.svelte";
   import EntityEditorField from "@ui/editor/EntityEditorField.svelte";
   import EntityEditorPinRow from "@ui/editor/EntityEditorPinRow.svelte";
+  import ImageUpload from "@ui/editor/ImageUpload.svelte";
+  import { fieldSaveActionLabel } from "@lib/editor/field-action-label";
   import { entityEditorSavedMessage } from "@lib/editor/field-action-label";
   import { tick } from "svelte";
   import {
@@ -45,7 +47,11 @@
     scheduleEntityContributorDraftSave,
   } from "@lib/contributor-drafts";
 
-  type BuildingEditableField = "buildingName" | "directions" | "buildingType";
+  type BuildingEditableField =
+    | "buildingName"
+    | "directions"
+    | "buildingType"
+    | "imageUrl";
 
   const appData = getAppData();
   const appActions = getAppActions();
@@ -88,6 +94,7 @@
   let nameDraft = $state("");
   let directionsDraft = $state("");
   let typeDraft = $state<BuildingData["buildingType"]>("non-admin");
+  let imageDraft = $state<string | null>(null);
   let savingField = $state<BuildingEditableField | null>(null);
   let savedField = $state<BuildingEditableField | null>(null);
   let fieldError = $state<string | null>(null);
@@ -107,6 +114,7 @@
     buildingName: "Building name",
     directions: "Building directions",
     buildingType: "Building type",
+    imageUrl: "Building photo",
   };
 
   // Room list must reload when the selected building changes (search result,
@@ -198,6 +206,7 @@
     nameDraft = current.buildingName;
     directionsDraft = current.directions ?? "";
     typeDraft = current.buildingType;
+    imageDraft = current.imageUrl ?? null;
     savedField = null;
     fieldError = null;
     mergePrompt = null;
@@ -275,6 +284,7 @@
       buildingName?: string;
       directions?: string;
       buildingType?: BuildingData["buildingType"];
+      imageUrl?: string | null;
     } = { version: current.version };
 
     if (field === "buildingName") {
@@ -288,6 +298,8 @@
       body.directions = directionsDraft.trim();
     } else if (field === "buildingType") {
       body.buildingType = typeDraft;
+    } else if (field === "imageUrl") {
+      body.imageUrl = imageDraft || null;
     }
 
     savingField = field;
@@ -568,11 +580,43 @@
                   </select>
                 {/snippet}
               </EntityEditorField>
+
+              {#if adminAuthStore.isLoggedIn}
+                <div class="editor-image-row">
+                  <ImageUpload
+                    label="Building photo"
+                    inputId="building-image-editor"
+                    prefix="buildings"
+                    bind:value={imageDraft}
+                    disabled={savingField !== null}
+                  />
+                  <button
+                    type="button"
+                    class="field-save-btn"
+                    disabled={savingField !== null ||
+                      (imageDraft ?? null) === (building.imageUrl ?? null)}
+                    onclick={() => saveField("imageUrl")}
+                  >
+                    {fieldSaveActionLabel({
+                      canPublish,
+                      isSaving: savingField === "imageUrl",
+                    })}
+                  </button>
+                </div>
+              {/if}
             </div>
           </details>
         </EntityEditorPanel>
       </section>
     {:else}
+      {#if building.imageUrl}
+        <img
+          class="entity-image"
+          src={building.imageUrl}
+          alt="Photo of {building.buildingName}"
+          loading="lazy"
+        />
+      {/if}
       <section class="entity-directions" aria-label="Directions">
         <div class="entity-directions__segment">
           {#if building.directions}

--- a/src/components/svelte/controls/DormEditorPanel.svelte
+++ b/src/components/svelte/controls/DormEditorPanel.svelte
@@ -4,6 +4,8 @@
   import EntityEditorPinRow from "@ui/editor/EntityEditorPinRow.svelte";
   import EntityEditorField from "@ui/editor/EntityEditorField.svelte";
   import EntityEditorCheckboxField from "@ui/editor/EntityEditorCheckboxField.svelte";
+  import ImageUpload from "@ui/editor/ImageUpload.svelte";
+  import { fieldSaveActionLabel } from "@lib/editor/field-action-label";
   import { entityEditorSavedMessage } from "@lib/editor/field-action-label";
   import {
     adminAuthStore,
@@ -25,7 +27,8 @@
     | "contactPhone"
     | "amenities"
     | "facebookLink"
-    | "osmLink";
+    | "osmLink"
+    | "imageUrl";
 
   type Props = {
     dorm: DormData;
@@ -50,6 +53,7 @@
     amenitiesDraft: string;
     facebookLinkDraft: string;
     osmLinkDraft: string;
+    imageDraft: string | null;
     fieldLabel: (field: DormEditableField) => string;
     fieldIsUnchanged: (field: DormEditableField, current: DormData) => boolean;
     saveField: (field: DormEditableField) => void;
@@ -79,6 +83,7 @@
     amenitiesDraft = $bindable(""),
     facebookLinkDraft = $bindable(""),
     osmLinkDraft = $bindable(""),
+    imageDraft = $bindable(null),
     fieldLabel,
     fieldIsUnchanged,
     saveField,
@@ -341,6 +346,29 @@
       />
     {/snippet}
   </EntityEditorField>
+
+  {#if adminAuthStore.isLoggedIn}
+    <div class="editor-image-row">
+      <ImageUpload
+        label="Dorm photo"
+        inputId="dorm-image-editor"
+        prefix="dorms"
+        bind:value={imageDraft}
+        {disabled}
+      />
+      <button
+        type="button"
+        class="field-save-btn"
+        disabled={disabled || fieldIsUnchanged("imageUrl", dorm)}
+        onclick={() => saveField("imageUrl")}
+      >
+        {fieldSaveActionLabel({
+          canPublish,
+          isSaving: savingField === "imageUrl",
+        })}
+      </button>
+    </div>
+  {/if}
 
   <p class="editor-note">
     {#if canPublish}

--- a/src/components/svelte/controls/DormResult.svelte
+++ b/src/components/svelte/controls/DormResult.svelte
@@ -47,7 +47,8 @@
     | "contactPhone"
     | "amenities"
     | "facebookLink"
-    | "osmLink";
+    | "osmLink"
+    | "imageUrl";
 
   type DormPatchResponse = {
     success?: boolean;
@@ -80,6 +81,7 @@
   let amenitiesDraft = $state("");
   let facebookLinkDraft = $state("");
   let osmLinkDraft = $state("");
+  let imageDraft = $state<string | null>(null);
   let savingField = $state<DormEditableField | null>(null);
   let savedField = $state<DormEditableField | null>(null);
   let fieldError = $state<string | null>(null);
@@ -109,6 +111,7 @@
     amenities: "Amenities",
     facebookLink: "Facebook link",
     osmLink: "OpenStreetMap link",
+    imageUrl: "Dorm photo",
   };
 
   const amenities = $derived(dorm?.amenities ?? []);
@@ -190,6 +193,7 @@
     amenitiesDraft = listToLines(current.amenities);
     facebookLinkDraft = current.facebookLink ?? "";
     osmLinkDraft = current.osmLink ?? "";
+    imageDraft = current.imageUrl ?? null;
     savedField = null;
     fieldError = null;
     mergePrompt = null;
@@ -335,6 +339,8 @@
         return facebookLinkDraft.trim() === (current.facebookLink ?? "");
       case "osmLink":
         return osmLinkDraft.trim() === (current.osmLink ?? "");
+      case "imageUrl":
+        return (imageDraft ?? null) === (current.imageUrl ?? null);
     }
   }
 
@@ -357,6 +363,7 @@
       amenities?: string[];
       facebookLink?: string | null;
       osmLink?: string | null;
+      imageUrl?: string | null;
     } = { version: current.version };
 
     if (field === "dormName") {
@@ -399,6 +406,8 @@
       body.facebookLink = facebookLinkDraft.trim() || null;
     } else if (field === "osmLink") {
       body.osmLink = osmLinkDraft.trim() || null;
+    } else if (field === "imageUrl") {
+      body.imageUrl = imageDraft || null;
     }
 
     savingField = field;
@@ -582,6 +591,15 @@
       </div>
     {/if}
 
+    {#if !editing && dorm.imageUrl}
+      <img
+        class="entity-image"
+        src={dorm.imageUrl}
+        alt="Photo of {dorm.dormName}"
+        loading="lazy"
+      />
+    {/if}
+
     {#if editing}
       <section
         class="entity-editor"
@@ -613,6 +631,7 @@
           bind:amenitiesDraft
           bind:facebookLinkDraft
           bind:osmLinkDraft
+          bind:imageDraft
           {fieldLabel}
           {fieldIsUnchanged}
           {saveField}

--- a/src/components/svelte/controls/entity-detail.css
+++ b/src/components/svelte/controls/entity-detail.css
@@ -791,3 +791,12 @@
   font-weight: 600;
   color: #71717a;
 }
+
+.entity-image {
+  width: 100%;
+  max-height: 12rem;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  border: 1px solid hsl(5, 53%, 90%);
+  background: white;
+}

--- a/src/components/svelte/editor/ImageUpload.svelte
+++ b/src/components/svelte/editor/ImageUpload.svelte
@@ -113,7 +113,9 @@
 </script>
 
 <div class="editor-field image-upload">
-  <label for={inputId}>{label}</label>
+  {#if label}
+    <label for={inputId}>{label}</label>
+  {/if}
   {#if value}
     <div class="image-upload-preview">
       <img src={value} alt="" loading="lazy" />
@@ -150,8 +152,8 @@
   />
   <p class="entity-editor-muted image-upload-hint">
     {#if uploadConfigured === false}
-      Image uploads are not configured on this server. You can still save the
-      event without a photo.
+      Image uploads are not configured on this server. You can still save
+      without a photo.
     {:else}
       JPEG, PNG, or WebP up to {maxSizeLabel}.
     {/if}

--- a/src/components/svelte/editor/entity-editor.css
+++ b/src/components/svelte/editor/entity-editor.css
@@ -414,3 +414,13 @@
   color: hsl(0, 0%, 46%);
   line-height: 1.4;
 }
+
+.editor-image-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.editor-image-row .field-save-btn {
+  align-self: flex-start;
+}

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -26,6 +26,8 @@
   import EntityEditorToggle from "@ui/editor/EntityEditorToggle.svelte";
   import EntityEditorPanel from "@ui/editor/EntityEditorPanel.svelte";
   import EntityEditorField from "@ui/editor/EntityEditorField.svelte";
+  import ImageUpload from "@ui/editor/ImageUpload.svelte";
+  import { fieldSaveActionLabel } from "@lib/editor/field-action-label";
   import { entityEditorSavedMessage } from "@lib/editor/field-action-label";
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import EntityShareCopyLink from "../controls/EntityShareCopyLink.svelte";
@@ -39,7 +41,12 @@
   import FinalExamsList from "./FinalExamsList.svelte";
 
   type RoomEditableField =
-    "roomCode" | "directions" | "buildingId" | "collegeId" | "divisionId";
+    | "roomCode"
+    | "directions"
+    | "buildingId"
+    | "collegeId"
+    | "divisionId"
+    | "imageUrl";
 
   const appData = getAppData();
   const app = $derived(appData());
@@ -53,6 +60,7 @@
     buildingId: "Building",
     collegeId: "College",
     divisionId: "Division",
+    imageUrl: "Room photo",
   };
 
   let draftRoomId = $state<number | null>(null);
@@ -62,6 +70,7 @@
   let buildingDraft = $state("");
   let collegeDraft = $state("");
   let divisionDraft = $state("");
+  let imageDraft = $state<string | null>(null);
   let savingField = $state<RoomEditableField | null>(null);
   let savedField = $state<RoomEditableField | null>(null);
   let fieldError = $state<string | null>(null);
@@ -131,6 +140,7 @@
     buildingDraft = room.buildingId === null ? "" : String(room.buildingId);
     collegeDraft = room.collegeId === null ? "" : String(room.collegeId);
     divisionDraft = room.divisionId === null ? "" : String(room.divisionId);
+    imageDraft = room.imageUrl ?? null;
     savedField = null;
     fieldError = null;
     mergePrompt = null;
@@ -205,6 +215,7 @@
       buildingId?: number | null;
       collegeId?: number | null;
       divisionId?: number | null;
+      imageUrl?: string | null;
     } = { version: room.version };
 
     if (field === "roomCode") {
@@ -222,6 +233,8 @@
       body.collegeId = selectValueToId(collegeDraft);
     } else if (field === "divisionId") {
       body.divisionId = selectValueToId(divisionDraft);
+    } else if (field === "imageUrl") {
+      body.imageUrl = imageDraft || null;
     }
 
     savingField = field;
@@ -576,6 +589,31 @@
                 </select>
               {/snippet}
             </EntityEditorField>
+
+            {#if adminAuthStore.isLoggedIn}
+              <div class="editor-image-row">
+                <ImageUpload
+                  label="Room photo"
+                  inputId="room-image-editor"
+                  prefix="rooms"
+                  bind:value={imageDraft}
+                  disabled={savingField !== null}
+                />
+                <button
+                  type="button"
+                  class="field-save-btn"
+                  disabled={savingField !== null ||
+                    (imageDraft ?? null) ===
+                      (currentRoom.value.imageUrl ?? null)}
+                  onclick={() => saveField("imageUrl")}
+                >
+                  {fieldSaveActionLabel({
+                    canPublish,
+                    isSaving: savingField === "imageUrl",
+                  })}
+                </button>
+              </div>
+            {/if}
           </div>
 
           {#if mergePrompt}
@@ -612,6 +650,15 @@
           {/if}
         </EntityEditorPanel>
       </section>
+    {/if}
+
+    {#if currentRoom.value.imageUrl}
+      <img
+        class="entity-image"
+        src={currentRoom.value.imageUrl}
+        alt="Photo of {currentRoom.value.code}"
+        loading="lazy"
+      />
     {/if}
 
     <section class="entity-directions" aria-label="Directions">

--- a/src/lib/email/digest-core.test.ts
+++ b/src/lib/email/digest-core.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { buildProposalDigest } from "./digest-core";
+
+const SITE = "https://room-tba.uplbtools.me";
+
+describe("buildProposalDigest", () => {
+  test("returns null with no pending proposals", () => {
+    expect(buildProposalDigest([], SITE)).toBeNull();
+  });
+
+  test("formats count, entity label, and submitter", () => {
+    const digest = buildProposalDigest(
+      [
+        {
+          entityType: "building",
+          entityLabel: "Physical Sciences",
+          submitterName: "Yeyel",
+          status: "pending",
+        },
+        {
+          entityType: "create_room",
+          entityLabel: "CEM 203",
+          submitterName: null,
+          status: "needs_changes",
+        },
+      ],
+      SITE,
+    );
+    expect(digest).not.toBeNull();
+    expect(digest?.subject).toBe("Room TBA: 2 proposals awaiting review");
+    expect(digest?.text).toContain(
+      "- building: Physical Sciences — from Yeyel",
+    );
+    expect(digest?.text).toContain(
+      "- new room: CEM 203 — from Anonymous (resubmit requested)",
+    );
+    expect(digest?.text).toContain(`${SITE}/?editor=login`);
+  });
+
+  test("singular subject for one proposal", () => {
+    const digest = buildProposalDigest(
+      [
+        {
+          entityType: "dorm",
+          entityLabel: "Makiling Hall",
+          submitterName: "Stimmie",
+          status: "pending",
+        },
+      ],
+      SITE,
+    );
+    expect(digest?.subject).toBe("Room TBA: 1 proposal awaiting review");
+    expect(digest?.text).toContain("is 1 contributor proposal");
+  });
+});

--- a/src/lib/email/digest-core.test.ts
+++ b/src/lib/email/digest-core.test.ts
@@ -29,10 +29,10 @@ describe("buildProposalDigest", () => {
     expect(digest).not.toBeNull();
     expect(digest?.subject).toBe("Room TBA: 2 proposals awaiting review");
     expect(digest?.text).toContain(
-      "- building: Physical Sciences — from Yeyel",
+      "- building: Physical Sciences, from Yeyel",
     );
     expect(digest?.text).toContain(
-      "- new room: CEM 203 — from Anonymous (resubmit requested)",
+      "- new room: CEM 203, from Anonymous (resubmit requested)",
     );
     expect(digest?.text).toContain(`${SITE}/?editor=login`);
   });

--- a/src/lib/email/digest-core.test.ts
+++ b/src/lib/email/digest-core.test.ts
@@ -28,9 +28,7 @@ describe("buildProposalDigest", () => {
     );
     expect(digest).not.toBeNull();
     expect(digest?.subject).toBe("Room TBA: 2 proposals awaiting review");
-    expect(digest?.text).toContain(
-      "- building: Physical Sciences, from Yeyel",
-    );
+    expect(digest?.text).toContain("- building: Physical Sciences, from Yeyel");
     expect(digest?.text).toContain(
       "- new room: CEM 203, from Anonymous (resubmit requested)",
     );

--- a/src/lib/email/digest-core.ts
+++ b/src/lib/email/digest-core.ts
@@ -22,7 +22,7 @@ export function buildProposalDigest(
     const kind = p.entityType.replace("create_", "new ");
     const submitter = p.submitterName?.trim() || "Anonymous";
     const status = p.status === "needs_changes" ? " (resubmit requested)" : "";
-    return `- ${kind}: ${p.entityLabel ?? "(unnamed)"} — from ${submitter}${status}`;
+    return `- ${kind}: ${p.entityLabel ?? "(unnamed)"}, from ${submitter}${status}`;
   });
 
   const count = proposals.length;

--- a/src/lib/email/digest-core.ts
+++ b/src/lib/email/digest-core.ts
@@ -1,0 +1,41 @@
+/** Pure digest formatting (no astro:env/db imports) so bun test can load it. */
+
+export type DigestProposal = {
+  entityType: string;
+  entityLabel: string | null;
+  submitterName: string | null;
+  status: string;
+};
+
+export type DigestEmail = {
+  subject: string;
+  text: string;
+};
+
+export function buildProposalDigest(
+  proposals: DigestProposal[],
+  siteUrl: string,
+): DigestEmail | null {
+  if (proposals.length === 0) return null;
+
+  const lines = proposals.map((p) => {
+    const kind = p.entityType.replace("create_", "new ");
+    const submitter = p.submitterName?.trim() || "Anonymous";
+    const status = p.status === "needs_changes" ? " (resubmit requested)" : "";
+    return `- ${kind}: ${p.entityLabel ?? "(unnamed)"} — from ${submitter}${status}`;
+  });
+
+  const count = proposals.length;
+  return {
+    subject: `Room TBA: ${count} proposal${count === 1 ? "" : "s"} awaiting review`,
+    text: [
+      `There ${count === 1 ? "is 1 contributor proposal" : `are ${count} contributor proposals`} waiting in the review queue:`,
+      "",
+      ...lines,
+      "",
+      `Review them in the editor: ${siteUrl}/?editor=login`,
+      "",
+      "You receive this daily digest because your Room TBA editor account has an email address on file.",
+    ].join("\n"),
+  };
+}

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,0 +1,42 @@
+import { RESEND_API_KEY, RESEND_FROM_EMAIL } from "astro:env/server";
+
+export function isResendConfigured(): boolean {
+  return Boolean(RESEND_API_KEY && RESEND_FROM_EMAIL);
+}
+
+export type SendEmailInput = {
+  to: string[];
+  subject: string;
+  text: string;
+  html?: string;
+};
+
+/**
+ * Send an email via the Resend REST API (no SDK dependency).
+ * Throws on non-2xx so callers can log per-recipient failures.
+ */
+export async function sendEmail(input: SendEmailInput): Promise<void> {
+  if (!isResendConfigured()) {
+    throw new Error(
+      "Resend is not configured (RESEND_API_KEY / RESEND_FROM_EMAIL).",
+    );
+  }
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: RESEND_FROM_EMAIL,
+      to: input.to,
+      subject: input.subject,
+      text: input.text,
+      ...(input.html ? { html: input.html } : {}),
+    }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Resend API error ${res.status}: ${detail.slice(0, 300)}`);
+  }
+}

--- a/src/lib/local/data/pgliteDB.ts
+++ b/src/lib/local/data/pgliteDB.ts
@@ -195,6 +195,15 @@ export async function initPGLiteDB(db: PGlite) {
     ADD COLUMN IF NOT EXISTS "image_url" text;
 
     ALTER TABLE buildings
+    ADD COLUMN IF NOT EXISTS "image_url" text;
+
+    ALTER TABLE rooms
+    ADD COLUMN IF NOT EXISTS "image_url" text;
+
+    ALTER TABLE dorms
+    ADD COLUMN IF NOT EXISTS "image_url" text;
+
+    ALTER TABLE buildings
     ADD COLUMN IF NOT EXISTS "version" integer NOT NULL DEFAULT 1;
 
     ALTER TABLE buildings

--- a/src/lib/local/data/sync.ts
+++ b/src/lib/local/data/sync.ts
@@ -108,8 +108,8 @@ export async function syncBuildings(
     try {
       await localDB.query(
         `
-        INSERT INTO buildings (id, building_name, lon, lat, directions, type, rooms_fetched, version, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, false, $7, $8)
+        INSERT INTO buildings (id, building_name, lon, lat, directions, type, rooms_fetched, image_url, version, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, false, $7, $8, $9)
         ON CONFLICT (id) DO UPDATE SET
         id = EXCLUDED.id,
         building_name = EXCLUDED.building_name,
@@ -118,6 +118,7 @@ export async function syncBuildings(
         directions = EXCLUDED.directions,
         type = EXCLUDED.type,
         rooms_fetched = EXCLUDED.rooms_fetched,
+        image_url = EXCLUDED.image_url,
         version = EXCLUDED.version,
         updated_at = EXCLUDED.updated_at;
         `,
@@ -128,6 +129,7 @@ export async function syncBuildings(
           b.lat,
           b.directions,
           b.buildingType,
+          b.imageUrl ?? null,
           b.version,
           b.updatedAt,
         ],
@@ -252,8 +254,8 @@ export async function syncDorms(
     try {
       await localDB.query(
         `
-        INSERT INTO dorms (id, dorm_name, short_name, lat, lon, gender, capacity, managing_office, contact_email, amenities, osm_link, description, is_up_managed, price_range, contact_phone, facebook_link, version, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+        INSERT INTO dorms (id, dorm_name, short_name, lat, lon, gender, capacity, managing_office, contact_email, amenities, osm_link, description, is_up_managed, price_range, contact_phone, facebook_link, image_url, version, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
         ON CONFLICT (id) DO UPDATE SET
         id = EXCLUDED.id,
         dorm_name = EXCLUDED.dorm_name,
@@ -271,6 +273,7 @@ export async function syncDorms(
         price_range = EXCLUDED.price_range,
         contact_phone = EXCLUDED.contact_phone,
         facebook_link = EXCLUDED.facebook_link,
+        image_url = EXCLUDED.image_url,
         version = EXCLUDED.version,
         updated_at = EXCLUDED.updated_at;
         `,
@@ -291,6 +294,7 @@ export async function syncDorms(
           b.priceRange,
           b.contactPhone,
           b.facebookLink,
+          b.imageUrl ?? null,
           b.version,
           b.updatedAt,
         ],
@@ -566,8 +570,8 @@ export async function syncBuildingRooms(
     try {
       await localDB.query(
         `
-            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, version, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (id) DO UPDATE SET
             id = EXCLUDED.id,
             room_code = EXCLUDED.room_code,
@@ -575,6 +579,7 @@ export async function syncBuildingRooms(
             building_id = EXCLUDED.building_id,
             college_id = EXCLUDED.college_id,
             division_id = EXCLUDED.division_id,
+            image_url = EXCLUDED.image_url,
             version = EXCLUDED.version,
             updated_at = EXCLUDED.updated_at;
             `,
@@ -585,6 +590,7 @@ export async function syncBuildingRooms(
           room.buildingId,
           room.collegeId,
           room.divisionId,
+          room.imageUrl ?? null,
           room.version,
           room.updatedAt,
         ],
@@ -694,8 +700,8 @@ export async function syncCollegeRooms(
     try {
       await localDB.query(
         `
-            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, version, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (id) DO UPDATE SET
             id = EXCLUDED.id,
             room_code = EXCLUDED.room_code,
@@ -703,6 +709,7 @@ export async function syncCollegeRooms(
             building_id = EXCLUDED.building_id,
             college_id = EXCLUDED.college_id,
             division_id = EXCLUDED.division_id,
+            image_url = EXCLUDED.image_url,
             version = EXCLUDED.version,
             updated_at = EXCLUDED.updated_at;
             `,
@@ -713,6 +720,7 @@ export async function syncCollegeRooms(
           room.buildingId,
           room.collegeId,
           room.divisionId,
+          room.imageUrl ?? null,
           room.version,
           room.updatedAt,
         ],
@@ -822,8 +830,8 @@ export async function syncDivisionRooms(
     try {
       await localDB.query(
         `
-            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, version, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (id) DO UPDATE SET
             id = EXCLUDED.id,
             room_code = EXCLUDED.room_code,
@@ -831,6 +839,7 @@ export async function syncDivisionRooms(
             building_id = EXCLUDED.building_id,
             college_id = EXCLUDED.college_id,
             division_id = EXCLUDED.division_id,
+            image_url = EXCLUDED.image_url,
             version = EXCLUDED.version,
             updated_at = EXCLUDED.updated_at;
             `,
@@ -841,6 +850,7 @@ export async function syncDivisionRooms(
           room.buildingId,
           room.collegeId,
           room.divisionId,
+          room.imageUrl ?? null,
           room.version,
           room.updatedAt,
         ],

--- a/src/lib/local/data/utils.ts
+++ b/src/lib/local/data/utils.ts
@@ -27,7 +27,7 @@ export async function getLocalBuildings(): Promise<BuildingData[] | undefined> {
     const localDB = getDB();
     await localDB.waitReady;
     const data = (await localDB.query(`
-        SELECT building_name AS "buildingName", lon, lat, id, directions, type AS "buildingType", version, updated_at AS "updatedAt" FROM buildings
+        SELECT building_name AS "buildingName", lon, lat, id, directions, type AS "buildingType", image_url AS "imageUrl", version, updated_at AS "updatedAt" FROM buildings
       `)) as Results<BuildingData>;
     return data.rows;
   } catch (e) {
@@ -86,6 +86,7 @@ export async function getLocalDorms(): Promise<DormData[] | undefined> {
         price_range AS "priceRange",
         contact_phone AS "contactPhone",
         facebook_link AS "facebookLink",
+        image_url AS "imageUrl",
         version,
         updated_at AS "updatedAt"
       FROM dorms;
@@ -215,6 +216,7 @@ export async function getLocalRoomByCode(code: string) {
             r.building_id as "buildingId",
             r.college_id as "collegeId",
             r.division_id as "divisionId",
+            r.image_url as "imageUrl",
             r.version,
             r.updated_at as "updatedAt"
             FROM rooms AS r
@@ -250,6 +252,7 @@ export async function getLocalRoomById(id: number) {
             r.building_id as "buildingId",
             r.college_id as "collegeId",
             r.division_id as "divisionId",
+            r.image_url as "imageUrl",
             r.version,
             r.updated_at as "updatedAt"
             FROM rooms AS r

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -168,7 +168,7 @@ const FIELD_LABELS: Record<string, string> = {
   startsAt: "Starts",
   endsAt: "Ends",
   sourceUrl: "Source URL",
-  imageUrl: "Event image",
+  imageUrl: "Image",
   recurrence: "Recurrence",
   rooms: "Bundled rooms",
 };

--- a/src/lib/r2-upload-core.ts
+++ b/src/lib/r2-upload-core.ts
@@ -87,16 +87,17 @@ export function publicUrlForKey(
   return key;
 }
 
-const EVENT_IMAGE_URL_MAX_LENGTH = 2048;
+const IMAGE_URL_MAX_LENGTH = 2048;
 
 export type ParsedEventImageUrl =
   | { ok: true; imageUrl: string | null; provided: boolean }
   | { ok: false; error: string };
 
-/** Validates image URLs saved on events (typically from /api/admin/upload). */
-export function parseEventImageUrl(
+/** Validates image URLs saved on entities (typically from /api/admin/upload). */
+export function parseImageUrl(
   value: unknown,
   publicBaseUrl?: string | null,
+  label = "Image",
 ): ParsedEventImageUrl {
   if (value === undefined) {
     return { ok: true, imageUrl: null, provided: false };
@@ -105,33 +106,32 @@ export function parseEventImageUrl(
     return { ok: true, imageUrl: null, provided: true };
   }
   if (typeof value !== "string") {
-    return { ok: false, error: "Event image URL must be a string" };
+    return { ok: false, error: `${label} URL must be a string` };
   }
 
   const trimmed = value.trim();
   if (!trimmed) {
     return { ok: true, imageUrl: null, provided: true };
   }
-  if (trimmed.length > EVENT_IMAGE_URL_MAX_LENGTH) {
-    return { ok: false, error: "Event image URL is too long" };
+  if (trimmed.length > IMAGE_URL_MAX_LENGTH) {
+    return { ok: false, error: `${label} URL is too long` };
   }
 
   let parsed: URL;
   try {
     parsed = new URL(trimmed);
   } catch {
-    return { ok: false, error: "Event image URL is invalid" };
+    return { ok: false, error: `${label} URL is invalid` };
   }
   if (parsed.protocol !== "https:") {
-    return { ok: false, error: "Event image URL must use HTTPS" };
+    return { ok: false, error: `${label} URL must use HTTPS` };
   }
 
   const base = publicBaseUrl?.trim().replace(/\/$/, "") ?? "";
   if (!base) {
     return {
       ok: false,
-      error:
-        "Event image URL requires upload storage (R2_PUBLIC_URL) to be configured",
+      error: `${label} URL requires upload storage (R2_PUBLIC_URL) to be configured`,
     };
   }
 
@@ -152,9 +152,16 @@ export function parseEventImageUrl(
   ) {
     return {
       ok: false,
-      error: "Event image URL must come from this site's upload storage",
+      error: `${label} URL must come from this site's upload storage`,
     };
   }
 
   return { ok: true, imageUrl: trimmed, provided: true };
+}
+
+export function parseEventImageUrl(
+  value: unknown,
+  publicBaseUrl?: string | null,
+): ParsedEventImageUrl {
+  return parseImageUrl(value, publicBaseUrl, "Event image");
 }

--- a/src/lib/services/admin-service.ts
+++ b/src/lib/services/admin-service.ts
@@ -134,6 +134,7 @@ export async function getRoomById(id: number): Promise<RoomData | null> {
       buildingId: roomsTable.buildingId,
       collegeId: roomsTable.collegeId,
       divisionId: roomsTable.divisionId,
+      imageUrl: roomsTable.imageUrl,
       version: roomsTable.version,
       updatedAt: roomsTable.updatedAt,
     })
@@ -163,6 +164,7 @@ export async function getAllRoomsAdmin(): Promise<RoomWithRelations[]> {
       buildingId: roomsTable.buildingId,
       collegeId: roomsTable.collegeId,
       divisionId: roomsTable.divisionId,
+      imageUrl: roomsTable.imageUrl,
       version: roomsTable.version,
       updatedAt: roomsTable.updatedAt,
     })
@@ -179,6 +181,7 @@ export type RoomUpdateInput = {
   buildingId?: number | null;
   collegeId?: number | null;
   divisionId?: number | null;
+  imageUrl?: string | null;
 };
 
 export async function findRoomMergeCandidate(
@@ -308,6 +311,7 @@ export async function updateRoom(
     updates["collegeId"] = input.collegeId ?? null;
   if (input.divisionId !== undefined)
     updates["divisionId"] = input.divisionId ?? null;
+  if (input.imageUrl !== undefined) updates["imageUrl"] = input.imageUrl;
 
   if (Object.keys(updates).length > 0) {
     if (input.roomCode !== undefined) {
@@ -594,6 +598,7 @@ export type BuildingUpdateInput = {
   lon?: number;
   buildingType?: "admin" | "non-admin";
   directions?: string;
+  imageUrl?: string | null;
 };
 
 export async function updateBuilding(
@@ -610,6 +615,7 @@ export async function updateBuilding(
   if (input.buildingType !== undefined)
     updates["buildingType"] = input.buildingType;
   if (input.directions !== undefined) updates["directions"] = input.directions;
+  if (input.imageUrl !== undefined) updates["imageUrl"] = input.imageUrl;
 
   if (Object.keys(updates).length > 0) {
     if (input.buildingName !== undefined) {
@@ -966,6 +972,7 @@ export type DormUpdateInput = Partial<{
   priceRange: string | null;
   contactPhone: string[];
   facebookLink: string | null;
+  imageUrl: string | null;
 }>;
 
 export async function updateDorm(

--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -64,6 +64,85 @@ export async function getAdminUserBySupabaseId(
   }
 }
 
+export type SupabaseIdentity = {
+  id: string;
+  email: string | null;
+  name?: string | null;
+};
+
+/**
+ * Resolve an OAuth (e.g. Google) Supabase user to an `admin_users` row.
+ * Links by supabase id, then by email (existing account without a link),
+ * else creates a new `contributor` account (#456).
+ */
+export async function linkOrCreateContributorFromSupabase(
+  identity: SupabaseIdentity,
+): Promise<SessionUser | null> {
+  const linked = await getAdminUserBySupabaseId(identity.id);
+  if (linked) return linked;
+
+  const email = identity.email?.trim().toLowerCase() ?? null;
+
+  if (email) {
+    const [byEmail] = await db
+      .select({
+        id: adminUsersTable.id,
+        username: adminUsersTable.username,
+        displayName: adminUsersTable.displayName,
+        role: adminUsersTable.role,
+        isActive: adminUsersTable.isActive,
+      })
+      .from(adminUsersTable)
+      .where(sql`lower(email) = ${email}`)
+      .limit(1);
+    if (byEmail) {
+      if (!byEmail.isActive) return null;
+      await db
+        .update(adminUsersTable)
+        .set({ supabaseUserId: identity.id, updatedAt: sql`now()` })
+        .where(eq(adminUsersTable.id, byEmail.id));
+      return toSessionUser(byEmail);
+    }
+  }
+
+  const base = (email?.split("@")[0] ?? `google-${identity.id.slice(0, 8)}`)
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "")
+    .slice(0, 48);
+  const displayName = identity.name?.trim() || base;
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const username =
+      attempt === 0 ? base : `${base.slice(0, 44)}-${attempt + 1}`;
+    try {
+      const [created] = await db
+        .insert(adminUsersTable)
+        .values({
+          username,
+          displayName,
+          // OAuth-only account: no usable password login.
+          passwordHash: "",
+          role: "contributor",
+          email,
+          isActive: true,
+          supabaseUserId: identity.id,
+        })
+        .returning({
+          id: adminUsersTable.id,
+          username: adminUsersTable.username,
+          displayName: adminUsersTable.displayName,
+          role: adminUsersTable.role,
+        });
+      if (created) return toSessionUser(created);
+    } catch (error) {
+      // Unique violation on username → retry with a suffix.
+      const code = (error as { code?: string })?.code;
+      if (code !== "23505") throw error;
+    }
+  }
+  return null;
+}
+
 async function findUserByLogin(login: string) {
   const normalized = login.trim().toLowerCase();
   if (!normalized) return null;

--- a/src/lib/services/digest-service.ts
+++ b/src/lib/services/digest-service.ts
@@ -1,0 +1,66 @@
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { adminUsersTable } from "@drizzle/schema";
+import { db } from "@lib/db";
+import { buildProposalDigest } from "@lib/email/digest-core";
+import { isResendConfigured, sendEmail } from "@lib/email/resend";
+import { listPendingProposals } from "@lib/services/proposal-service";
+import { SITE_URL } from "@lib/site";
+
+export async function listDigestRecipients(): Promise<string[]> {
+  const rows = await db
+    .select({ email: adminUsersTable.email })
+    .from(adminUsersTable)
+    .where(
+      and(
+        eq(adminUsersTable.isActive, true),
+        isNotNull(adminUsersTable.email),
+        sql`${adminUsersTable.email} <> ''`,
+        inArray(adminUsersTable.role, ["admin", "editor"] as const),
+      ),
+    );
+  return rows
+    .map((row) => row.email?.trim().toLowerCase())
+    .filter((email): email is string => Boolean(email));
+}
+
+export type DigestRunResult = {
+  skipped: "unconfigured" | "no_pending" | "no_recipients" | null;
+  pendingCount: number;
+  recipientCount: number;
+};
+
+export async function sendProposalDigest(): Promise<DigestRunResult> {
+  if (!isResendConfigured()) {
+    return { skipped: "unconfigured", pendingCount: 0, recipientCount: 0 };
+  }
+
+  const proposals = await listPendingProposals();
+  const digest = buildProposalDigest(proposals, SITE_URL);
+  if (!digest) {
+    return { skipped: "no_pending", pendingCount: 0, recipientCount: 0 };
+  }
+
+  const recipients = await listDigestRecipients();
+  if (recipients.length === 0) {
+    return {
+      skipped: "no_recipients",
+      pendingCount: proposals.length,
+      recipientCount: 0,
+    };
+  }
+
+  // Individual sends keep recipient addresses private to each editor.
+  for (const to of recipients) {
+    try {
+      await sendEmail({ to: [to], ...digest });
+    } catch (error) {
+      console.error(`Proposal digest to ${to} failed:`, error);
+    }
+  }
+
+  return {
+    skipped: null,
+    pendingCount: proposals.length,
+    recipientCount: recipients.length,
+  };
+}

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -53,6 +53,7 @@ export async function getAllRoomsCached(): Promise<RoomData[]> {
       buildingId: roomsTable.buildingId,
       collegeId: roomsTable.collegeId,
       divisionId: roomsTable.divisionId,
+      imageUrl: roomsTable.imageUrl,
       version: roomsTable.version,
       updatedAt: roomsTable.updatedAt,
     })
@@ -117,6 +118,7 @@ export async function getAllRooms(): Promise<RoomData[]> {
         buildingId: roomsTable.buildingId,
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
+        imageUrl: roomsTable.imageUrl,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })
@@ -150,6 +152,7 @@ export async function getRoomByCode(code: string) {
         buildingId: roomsTable.buildingId,
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
+        imageUrl: roomsTable.imageUrl,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })
@@ -207,6 +210,7 @@ export async function getBuildingRooms(
         buildingId: roomsTable.buildingId,
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
+        imageUrl: roomsTable.imageUrl,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })
@@ -239,6 +243,7 @@ export async function getCollegeRooms(collegeId: number): Promise<RoomData[]> {
         buildingId: roomsTable.buildingId,
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
+        imageUrl: roomsTable.imageUrl,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })
@@ -273,6 +278,7 @@ export async function getDivisionRooms(
         buildingId: roomsTable.buildingId,
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
+        imageUrl: roomsTable.imageUrl,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -525,7 +525,7 @@ export class ProposalActionError extends Error {
   }
 }
 
-function validateProposalEventImageUrl(patch: Record<string, unknown>) {
+function validateProposalImageUrl(patch: Record<string, unknown>) {
   if (!("imageUrl" in patch)) return;
   const parsed = parseEventImageUrl(patch.imageUrl, R2_PUBLIC_URL);
   if (!parsed.ok) {
@@ -536,12 +536,21 @@ function validateProposalEventImageUrl(patch: Record<string, unknown>) {
   }
 }
 
+const IMAGE_PATCH_ENTITY_TYPES: ReadonlySet<string> = new Set([
+  "create_event",
+  "event",
+  "building",
+  "room",
+  "dorm",
+  "create_dorm",
+]);
+
 async function applyProposalPatch(proposal: EditProposalRow, editedBy: string) {
   const patch = proposal.proposedPatch as Record<string, unknown>;
   const entityType = proposal.entityType as ProposalEntityType;
 
-  if (entityType === "create_event" || entityType === "event") {
-    validateProposalEventImageUrl(patch);
+  if (IMAGE_PATCH_ENTITY_TYPES.has(entityType)) {
+    validateProposalImageUrl(patch);
   }
 
   if (isCreateProposalType(entityType)) {

--- a/src/lib/services/ssg-service.ts
+++ b/src/lib/services/ssg-service.ts
@@ -143,6 +143,7 @@ export async function getRoomPageData(roomId: number) {
       buildingId: roomsTable.buildingId,
       collegeId: roomsTable.collegeId,
       divisionId: roomsTable.divisionId,
+      imageUrl: roomsTable.imageUrl,
       version: roomsTable.version,
       updatedAt: roomsTable.updatedAt,
     })

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -72,6 +72,7 @@ type RoomData = {
   divisionId: number | null;
   collegeName: string | null;
   divisionName: string | null;
+  imageUrl?: string | null;
   version: number;
   updatedAt: string;
 };
@@ -362,6 +363,8 @@ class AdminAuthStore {
   canReview: boolean = $state(false);
   loading: boolean = $state(false);
   loginOpen: boolean = $state(false);
+  /** Error code from a failed OAuth redirect (`?auth_error=`). */
+  oauthError: string | null = $state(null);
   private _hydrated = false;
 
   private applySession(data: {
@@ -469,6 +472,31 @@ class AdminAuthStore {
     }
   };
 
+  /** Start Google OAuth (#456); resolves to an error message or redirects away. */
+  loginWithGoogle = async (): Promise<string | null> => {
+    try {
+      const [{ isSupabaseConfigured }, { createBrowserSupabaseClient }] =
+        await Promise.all([
+          import("@lib/supabase/env"),
+          import("@lib/supabase/client"),
+        ]);
+      if (!isSupabaseConfigured()) {
+        return "Google sign-in is not configured on this server.";
+      }
+      const supabase = createBrowserSupabaseClient();
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: `${window.location.origin}/api/auth/callback`,
+        },
+      });
+      if (error) return error.message;
+      return null;
+    } catch {
+      return "Google sign-in failed to start. Try again.";
+    }
+  };
+
   logout = async () => {
     try {
       await fetch("/api/admin/auth", {
@@ -496,6 +524,7 @@ class AdminAuthStore {
 
   closeLogin = () => {
     this.loginOpen = false;
+    this.oauthError = null;
   };
 }
 

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -57,6 +57,7 @@ type RoomData = {
   divisionId: number | null;
   collegeName: string | null;
   divisionName: string | null;
+  imageUrl?: string | null;
   version: number;
   updatedAt: string;
   floor?: number | null;

--- a/src/pages/api/admin/buildings/[id].ts
+++ b/src/pages/api/admin/buildings/[id].ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from "astro";
+import { R2_PUBLIC_URL } from "astro:env/server";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
 import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
+import { parseImageUrl } from "@lib/r2-upload-core";
 import {
   EditConflictError,
   updateBuilding,
@@ -15,6 +17,7 @@ type BuildingPatchBody = {
   lon?: number;
   buildingType?: "admin" | "non-admin";
   directions?: string;
+  imageUrl?: string | null;
   version?: number;
 };
 
@@ -63,6 +66,18 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
     });
   }
 
+  const parsedImageUrl = parseImageUrl(
+    body.imageUrl,
+    R2_PUBLIC_URL,
+    "Building image",
+  );
+  if (!parsedImageUrl.ok) {
+    return new Response(JSON.stringify({ error: parsedImageUrl.error }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   const parsedVersion = parseRequiredEditorVersion(body.version);
   if (!parsedVersion.ok) return parsedVersion.response;
   const expectedVersion = parsedVersion.version;
@@ -76,6 +91,7 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
     if (body.buildingType !== undefined)
       updates.buildingType = body.buildingType;
     if (body.directions !== undefined) updates.directions = body.directions;
+    if (parsedImageUrl.provided) updates.imageUrl = parsedImageUrl.imageUrl;
 
     const building = await updateBuilding(
       id,

--- a/src/pages/api/admin/dorms/[id].ts
+++ b/src/pages/api/admin/dorms/[id].ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from "astro";
+import { R2_PUBLIC_URL } from "astro:env/server";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
 import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
+import { parseImageUrl } from "@lib/r2-upload-core";
 import {
   EditConflictError,
   updateDorm,
@@ -10,6 +12,7 @@ import {
 export const prerender = false;
 
 type DormPatchBody = {
+  imageUrl?: string | null;
   dormName?: string;
   shortName?: string;
   lat?: number | null;
@@ -57,12 +60,25 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
     });
   }
 
+  const parsedImageUrl = parseImageUrl(
+    body.imageUrl,
+    R2_PUBLIC_URL,
+    "Dorm image",
+  );
+  if (!parsedImageUrl.ok) {
+    return new Response(JSON.stringify({ error: parsedImageUrl.error }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   const parsedVersion = parseRequiredEditorVersion(body.version);
   if (!parsedVersion.ok) return parsedVersion.response;
   const expectedVersion = parsedVersion.version;
 
   try {
     const updates: Parameters<typeof updateDorm>[1] = {};
+    if (parsedImageUrl.provided) updates.imageUrl = parsedImageUrl.imageUrl;
     if (body.dormName !== undefined) updates.dormName = body.dormName.trim();
     if (body.shortName !== undefined)
       updates.shortName = body.shortName || null;

--- a/src/pages/api/admin/rooms/[id].ts
+++ b/src/pages/api/admin/rooms/[id].ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from "astro";
+import { R2_PUBLIC_URL } from "astro:env/server";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
 import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
+import { parseImageUrl } from "@lib/r2-upload-core";
 import {
   EditConflictError,
   DuplicateNameError,
@@ -16,6 +18,7 @@ type RoomPatchBody = {
   buildingId?: number | null;
   collegeId?: number | null;
   divisionId?: number | null;
+  imageUrl?: string | null;
   version?: number;
   position?: { floor: number; posX: string; posY: string };
 };
@@ -79,6 +82,15 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
     );
   }
 
+  const parsedImageUrl = parseImageUrl(
+    body.imageUrl,
+    R2_PUBLIC_URL,
+    "Room image",
+  );
+  if (!parsedImageUrl.ok) {
+    return json({ error: parsedImageUrl.error }, 400);
+  }
+
   const parsedVersion = parseRequiredEditorVersion(body.version);
   if (!parsedVersion.ok) return parsedVersion.response;
   const expectedVersion = parsedVersion.version;
@@ -92,6 +104,7 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
     if (body.buildingId !== undefined) updates.buildingId = body.buildingId;
     if (body.collegeId !== undefined) updates.collegeId = body.collegeId;
     if (body.divisionId !== undefined) updates.divisionId = body.divisionId;
+    if (parsedImageUrl.provided) updates.imageUrl = parsedImageUrl.imageUrl;
     const hasRoomFieldUpdates = Object.keys(updates).length > 0;
 
     if (body.position && hasRoomFieldUpdates) {

--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -1,0 +1,50 @@
+import type { APIRoute } from "astro";
+import { createSessionToken, setSessionCookie } from "@lib/admin/auth";
+import { linkOrCreateContributorFromSupabase } from "@lib/services/admin-user-service";
+import { createServerSupabaseClient } from "@lib/supabase/server";
+
+export const prerender = false;
+
+/**
+ * OAuth callback (#456). Supabase redirects here with a `code` after
+ * Google sign-in; we exchange it, link or create the contributor account,
+ * and set the same `admin_session` cookie password login uses.
+ */
+export const GET: APIRoute = async ({ url, request, cookies }) => {
+  const fail = (reason: string) =>
+    new Response(null, {
+      status: 303,
+      headers: { Location: `/?auth_error=${encodeURIComponent(reason)}` },
+    });
+
+  const code = url.searchParams.get("code");
+  if (!code) return fail("missing_code");
+
+  try {
+    const supabase = createServerSupabaseClient({ request, cookies });
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error || !data.user) return fail("oauth_failed");
+
+    const meta = data.user.user_metadata as
+      | { full_name?: string; name?: string }
+      | undefined;
+    const user = await linkOrCreateContributorFromSupabase({
+      id: data.user.id,
+      email: data.user.email ?? null,
+      name: meta?.full_name ?? meta?.name ?? null,
+    });
+    if (!user) return fail("account_unavailable");
+
+    const token = createSessionToken(user);
+    return new Response(null, {
+      status: 303,
+      headers: {
+        Location: "/",
+        "Set-Cookie": setSessionCookie(token),
+      },
+    });
+  } catch (error) {
+    console.error("OAuth callback failed:", error);
+    return fail("oauth_failed");
+  }
+};

--- a/src/pages/api/cron/proposal-digest.ts
+++ b/src/pages/api/cron/proposal-digest.ts
@@ -1,0 +1,30 @@
+import type { APIRoute } from "astro";
+import { CRON_SECRET } from "astro:env/server";
+import { sendProposalDigest } from "@lib/services/digest-service";
+
+export const prerender = false;
+
+/** Daily editor digest of pending proposals (#272). Invoked by Vercel Cron. */
+export const GET: APIRoute = async ({ request }) => {
+  if (!CRON_SECRET) {
+    return json({ error: "Cron is not configured on this server." }, 503);
+  }
+  if (request.headers.get("authorization") !== `Bearer ${CRON_SECRET}`) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+
+  try {
+    const result = await sendProposalDigest();
+    return json({ success: true, ...result });
+  } catch (error) {
+    console.error("Proposal digest run failed:", error);
+    return json({ error: "Digest run failed." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/building/[slug].astro
+++ b/src/pages/building/[slug].astro
@@ -57,7 +57,7 @@ const structuredData = jsonLd(
     name: buildingName,
     description: building.directions ?? description,
     url: absoluteUrl(canonicalPath),
-    image: ogImageUrl(),
+    image: ogImageUrl(building.imageUrl ?? undefined),
     geo:
       building.lat !== null && building.lon !== null
         ? {
@@ -74,6 +74,9 @@ const structuredData = jsonLd(
   title={title}
   description={description}
   {canonicalPath}
+  image={building.imageUrl
+    ? { src: building.imageUrl, alt: `Photo of ${buildingName}` }
+    : null}
   heading={`${buildingName} at UPLB`}
   {intro}
   {facts}

--- a/src/pages/dorm/[slug].astro
+++ b/src/pages/dorm/[slug].astro
@@ -59,7 +59,7 @@ const structuredData = jsonLd(
     name: dorm.dormName,
     description,
     url: absoluteUrl(canonicalPath),
-    image: ogImageUrl(),
+    image: ogImageUrl(dorm.imageUrl ?? undefined),
     address: {
       "@type": "PostalAddress",
       addressLocality: "Los Banos",
@@ -82,6 +82,9 @@ const structuredData = jsonLd(
   title={title}
   description={description}
   {canonicalPath}
+  image={dorm.imageUrl
+    ? { src: dorm.imageUrl, alt: `Photo of ${dorm.dormName}` }
+    : null}
   heading={`${dorm.dormName} at UPLB`}
   {intro}
   {facts}

--- a/src/pages/room/[slug].astro
+++ b/src/pages/room/[slug].astro
@@ -58,7 +58,7 @@ const structuredData = jsonLd(
     name: room.code,
     description,
     url: absoluteUrl(canonicalPath),
-    image: ogImageUrl(),
+    image: ogImageUrl(room.imageUrl ?? undefined),
     containedInPlace: room.building?.name
       ? {
           "@type": "Place",
@@ -73,6 +73,9 @@ const structuredData = jsonLd(
   title={title}
   description={description}
   {canonicalPath}
+  image={room.imageUrl
+    ? { src: room.imageUrl, alt: `Photo of ${room.code}` }
+    : null}
   heading={`${room.code} at UPLB`}
   {intro}
   {facts}

--- a/src/test/astro-env-client-stub.ts
+++ b/src/test/astro-env-client-stub.ts
@@ -1,0 +1,4 @@
+// Vitest stand-in for `astro:env/client` (Supabase off in component tests).
+export const PUBLIC_SUPABASE_URL = undefined;
+export const PUBLIC_SUPABASE_PUBLISHABLE_KEY = undefined;
+export const PUBLIC_MAPTILER_KEY = undefined;

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,11 @@
       "main": true,
       "staging": true
     }
-  }
+  },
+  "crons": [
+    {
+      "path": "/api/cron/proposal-digest",
+      "schedule": "0 0 * * *"
+    }
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
       "@constants": path.resolve(__dirname, "src/constants"),
       "@drizzle": path.resolve(__dirname, "drizzle"),
       "@test": path.resolve(__dirname, "src/test"),
+      "astro:env/client": path.resolve(
+        __dirname,
+        "src/test/astro-env-client-stub.ts",
+      ),
     },
     conditions: ["browser"],
   },


### PR DESCRIPTION
Closes #191. Progresses #456 and #272.

## What

### Entity images (#191)
- `image_url` on `buildings`, `rooms`, `dorms` (`drizzle/0019`), applied to Supabase.
- Editor UI: photo upload field on Building/Room/Dorm edit panels (reuses `ImageUpload.svelte` + `/api/admin/upload`; prefixes `buildings/`, `rooms/`, `dorms/`). Visible to logged-in accounts; contributors' image changes go through the proposal queue like other fields.
- PATCH routes validate URLs with the generalized `parseImageUrl` (same R2-origin rule events use); proposal approval validates too.
- PGlite: DDL + idempotent ALTERs + sync INSERT columns updated for offline cache.
- Side panel shows the photo; entity SEO pages emit it as `og:image` / schema `image`.

### Continue with Google (#456)
- New `/api/auth/callback`: exchanges the Supabase OAuth code, resolves the account via new `linkOrCreateContributorFromSupabase()` (link by supabase id → link by email → create `contributor`), then sets the same `admin_session` cookie password login uses.
- `admin_users.email` column (`drizzle/0020`, unique on `lower(email)`), also unblocks the digest below and the existing email-login branch in `findUserByLogin`.
- Login modal: **Continue with Google** button (rendered only when `PUBLIC_SUPABASE_*` set); OAuth failures land as `?auth_error=` and surface in the modal.
- **Not yet active in prod:** needs Google provider enabled in Supabase (steps in PR comment below).

### Editor email digest (#272 slice)
- Daily Resend digest of pending/needs-changes proposals to active admin/editor accounts that have an email. Per-recipient sends; failures logged per address.
- `/api/cron/proposal-digest` guarded by `CRON_SECRET` Bearer; `vercel.json` cron at 00:00 UTC (08:00 Manila).
- No new dependency — raw `fetch` to the Resend API. Skips cleanly (`skipped: unconfigured`) until `RESEND_API_KEY` + `RESEND_FROM_EMAIL` are set.

## Tests / QA
- `bun run test` 168 pass; `bun run test:components` 20 files pass (added `astro:env/client` stub to vitest config); `bun run build` green; `bun run check:migrations` OK.
- New unit tests: `digest-core.test.ts` (formatter). New integration test: `contributor-link.integration.test.ts` (create / idempotent / link-by-email), runs in CI with the E2E DB.
- Runtime smoke on dev server: `/api/admin/upload` 401 unauthenticated, `/api/cron/proposal-digest` 503 without `CRON_SECRET`, `/api/auth/callback` without code → 303 to `/?auth_error=missing_code`.
- Migrations 0019/0020 applied to the shared Supabase DB and added to the E2E reset list.

## Ops needed before features go live
1. **Google OAuth:** create OAuth client in Google Cloud, enable Google provider in Supabase, add redirect URLs (details in follow-up comment).
2. **Resend:** create API key, verify sender domain, set `RESEND_API_KEY` + `RESEND_FROM_EMAIL` in Vercel; `CRON_SECRET` is injected by Vercel automatically.
3. Editors need `email` set on their `admin_users` row to receive digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> OAuth account linking and auto-created contributor rows touch authentication; entity images and the optional digest are lower risk when env vars are unset.
> 
> **Overview**
> Adds **entity photos** for buildings, rooms, and dorms via new `image_url` columns and migrations, with logged-in editor upload/save in the side panel (contributors queue image changes like other fields), R2 URL validation on PATCH and proposal approval, PGlite/offline sync updates, and display plus SEO `og:image` on entity pages.
> 
> Adds **Continue with Google** when Supabase is configured: `/api/auth/callback` exchanges the OAuth code, `linkOrCreateContributorFromSupabase` links by Supabase id or email or creates a contributor, then issues the same `admin_session` cookie as password login; `admin_users.email` is added for linking and digests; failures surface as `?auth_error=` in the login modal.
> 
> Adds a **daily proposal digest** (#272): Resend-backed `sendProposalDigest` emails active admin/editors with an email on file, triggered by `/api/cron/proposal-digest` (Bearer `CRON_SECRET`) on a Vercel cron at 00:00 UTC; skips when Resend or recipients/pending queue are absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe15793858be8fd0474f1fde9120db305187cefd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->