### PR TITLE
feat(auth): self-service account settings, admin user management, forgot password

### DIFF
--- a/drizzle/0021_account_management.sql
+++ b/drizzle/0021_account_management.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "admin_users" ADD COLUMN IF NOT EXISTS "deleted_at" timestamp;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -332,6 +332,7 @@ export const adminUsersTable = pgTable(
     email: text(),
     isActive: boolean("is_active").default(true).notNull(),
     supabaseUserId: uuid("supabase_user_id"),
+    deletedAt: timestamp("deleted_at", { mode: "string" }),
     createdAt: timestamp("created_at", { mode: "string" })
       .defaultNow()
       .notNull(),

--- a/integration/services/account-management.integration.test.ts
+++ b/integration/services/account-management.integration.test.ts
@@ -23,6 +23,18 @@ describeIntegration(
     let oauthUserId: number;
 
     const cleanup = async () => {
+      // Delete dependent rows first — if an earlier test's own inline
+      // cleanup didn't run (e.g. an assertion above it threw), a leftover
+      // edit_proposals/contributions row would otherwise block every
+      // subsequent DELETE FROM admin_users via the FK constraint.
+      await client.query(
+        `DELETE FROM edit_proposals WHERE submitter_user_id IN (SELECT id FROM admin_users WHERE username LIKE $1)`,
+        [`${PREFIX}%`],
+      );
+      await client.query(
+        `DELETE FROM contributions WHERE user_id IN (SELECT id FROM admin_users WHERE username LIKE $1)`,
+        [`${PREFIX}%`],
+      );
       await client.query(`DELETE FROM admin_users WHERE username LIKE $1`, [
         `${PREFIX}%`,
       ]);

--- a/integration/services/account-management.integration.test.ts
+++ b/integration/services/account-management.integration.test.ts
@@ -1,0 +1,266 @@
+import {
+  describe,
+  expect,
+  test,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
+import pg from "pg";
+import bcrypt from "bcrypt";
+import { integrationDatabaseUrl, skipWithoutE2eDb } from "../helpers/env";
+
+const describeIntegration = skipWithoutE2eDb() ? describe.skip : describe;
+
+const PREFIX = "e2e-account-mgmt";
+const PASSWORD = "e2e-test-password-12345";
+
+describeIntegration(
+  "account management service integration (#456/#272 follow-up)",
+  () => {
+    let client: pg.Client;
+    let passwordUserId: number;
+    let oauthUserId: number;
+
+    const cleanup = async () => {
+      await client.query(`DELETE FROM admin_users WHERE username LIKE $1`, [
+        `${PREFIX}%`,
+      ]);
+    };
+
+    beforeAll(async () => {
+      const url = integrationDatabaseUrl();
+      if (!url) return;
+      client = new pg.Client({ connectionString: url });
+      await client.connect();
+    });
+
+    afterAll(async () => {
+      await cleanup();
+      await client?.end();
+    });
+
+    beforeEach(async () => {
+      await cleanup();
+      const passwordHash = await bcrypt.hash(PASSWORD, 12);
+      const { rows: passwordRows } = await client.query<{ id: number }>(
+        `INSERT INTO admin_users (username, display_name, password_hash, role, email, is_active)
+       VALUES ($1, 'Password User', $2, 'editor', $3, true) RETURNING id`,
+        [`${PREFIX}-password`, passwordHash, `${PREFIX}-password@example.com`],
+      );
+      passwordUserId = passwordRows[0]!.id;
+
+      const { rows: oauthRows } = await client.query<{ id: number }>(
+        `INSERT INTO admin_users (username, display_name, password_hash, role, email, is_active, supabase_user_id)
+       VALUES ($1, 'OAuth User', '', 'contributor', $2, true, $3) RETURNING id`,
+        [
+          `${PREFIX}-oauth`,
+          `${PREFIX}-oauth@example.com`,
+          "00000000-0000-4000-8000-0000000000e1",
+        ],
+      );
+      oauthUserId = oauthRows[0]!.id;
+    });
+
+    test("changePassword rejects wrong current password", async () => {
+      const { changePassword, AccountActionError } = await import(
+        "@lib/services/admin-user-service"
+      );
+      await expect(
+        changePassword(passwordUserId, "wrong-password", "a-new-password-123"),
+      ).rejects.toBeInstanceOf(AccountActionError);
+    });
+
+    test("changePassword succeeds with correct current password", async () => {
+      const { changePassword } = await import(
+        "@lib/services/admin-user-service"
+      );
+      await changePassword(passwordUserId, PASSWORD, "a-new-password-123");
+      const { rows } = await client.query<{ password_hash: string }>(
+        `SELECT password_hash FROM admin_users WHERE id = $1`,
+        [passwordUserId],
+      );
+      expect(
+        await bcrypt.compare("a-new-password-123", rows[0]!.password_hash),
+      ).toBe(true);
+    });
+
+    test("changePassword skips the current-password check for OAuth-only accounts", async () => {
+      const { changePassword } = await import(
+        "@lib/services/admin-user-service"
+      );
+      await changePassword(oauthUserId, null, "first-password-123");
+      const { rows } = await client.query<{ password_hash: string }>(
+        `SELECT password_hash FROM admin_users WHERE id = $1`,
+        [oauthUserId],
+      );
+      expect(rows[0]!.password_hash).not.toBe("");
+    });
+
+    test("changePassword enforces a minimum length", async () => {
+      const { changePassword, AccountActionError } = await import(
+        "@lib/services/admin-user-service"
+      );
+      await expect(
+        changePassword(passwordUserId, PASSWORD, "short"),
+      ).rejects.toBeInstanceOf(AccountActionError);
+    });
+
+    test("email-change token round-trip updates the email", async () => {
+      const { requestEmailChange, confirmEmailChange } = await import(
+        "@lib/services/admin-user-service"
+      );
+      const { createSignedToken } = await import("@lib/admin/signed-token");
+      const newEmail = `${PREFIX}-new@example.com`;
+
+      // requestEmailChange sends via Resend (unconfigured in tests) — assert it
+      // validates instead of relying on the network call succeeding.
+      await expect(
+        requestEmailChange(passwordUserId, "not-an-email"),
+      ).rejects.toThrow();
+
+      const token = createSignedToken({ userId: passwordUserId, newEmail }, 60);
+      await confirmEmailChange(token);
+      const { rows } = await client.query<{ email: string }>(
+        `SELECT email FROM admin_users WHERE id = $1`,
+        [passwordUserId],
+      );
+      expect(rows[0]!.email).toBe(newEmail);
+    });
+
+    test("linkGoogleIdentity rejects an identity already linked to another account", async () => {
+      const { linkGoogleIdentity, AccountActionError } = await import(
+        "@lib/services/admin-user-service"
+      );
+      const { rows } = await client.query<{ supabase_user_id: string }>(
+        `SELECT supabase_user_id FROM admin_users WHERE id = $1`,
+        [oauthUserId],
+      );
+      await expect(
+        linkGoogleIdentity(passwordUserId, rows[0]!.supabase_user_id),
+      ).rejects.toBeInstanceOf(AccountActionError);
+    });
+
+    test("unlinkGoogleIdentity requires a password to already be set", async () => {
+      const { unlinkGoogleIdentity, AccountActionError } = await import(
+        "@lib/services/admin-user-service"
+      );
+      await expect(unlinkGoogleIdentity(oauthUserId)).rejects.toBeInstanceOf(
+        AccountActionError,
+      );
+    });
+
+    test("softDeleteAccount scrubs PII and blocks future login", async () => {
+      const { softDeleteAccount } = await import(
+        "@lib/services/admin-user-service"
+      );
+      await softDeleteAccount(passwordUserId, PASSWORD);
+
+      const { rows } = await client.query<{
+        is_active: boolean;
+        email: string | null;
+        password_hash: string;
+        deleted_at: string | null;
+      }>(
+        `SELECT is_active, email, password_hash, deleted_at FROM admin_users WHERE id = $1`,
+        [passwordUserId],
+      );
+      expect(rows[0]!.is_active).toBe(false);
+      expect(rows[0]!.email).toBeNull();
+      expect(rows[0]!.password_hash).toBe("");
+      expect(rows[0]!.deleted_at).not.toBeNull();
+
+      const { authenticateAdminUser } = await import(
+        "@lib/services/admin-user-service"
+      );
+      const stillLogsIn = await authenticateAdminUser(
+        `${PREFIX}-password`,
+        PASSWORD,
+      );
+      expect(stillLogsIn).toBeNull();
+    });
+
+    test("softDeleteAccount preserves proposal/contribution FK attribution", async () => {
+      const { rows: proposalRows } = await client.query<{ id: number }>(
+        `INSERT INTO edit_proposals
+         (entity_type, entity_id, status, proposed_patch, base_version, submitter_name, submitter_user_id)
+       VALUES ('building', 1, 'pending', '{}'::jsonb, 1, 'Password User', $1)
+       RETURNING id`,
+        [passwordUserId],
+      );
+
+      const { softDeleteAccount } = await import(
+        "@lib/services/admin-user-service"
+      );
+      await softDeleteAccount(passwordUserId, PASSWORD);
+
+      const { rows } = await client.query<{ submitter_user_id: number }>(
+        `SELECT submitter_user_id FROM edit_proposals WHERE id = $1`,
+        [proposalRows[0]!.id],
+      );
+      expect(rows[0]!.submitter_user_id).toBe(passwordUserId);
+
+      await client.query(`DELETE FROM edit_proposals WHERE id = $1`, [
+        proposalRows[0]!.id,
+      ]);
+    });
+
+    test("createAdminUser + updateManagedUser role change", async () => {
+      const { createAdminUser, updateManagedUser } = await import(
+        "@lib/services/admin-user-service"
+      );
+
+      const created = await createAdminUser({
+        username: `${PREFIX}-newadmin`,
+        password: "another-password-123",
+        role: "admin",
+      });
+      expect(created.role).toBe("admin");
+
+      const demoted = await updateManagedUser(created.id, { role: "editor" });
+      expect(demoted.role).toBe("editor");
+
+      const promoted = await updateManagedUser(created.id, { role: "admin" });
+      expect(promoted.role).toBe("admin");
+    });
+
+    test("updateManagedUser blocks demoting the last remaining admin", async () => {
+      const { createAdminUser, updateManagedUser, AccountActionError } =
+        await import("@lib/services/admin-user-service");
+
+      const created = await createAdminUser({
+        username: `${PREFIX}-soleadmin`,
+        password: "another-password-123",
+        role: "admin",
+      });
+
+      // Snapshot every other currently-active admin so the guard sees exactly
+      // one admin (`created`); restore each row's exact prior role afterward
+      // rather than assuming a fixed shared-fixture layout.
+      const { rows: otherAdmins } = await client.query<{
+        id: number;
+        role: string;
+      }>(
+        `SELECT id, role FROM admin_users WHERE role = 'admin' AND is_active = true AND id <> $1`,
+        [created.id],
+      );
+      await client.query(
+        `UPDATE admin_users SET role = 'contributor' WHERE role = 'admin' AND is_active = true AND id <> $1`,
+        [created.id],
+      );
+
+      try {
+        await expect(
+          updateManagedUser(created.id, { role: "editor" }),
+        ).rejects.toBeInstanceOf(AccountActionError);
+      } finally {
+        for (const admin of otherAdmins) {
+          await client.query(`UPDATE admin_users SET role = $1 WHERE id = $2`, [
+            admin.role,
+            admin.id,
+          ]);
+        }
+      }
+    });
+  },
+);

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -46,6 +46,7 @@ const E2E_MIGRATION_FILES = [
   "0018_contributions_ledger.sql",
   "0019_add_entity_image_url.sql",
   "0020_add_admin_user_email.sql",
+  "0021_account_management.sql",
 ] as const;
 
 async function applyE2eMigrations(client: pg.Client) {

--- a/src/components/svelte/AccountSettingsModal.svelte
+++ b/src/components/svelte/AccountSettingsModal.svelte
@@ -1,0 +1,603 @@
+<script lang="ts">
+  import { fade, fly } from "svelte/transition";
+  import { X, User2 } from "@lucide/svelte";
+  import { adminAuthStore, toastStore } from "@lib/store.svelte";
+  import {
+    modalContentDismiss,
+    modalContentReveal,
+    overlayFade,
+  } from "@lib/motion";
+  import { trapFocus } from "@lib/focus-trap";
+  import EntityEditorFormField from "@ui/editor/EntityEditorFormField.svelte";
+  import EntityEditorSubmitButton from "@ui/editor/EntityEditorSubmitButton.svelte";
+  import EntityEditorMessage from "@ui/editor/EntityEditorMessage.svelte";
+  import "./editor/entity-editor.css";
+  import { MediaQuery } from "svelte/reactivity";
+
+  const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
+
+  type Profile = {
+    username: string;
+    displayName: string;
+    email: string | null;
+    role: "admin" | "editor" | "contributor";
+    hasPassword: boolean;
+    linkedGoogle: boolean;
+  };
+
+  let frameEl = $state<HTMLDivElement | null>(null);
+  let profile = $state<Profile | null>(null);
+  let loadError = $state<string | null>(null);
+
+  let displayNameDraft = $state("");
+  let savingDisplayName = $state(false);
+  let displayNameError = $state<string | null>(null);
+  let displayNameSaved = $state(false);
+
+  let newEmailDraft = $state("");
+  let showChangeEmail = $state(false);
+  let emailRequestPending = $state(false);
+  let emailRequestSent = $state(false);
+  let emailError = $state<string | null>(null);
+
+  let currentPasswordDraft = $state("");
+  let newPasswordDraft = $state("");
+  let savingPassword = $state(false);
+  let passwordError = $state<string | null>(null);
+  let passwordSaved = $state(false);
+
+  let unlinkingGoogle = $state(false);
+  let identityError = $state<string | null>(null);
+
+  let showDeleteConfirm = $state(false);
+  let deletePasswordDraft = $state("");
+  let deleting = $state(false);
+  let deleteError = $state<string | null>(null);
+
+  async function loadProfile() {
+    loadError = null;
+    try {
+      const res = await fetch("/api/account/me", { credentials: "same-origin" });
+      if (!res.ok) {
+        loadError = "Could not load your account.";
+        return;
+      }
+      profile = (await res.json()) as Profile;
+      displayNameDraft = profile.displayName;
+    } catch {
+      loadError = "Network error loading your account.";
+    }
+  }
+
+  $effect(() => {
+    if (adminAuthStore.accountSettingsOpen) void loadProfile();
+  });
+
+  function close() {
+    adminAuthStore.closeAccountSettings();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") close();
+  }
+
+  $effect(() => {
+    if (!frameEl) return;
+    return trapFocus(frameEl, { onEscape: close });
+  });
+
+  async function saveDisplayName() {
+    if (!profile) return;
+    savingDisplayName = true;
+    displayNameError = null;
+    displayNameSaved = false;
+    try {
+      const res = await fetch("/api/account/me", {
+        method: "PATCH",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: displayNameDraft }),
+      });
+      const data = await res.json().catch(() => ({}) as { error?: string });
+      if (!res.ok) {
+        displayNameError = data.error ?? "Could not save display name.";
+        return;
+      }
+      profile = { ...profile, displayName: displayNameDraft.trim() };
+      await adminAuthStore.refresh();
+      displayNameSaved = true;
+      setTimeout(() => {
+        displayNameSaved = false;
+      }, 1800);
+    } catch {
+      displayNameError = "Network error. Try again.";
+    } finally {
+      savingDisplayName = false;
+    }
+  }
+
+  async function requestEmailChange() {
+    emailRequestPending = true;
+    emailError = null;
+    emailRequestSent = false;
+    try {
+      const res = await fetch("/api/account/request-email-change", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newEmail: newEmailDraft }),
+      });
+      const data = await res.json().catch(() => ({}) as { error?: string });
+      if (!res.ok) {
+        emailError = data.error ?? "Could not send confirmation email.";
+        return;
+      }
+      emailRequestSent = true;
+      newEmailDraft = "";
+    } catch {
+      emailError = "Network error. Try again.";
+    } finally {
+      emailRequestPending = false;
+    }
+  }
+
+  async function savePassword() {
+    if (!profile) return;
+    savingPassword = true;
+    passwordError = null;
+    passwordSaved = false;
+    try {
+      const res = await fetch("/api/account/change-password", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          currentPassword: profile.hasPassword ? currentPasswordDraft : undefined,
+          newPassword: newPasswordDraft,
+        }),
+      });
+      const data = await res.json().catch(() => ({}) as { error?: string });
+      if (!res.ok) {
+        passwordError = data.error ?? "Could not change password.";
+        return;
+      }
+      currentPasswordDraft = "";
+      newPasswordDraft = "";
+      profile = { ...profile, hasPassword: true };
+      passwordSaved = true;
+      setTimeout(() => {
+        passwordSaved = false;
+      }, 1800);
+    } catch {
+      passwordError = "Network error. Try again.";
+    } finally {
+      savingPassword = false;
+    }
+  }
+
+  async function connectGoogle() {
+    identityError = null;
+    const err = await adminAuthStore.linkGoogle();
+    if (err) identityError = err;
+  }
+
+  async function disconnectGoogle() {
+    if (!profile) return;
+    unlinkingGoogle = true;
+    identityError = null;
+    try {
+      const res = await fetch("/api/account/unlink-google", {
+        method: "POST",
+        credentials: "same-origin",
+      });
+      const data = await res.json().catch(() => ({}) as { error?: string });
+      if (!res.ok) {
+        identityError = data.error ?? "Could not disconnect Google.";
+        return;
+      }
+      profile = { ...profile, linkedGoogle: false };
+      toastStore.show("Google account disconnected.", "success");
+    } catch {
+      identityError = "Network error. Try again.";
+    } finally {
+      unlinkingGoogle = false;
+    }
+  }
+
+  function downloadExport() {
+    window.open("/api/account/export", "_blank", "noopener,noreferrer");
+  }
+
+  async function confirmDelete() {
+    if (!profile) return;
+    deleting = true;
+    deleteError = null;
+    try {
+      const res = await fetch("/api/account/delete", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          currentPassword: profile.hasPassword ? deletePasswordDraft : undefined,
+        }),
+      });
+      const data = await res.json().catch(() => ({}) as { error?: string });
+      if (!res.ok) {
+        deleteError = data.error ?? "Could not delete account.";
+        return;
+      }
+      close();
+      await adminAuthStore.logout();
+      toastStore.show("Your account has been deleted.", "success");
+    } catch {
+      deleteError = "Network error. Try again.";
+    } finally {
+      deleting = false;
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div class="settings-overlay" transition:fade={overlayFade(reducedMotion.current)}>
+  <div
+    bind:this={frameEl}
+    class="settings-frame"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="account-settings-title"
+    in:fly={modalContentReveal(reducedMotion.current)}
+    out:fly={modalContentDismiss(reducedMotion.current)}
+  >
+    <header class="settings-header">
+      <div class="settings-title" id="account-settings-title">
+        <User2 size={16} aria-hidden="true" />
+        <span>Account settings</span>
+      </div>
+      <button
+        type="button"
+        class="settings-close"
+        onclick={close}
+        aria-label="Close account settings"
+      >
+        <X size={18} aria-hidden="true" />
+      </button>
+    </header>
+
+    <div class="settings-body">
+      {#if loadError}
+        <EntityEditorMessage variant="error" message={loadError} />
+      {:else if !profile}
+        <p class="settings-loading">Loading…</p>
+      {:else}
+        <section class="settings-section">
+          <h3>Profile</h3>
+          <EntityEditorFormField label="Username" inputId="account-username">
+            {#snippet control()}
+              <input id="account-username" value={profile.username} disabled />
+            {/snippet}
+          </EntityEditorFormField>
+          <EntityEditorFormField label="Role" inputId="account-role">
+            {#snippet control()}
+              <input id="account-role" value={profile.role} disabled />
+            {/snippet}
+          </EntityEditorFormField>
+          <EntityEditorFormField label="Display name" inputId="account-display-name">
+            {#snippet control()}
+              <input
+                id="account-display-name"
+                bind:value={displayNameDraft}
+                disabled={savingDisplayName}
+              />
+            {/snippet}
+          </EntityEditorFormField>
+          {#if displayNameError}
+            <EntityEditorMessage variant="error" message={displayNameError} />
+          {/if}
+          {#if displayNameSaved}
+            <EntityEditorMessage variant="success" message="Display name saved." />
+          {/if}
+          <EntityEditorSubmitButton
+            label="Save display name"
+            savingLabel="Saving…"
+            saving={savingDisplayName}
+            disabled={displayNameDraft.trim() === profile.displayName}
+            onclick={saveDisplayName}
+          />
+
+          <EntityEditorFormField label="Email" inputId="account-email">
+            {#snippet control()}
+              <input id="account-email" value={profile.email ?? "(none)"} disabled />
+            {/snippet}
+          </EntityEditorFormField>
+          {#if !showChangeEmail}
+            <button
+              type="button"
+              class="settings-link-btn"
+              onclick={() => (showChangeEmail = true)}
+            >
+              Change email
+            </button>
+          {:else}
+            <EntityEditorFormField label="New email" inputId="account-new-email">
+              {#snippet control()}
+                <input
+                  id="account-new-email"
+                  type="email"
+                  bind:value={newEmailDraft}
+                  disabled={emailRequestPending}
+                />
+              {/snippet}
+            </EntityEditorFormField>
+            {#if emailError}
+              <EntityEditorMessage variant="error" message={emailError} />
+            {/if}
+            {#if emailRequestSent}
+              <EntityEditorMessage
+                variant="success"
+                message="Check your new inbox for a confirmation link."
+              />
+            {/if}
+            <EntityEditorSubmitButton
+              label="Send confirmation link"
+              savingLabel="Sending…"
+              saving={emailRequestPending}
+              disabled={!newEmailDraft.trim()}
+              onclick={requestEmailChange}
+            />
+          {/if}
+        </section>
+
+        <section class="settings-section">
+          <h3>{profile.hasPassword ? "Change password" : "Set a password"}</h3>
+          {#if profile.hasPassword}
+            <EntityEditorFormField label="Current password" inputId="account-current-password">
+              {#snippet control()}
+                <input
+                  id="account-current-password"
+                  type="password"
+                  autocomplete="current-password"
+                  bind:value={currentPasswordDraft}
+                  disabled={savingPassword}
+                />
+              {/snippet}
+            </EntityEditorFormField>
+          {/if}
+          <EntityEditorFormField
+            label="New password"
+            inputId="account-new-password"
+            hint="At least 10 characters."
+          >
+            {#snippet control()}
+              <input
+                id="account-new-password"
+                type="password"
+                autocomplete="new-password"
+                bind:value={newPasswordDraft}
+                disabled={savingPassword}
+              />
+            {/snippet}
+          </EntityEditorFormField>
+          {#if passwordError}
+            <EntityEditorMessage variant="error" message={passwordError} />
+          {/if}
+          {#if passwordSaved}
+            <EntityEditorMessage variant="success" message="Password saved." />
+          {/if}
+          <EntityEditorSubmitButton
+            label={profile.hasPassword ? "Change password" : "Set password"}
+            savingLabel="Saving…"
+            saving={savingPassword}
+            disabled={newPasswordDraft.length < 10 ||
+              (profile.hasPassword && !currentPasswordDraft)}
+            onclick={savePassword}
+          />
+        </section>
+
+        <section class="settings-section">
+          <h3>Connected accounts</h3>
+          {#if identityError}
+            <EntityEditorMessage variant="error" message={identityError} />
+          {/if}
+          {#if profile.linkedGoogle}
+            <p class="settings-status">Google is connected.</p>
+            <EntityEditorSubmitButton
+              label="Disconnect Google"
+              savingLabel="Disconnecting…"
+              saving={unlinkingGoogle}
+              disabled={!profile.hasPassword}
+              variant="secondary"
+              onclick={disconnectGoogle}
+            />
+            {#if !profile.hasPassword}
+              <p class="field-hint">Set a password first to disconnect Google.</p>
+            {/if}
+          {:else}
+            <EntityEditorSubmitButton
+              label="Connect Google"
+              variant="secondary"
+              onclick={connectGoogle}
+            />
+          {/if}
+        </section>
+
+        <section class="settings-section">
+          <h3>Data &amp; privacy</h3>
+          <EntityEditorSubmitButton
+            label="Download my data"
+            variant="secondary"
+            onclick={downloadExport}
+          />
+
+          {#if !showDeleteConfirm}
+            <button
+              type="button"
+              class="settings-link-btn settings-link-btn--danger"
+              onclick={() => (showDeleteConfirm = true)}
+            >
+              Delete my account
+            </button>
+          {:else}
+            <div class="settings-danger-zone">
+              <p>
+                This deactivates your account and removes your email, display
+                name, and password. Your past proposals and edit history stay
+                on record, attributed to a deleted user.
+              </p>
+              {#if profile.hasPassword}
+                <EntityEditorFormField label="Confirm password" inputId="account-delete-password">
+                  {#snippet control()}
+                    <input
+                      id="account-delete-password"
+                      type="password"
+                      bind:value={deletePasswordDraft}
+                      disabled={deleting}
+                    />
+                  {/snippet}
+                </EntityEditorFormField>
+              {/if}
+              {#if deleteError}
+                <EntityEditorMessage variant="error" message={deleteError} />
+              {/if}
+              <div class="settings-danger-actions">
+                <EntityEditorSubmitButton
+                  label="Permanently delete my account"
+                  savingLabel="Deleting…"
+                  saving={deleting}
+                  disabled={profile.hasPassword && !deletePasswordDraft}
+                  variant="danger"
+                  onclick={confirmDelete}
+                />
+                <EntityEditorSubmitButton
+                  label="Cancel"
+                  variant="secondary"
+                  disabled={deleting}
+                  onclick={() => (showDeleteConfirm = false)}
+                />
+              </div>
+            </div>
+          {/if}
+        </section>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .settings-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(8, 12, 22, 0.55);
+    z-index: var(--z-login-modal, 200);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+  .settings-frame {
+    width: min(26rem, 100%);
+    max-height: min(38rem, 90vh);
+    background: white;
+    border-radius: 0.75rem;
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.3);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  .settings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid hsl(0, 0%, 92%);
+  }
+  .settings-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 15%);
+  }
+  .settings-close {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 0.375rem;
+    color: hsl(0, 0%, 30%);
+    display: flex;
+  }
+  .settings-close:hover,
+  .settings-close:focus-visible {
+    background-color: hsl(0, 0%, 95%);
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 1px;
+  }
+  .settings-body {
+    padding: 1rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+  .settings-loading {
+    margin: 0;
+    color: hsl(0, 0%, 45%);
+  }
+  .settings-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid hsl(0, 0%, 93%);
+  }
+  .settings-section:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+  .settings-section h3 {
+    margin: 0 0 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: hsl(5, 53%, 32%);
+  }
+  .settings-status {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: hsl(0, 0%, 35%);
+  }
+  .settings-link-btn {
+    align-self: flex-start;
+    background: none;
+    border: none;
+    padding: 0;
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+    font-size: 0.8125rem;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .settings-link-btn--danger {
+    color: #9a1b1b;
+  }
+  .settings-danger-zone {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    border: 1px solid #f0c9c9;
+    border-radius: 0.5rem;
+    background: #fdf6f6;
+  }
+  .settings-danger-zone p {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: hsl(0, 0%, 30%);
+  }
+  .settings-danger-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+</style>

--- a/src/components/svelte/AdminLoginModal.svelte
+++ b/src/components/svelte/AdminLoginModal.svelte
@@ -35,6 +35,38 @@
   let error: string | null = $state(null);
   let googleLoading = $state(false);
 
+  let showForgotPassword = $state(false);
+  let forgotLoginDraft = $state("");
+  let forgotPasswordSending = $state(false);
+  let forgotPasswordSent = $state(false);
+  let forgotPasswordError = $state<string | null>(null);
+
+  async function sendForgotPassword() {
+    forgotPasswordSending = true;
+    forgotPasswordError = null;
+    try {
+      const res = await fetch("/api/account/request-password-reset", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ login: forgotLoginDraft }),
+      });
+      if (!res.ok && res.status === 429) {
+        const data = await res.json().catch(() => ({}) as { error?: string });
+        forgotPasswordError =
+          data.error ?? "Too many attempts. Wait a bit and try again.";
+        return;
+      }
+      // Always show success — the endpoint never reveals whether the
+      // account exists, so neither should the UI.
+      forgotPasswordSent = true;
+    } catch {
+      forgotPasswordError = "Network error. Try again.";
+    } finally {
+      forgotPasswordSending = false;
+    }
+  }
+
   $effect(() => {
     const code = adminAuthStore.oauthError;
     if (code) {
@@ -136,6 +168,15 @@
           />
         {/snippet}
       </EntityEditorFormField>
+      {#if !showForgotPassword}
+        <button
+          type="button"
+          class="forgot-password-link"
+          onclick={() => (showForgotPassword = true)}
+        >
+          Forgot password?
+        </button>
+      {/if}
       {#if error}
         <EntityEditorMessage
           variant="error"
@@ -143,13 +184,70 @@
           id={loginErrorId}
         />
       {/if}
-      <EntityEditorSubmitButton
-        type="submit"
-        label="Sign in"
-        savingLabel="Signing in…"
-        saving={adminAuthStore.loading}
-      />
-      {#if googleEnabled}
+      {#if !showForgotPassword}
+        <EntityEditorSubmitButton
+          type="submit"
+          label="Sign in"
+          savingLabel="Signing in…"
+          saving={adminAuthStore.loading}
+        />
+      {/if}
+      {#if showForgotPassword}
+        <div class="forgot-password-panel">
+          {#if forgotPasswordSent}
+            <EntityEditorMessage
+              variant="success"
+              message="If that account exists, check its email for a reset link."
+            />
+            <button
+              type="button"
+              class="forgot-password-link"
+              onclick={() => {
+                showForgotPassword = false;
+                forgotPasswordSent = false;
+                forgotLoginDraft = "";
+              }}
+            >
+              Back to sign in
+            </button>
+          {:else}
+            <EntityEditorFormField
+              label="Username or email"
+              inputId="forgot-password-login"
+            >
+              {#snippet control()}
+                <input
+                  id="forgot-password-login"
+                  type="text"
+                  autocomplete="username"
+                  bind:value={forgotLoginDraft}
+                  disabled={forgotPasswordSending}
+                />
+              {/snippet}
+            </EntityEditorFormField>
+            {#if forgotPasswordError}
+              <EntityEditorMessage variant="error" message={forgotPasswordError} />
+            {/if}
+            <div class="forgot-password-actions">
+              <EntityEditorSubmitButton
+                label="Send reset link"
+                savingLabel="Sending…"
+                saving={forgotPasswordSending}
+                disabled={!forgotLoginDraft.trim()}
+                onclick={sendForgotPassword}
+              />
+              <button
+                type="button"
+                class="forgot-password-link"
+                onclick={() => (showForgotPassword = false)}
+              >
+                Cancel
+              </button>
+            </div>
+          {/if}
+        </div>
+      {/if}
+      {#if googleEnabled && !showForgotPassword}
         <div class="login-divider" aria-hidden="true">or</div>
         <button
           type="button"
@@ -244,6 +342,9 @@
   .login-body {
     padding: 1rem;
   }
+  .login-body :global(.entity-editor-submit) {
+    width: 100%;
+  }
   .login-footer {
     margin: 0;
     padding: 0.75rem 1rem 1rem;
@@ -282,6 +383,7 @@
     border-top: 1px solid hsl(0, 0%, 90%);
   }
   .google-login-btn {
+    box-sizing: border-box;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -305,5 +407,28 @@
   .google-login-btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+  }
+  .forgot-password-link {
+    align-self: flex-start;
+    background: none;
+    border: none;
+    padding: 0;
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+    font-size: 0.75rem;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .forgot-password-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .forgot-password-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
   }
 </style>

--- a/src/components/svelte/EditorShelf.svelte
+++ b/src/components/svelte/EditorShelf.svelte
@@ -4,6 +4,8 @@
   import MapPinPlus from "@lucide/svelte/icons/map-pin-plus";
   import Pencil from "@lucide/svelte/icons/pencil";
   import ShieldCheck from "@lucide/svelte/icons/shield-check";
+  import Settings from "@lucide/svelte/icons/settings";
+  import Users from "@lucide/svelte/icons/users";
   import {
     adminAuthStore,
     editorChromeStore,
@@ -60,6 +62,18 @@
     toastStore.show("Signed out.", "info");
   }
 
+  function handleAccountSettings() {
+    editorChromeStore.closeShelf();
+    onclose?.();
+    adminAuthStore.openAccountSettings();
+  }
+
+  function handleManageUsers() {
+    editorChromeStore.closeShelf();
+    onclose?.();
+    adminAuthStore.openManageUsers();
+  }
+
   function addEventLabel() {
     if (eventPlacementStore.creating) return "Creating event…";
     if (eventPlacementStore.active) return "Choose event location";
@@ -114,6 +128,26 @@
   {/if}
 
   <ProposalReviewPanel />
+
+  <button
+    type="button"
+    class="editor-shelf-action"
+    onclick={handleAccountSettings}
+  >
+    <Settings size={16} aria-hidden="true" />
+    Account settings
+  </button>
+
+  {#if adminAuthStore.role === "admin"}
+    <button
+      type="button"
+      class="editor-shelf-action"
+      onclick={handleManageUsers}
+    >
+      <Users size={16} aria-hidden="true" />
+      Manage users
+    </button>
+  {/if}
 
   <button
     type="button"

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -27,6 +27,8 @@
   import Toast from "@ui/Toast.svelte";
   import Building3DViewer from "@ui/Building3DViewer.svelte";
   import AdminLoginModal from "@ui/AdminLoginModal.svelte";
+  import AccountSettingsModal from "@ui/AccountSettingsModal.svelte";
+  import ManageUsersModal from "@ui/ManageUsersModal.svelte";
   import EditorAdditionModal from "@ui/EditorAdditionModal.svelte";
   import EditorScreen from "@ui/EditorScreen.svelte";
   import EntityUrlSync from "@ui/EntityUrlSync.svelte";
@@ -82,6 +84,37 @@
     if (authError) {
       adminAuthStore.oauthError = authError;
       adminAuthStore.openLogin();
+      window.history.replaceState({}, "", window.location.pathname);
+    }
+
+    const accountEvent = urlParams.get("account");
+    if (accountEvent === "email-changed") {
+      toastStore.show("Email address updated.", "success");
+      adminAuthStore.openAccountSettings();
+      window.history.replaceState({}, "", window.location.pathname);
+    } else if (accountEvent === "google-linked") {
+      toastStore.show("Google account connected.", "success");
+      adminAuthStore.openAccountSettings();
+      window.history.replaceState({}, "", window.location.pathname);
+    }
+
+    const accountError = urlParams.get("account_error");
+    if (accountError) {
+      const messages: Record<string, string> = {
+        missing_token: "That confirmation link is missing its token.",
+        invalid_or_expired_token:
+          "That confirmation link is invalid or has expired. Request a new one.",
+        not_logged_in: "Sign in first, then connect Google from account settings.",
+        missing_code: "Google sign-in was cancelled or incomplete. Try again.",
+        oauth_failed: "Connecting Google failed. Try again.",
+        already_linked:
+          "That Google account is already connected to a different Room TBA account.",
+      };
+      toastStore.show(
+        messages[accountError] ?? "Something went wrong. Try again.",
+        "error",
+      );
+      adminAuthStore.openAccountSettings();
       window.history.replaceState({}, "", window.location.pathname);
     }
 
@@ -273,6 +306,12 @@
   {/if}
   {#if adminAuthStore.loginOpen}
     <AdminLoginModal />
+  {/if}
+  {#if adminAuthStore.accountSettingsOpen}
+    <AccountSettingsModal />
+  {/if}
+  {#if adminAuthStore.manageUsersOpen}
+    <ManageUsersModal />
   {/if}
   <EditorAdditionModal />
   <EditorScreen />

--- a/src/components/svelte/ManageUsersModal.svelte
+++ b/src/components/svelte/ManageUsersModal.svelte
@@ -1,0 +1,425 @@
+<script lang="ts">
+  import { fade, fly } from "svelte/transition";
+  import { X, Users } from "@lucide/svelte";
+  import { adminAuthStore, toastStore } from "@lib/store.svelte";
+  import {
+    modalContentDismiss,
+    modalContentReveal,
+    overlayFade,
+  } from "@lib/motion";
+  import { trapFocus } from "@lib/focus-trap";
+  import EntityEditorFormField from "@ui/editor/EntityEditorFormField.svelte";
+  import EntityEditorSubmitButton from "@ui/editor/EntityEditorSubmitButton.svelte";
+  import EntityEditorMessage from "@ui/editor/EntityEditorMessage.svelte";
+  import "./editor/entity-editor.css";
+  import { MediaQuery } from "svelte/reactivity";
+
+  const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
+
+  type ManagedUser = {
+    id: number;
+    username: string;
+    displayName: string;
+    email: string | null;
+    role: "admin" | "editor" | "contributor";
+    isActive: boolean;
+  };
+
+  let frameEl = $state<HTMLDivElement | null>(null);
+  let users = $state<ManagedUser[] | null>(null);
+  let loadError = $state<string | null>(null);
+  let rowError = $state<string | null>(null);
+  let savingUserId = $state<number | null>(null);
+
+  let showCreateForm = $state(false);
+  let newUsername = $state("");
+  let newDisplayName = $state("");
+  let newEmail = $state("");
+  let newPassword = $state("");
+  let newRole = $state<"admin" | "editor" | "contributor">("editor");
+  let creating = $state(false);
+  let createError = $state<string | null>(null);
+
+  async function loadUsers() {
+    loadError = null;
+    try {
+      const res = await fetch("/api/admin/users", { credentials: "same-origin" });
+      if (!res.ok) {
+        loadError = "Could not load users.";
+        return;
+      }
+      const data = (await res.json()) as { users: ManagedUser[] };
+      users = data.users;
+    } catch {
+      loadError = "Network error loading users.";
+    }
+  }
+
+  $effect(() => {
+    if (adminAuthStore.manageUsersOpen) void loadUsers();
+  });
+
+  function close() {
+    adminAuthStore.closeManageUsers();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") close();
+  }
+
+  $effect(() => {
+    if (!frameEl) return;
+    return trapFocus(frameEl, { onEscape: close });
+  });
+
+  async function changeRole(user: ManagedUser, role: ManagedUser["role"]) {
+    if (role === user.role) return;
+    savingUserId = user.id;
+    rowError = null;
+    try {
+      const res = await fetch(`/api/admin/users/${user.id}`, {
+        method: "PATCH",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role }),
+      });
+      const data = await res.json().catch(() => ({}) as { error?: string });
+      if (!res.ok) {
+        rowError = data.error ?? "Could not update role.";
+        return;
+      }
+      users = (users ?? []).map((u) => (u.id === user.id ? { ...u, role } : u));
+    } catch {
+      rowError = "Network error. Try again.";
+    } finally {
+      savingUserId = null;
+    }
+  }
+
+  async function toggleActive(user: ManagedUser) {
+    savingUserId = user.id;
+    rowError = null;
+    try {
+      const res = await fetch(`/api/admin/users/${user.id}`, {
+        method: "PATCH",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isActive: !user.isActive }),
+      });
+      const data = await res.json().catch(() => ({}) as { error?: string });
+      if (!res.ok) {
+        rowError = data.error ?? "Could not update account.";
+        return;
+      }
+      users = (users ?? []).map((u) =>
+        u.id === user.id ? { ...u, isActive: !user.isActive } : u,
+      );
+    } catch {
+      rowError = "Network error. Try again.";
+    } finally {
+      savingUserId = null;
+    }
+  }
+
+  async function createUser() {
+    creating = true;
+    createError = null;
+    try {
+      const res = await fetch("/api/admin/users", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: newUsername,
+          displayName: newDisplayName || undefined,
+          email: newEmail || undefined,
+          password: newPassword,
+          role: newRole,
+        }),
+      });
+      const data = await res.json().catch(() => ({}) as { error?: string });
+      if (!res.ok) {
+        createError = data.error ?? "Could not create account.";
+        return;
+      }
+      toastStore.show(`${newUsername} created. Share the temp password with them.`, "success");
+      newUsername = "";
+      newDisplayName = "";
+      newEmail = "";
+      newPassword = "";
+      newRole = "editor";
+      showCreateForm = false;
+      await loadUsers();
+    } catch {
+      createError = "Network error. Try again.";
+    } finally {
+      creating = false;
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div class="settings-overlay" transition:fade={overlayFade(reducedMotion.current)}>
+  <div
+    bind:this={frameEl}
+    class="settings-frame"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="manage-users-title"
+    in:fly={modalContentReveal(reducedMotion.current)}
+    out:fly={modalContentDismiss(reducedMotion.current)}
+  >
+    <header class="settings-header">
+      <div class="settings-title" id="manage-users-title">
+        <Users size={16} aria-hidden="true" />
+        <span>Manage users</span>
+      </div>
+      <button type="button" class="settings-close" onclick={close} aria-label="Close">
+        <X size={18} aria-hidden="true" />
+      </button>
+    </header>
+
+    <div class="settings-body">
+      {#if loadError}
+        <EntityEditorMessage variant="error" message={loadError} />
+      {:else if !users}
+        <p class="settings-loading">Loading…</p>
+      {:else}
+        {#if rowError}
+          <EntityEditorMessage variant="error" message={rowError} />
+        {/if}
+        <ul class="user-list">
+          {#each users as user (user.id)}
+            <li class="user-row" class:user-row--inactive={!user.isActive}>
+              <div class="user-row-info">
+                <strong>{user.displayName}</strong>
+                <small>{user.username}{user.email ? ` · ${user.email}` : ""}</small>
+              </div>
+              <select
+                value={user.role}
+                disabled={savingUserId === user.id}
+                onchange={(e) =>
+                  changeRole(user, (e.currentTarget as HTMLSelectElement).value as ManagedUser["role"])}
+              >
+                <option value="admin">Admin</option>
+                <option value="editor">Editor</option>
+                <option value="contributor">Contributor</option>
+              </select>
+              <button
+                type="button"
+                class="settings-link-btn"
+                disabled={savingUserId === user.id}
+                onclick={() => toggleActive(user)}
+              >
+                {user.isActive ? "Deactivate" : "Reactivate"}
+              </button>
+            </li>
+          {/each}
+        </ul>
+
+        {#if !showCreateForm}
+          <EntityEditorSubmitButton
+            label="Invite admin / editor"
+            variant="secondary"
+            onclick={() => (showCreateForm = true)}
+          />
+        {:else}
+          <section class="settings-section">
+            <h3>Invite admin / editor</h3>
+            <EntityEditorFormField label="Username" inputId="new-user-username">
+              {#snippet control()}
+                <input id="new-user-username" bind:value={newUsername} disabled={creating} />
+              {/snippet}
+            </EntityEditorFormField>
+            <EntityEditorFormField label="Display name" inputId="new-user-display-name">
+              {#snippet control()}
+                <input
+                  id="new-user-display-name"
+                  bind:value={newDisplayName}
+                  disabled={creating}
+                />
+              {/snippet}
+            </EntityEditorFormField>
+            <EntityEditorFormField label="Email" inputId="new-user-email">
+              {#snippet control()}
+                <input
+                  id="new-user-email"
+                  type="email"
+                  bind:value={newEmail}
+                  disabled={creating}
+                />
+              {/snippet}
+            </EntityEditorFormField>
+            <EntityEditorFormField
+              label="Temporary password"
+              inputId="new-user-password"
+              hint="At least 10 characters. Share it with them out of band; they can change it after signing in."
+            >
+              {#snippet control()}
+                <input
+                  id="new-user-password"
+                  type="password"
+                  bind:value={newPassword}
+                  disabled={creating}
+                />
+              {/snippet}
+            </EntityEditorFormField>
+            <EntityEditorFormField label="Role" inputId="new-user-role">
+              {#snippet control()}
+                <select id="new-user-role" bind:value={newRole} disabled={creating}>
+                  <option value="admin">Admin</option>
+                  <option value="editor">Editor</option>
+                  <option value="contributor">Contributor</option>
+                </select>
+              {/snippet}
+            </EntityEditorFormField>
+            {#if createError}
+              <EntityEditorMessage variant="error" message={createError} />
+            {/if}
+            <div class="settings-danger-actions">
+              <EntityEditorSubmitButton
+                label="Create account"
+                savingLabel="Creating…"
+                saving={creating}
+                disabled={!newUsername.trim() || newPassword.length < 10}
+                onclick={createUser}
+              />
+              <EntityEditorSubmitButton
+                label="Cancel"
+                variant="secondary"
+                disabled={creating}
+                onclick={() => (showCreateForm = false)}
+              />
+            </div>
+          </section>
+        {/if}
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .settings-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(8, 12, 22, 0.55);
+    z-index: var(--z-login-modal, 200);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+  .settings-frame {
+    width: min(28rem, 100%);
+    max-height: min(38rem, 90vh);
+    background: white;
+    border-radius: 0.75rem;
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.3);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  .settings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid hsl(0, 0%, 92%);
+  }
+  .settings-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 15%);
+  }
+  .settings-close {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 0.375rem;
+    color: hsl(0, 0%, 30%);
+    display: flex;
+  }
+  .settings-close:hover,
+  .settings-close:focus-visible {
+    background-color: hsl(0, 0%, 95%);
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 1px;
+  }
+  .settings-body {
+    padding: 1rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .settings-loading {
+    margin: 0;
+    color: hsl(0, 0%, 45%);
+  }
+  .settings-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .settings-section h3 {
+    margin: 0 0 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: hsl(5, 53%, 32%);
+  }
+  .settings-link-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+    font-size: 0.75rem;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .settings-danger-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .user-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .user-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    border: 1px solid hsl(0, 0%, 92%);
+    border-radius: 0.5rem;
+  }
+  .user-row--inactive {
+    opacity: 0.55;
+  }
+  .user-row-info {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .user-row-info strong {
+    font-size: 0.8125rem;
+  }
+  .user-row-info small {
+    font-size: 0.6875rem;
+    color: hsl(0, 0%, 45%);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/svelte/ResetPasswordForm.svelte
+++ b/src/components/svelte/ResetPasswordForm.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import EntityEditorFormField from "@ui/editor/EntityEditorFormField.svelte";
+  import EntityEditorSubmitButton from "@ui/editor/EntityEditorSubmitButton.svelte";
+  import EntityEditorMessage from "@ui/editor/EntityEditorMessage.svelte";
+  import "./editor/entity-editor.css";
+
+  const token = $derived(
+    new URLSearchParams(window.location.search).get("token"),
+  );
+  let newPassword = $state("");
+  let saving = $state(false);
+  let error = $state<string | null>(null);
+  let done = $state(false);
+
+  async function submit(e: Event) {
+    e.preventDefault();
+    if (!token) return;
+    saving = true;
+    error = null;
+    try {
+      const res = await fetch("/api/account/confirm-password-reset", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, newPassword }),
+      });
+      const data = await res.json().catch(() => ({}) as { error?: string });
+      if (!res.ok) {
+        error = data.error ?? "Could not reset password.";
+        return;
+      }
+      done = true;
+    } catch {
+      error = "Network error. Try again.";
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<div class="reset-password-card">
+  {#if !token}
+    <EntityEditorMessage
+      variant="error"
+      message="This link is missing its token. Request a new password reset from the editor login."
+    />
+  {:else if done}
+    <EntityEditorMessage
+      variant="success"
+      message="Password updated. You can sign in with it now."
+    />
+    <a class="reset-password-link" href="/?editor=login">Go to sign in</a>
+  {:else}
+    <form class="entity-editor-form" onsubmit={submit}>
+      <EntityEditorFormField
+        label="New password"
+        inputId="reset-password-new"
+        hint="At least 10 characters."
+      >
+        {#snippet control()}
+          <input
+            id="reset-password-new"
+            type="password"
+            autocomplete="new-password"
+            bind:value={newPassword}
+            disabled={saving}
+            required
+          />
+        {/snippet}
+      </EntityEditorFormField>
+      {#if error}
+        <EntityEditorMessage variant="error" message={error} />
+      {/if}
+      <EntityEditorSubmitButton
+        type="submit"
+        label="Set new password"
+        savingLabel="Saving…"
+        saving={saving}
+        disabled={newPassword.length < 10}
+      />
+    </form>
+  {/if}
+</div>
+
+<style>
+  .reset-password-card {
+    max-width: 24rem;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .reset-password-link {
+    align-self: flex-start;
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+</style>

--- a/src/components/svelte/community/CommunityBrandIcon.component.test.ts
+++ b/src/components/svelte/community/CommunityBrandIcon.component.test.ts
@@ -10,7 +10,7 @@ describe("CommunityBrandIcon", () => {
     const svg = container.querySelector("svg");
     expect(svg).toBeTruthy();
     expect(svg?.getAttribute("width")).toBe("18");
-    expect(container.querySelector("linearGradient")).toBeTruthy();
+    expect(container.querySelector("radialGradient")).toBeTruthy();
   });
 
   test("renders Discord brand SVG", () => {

--- a/src/components/svelte/community/CommunityBrandIcon.svelte
+++ b/src/components/svelte/community/CommunityBrandIcon.svelte
@@ -26,27 +26,35 @@
     />
   </svg>
 {:else}
+  <!-- Official Meta Messenger logo (2020 redesign): radial gradient bubble + bolt. -->
   <svg
     class="community-brand-icon"
     width={size}
     height={size}
-    viewBox="0 0 36 36"
+    viewBox="0 0 800 800"
     aria-hidden="true"
     focusable="false"
   >
-    <defs>
-      <linearGradient id={gradientId} x1="50%" x2="50%" y1="0%" y2="100%">
-        <stop offset="0%" stop-color="#00B2FF" />
-        <stop offset="100%" stop-color="#006AFF" />
-      </linearGradient>
-    </defs>
+    <radialGradient
+      id={gradientId}
+      cx="101.9"
+      cy="809"
+      r="1.1"
+      gradientTransform="matrix(800 0 0 -800 -81386 648000)"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop offset="0" style="stop-color:#09f" />
+      <stop offset=".6" style="stop-color:#a033ff" />
+      <stop offset=".9" style="stop-color:#ff5280" />
+      <stop offset="1" style="stop-color:#ff7061" />
+    </radialGradient>
     <path
       fill={`url(#${gradientId})`}
-      d="M18 0C8.059 0 0 7.875 0 17.604c0 5.487 2.713 10.366 6.939 13.489V36l6.098-3.347c1.626.448 3.347.687 5.147.687 9.941 0 18-7.875 18-17.604C36 7.875 28.059 0 18 0z"
+      d="M400 0C174.7 0 0 165.1 0 388c0 116.6 47.8 217.4 125.6 287 6.5 5.8 10.5 14 10.7 22.8l2.2 71.2a32 32 0 0 0 44.9 28.3l79.4-35c6.7-3 14.3-3.5 21.4-1.6 36.5 10 75.3 15.4 115.8 15.4 225.3 0 400-165.1 400-388S625.3 0 400 0z"
     />
     <path
       fill="#FFF"
-      d="m23.5 18.5-5.5-5.875-10.75 5.875L15.25 13l5.5 5.875L26.25 13l-2.75 5.5z"
+      d="m159.8 501.5 117.5-186.4a60 60 0 0 1 86.8-16l93.5 70.1a24 24 0 0 0 28.9-.1l126.2-95.8c16.8-12.8 38.8 7.4 27.6 25.3L522.7 484.9a60 60 0 0 1-86.8 16l-93.5-70.1a24 24 0 0 0-28.9.1l-126.2 95.8c-16.8 12.8-38.8-7.3-27.5-25.2z"
     />
   </svg>
 {/if}

--- a/src/components/svelte/editor/entity-editor.css
+++ b/src/components/svelte/editor/entity-editor.css
@@ -187,6 +187,7 @@
 .entity-editor-form .editor-field input,
 .entity-editor-form .editor-field select,
 .entity-editor-form .editor-field textarea {
+  box-sizing: border-box;
   min-width: 0;
   width: 100%;
   border: 1px solid #d8d8d8;
@@ -231,6 +232,7 @@
 }
 
 .entity-editor-submit {
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/src/components/svelte/map-chrome/MapChromeSession.svelte
+++ b/src/components/svelte/map-chrome/MapChromeSession.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import LogOut from "@lucide/svelte/icons/log-out";
+  import Settings from "@lucide/svelte/icons/settings";
   import ShieldCheck from "@lucide/svelte/icons/shield-check";
+  import { adminAuthStore } from "@lib/store.svelte";
   import MapChromeGhostButton from "./MapChromeGhostButton.svelte";
   import "./map-chrome.css";
 
@@ -50,6 +52,10 @@
       <ShieldCheck size={14} aria-hidden="true" />
       <span>{roleLabel}</span>
     </span>
+    <MapChromeGhostButton onclick={() => adminAuthStore.openAccountSettings()}>
+      <Settings size={14} aria-hidden="true" />
+      Account
+    </MapChromeGhostButton>
     <MapChromeGhostButton onclick={() => void onSignOut()}>
       <LogOut size={14} aria-hidden="true" />
       Sign out
@@ -61,6 +67,10 @@
       <ShieldCheck size={16} aria-hidden="true" />
       <span>{expandedLabel}</span>
     </div>
+    <MapChromeGhostButton onclick={() => adminAuthStore.openAccountSettings()}>
+      <Settings size={14} aria-hidden="true" />
+      Account
+    </MapChromeGhostButton>
     <MapChromeGhostButton onclick={() => void onSignOut()}>
       <LogOut size={14} aria-hidden="true" />
       Sign out

--- a/src/lib/admin/require-editor.ts
+++ b/src/lib/admin/require-editor.ts
@@ -17,6 +17,7 @@ export function getEditorSession(cookies: AstroCookies): SessionUser | null {
 type EditorSessionOptions = {
   requirePublish?: boolean;
   requireReview?: boolean;
+  requireAdmin?: boolean;
 };
 
 export function editorSessionOrUnauthorized(
@@ -34,6 +35,9 @@ export function editorSessionOrUnauthorized(
   }
   if (options.requireReview && !canReviewProposals(session.role)) {
     return forbidden("Your account cannot review edit proposals.");
+  }
+  if (options.requireAdmin && session.role !== "admin") {
+    return forbidden("Your account cannot manage other users.");
   }
   return {
     session,

--- a/src/lib/admin/signed-token-core.ts
+++ b/src/lib/admin/signed-token-core.ts
@@ -1,0 +1,59 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+function signBody(body: string, secret: string): string {
+  return createHmac("sha256", secret).update(body).digest("base64url");
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+/**
+ * Stateless signed token for short-lived, single-purpose confirmations
+ * (e.g. email-change links). Not session auth — no DB round-trip needed;
+ * expiry alone bounds replay risk at this scale.
+ */
+export function createSignedToken<T extends Record<string, unknown>>(
+  payload: T,
+  ttlSeconds: number,
+  secret: string,
+): string {
+  const body = Buffer.from(
+    JSON.stringify({
+      ...payload,
+      exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+    }),
+  ).toString("base64url");
+  return `${body}.${signBody(body, secret)}`;
+}
+
+export function verifySignedToken<T>(token: string, secret: string): T | null {
+  if (!token?.includes(".")) return null;
+  const dot = token.lastIndexOf(".");
+  if (dot <= 0) return null;
+
+  const body = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+  if (!body || !sig) return null;
+
+  try {
+    if (!safeEqual(signBody(body, secret), sig)) return null;
+    const payload = JSON.parse(
+      Buffer.from(body, "base64url").toString("utf8"),
+    ) as {
+      exp: number;
+    };
+    if (
+      typeof payload.exp !== "number" ||
+      payload.exp <= Math.floor(Date.now() / 1000)
+    ) {
+      return null;
+    }
+    return payload as T;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/admin/signed-token.test.ts
+++ b/src/lib/admin/signed-token.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { createSignedToken, verifySignedToken } from "./signed-token-core";
+
+type Payload = { userId: number; newEmail: string };
+
+const SECRET = "test-secret-at-least-32-chars-long!!";
+
+describe("signed-token", () => {
+  test("round-trips a valid token", () => {
+    const token = createSignedToken<Payload>(
+      { userId: 42, newEmail: "a@example.com" },
+      60,
+      SECRET,
+    );
+    const payload = verifySignedToken<Payload>(token, SECRET);
+    expect(payload?.userId).toBe(42);
+    expect(payload?.newEmail).toBe("a@example.com");
+  });
+
+  test("rejects an expired token", () => {
+    const token = createSignedToken<Payload>(
+      { userId: 1, newEmail: "b@example.com" },
+      -1,
+      SECRET,
+    );
+    expect(verifySignedToken<Payload>(token, SECRET)).toBeNull();
+  });
+
+  test("rejects a tampered token", () => {
+    const token = createSignedToken<Payload>(
+      { userId: 1, newEmail: "c@example.com" },
+      60,
+      SECRET,
+    );
+    const [body, sig] = token.split(".");
+    const tampered = `${body}x.${sig}`;
+    expect(verifySignedToken<Payload>(tampered, SECRET)).toBeNull();
+  });
+
+  test("rejects a token signed with a different secret", () => {
+    const token = createSignedToken<Payload>(
+      { userId: 1, newEmail: "d@example.com" },
+      60,
+      SECRET,
+    );
+    expect(verifySignedToken<Payload>(token, "different-secret")).toBeNull();
+  });
+
+  test("rejects garbage input", () => {
+    expect(verifySignedToken("not-a-token", SECRET)).toBeNull();
+    expect(verifySignedToken("", SECRET)).toBeNull();
+  });
+});

--- a/src/lib/admin/signed-token.ts
+++ b/src/lib/admin/signed-token.ts
@@ -1,0 +1,22 @@
+import { ADMIN_PASSWORD, ADMIN_SESSION_SECRET } from "astro:env/server";
+import {
+  createSignedToken as createSignedTokenCore,
+  verifySignedToken as verifySignedTokenCore,
+} from "./signed-token-core";
+
+function signingSecret(): string {
+  if (ADMIN_SESSION_SECRET) return ADMIN_SESSION_SECRET;
+  if (ADMIN_PASSWORD) return ADMIN_PASSWORD;
+  throw new Error("ADMIN_SESSION_SECRET or ADMIN_PASSWORD must be configured");
+}
+
+export function createSignedToken<T extends Record<string, unknown>>(
+  payload: T,
+  ttlSeconds: number,
+): string {
+  return createSignedTokenCore(payload, ttlSeconds, signingSecret());
+}
+
+export function verifySignedToken<T>(token: string): T | null {
+  return verifySignedTokenCore<T>(token, signingSecret());
+}

--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -418,7 +418,7 @@ export async function requestPasswordReset(login: string): Promise<void> {
       "",
       `Choose a new password: ${resetUrl}`,
       "",
-      "This link expires in 30 minutes. If you didn't request this, ignore this email — your password stays unchanged.",
+      "This link expires in 30 minutes. If you didn't request this, ignore this email. Your password stays unchanged.",
     ].join("\n"),
   });
 }

--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -1,9 +1,33 @@
 import bcrypt from "bcrypt";
-import { and, eq, sql } from "drizzle-orm";
+import { and, desc, eq, ne, sql } from "drizzle-orm";
 import { ADMIN_PASSWORD } from "astro:env/server";
-import { adminUsersTable } from "@drizzle/schema";
+import {
+  adminUsersTable,
+  contributionsTable,
+  editProposalsTable,
+} from "@drizzle/schema";
 import { db } from "@lib/db";
 import type { SessionUser } from "@lib/admin/auth";
+import { createSignedToken, verifySignedToken } from "@lib/admin/signed-token";
+import { sendEmail } from "@lib/email/resend";
+import { SITE_URL } from "@lib/site";
+
+export class AccountActionError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "AccountActionError";
+    this.status = status;
+  }
+}
+
+const MIN_PASSWORD_LENGTH = 10;
+const EMAIL_CHANGE_TOKEN_TTL_SECONDS = 30 * 60;
+
+function hasPassword(passwordHash: string): boolean {
+  return passwordHash.length > 0;
+}
 
 /** Columns safe before migration 0015 (`supabase_user_id`). */
 const adminUserCredentialColumns = {
@@ -213,4 +237,496 @@ export async function authenticateLegacyAdminPassword(
   if (!ADMIN_PASSWORD || password !== ADMIN_PASSWORD) return null;
   await ensureBootstrapAdminUser();
   return authenticateAdminUser("admin", password);
+}
+
+// ── Self-service account management (#456/#272 follow-up) ──
+
+export type AccountProfile = {
+  id: number;
+  username: string;
+  displayName: string;
+  email: string | null;
+  role: SessionUser["role"];
+  hasPassword: boolean;
+  linkedGoogle: boolean;
+  createdAt: string;
+};
+
+export async function getAccountProfile(
+  userId: number,
+): Promise<AccountProfile | null> {
+  const [row] = await db
+    .select({
+      id: adminUsersTable.id,
+      username: adminUsersTable.username,
+      displayName: adminUsersTable.displayName,
+      email: adminUsersTable.email,
+      role: adminUsersTable.role,
+      passwordHash: adminUsersTable.passwordHash,
+      supabaseUserId: adminUsersTable.supabaseUserId,
+      createdAt: adminUsersTable.createdAt,
+    })
+    .from(adminUsersTable)
+    .where(
+      and(eq(adminUsersTable.id, userId), eq(adminUsersTable.isActive, true)),
+    )
+    .limit(1);
+  if (!row) return null;
+  return {
+    id: row.id,
+    username: row.username,
+    displayName: row.displayName ?? row.username,
+    email: row.email,
+    role: row.role ?? "editor",
+    hasPassword: hasPassword(row.passwordHash),
+    linkedGoogle: row.supabaseUserId !== null,
+    createdAt: row.createdAt,
+  };
+}
+
+export async function updateDisplayName(
+  userId: number,
+  displayName: string,
+): Promise<void> {
+  const trimmed = displayName.trim();
+  if (!trimmed) {
+    throw new AccountActionError("Display name cannot be empty.");
+  }
+  await db
+    .update(adminUsersTable)
+    .set({ displayName: trimmed, updatedAt: sql`now()` })
+    .where(eq(adminUsersTable.id, userId));
+}
+
+export async function changePassword(
+  userId: number,
+  currentPassword: string | null,
+  newPassword: string,
+): Promise<void> {
+  if (newPassword.length < MIN_PASSWORD_LENGTH) {
+    throw new AccountActionError(
+      `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+    );
+  }
+
+  const [row] = await db
+    .select({ passwordHash: adminUsersTable.passwordHash })
+    .from(adminUsersTable)
+    .where(eq(adminUsersTable.id, userId))
+    .limit(1);
+  if (!row) throw new AccountActionError("Account not found.", 404);
+
+  if (hasPassword(row.passwordHash)) {
+    const valid =
+      typeof currentPassword === "string" &&
+      currentPassword.length > 0 &&
+      (await bcrypt.compare(currentPassword, row.passwordHash));
+    if (!valid) {
+      throw new AccountActionError("Current password is incorrect.", 401);
+    }
+  }
+
+  const passwordHash = await bcrypt.hash(newPassword, 12);
+  await db
+    .update(adminUsersTable)
+    .set({ passwordHash, updatedAt: sql`now()` })
+    .where(eq(adminUsersTable.id, userId));
+}
+
+type EmailChangeTokenPayload = { userId: number; newEmail: string };
+
+export async function requestEmailChange(
+  userId: number,
+  newEmail: string,
+): Promise<void> {
+  const normalized = newEmail.trim().toLowerCase();
+  if (!normalized.includes("@")) {
+    throw new AccountActionError("Enter a valid email address.");
+  }
+
+  const [existing] = await db
+    .select({ id: adminUsersTable.id })
+    .from(adminUsersTable)
+    .where(
+      and(sql`lower(email) = ${normalized}`, ne(adminUsersTable.id, userId)),
+    )
+    .limit(1);
+  if (existing) {
+    throw new AccountActionError("That email is already in use.", 409);
+  }
+
+  const token = createSignedToken<EmailChangeTokenPayload>(
+    { userId, newEmail: normalized },
+    EMAIL_CHANGE_TOKEN_TTL_SECONDS,
+  );
+  const confirmUrl = `${SITE_URL}/api/account/confirm-email-change?token=${encodeURIComponent(token)}`;
+
+  await sendEmail({
+    to: [normalized],
+    subject: "Confirm your Room TBA email change",
+    text: [
+      "Someone (hopefully you) requested to change the email on a Room TBA account to this address.",
+      "",
+      `Confirm the change: ${confirmUrl}`,
+      "",
+      "This link expires in 30 minutes. If you didn't request this, ignore this email.",
+    ].join("\n"),
+  });
+}
+
+type PasswordResetTokenPayload = { userId: number };
+
+/**
+ * Request a password-reset email. Always resolves without error, whether or
+ * not the login matches an account — reporting failure here would let an
+ * attacker enumerate valid usernames/emails.
+ */
+export async function requestPasswordReset(login: string): Promise<void> {
+  const normalized = login.trim().toLowerCase();
+  if (!normalized) return;
+
+  const [user] = await db
+    .select({
+      id: adminUsersTable.id,
+      email: adminUsersTable.email,
+      isActive: adminUsersTable.isActive,
+    })
+    .from(adminUsersTable)
+    .where(
+      and(
+        eq(adminUsersTable.isActive, true),
+        normalized.includes("@")
+          ? sql`lower(email) = ${normalized}`
+          : eq(adminUsersTable.username, normalized),
+      ),
+    )
+    .limit(1);
+
+  if (!user?.isActive || !user.email) return;
+
+  const token = createSignedToken<PasswordResetTokenPayload>(
+    { userId: user.id },
+    EMAIL_CHANGE_TOKEN_TTL_SECONDS,
+  );
+  const resetUrl = `${SITE_URL}/reset-password?token=${encodeURIComponent(token)}`;
+
+  await sendEmail({
+    to: [user.email],
+    subject: "Reset your Room TBA password",
+    text: [
+      "Someone (hopefully you) requested a password reset for a Room TBA account.",
+      "",
+      `Choose a new password: ${resetUrl}`,
+      "",
+      "This link expires in 30 minutes. If you didn't request this, ignore this email — your password stays unchanged.",
+    ].join("\n"),
+  });
+}
+
+export async function confirmPasswordReset(
+  token: string,
+  newPassword: string,
+): Promise<void> {
+  if (newPassword.length < MIN_PASSWORD_LENGTH) {
+    throw new AccountActionError(
+      `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+    );
+  }
+  const payload = verifySignedToken<PasswordResetTokenPayload>(token);
+  if (!payload || !Number.isInteger(payload.userId)) {
+    throw new AccountActionError("This link is invalid or has expired.", 400);
+  }
+  const passwordHash = await bcrypt.hash(newPassword, 12);
+  await db
+    .update(adminUsersTable)
+    .set({ passwordHash, updatedAt: sql`now()` })
+    .where(eq(adminUsersTable.id, payload.userId));
+}
+
+export async function confirmEmailChange(token: string): Promise<void> {
+  const payload = verifySignedToken<EmailChangeTokenPayload>(token);
+  if (!payload || !Number.isInteger(payload.userId) || !payload.newEmail) {
+    throw new AccountActionError("This link is invalid or has expired.", 400);
+  }
+  await db
+    .update(adminUsersTable)
+    .set({ email: payload.newEmail, updatedAt: sql`now()` })
+    .where(eq(adminUsersTable.id, payload.userId));
+}
+
+export async function linkGoogleIdentity(
+  userId: number,
+  supabaseUserId: string,
+): Promise<void> {
+  const [existing] = await db
+    .select({ id: adminUsersTable.id })
+    .from(adminUsersTable)
+    .where(
+      and(
+        eq(adminUsersTable.supabaseUserId, supabaseUserId),
+        ne(adminUsersTable.id, userId),
+      ),
+    )
+    .limit(1);
+  if (existing) {
+    throw new AccountActionError(
+      "This Google account is already linked to a different Room TBA account.",
+      409,
+    );
+  }
+  await db
+    .update(adminUsersTable)
+    .set({ supabaseUserId, updatedAt: sql`now()` })
+    .where(eq(adminUsersTable.id, userId));
+}
+
+export async function unlinkGoogleIdentity(userId: number): Promise<void> {
+  const [row] = await db
+    .select({ passwordHash: adminUsersTable.passwordHash })
+    .from(adminUsersTable)
+    .where(eq(adminUsersTable.id, userId))
+    .limit(1);
+  if (!row) throw new AccountActionError("Account not found.", 404);
+  if (!hasPassword(row.passwordHash)) {
+    throw new AccountActionError(
+      "Set a password before disconnecting Google, so you can still sign in.",
+    );
+  }
+  await db
+    .update(adminUsersTable)
+    .set({ supabaseUserId: null, updatedAt: sql`now()` })
+    .where(eq(adminUsersTable.id, userId));
+}
+
+export async function softDeleteAccount(
+  userId: number,
+  currentPassword: string | null,
+): Promise<void> {
+  const [row] = await db
+    .select({ passwordHash: adminUsersTable.passwordHash })
+    .from(adminUsersTable)
+    .where(eq(adminUsersTable.id, userId))
+    .limit(1);
+  if (!row) throw new AccountActionError("Account not found.", 404);
+
+  if (hasPassword(row.passwordHash)) {
+    const valid =
+      typeof currentPassword === "string" &&
+      currentPassword.length > 0 &&
+      (await bcrypt.compare(currentPassword, row.passwordHash));
+    if (!valid) {
+      throw new AccountActionError("Current password is incorrect.", 401);
+    }
+  }
+
+  await db
+    .update(adminUsersTable)
+    .set({
+      isActive: false,
+      deletedAt: sql`now()`,
+      email: null,
+      displayName: "Deleted user",
+      passwordHash: "",
+      supabaseUserId: null,
+      updatedAt: sql`now()`,
+    })
+    .where(eq(adminUsersTable.id, userId));
+}
+
+export type AccountDataExport = {
+  profile: AccountProfile;
+  proposals: unknown[];
+  contributions: unknown[];
+};
+
+export async function exportAccountData(
+  userId: number,
+): Promise<AccountDataExport | null> {
+  const profile = await getAccountProfile(userId);
+  if (!profile) return null;
+
+  const [proposals, contributions] = await Promise.all([
+    db
+      .select()
+      .from(editProposalsTable)
+      .where(eq(editProposalsTable.submitterUserId, userId))
+      .orderBy(desc(editProposalsTable.createdAt)),
+    db
+      .select()
+      .from(contributionsTable)
+      .where(eq(contributionsTable.userId, userId))
+      .orderBy(desc(contributionsTable.createdAt)),
+  ]);
+
+  return { profile, proposals, contributions };
+}
+
+// ── Admin-managed users (#225 follow-up: admin creates admin/editor) ──
+
+export type AdminManagedUser = {
+  id: number;
+  username: string;
+  displayName: string;
+  email: string | null;
+  role: SessionUser["role"];
+  isActive: boolean;
+  createdAt: string;
+};
+
+export async function listAllAdminUsers(): Promise<AdminManagedUser[]> {
+  const rows = await db
+    .select({
+      id: adminUsersTable.id,
+      username: adminUsersTable.username,
+      displayName: adminUsersTable.displayName,
+      email: adminUsersTable.email,
+      role: adminUsersTable.role,
+      isActive: adminUsersTable.isActive,
+      createdAt: adminUsersTable.createdAt,
+    })
+    .from(adminUsersTable)
+    .orderBy(adminUsersTable.username);
+  return rows.map((row) => ({
+    ...row,
+    displayName: row.displayName ?? row.username,
+    role: row.role ?? "editor",
+  }));
+}
+
+export type CreateAdminUserInput = {
+  username: string;
+  displayName?: string;
+  email?: string;
+  password: string;
+  role: SessionUser["role"];
+};
+
+export async function createAdminUser(
+  input: CreateAdminUserInput,
+): Promise<AdminManagedUser> {
+  const username = input.username.trim().toLowerCase();
+  if (!username) throw new AccountActionError("Username is required.");
+  if (input.password.length < MIN_PASSWORD_LENGTH) {
+    throw new AccountActionError(
+      `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+    );
+  }
+  const email = input.email?.trim().toLowerCase() || null;
+  const passwordHash = await bcrypt.hash(input.password, 12);
+
+  try {
+    const [created] = await db
+      .insert(adminUsersTable)
+      .values({
+        username,
+        displayName: input.displayName?.trim() || username,
+        email,
+        passwordHash,
+        role: input.role,
+        isActive: true,
+      })
+      .returning({
+        id: adminUsersTable.id,
+        username: adminUsersTable.username,
+        displayName: adminUsersTable.displayName,
+        email: adminUsersTable.email,
+        role: adminUsersTable.role,
+        isActive: adminUsersTable.isActive,
+        createdAt: adminUsersTable.createdAt,
+      });
+    if (!created)
+      throw new AccountActionError("Failed to create account.", 500);
+    return {
+      ...created,
+      displayName: created.displayName ?? created.username,
+      role: created.role ?? "editor",
+    };
+  } catch (error) {
+    const code = (error as { code?: string })?.code;
+    if (code === "23505") {
+      throw new AccountActionError(
+        "That username or email is already taken.",
+        409,
+      );
+    }
+    throw error;
+  }
+}
+
+async function countActiveAdmins(excludingUserId?: number): Promise<number> {
+  const rows = await db
+    .select({ c: sql<number>`count(*)` })
+    .from(adminUsersTable)
+    .where(
+      and(
+        eq(adminUsersTable.role, "admin"),
+        eq(adminUsersTable.isActive, true),
+        excludingUserId !== undefined
+          ? ne(adminUsersTable.id, excludingUserId)
+          : sql`true`,
+      ),
+    );
+  return Number(rows[0]?.c ?? 0);
+}
+
+export type UpdateManagedUserInput = {
+  role?: SessionUser["role"];
+  isActive?: boolean;
+};
+
+export async function updateManagedUser(
+  targetUserId: number,
+  input: UpdateManagedUserInput,
+): Promise<AdminManagedUser> {
+  const [target] = await db
+    .select({
+      id: adminUsersTable.id,
+      role: adminUsersTable.role,
+      isActive: adminUsersTable.isActive,
+    })
+    .from(adminUsersTable)
+    .where(eq(adminUsersTable.id, targetUserId))
+    .limit(1);
+  if (!target) throw new AccountActionError("Account not found.", 404);
+
+  const demotingFromAdmin =
+    target.role === "admin" &&
+    input.role !== undefined &&
+    input.role !== "admin";
+  const deactivatingAdmin =
+    target.role === "admin" && input.isActive === false && target.isActive;
+
+  if (demotingFromAdmin || deactivatingAdmin) {
+    const remaining = await countActiveAdmins(targetUserId);
+    if (remaining < 1) {
+      throw new AccountActionError(
+        "Cannot remove the last remaining admin.",
+        400,
+      );
+    }
+  }
+
+  const updates: Record<string, unknown> = { updatedAt: sql`now()` };
+  if (input.role !== undefined) updates["role"] = input.role;
+  if (input.isActive !== undefined) updates["isActive"] = input.isActive;
+
+  const [updated] = await db
+    .update(adminUsersTable)
+    .set(updates)
+    .where(eq(adminUsersTable.id, targetUserId))
+    .returning({
+      id: adminUsersTable.id,
+      username: adminUsersTable.username,
+      displayName: adminUsersTable.displayName,
+      email: adminUsersTable.email,
+      role: adminUsersTable.role,
+      isActive: adminUsersTable.isActive,
+      createdAt: adminUsersTable.createdAt,
+    });
+  if (!updated) throw new AccountActionError("Failed to update account.", 500);
+  return {
+    ...updated,
+    displayName: updated.displayName ?? updated.username,
+    role: updated.role ?? "editor",
+  };
 }

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -365,6 +365,8 @@ class AdminAuthStore {
   loginOpen: boolean = $state(false);
   /** Error code from a failed OAuth redirect (`?auth_error=`). */
   oauthError: string | null = $state(null);
+  accountSettingsOpen: boolean = $state(false);
+  manageUsersOpen: boolean = $state(false);
   private _hydrated = false;
 
   private applySession(data: {
@@ -497,6 +499,33 @@ class AdminAuthStore {
     }
   };
 
+  /** Start Google OAuth to link an identity onto the *already logged-in*
+   * account (Account settings → Connect Google), distinct from
+   * `loginWithGoogle` which creates/logs into a new account. */
+  linkGoogle = async (): Promise<string | null> => {
+    try {
+      const [{ isSupabaseConfigured }, { createBrowserSupabaseClient }] =
+        await Promise.all([
+          import("@lib/supabase/env"),
+          import("@lib/supabase/client"),
+        ]);
+      if (!isSupabaseConfigured()) {
+        return "Google sign-in is not configured on this server.";
+      }
+      const supabase = createBrowserSupabaseClient();
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: `${window.location.origin}/api/auth/link-callback`,
+        },
+      });
+      if (error) return error.message;
+      return null;
+    } catch {
+      return "Google sign-in failed to start. Try again.";
+    }
+  };
+
   logout = async () => {
     try {
       await fetch("/api/admin/auth", {
@@ -525,6 +554,26 @@ class AdminAuthStore {
   closeLogin = () => {
     this.loginOpen = false;
     this.oauthError = null;
+  };
+
+  openAccountSettings = () => {
+    dismissEphemeralOverlays();
+    modalStore.closeModal();
+    this.accountSettingsOpen = true;
+  };
+
+  closeAccountSettings = () => {
+    this.accountSettingsOpen = false;
+  };
+
+  openManageUsers = () => {
+    dismissEphemeralOverlays();
+    modalStore.closeModal();
+    this.manageUsersOpen = true;
+  };
+
+  closeManageUsers = () => {
+    this.manageUsersOpen = false;
   };
 }
 

--- a/src/pages/api/account/change-password.ts
+++ b/src/pages/api/account/change-password.ts
@@ -1,0 +1,60 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import {
+  checkRateLimit,
+  clientIp,
+  rateLimitResponse,
+} from "@lib/api/rate-limit";
+import {
+  AccountActionError,
+  changePassword,
+} from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+const LIMIT = { max: 8, windowMs: 30 * 1000 };
+
+export const POST: APIRoute = async ({ cookies, request }) => {
+  const auth = editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return auth;
+
+  const rate = checkRateLimit(
+    `account-change-password:${auth.session.id}:${clientIp(request)}`,
+    LIMIT.max,
+    LIMIT.windowMs,
+  );
+  if (!rate.allowed) return rateLimitResponse(rate.resetAt);
+
+  let body: { currentPassword?: string; newPassword?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (typeof body.newPassword !== "string") {
+    return json({ error: "newPassword is required." }, 400);
+  }
+
+  try {
+    await changePassword(
+      auth.session.id,
+      typeof body.currentPassword === "string" ? body.currentPassword : null,
+      body.newPassword,
+    );
+    return json({ success: true });
+  } catch (error) {
+    if (error instanceof AccountActionError) {
+      return json({ error: error.message }, error.status);
+    }
+    console.error("Change password failed:", error);
+    return json({ error: "Failed to change password." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/account/confirm-email-change.ts
+++ b/src/pages/api/account/confirm-email-change.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from "astro";
+import { confirmEmailChange } from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+/** Email-change confirmation link (#272 follow-up). No session required — the
+ * signed token itself proves intent; the account it targets was already
+ * verified when the change was requested. */
+export const GET: APIRoute = async ({ url }) => {
+  const token = url.searchParams.get("token");
+  const fail = (reason: string) =>
+    new Response(null, {
+      status: 303,
+      headers: { Location: `/?account_error=${encodeURIComponent(reason)}` },
+    });
+
+  if (!token) return fail("missing_token");
+
+  try {
+    await confirmEmailChange(token);
+    return new Response(null, {
+      status: 303,
+      headers: { Location: "/?account=email-changed" },
+    });
+  } catch (error) {
+    console.error("Confirm email change failed:", error);
+    return fail("invalid_or_expired_token");
+  }
+};

--- a/src/pages/api/account/confirm-password-reset.ts
+++ b/src/pages/api/account/confirm-password-reset.ts
@@ -1,0 +1,52 @@
+import type { APIRoute } from "astro";
+import {
+  checkRateLimit,
+  clientIp,
+  rateLimitResponse,
+} from "@lib/api/rate-limit";
+import {
+  AccountActionError,
+  confirmPasswordReset,
+} from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+const LIMIT = { max: 8, windowMs: 60 * 1000 };
+
+export const POST: APIRoute = async ({ request }) => {
+  const rate = checkRateLimit(
+    `account-confirm-password-reset:${clientIp(request)}`,
+    LIMIT.max,
+    LIMIT.windowMs,
+  );
+  if (!rate.allowed) return rateLimitResponse(rate.resetAt);
+
+  let body: { token?: string; newPassword?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (typeof body.token !== "string" || typeof body.newPassword !== "string") {
+    return json({ error: "token and newPassword are required." }, 400);
+  }
+
+  try {
+    await confirmPasswordReset(body.token, body.newPassword);
+    return json({ success: true });
+  } catch (error) {
+    if (error instanceof AccountActionError) {
+      return json({ error: error.message }, error.status);
+    }
+    console.error("Confirm password reset failed:", error);
+    return json({ error: "Failed to reset password." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/account/delete.ts
+++ b/src/pages/api/account/delete.ts
@@ -1,0 +1,62 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import { clearSessionCookie } from "@lib/admin/auth";
+import {
+  checkRateLimit,
+  clientIp,
+  rateLimitResponse,
+} from "@lib/api/rate-limit";
+import {
+  AccountActionError,
+  softDeleteAccount,
+} from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+const LIMIT = { max: 5, windowMs: 60 * 1000 };
+
+export const POST: APIRoute = async ({ cookies, request }) => {
+  const auth = editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return auth;
+
+  const rate = checkRateLimit(
+    `account-delete:${auth.session.id}:${clientIp(request)}`,
+    LIMIT.max,
+    LIMIT.windowMs,
+  );
+  if (!rate.allowed) return rateLimitResponse(rate.resetAt);
+
+  let body: { currentPassword?: string };
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  try {
+    await softDeleteAccount(
+      auth.session.id,
+      typeof body.currentPassword === "string" ? body.currentPassword : null,
+    );
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Set-Cookie": clearSessionCookie(),
+      },
+    });
+  } catch (error) {
+    if (error instanceof AccountActionError) {
+      return json({ error: error.message }, error.status);
+    }
+    console.error("Delete account failed:", error);
+    return json({ error: "Failed to delete account." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/account/export.ts
+++ b/src/pages/api/account/export.ts
@@ -1,0 +1,26 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import { exportAccountData } from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ cookies }) => {
+  const auth = editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return auth;
+
+  const data = await exportAccountData(auth.session.id);
+  if (!data) {
+    return new Response(JSON.stringify({ error: "Account not found." }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify(data, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Disposition": `attachment; filename="room-tba-account-${auth.session.id}.json"`,
+    },
+  });
+};

--- a/src/pages/api/account/me.ts
+++ b/src/pages/api/account/me.ts
@@ -1,0 +1,53 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import {
+  AccountActionError,
+  getAccountProfile,
+  updateDisplayName,
+} from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ cookies }) => {
+  const auth = editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return auth;
+
+  const profile = await getAccountProfile(auth.session.id);
+  if (!profile) return json({ error: "Account not found." }, 404);
+  return json(profile);
+};
+
+export const PATCH: APIRoute = async ({ cookies, request }) => {
+  const auth = editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return auth;
+
+  let body: { displayName?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (typeof body.displayName !== "string") {
+    return json({ error: "displayName is required." }, 400);
+  }
+
+  try {
+    await updateDisplayName(auth.session.id, body.displayName);
+    const profile = await getAccountProfile(auth.session.id);
+    return json({ success: true, profile });
+  } catch (error) {
+    if (error instanceof AccountActionError) {
+      return json({ error: error.message }, error.status);
+    }
+    console.error("Update display name failed:", error);
+    return json({ error: "Failed to update display name." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/account/request-email-change.ts
+++ b/src/pages/api/account/request-email-change.ts
@@ -1,0 +1,56 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import {
+  checkRateLimit,
+  clientIp,
+  rateLimitResponse,
+} from "@lib/api/rate-limit";
+import {
+  AccountActionError,
+  requestEmailChange,
+} from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+const LIMIT = { max: 5, windowMs: 60 * 1000 };
+
+export const POST: APIRoute = async ({ cookies, request }) => {
+  const auth = editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return auth;
+
+  const rate = checkRateLimit(
+    `account-request-email-change:${auth.session.id}:${clientIp(request)}`,
+    LIMIT.max,
+    LIMIT.windowMs,
+  );
+  if (!rate.allowed) return rateLimitResponse(rate.resetAt);
+
+  let body: { newEmail?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (typeof body.newEmail !== "string") {
+    return json({ error: "newEmail is required." }, 400);
+  }
+
+  try {
+    await requestEmailChange(auth.session.id, body.newEmail);
+    return json({ success: true });
+  } catch (error) {
+    if (error instanceof AccountActionError) {
+      return json({ error: error.message }, error.status);
+    }
+    console.error("Request email change failed:", error);
+    return json({ error: "Failed to send confirmation email." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/account/request-password-reset.ts
+++ b/src/pages/api/account/request-password-reset.ts
@@ -1,0 +1,49 @@
+import type { APIRoute } from "astro";
+import {
+  checkRateLimit,
+  clientIp,
+  rateLimitResponse,
+} from "@lib/api/rate-limit";
+import { requestPasswordReset } from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+const LIMIT = { max: 5, windowMs: 60 * 1000 };
+
+/** Public — a locked-out user has no session yet. Always returns success
+ * regardless of whether the login matched, to avoid account enumeration. */
+export const POST: APIRoute = async ({ request }) => {
+  const rate = checkRateLimit(
+    `account-request-password-reset:${clientIp(request)}`,
+    LIMIT.max,
+    LIMIT.windowMs,
+  );
+  if (!rate.allowed) return rateLimitResponse(rate.resetAt);
+
+  let body: { login?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (typeof body.login !== "string" || !body.login.trim()) {
+    return json({ error: "login is required." }, 400);
+  }
+
+  try {
+    await requestPasswordReset(body.login);
+  } catch (error) {
+    console.error("Request password reset failed:", error);
+    // Still report success to the client — avoid leaking whether the
+    // account exists or the email send failed.
+  }
+  return json({ success: true });
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/account/unlink-google.ts
+++ b/src/pages/api/account/unlink-google.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import {
+  AccountActionError,
+  unlinkGoogleIdentity,
+} from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ cookies }) => {
+  const auth = editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return auth;
+
+  try {
+    await unlinkGoogleIdentity(auth.session.id);
+    return json({ success: true });
+  } catch (error) {
+    if (error instanceof AccountActionError) {
+      return json({ error: error.message }, error.status);
+    }
+    console.error("Unlink Google failed:", error);
+    return json({ error: "Failed to disconnect Google." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/admin/users/[id].ts
+++ b/src/pages/api/admin/users/[id].ts
@@ -1,0 +1,54 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import {
+  AccountActionError,
+  updateManagedUser,
+} from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+export const PATCH: APIRoute = async ({ cookies, params, request }) => {
+  const auth = editorSessionOrUnauthorized(cookies, { requireAdmin: true });
+  if (auth instanceof Response) return auth;
+
+  const id = parseInt(params["id"] ?? "");
+  if (Number.isNaN(id)) return json({ error: "Invalid user ID" }, 400);
+
+  let body: {
+    role?: "admin" | "editor" | "contributor";
+    isActive?: boolean;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (
+    body.role !== undefined &&
+    !["admin", "editor", "contributor"].includes(body.role)
+  ) {
+    return json({ error: "Invalid role." }, 400);
+  }
+
+  try {
+    const user = await updateManagedUser(id, {
+      role: body.role,
+      isActive: body.isActive,
+    });
+    return json({ success: true, user });
+  } catch (error) {
+    if (error instanceof AccountActionError) {
+      return json({ error: error.message }, error.status);
+    }
+    console.error("Update managed user failed:", error);
+    return json({ error: "Failed to update account." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/admin/users/index.ts
+++ b/src/pages/api/admin/users/index.ts
@@ -1,0 +1,67 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import {
+  AccountActionError,
+  createAdminUser,
+  listAllAdminUsers,
+} from "@lib/services/admin-user-service";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ cookies }) => {
+  const auth = editorSessionOrUnauthorized(cookies, { requireAdmin: true });
+  if (auth instanceof Response) return auth;
+
+  const users = await listAllAdminUsers();
+  return json({ users });
+};
+
+export const POST: APIRoute = async ({ cookies, request }) => {
+  const auth = editorSessionOrUnauthorized(cookies, { requireAdmin: true });
+  if (auth instanceof Response) return auth;
+
+  let body: {
+    username?: string;
+    displayName?: string;
+    email?: string;
+    password?: string;
+    role?: "admin" | "editor" | "contributor";
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (typeof body.username !== "string" || typeof body.password !== "string") {
+    return json({ error: "username and password are required." }, 400);
+  }
+  const role = body.role ?? "editor";
+  if (!["admin", "editor", "contributor"].includes(role)) {
+    return json({ error: "Invalid role." }, 400);
+  }
+
+  try {
+    const user = await createAdminUser({
+      username: body.username,
+      displayName: body.displayName,
+      email: body.email,
+      password: body.password,
+      role,
+    });
+    return json({ success: true, user }, 201);
+  } catch (error) {
+    if (error instanceof AccountActionError) {
+      return json({ error: error.message }, error.status);
+    }
+    console.error("Create admin user failed:", error);
+    return json({ error: "Failed to create account." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/auth/link-callback.ts
+++ b/src/pages/api/auth/link-callback.ts
@@ -1,0 +1,44 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import { linkGoogleIdentity } from "@lib/services/admin-user-service";
+import { createServerSupabaseClient } from "@lib/supabase/server";
+
+export const prerender = false;
+
+/**
+ * OAuth callback for linking Google to an *already logged-in* account
+ * (Account settings → Connect Google), distinct from the login callback
+ * (`/api/auth/callback`) which creates/logs-in a new account.
+ */
+export const GET: APIRoute = async ({ url, request, cookies }) => {
+  const fail = (reason: string) =>
+    new Response(null, {
+      status: 303,
+      headers: { Location: `/?account_error=${encodeURIComponent(reason)}` },
+    });
+
+  const auth = editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return fail("not_logged_in");
+
+  const code = url.searchParams.get("code");
+  if (!code) return fail("missing_code");
+
+  try {
+    const supabase = createServerSupabaseClient({ request, cookies });
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error || !data.user) return fail("oauth_failed");
+
+    await linkGoogleIdentity(auth.session.id, data.user.id);
+    return new Response(null, {
+      status: 303,
+      headers: { Location: "/?account=google-linked" },
+    });
+  } catch (error) {
+    console.error("Google link callback failed:", error);
+    const message =
+      error instanceof Error && error.name === "AccountActionError"
+        ? "already_linked"
+        : "oauth_failed";
+    return fail(message);
+  }
+};

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -120,7 +120,14 @@ import {
             Sign out of editor/contributor sessions when using shared devices.
           </li>
           <li>
-            Ask a maintainer to deactivate an editor account you no longer need.
+            If you have an editor or contributor account, open <strong
+              >Account settings</strong
+            > (from the app menu) to change your display name, email, or password;
+            connect or disconnect a Google sign-in; download a copy of your account
+            data; or delete your account. Deleting an account removes your email,
+            display name, and password — past proposals and edit history remain on
+            record, attributed to a deleted user, so the audit trail for published
+            changes stays intact.
           </li>
         </ul>
       </section>

--- a/src/pages/reset-password.astro
+++ b/src/pages/reset-password.astro
@@ -1,0 +1,48 @@
+---
+export const prerender = false;
+import Layout from "@layouts/Layout.astro";
+import ResetPasswordForm from "@ui/ResetPasswordForm.svelte";
+---
+
+<Layout
+  title="Reset password | Room TBA"
+  description="Set a new password for your Room TBA editor account."
+  canonicalPath="/reset-password"
+  showAppLoadingShell={false}
+  robots="noindex,nofollow"
+>
+  <main class="reset-password-page">
+    <a href="/" class="back-link">
+      <span aria-hidden="true">←</span> Back to Room TBA
+    </a>
+    <h1>Reset your password</h1>
+    <ResetPasswordForm client:load />
+  </main>
+</Layout>
+
+<style>
+  .reset-password-page {
+    max-width: 32rem;
+    margin: 0 auto;
+    padding: 2rem 1rem 4rem;
+  }
+  .back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-bottom: 1.5rem;
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+    text-decoration: none;
+    font-size: 0.875rem;
+  }
+  .back-link:hover,
+  .back-link:focus-visible {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  h1 {
+    font-size: 1.5rem;
+    margin: 0 0 1.25rem;
+  }
+</style>


### PR DESCRIPTION
Stacks on #517 (needs `admin_users.email`/`supabase_user_id` and the Google login callback it adds). Builds out the account-management epic requested in chat: profile, change email/password, Google identity link/unlink, data export/delete, admin-creates-admin, and forgot-password.

## What

### Self-service account settings
- New **Account settings** modal (entry point: app menu / editor shelf "Account settings", contributor session chip "Account").
- Edit display name (direct save).
- Change email: request sends a signed confirmation link to the *new* address (reuses the Resend pipeline from #272); email only changes on click-through.
- Change/set password: existing password required if one is set; OAuth-only accounts (empty `password_hash`) skip that check — this call is literally "set a password" the first time.
- Connect/disconnect Google: disconnect blocked until a password is set (so the account stays loginable); connect rejects an identity already linked to a different account.
- Download my data (`GET /api/account/export`): own profile + `edit_proposals` + `contributions`, as a JSON download.
- Delete my account: **soft-delete + PII scrub** (`is_active=false`, `deleted_at` set, email/display name/password cleared) — not a hard delete, because `edit_proposals.submitter_user_id` / `contributions.user_id` are FKs that must stay intact for the immutable audit history (`AGENTS.md`). Blocks future login via the existing `isActive` gate; past proposals still show correctly, attributed to a scrubbed row.

### Forgot password
- `POST /api/account/request-password-reset` — enumeration-safe, always returns success regardless of whether the login matches.
- `POST /api/account/confirm-password-reset` + new `/reset-password` page — same stateless signed-token pattern as email-change confirmation (HMAC, 30 min TTL, no DB table needed).
- "Forgot password?" link added to the existing login modal.

### Admin creates admin/editor (#225 follow-up)
- `POST/GET /api/admin/users`, `PATCH /api/admin/users/[id]` — admin-only (new `requireAdmin` option on `editorSessionOrUnauthorized`).
- Guards against demoting or deactivating the **last remaining admin**.
- New **Manage users** modal (admin-only entry point next to Account settings): role dropdown per row, activate/deactivate, invite form (username/email/temp password/role) — no email-invite flow for v1, matches the existing `ADMIN_PASSWORD` bootstrap pattern (admin shares the temp password out of band; the new user changes it via the account settings above).

### Bugs found and fixed along the way
- **Real, measured layout bug**: the shared `entity-editor-form` input/button CSS was `box-sizing: content-box`. `width:100%` plus padding/border silently overflowed the grid track by exactly the padding amount, eating the right-side gap on *every* form built on this pattern (not just login — this was invisible elsewhere because most buttons use `width:max-content`, but any full-width field had it). Confirmed via Playwright bounding-box measurements before and after (`left:16,right:0` → `left:16,right:16`). Fixed at the shared CSS source plus the two custom Google-button/login-submit overrides that had the same issue.
- Swapped the hand-drawn Messenger icon placeholder for the real Meta 2020 gradient mark (sourced from Wikimedia, same official-asset approach the Discord icon already uses).

## Migrations
- `0021_account_management.sql` — `admin_users.deleted_at` (nullable timestamp). Applied to the shared Supabase project; added to `scripts/e2e-reset-db.ts`.

## Tests
- Unit: `signed-token.test.ts` (round-trip, expiry, tamper, wrong-secret rejection — pure logic split into `signed-token-core.ts` so it doesn't need `astro:env`, same pattern as `digest-core.ts`).
- Integration: `account-management.integration.test.ts` — change-password (correct/incorrect/OAuth-skip/min-length), email-change token round-trip, Google link rejection (already-linked-elsewhere), unlink guard (no password set), soft-delete (PII scrub + login blocked + FK attribution survives), admin role change + last-admin guard (snapshots and restores any real admin rows it touches, doesn't leave shared E2E fixtures mutated).
- `bun run test` (176 pass), `bun run test:components` (52 pass, fixed a pre-existing test asserting the old placeholder Messenger `linearGradient`), `bun run build`, `bun run check:migrations` all green.
- Manual end-to-end verification on the dev server against the shared staging DB: request-password-reset → confirm-password-reset → login with new password → change-password, full loop confirmed working.

## Test plan
- [ ] Sign in, open Account settings, change display name, verify it persists after reload
- [ ] Request email change, confirm the link updates the email
- [ ] Set a password on an OAuth-only account, then disconnect Google succeeds; without a password, disconnect is blocked
- [ ] Download data, confirm JSON contains own proposals/contributions
- [ ] Delete account, confirm login is blocked and existing proposals still render
- [ ] As admin, create an editor account, log in as it; attempt to demote the sole admin and confirm it's rejected
- [ ] Forgot password end-to-end with `RESEND_API_KEY` configured on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, password reset, account deletion, role changes, and signed-token email flows across many new API routes; mistakes could lock users out or weaken authorization.
> 
> **Overview**
> Adds **self-service account management** for signed-in editors: profile/display name, signed-token email change and password reset, Google link/unlink (separate OAuth callback), JSON data export, and soft-delete with PII scrub while keeping proposal/contribution FKs. New **Account settings** and **Manage users** modals, plus map chrome and editor shelf entry points; URL query params drive post-confirmation toasts.
> 
> Adds **forgot password** in the login modal and a **`/reset-password`** page wired to enumeration-safe reset APIs with rate limits on sensitive routes.
> 
> Extends **`admin-user-service`** with `AccountActionError`, admin-only user CRUD, and a guard against removing the last active admin. **`requireAdmin`** on session checks protects `/api/admin/users`. Migration **`0021`** adds `admin_users.deleted_at`; HMAC **signed tokens** back email/reset links.
> 
> Also fixes shared **entity-editor** `box-sizing` overflow on full-width fields and updates the Messenger brand icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de211bd9194f359ba4f8182c0419b1ecc944355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->