### PR TITLE
feat(auth): Cloudflare Turnstile on editor login (#443)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,11 @@ R2_PUBLIC_URL=
 # RESEND_FROM_EMAIL="Room TBA <digest@uplbtools.me>"
 # CRON_SECRET=
 
+# Cloudflare Turnstile on editor login (#443). Optional; widget is hidden and
+# server-side verification is skipped when unset (local dev).
+# PUBLIC_TURNSTILE_SITE_KEY=
+# TURNSTILE_SECRET_KEY=
+
 # AMIS import (scripts/import-amis-classes.ts) — copy bearer token from browser DevTools after AMIS login.
 # Tokens expire in about an hour; paste fresh when running --fetch. Never commit real tokens.
 # Fetch once with --fetch (while token is valid); later imports read data/amis-*-{termId}.json (gitignored).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -215,6 +215,18 @@ export default defineConfig({
         context: "server",
         optional: true,
       }),
+      // Cloudflare Turnstile on editor login (#443). Widget is hidden and
+      // server verification skipped when unset (local dev).
+      PUBLIC_TURNSTILE_SITE_KEY: envField.string({
+        access: "public",
+        context: "client",
+        optional: true,
+      }),
+      TURNSTILE_SECRET_KEY: envField.string({
+        access: "secret",
+        context: "server",
+        optional: true,
+      }),
     },
   },
   adapter: e2eNodeAdapter

--- a/src/components/svelte/AdminLoginModal.component.test.ts
+++ b/src/components/svelte/AdminLoginModal.component.test.ts
@@ -18,7 +18,7 @@ describe("AdminLoginModal", () => {
     const frame = document.querySelector(".login-frame") as HTMLElement;
     expect(frame).toBeTruthy();
     expectNoHorizontalOverflow(frame);
-    expect(screen.getByLabelText("Username")).toBeVisible();
+    expect(screen.getByLabelText("Username or email")).toBeVisible();
     expect(screen.getByLabelText("Password")).toBeVisible();
     expect(
       screen.getByRole("link", { name: /Message maintainers/i }),

--- a/src/components/svelte/AdminLoginModal.svelte
+++ b/src/components/svelte/AdminLoginModal.svelte
@@ -156,31 +156,34 @@
       </button>
     </header>
     <form class="login-body entity-editor-form" onsubmit={submit}>
-      <EntityEditorFormField label="Username" inputId="admin-login-username">
-        {#snippet control()}
-          <input
-            id="admin-login-username"
-            type="text"
-            autocomplete="username"
-            bind:value={username}
-            required
-          />
-        {/snippet}
-      </EntityEditorFormField>
-      <EntityEditorFormField label="Password" inputId="admin-login-password">
-        {#snippet control()}
-          <input
-            id="admin-login-password"
-            type="password"
-            autocomplete="current-password"
-            bind:value={password}
-            required
-            aria-invalid={error ? true : undefined}
-            aria-describedby={error ? loginErrorId : undefined}
-          />
-        {/snippet}
-      </EntityEditorFormField>
       {#if !showForgotPassword}
+        <EntityEditorFormField
+          label="Username or email"
+          inputId="admin-login-username"
+        >
+          {#snippet control()}
+            <input
+              id="admin-login-username"
+              type="text"
+              autocomplete="username"
+              bind:value={username}
+              required
+            />
+          {/snippet}
+        </EntityEditorFormField>
+        <EntityEditorFormField label="Password" inputId="admin-login-password">
+          {#snippet control()}
+            <input
+              id="admin-login-password"
+              type="password"
+              autocomplete="current-password"
+              bind:value={password}
+              required
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? loginErrorId : undefined}
+            />
+          {/snippet}
+        </EntityEditorFormField>
         <button
           type="button"
           class="forgot-password-link"

--- a/src/components/svelte/AdminLoginModal.svelte
+++ b/src/components/svelte/AdminLoginModal.svelte
@@ -12,15 +12,22 @@
   import EntityEditorSubmitButton from "@ui/editor/EntityEditorSubmitButton.svelte";
   import EntityEditorMessage from "@ui/editor/EntityEditorMessage.svelte";
   import CommunityBrandIcon from "@ui/community/CommunityBrandIcon.svelte";
+  import TurnstileWidget from "@ui/TurnstileWidget.svelte";
   import { MESSENGER_MAINTAIN_TARGET } from "@constants/community-links";
   import "./editor/entity-editor.css";
   import { MediaQuery } from "svelte/reactivity";
 
   import { isSupabaseConfigured } from "@lib/supabase/env";
+  import {
+    getTurnstileSiteKey,
+    isTurnstileWidgetConfigured,
+  } from "@lib/turnstile-client";
 
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
   const loginErrorId = "admin-login-error";
   const googleEnabled = isSupabaseConfigured();
+  const turnstileEnabled = isTurnstileWidgetConfigured();
+  const turnstileSiteKey = turnstileEnabled ? getTurnstileSiteKey() : "";
 
   const OAUTH_ERROR_MESSAGES: Record<string, string> = {
     missing_code: "Google sign-in was cancelled or incomplete. Try again.",
@@ -34,6 +41,7 @@
   let password = $state("");
   let error: string | null = $state(null);
   let googleLoading = $state(false);
+  let turnstileToken = $state<string | null>(null);
 
   let showForgotPassword = $state(false);
   let forgotLoginDraft = $state("");
@@ -89,8 +97,12 @@
 
   async function submit(e: Event) {
     e.preventDefault();
+    if (turnstileEnabled && !turnstileToken) {
+      error = "Complete the verification check, then try again.";
+      return;
+    }
     error = null;
-    const err = await adminAuthStore.login(username, password);
+    const err = await adminAuthStore.login(username, password, turnstileToken);
     if (err) {
       error = err;
       return;
@@ -177,6 +189,9 @@
           Forgot password?
         </button>
       {/if}
+      {#if turnstileEnabled && !showForgotPassword}
+        <TurnstileWidget siteKey={turnstileSiteKey} bind:token={turnstileToken} />
+      {/if}
       {#if error}
         <EntityEditorMessage
           variant="error"
@@ -190,6 +205,7 @@
           label="Sign in"
           savingLabel="Signing in…"
           saving={adminAuthStore.loading}
+          disabled={turnstileEnabled && !turnstileToken}
         />
       {/if}
       {#if showForgotPassword}

--- a/src/components/svelte/TurnstileWidget.svelte
+++ b/src/components/svelte/TurnstileWidget.svelte
@@ -1,0 +1,74 @@
+<script lang="ts" module>
+  const SCRIPT_URL = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+  let scriptPromise: Promise<void> | null = null;
+
+  function loadTurnstileScript(): Promise<void> {
+    if (typeof window === "undefined") return Promise.resolve();
+    if (window.turnstile) return Promise.resolve();
+    scriptPromise ??= new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = SCRIPT_URL;
+      script.async = true;
+      script.defer = true;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error("Failed to load Turnstile"));
+      document.head.appendChild(script);
+    });
+    return scriptPromise;
+  }
+</script>
+
+<script lang="ts">
+  type Props = {
+    siteKey: string;
+    token?: string | null;
+  };
+
+  // eslint-disable-next-line no-useless-assignment -- write-only bindable: parent reads it, this component never does
+  let { siteKey, token = $bindable(null) }: Props = $props();
+
+  let containerEl = $state<HTMLDivElement | null>(null);
+  let widgetId: string | null = null;
+
+  $effect(() => {
+    if (!containerEl) return;
+    let cancelled = false;
+
+    loadTurnstileScript()
+      .then(() => {
+        if (cancelled || !containerEl || !window.turnstile) return;
+        widgetId = window.turnstile.render(containerEl, {
+          sitekey: siteKey,
+          callback: (t: string) => {
+            token = t;
+          },
+          "expired-callback": () => {
+            token = null;
+          },
+          "error-callback": () => {
+            token = null;
+          },
+        });
+      })
+      .catch((error) => {
+        console.error("Turnstile failed to load:", error);
+      });
+
+    return () => {
+      cancelled = true;
+      if (widgetId && window.turnstile) {
+        window.turnstile.remove(widgetId);
+        widgetId = null;
+      }
+    };
+  });
+</script>
+
+<div bind:this={containerEl} class="turnstile-widget"></div>
+
+<style>
+  .turnstile-widget {
+    display: flex;
+    justify-content: center;
+  }
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -9,3 +9,18 @@ declare namespace App {
     supabaseCacheHeaders?: Record<string, string>;
   }
 }
+
+/** Cloudflare Turnstile client widget (#443), loaded lazily via <script>. */
+interface TurnstileRenderOptions {
+  sitekey: string;
+  callback?: (token: string) => void;
+  "expired-callback"?: () => void;
+  "error-callback"?: () => void;
+}
+
+interface Window {
+  turnstile?: {
+    render: (container: HTMLElement, options: TurnstileRenderOptions) => string;
+    remove: (widgetId: string) => void;
+  };
+}

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -422,12 +422,14 @@ class AdminAuthStore {
   login = async (
     username: string,
     password: string,
+    turnstileToken?: string | null,
   ): Promise<string | null> => {
     this.loading = true;
     try {
       const formData = new FormData();
       formData.set("username", username.trim());
       formData.set("password", password);
+      if (turnstileToken) formData.set("turnstileToken", turnstileToken);
 
       const res = await fetch("/api/admin/auth", {
         method: "POST",

--- a/src/lib/turnstile-client.ts
+++ b/src/lib/turnstile-client.ts
@@ -1,0 +1,9 @@
+import { PUBLIC_TURNSTILE_SITE_KEY } from "astro:env/client";
+
+export function isTurnstileWidgetConfigured(): boolean {
+  return Boolean(PUBLIC_TURNSTILE_SITE_KEY);
+}
+
+export function getTurnstileSiteKey(): string {
+  return PUBLIC_TURNSTILE_SITE_KEY;
+}

--- a/src/lib/turnstile.ts
+++ b/src/lib/turnstile.ts
@@ -1,0 +1,38 @@
+import { TURNSTILE_SECRET_KEY } from "astro:env/server";
+
+const SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+export function isTurnstileConfigured(): boolean {
+  return Boolean(TURNSTILE_SECRET_KEY);
+}
+
+/** Verifies a Turnstile token from the client widget (#443). Always
+ * returns true when Turnstile is unconfigured (local dev). */
+export async function verifyTurnstileToken(
+  token: string | null | undefined,
+  remoteIp?: string,
+): Promise<boolean> {
+  if (!isTurnstileConfigured()) return true;
+  if (!token) return false;
+
+  try {
+    const body = new URLSearchParams({
+      secret: TURNSTILE_SECRET_KEY,
+      response: token,
+    });
+    if (remoteIp && remoteIp !== "unknown") body.set("remoteip", remoteIp);
+
+    const res = await fetch(SITEVERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { success?: boolean };
+    return data.success === true;
+  } catch (error) {
+    console.error("Turnstile siteverify failed:", error);
+    return false;
+  }
+}

--- a/src/pages/api/admin/auth.ts
+++ b/src/pages/api/admin/auth.ts
@@ -18,6 +18,7 @@ import {
   getAdminUserBySupabaseId,
 } from "@lib/services/admin-user-service";
 import { createServerSupabaseClient } from "@lib/supabase/server";
+import { verifyTurnstileToken } from "@lib/turnstile";
 
 export const prerender = false;
 
@@ -81,6 +82,18 @@ export const POST: APIRoute = async ({ request, cookies }) => {
 
     if (!password) {
       return json({ error: "Password is required" }, 400);
+    }
+
+    const turnstileToken = formData.get("turnstileToken");
+    const turnstileOk = await verifyTurnstileToken(
+      typeof turnstileToken === "string" ? turnstileToken : null,
+      ip,
+    );
+    if (!turnstileOk) {
+      return json(
+        { error: "Verification failed. Refresh the page and try again." },
+        400,
+      );
     }
 
     let user: Awaited<ReturnType<typeof authenticateAdminUser>> = null;

--- a/src/pages/api/admin/auth.ts
+++ b/src/pages/api/admin/auth.ts
@@ -98,16 +98,24 @@ export const POST: APIRoute = async ({ request, cookies }) => {
 
     let user: Awaited<ReturnType<typeof authenticateAdminUser>> = null;
 
-    // Try Supabase Auth when configured (#293)
+    // Try Supabase Auth when configured (#293). Bounded with a timeout — a
+    // slow/unreachable Supabase Auth call must not block sign-in forever;
+    // fall through to bcrypt just like the "not configured" case.
     try {
       const supabase = createServerSupabaseClient({
         request,
         cookies,
       });
-      const { data, error } = await supabase.auth.signInWithPassword({
-        email: username,
-        password,
-      });
+      const SUPABASE_LOGIN_TIMEOUT_MS = 5000;
+      const { data, error } = await Promise.race([
+        supabase.auth.signInWithPassword({ email: username, password }),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Supabase sign-in timed out")),
+            SUPABASE_LOGIN_TIMEOUT_MS,
+          ),
+        ),
+      ]);
       if (data.user && !error) {
         user = await getAdminUserBySupabaseId(data.user.id);
       }

--- a/src/test/astro-env-client-stub.ts
+++ b/src/test/astro-env-client-stub.ts
@@ -1,4 +1,5 @@
-// Vitest stand-in for `astro:env/client` (Supabase off in component tests).
+// Vitest stand-in for `astro:env/client` (Supabase/Turnstile off in component tests).
 export const PUBLIC_SUPABASE_URL = undefined;
 export const PUBLIC_SUPABASE_PUBLISHABLE_KEY = undefined;
 export const PUBLIC_MAPTILER_KEY = undefined;
+export const PUBLIC_TURNSTILE_SITE_KEY = undefined;


### PR DESCRIPTION
Closes #443. Stacks on #520 (account-management) since both touch `AdminLoginModal.svelte` and `/api/admin/auth`.

## What

- `PUBLIC_TURNSTILE_SITE_KEY` (client) + `TURNSTILE_SECRET_KEY` (server), both optional in `astro.config.mjs`/`.env.example` — same graceful-degradation pattern as R2/Resend: widget hidden and server verification skipped entirely when unset.
- `src/lib/turnstile.ts`: `verifyTurnstileToken()` posts to Cloudflare's `siteverify` API; wired into `POST /api/admin/auth` right after the existing password-required check, before any DB/Supabase auth work.
- `TurnstileWidget.svelte`: lazy-loads `https://challenges.cloudflare.com/turnstile/v0/api.js` once (module-level promise, no duplicate script tags across remounts), explicit-renders the widget into a container, exposes the response token via a write-only `$bindable` prop, cleans up (`turnstile.remove`) on unmount.
- Login modal: widget renders above the Sign in button when configured; button stays disabled until a token is captured; server rejects with a clear "Verification failed" message on missing/invalid token.
- Forgot-password and other account-settings flows are **not** gated — scope matches the issue (editor login surface only).

## Verified locally
- `bun run test` (176 pass), `bun run test:components` (52 pass), `bun run build`, lint at baseline (92, unchanged).
- Live end-to-end against the dev server (found and worked around a real gotcha: `astro dev` runs as a persistent daemon — `pkill` doesn't stop it, only `astro dev stop` does, so env-var changes need that, not just a new `bun dev` invocation):
  - `TURNSTILE_SECRET_KEY` unset → login succeeds normally, no behavior change.
  - `TURNSTILE_SECRET_KEY` set, no token submitted → `POST /api/admin/auth` returns 400 "Verification failed. Refresh the page and try again." before any password check.

## Ops needed before this is live in prod/staging
1. Cloudflare dashboard → Turnstile → create a widget for the site, get the site key + secret key.
2. `vercel env add PUBLIC_TURNSTILE_SITE_KEY` (Production + Preview/staging).
3. `vercel env add TURNSTILE_SECRET_KEY` (Production + Preview/staging).
4. No key rotation/redirect-URI setup needed (unlike the Google OAuth client) — Turnstile keys are scoped by domain in the Cloudflare dashboard when you create the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the editor authentication path; misconfigured Turnstile keys or verify failures could block legitimate sign-ins until env is correct.
> 
> **Overview**
> Adds **optional Cloudflare Turnstile** on password-based editor sign-in, using the same pattern as other integrations: when `PUBLIC_TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` are unset, the widget stays hidden and server verification is skipped.
> 
> The login modal shows a lazy-loaded **`TurnstileWidget`** (only on the main sign-in path, not forgot-password), keeps **Sign in** disabled until a token exists, and posts `turnstileToken` with credentials. **`POST /api/admin/auth`** calls `verifyTurnstileToken()` against Cloudflare **before** any Supabase/bcrypt work and returns 400 on failure.
> 
> Also in this diff: the username field label becomes **Username or email**, and Supabase `signInWithPassword` is wrapped in a **5s timeout** so a hung Auth call falls through to legacy login instead of blocking indefinitely. Google OAuth is unchanged (not Turnstile-gated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe630be0c3912b864cf46196a0cae8e980571b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->