### PR TITLE
test: fill test-pyramid gaps for entity images, Turnstile, digest

### DIFF
--- a/integration/services/digest.integration.test.ts
+++ b/integration/services/digest.integration.test.ts
@@ -1,0 +1,80 @@
+import {
+  describe,
+  expect,
+  test,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
+import pg from "pg";
+import { integrationDatabaseUrl, skipWithoutE2eDb } from "../helpers/env";
+
+const describeIntegration = skipWithoutE2eDb() ? describe.skip : describe;
+
+const PREFIX = "e2e-digest";
+
+describeIntegration("digest service integration (#272 follow-up)", () => {
+  let client: pg.Client;
+
+  const cleanup = async () => {
+    await client.query(`DELETE FROM admin_users WHERE username LIKE $1`, [
+      `${PREFIX}%`,
+    ]);
+  };
+
+  beforeAll(async () => {
+    const url = integrationDatabaseUrl();
+    if (!url) return;
+    client = new pg.Client({ connectionString: url });
+    await client.connect();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await client?.end();
+  });
+
+  beforeEach(cleanup);
+
+  test("listDigestRecipients only includes active admins/editors with an email", async () => {
+    await client.query(
+      `INSERT INTO admin_users (username, password_hash, role, email, is_active) VALUES
+         ($1, 'x', 'editor', $2, true),
+         ($3, 'x', 'admin', $4, true),
+         ($5, 'x', 'contributor', $6, true),
+         ($7, 'x', 'editor', NULL, true),
+         ($8, 'x', 'editor', $9, false)`,
+      [
+        `${PREFIX}-editor`,
+        `${PREFIX}-editor@example.com`,
+        `${PREFIX}-admin`,
+        `${PREFIX}-ADMIN@Example.com`,
+        `${PREFIX}-contributor`,
+        `${PREFIX}-contributor@example.com`,
+        `${PREFIX}-no-email`,
+        `${PREFIX}-inactive`,
+        `${PREFIX}-inactive@example.com`,
+      ],
+    );
+
+    const { listDigestRecipients } = await import(
+      "@lib/services/digest-service"
+    );
+    const recipients = await listDigestRecipients();
+
+    expect(recipients).toContain(`${PREFIX}-editor@example.com`);
+    // normalized to lowercase
+    expect(recipients).toContain(`${PREFIX}-admin@example.com`);
+    expect(recipients).not.toContain(`${PREFIX}-contributor@example.com`);
+    expect(recipients).not.toContain(`${PREFIX}-inactive@example.com`);
+  });
+
+  test("sendProposalDigest skips cleanly when Resend is unconfigured", async () => {
+    const { sendProposalDigest } = await import("@lib/services/digest-service");
+    const result = await sendProposalDigest();
+    // Integration harness never sets RESEND_API_KEY/RESEND_FROM_EMAIL.
+    expect(result.skipped).toBe("unconfigured");
+    expect(result.pendingCount).toBe(0);
+    expect(result.recipientCount).toBe(0);
+  });
+});

--- a/src/lib/r2-upload.test.ts
+++ b/src/lib/r2-upload.test.ts
@@ -3,6 +3,7 @@ import {
   buildUploadKey,
   detectImageContentType,
   parseEventImageUrl,
+  parseImageUrl,
   sanitizeUploadPrefix,
 } from "./r2-upload-core";
 
@@ -88,6 +89,70 @@ describe("parseEventImageUrl", () => {
     ).toEqual({
       ok: false,
       error: "Event image URL must come from this site's upload storage",
+    });
+  });
+});
+
+describe("parseImageUrl (generic entity images, #191)", () => {
+  test("uses the given label in error messages", () => {
+    expect(
+      parseImageUrl(
+        "http://cdn.example.com/a.jpg",
+        "https://cdn.example.com",
+        "Building image",
+      ),
+    ).toEqual({
+      ok: false,
+      error: "Building image URL must use HTTPS",
+    });
+    expect(
+      parseImageUrl("https://cdn.example.com/a.jpg", null, "Room image"),
+    ).toEqual({
+      ok: false,
+      error:
+        "Room image URL requires upload storage (R2_PUBLIC_URL) to be configured",
+    });
+  });
+
+  test("accepts a valid URL from the configured storage origin", () => {
+    expect(
+      parseImageUrl(
+        "https://cdn.example.com/dorms/a.jpg",
+        "https://cdn.example.com",
+        "Dorm image",
+      ),
+    ).toEqual({
+      ok: true,
+      imageUrl: "https://cdn.example.com/dorms/a.jpg",
+      provided: true,
+    });
+  });
+
+  test("rejects a URL from a different origin", () => {
+    expect(
+      parseImageUrl(
+        "https://evil.example/photo.jpg",
+        "https://cdn.example.com",
+        "Building image",
+      ),
+    ).toEqual({
+      ok: false,
+      error: "Building image URL must come from this site's upload storage",
+    });
+  });
+
+  test("treats empty string as clearing the image", () => {
+    expect(parseImageUrl("", "https://cdn.example.com", "Room image")).toEqual({
+      ok: true,
+      imageUrl: null,
+      provided: true,
+    });
+  });
+
+  test("defaults to 'Image' label when none given", () => {
+    expect(parseImageUrl("http://cdn.example.com/a.jpg")).toEqual({
+      ok: false,
+      error: "Image URL must use HTTPS",
     });
   });
 });

--- a/src/lib/turnstile-core.test.ts
+++ b/src/lib/turnstile-core.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { verifyTurnstileToken } from "./turnstile-core";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("verifyTurnstileToken", () => {
+  test("always passes when unconfigured (empty secret)", async () => {
+    expect(await verifyTurnstileToken(null, "")).toBe(true);
+    expect(await verifyTurnstileToken("some-token", "")).toBe(true);
+  });
+
+  test("rejects a missing token when configured", async () => {
+    expect(await verifyTurnstileToken(null, "secret")).toBe(false);
+    expect(await verifyTurnstileToken(undefined, "secret")).toBe(false);
+  });
+
+  test("accepts a token Cloudflare confirms as valid", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+      })) as typeof fetch;
+    expect(await verifyTurnstileToken("good-token", "secret")).toBe(true);
+  });
+
+  test("rejects a token Cloudflare marks invalid", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ success: false }), {
+        status: 200,
+      })) as typeof fetch;
+    expect(await verifyTurnstileToken("bad-token", "secret")).toBe(false);
+  });
+
+  test("rejects on a non-2xx siteverify response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("", { status: 500 })) as typeof fetch;
+    expect(await verifyTurnstileToken("token", "secret")).toBe(false);
+  });
+
+  test("rejects when the network call throws", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+    expect(await verifyTurnstileToken("token", "secret")).toBe(false);
+  });
+});

--- a/src/lib/turnstile-core.ts
+++ b/src/lib/turnstile-core.ts
@@ -1,0 +1,32 @@
+const SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/**
+ * Verifies a Turnstile token from the client widget (#443). Always returns
+ * true when `secret` is empty (Turnstile unconfigured — local dev).
+ */
+export async function verifyTurnstileToken(
+  token: string | null | undefined,
+  secret: string,
+  remoteIp?: string,
+): Promise<boolean> {
+  if (!secret) return true;
+  if (!token) return false;
+
+  try {
+    const body = new URLSearchParams({ secret, response: token });
+    if (remoteIp && remoteIp !== "unknown") body.set("remoteip", remoteIp);
+
+    const res = await fetch(SITEVERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { success?: boolean };
+    return data.success === true;
+  } catch (error) {
+    console.error("Turnstile siteverify failed:", error);
+    return false;
+  }
+}

--- a/src/lib/turnstile.ts
+++ b/src/lib/turnstile.ts
@@ -1,38 +1,13 @@
 import { TURNSTILE_SECRET_KEY } from "astro:env/server";
-
-const SITEVERIFY_URL =
-  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+import { verifyTurnstileToken as verifyTurnstileTokenCore } from "./turnstile-core";
 
 export function isTurnstileConfigured(): boolean {
   return Boolean(TURNSTILE_SECRET_KEY);
 }
 
-/** Verifies a Turnstile token from the client widget (#443). Always
- * returns true when Turnstile is unconfigured (local dev). */
 export async function verifyTurnstileToken(
   token: string | null | undefined,
   remoteIp?: string,
 ): Promise<boolean> {
-  if (!isTurnstileConfigured()) return true;
-  if (!token) return false;
-
-  try {
-    const body = new URLSearchParams({
-      secret: TURNSTILE_SECRET_KEY,
-      response: token,
-    });
-    if (remoteIp && remoteIp !== "unknown") body.set("remoteip", remoteIp);
-
-    const res = await fetch(SITEVERIFY_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body,
-    });
-    if (!res.ok) return false;
-    const data = (await res.json()) as { success?: boolean };
-    return data.success === true;
-  } catch (error) {
-    console.error("Turnstile siteverify failed:", error);
-    return false;
-  }
+  return verifyTurnstileTokenCore(token, TURNSTILE_SECRET_KEY, remoteIp);
 }


### PR DESCRIPTION
Follow-up to today's release batch (#517/#520/#524/#501/#502, now on main). Ran a coverage audit across all 8 features shipped this session; two had zero tests, one had a gap in the send/skip paths.

## Audit result (before this PR)
- Entity images (#191): **not tested** — parseImageUrl (generic buildings/rooms/dorms) had no coverage, only the event-specific variant did.
- Turnstile (#443): **not tested** — zero references anywhere.
- Digest service (#272): partially tested — pure formatter (digest-core.ts) covered, but listDigestRecipients' filtering and sendProposalDigest's skip logic were not.
- Google sign-in, account settings, admin user management, proposal diffs, version history: already have service-level integration coverage (contributor-link/account-management/history integration tests) plus, for proposal diffs, solid unit + component coverage. Left alone.

## Added
- `src/lib/r2-upload.test.ts`: `parseImageUrl` — custom label, empty-clears-image, cross-origin rejection, default label fallback.
- `src/lib/turnstile-core.ts` (new): extracted `verifyTurnstileToken` to take the secret as a parameter, same split as `signed-token-core.ts`, so it doesn't need `astro:env` and is unit-testable. `turnstile.ts` now wraps it.
- `src/lib/turnstile-core.test.ts`: unconfigured bypass, missing-token rejection, Cloudflare success/failure/non-2xx/network-error paths (mocked `fetch`).
- `integration/services/digest.integration.test.ts`: `listDigestRecipients` (active admin/editor + has-email + case-insensitive), `sendProposalDigest`'s unconfigured-Resend skip.

## Deliberately not added
HTTP-route-level tests for every `/api/account/*` and `/api/admin/users/*` endpoint — the shared auth guard (`editorSessionOrUnauthorized`, already tested in `require-editor.test.ts`) and the underlying service functions (already integration-tested) cover the actual logic; re-wrapping each route would just be redundant coverage for the time spent.

## Verified
`bun run test` (193 pass, up from 182), `bun run test:components` (56 pass), `bun run build`, lint at baseline (91 pre-existing errors, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage plus a thin extraction of Turnstile verify logic with the same runtime behavior via turnstile.ts; no production feature changes beyond that delegate.
> 
> **Overview**
> Adds tests for previously untested or partially tested release features, plus a small Turnstile refactor so verification can be unit-tested without Astro env.
> 
> **Entity images (#191):** New unit tests for `parseImageUrl` (custom labels in errors, HTTPS/R2 origin checks, clearing via empty string, default label).
> 
> **Turnstile (#443):** Siteverify logic moves to `turnstile-core.ts` with an injectable secret; `turnstile.ts` delegates unchanged behavior. Unit tests cover dev bypass (empty secret), missing token, mocked Cloudflare success/failure, non-2xx responses, and network errors.
> 
> **Digest (#272):** Integration tests seed `admin_users` to assert `listDigestRecipients` only returns active admin/editor emails (lowercased), and that `sendProposalDigest` returns `skipped: "unconfigured"` when Resend env is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ca3528decee5dbbe44030b82266ad632a68193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->