### PR TITLE
fix(security): harden account tokens, sessions, and review flows

### DIFF
--- a/e2e/admin/auth.spec.ts
+++ b/e2e/admin/auth.spec.ts
@@ -20,7 +20,7 @@ test.describe("admin auth", () => {
     await page.getByLabel("Username").fill(E2E_FIXTURES.users.admin);
     await page.getByLabel("Password").fill("not-the-password");
     await page.getByRole("button", { name: /sign in/i }).click();
-    await expect(page.getByText(/invalid|password/i)).toBeVisible();
+    await expect(page.locator("#admin-login-error")).toBeVisible();
   });
 
   test("disabled user cannot login", async ({ page }) => {
@@ -30,6 +30,6 @@ test.describe("admin auth", () => {
     await page.getByLabel("Username").fill(E2E_FIXTURES.users.disabled);
     await page.getByLabel("Password").fill(password);
     await page.getByRole("button", { name: /sign in/i }).click();
-    await expect(page.getByText(/invalid|password/i)).toBeVisible();
+    await expect(page.locator("#admin-login-error")).toBeVisible();
   });
 });

--- a/integration/preload.ts
+++ b/integration/preload.ts
@@ -27,4 +27,8 @@ mock.module("astro:env/server", () => ({
   R2_SECRET_ACCESS_KEY: "",
   R2_BUCKET_NAME: "",
   R2_PUBLIC_URL: "",
+  // Unconfigured on purpose: services must take their skip/bypass paths.
+  RESEND_API_KEY: "",
+  RESEND_FROM_EMAIL: "",
+  TURNSTILE_SECRET_KEY: "",
 }));

--- a/integration/services/account-management.integration.test.ts
+++ b/integration/services/account-management.integration.test.ts
@@ -131,13 +131,106 @@ describeIntegration(
         requestEmailChange(passwordUserId, "not-an-email"),
       ).rejects.toThrow();
 
-      const token = createSignedToken({ userId: passwordUserId, newEmail }, 60);
+      const token = createSignedToken(
+        {
+          purpose: "email-change",
+          userId: passwordUserId,
+          newEmail,
+          fromEmail: `${PREFIX}-password@example.com`,
+        },
+        60,
+      );
       await confirmEmailChange(token);
       const { rows } = await client.query<{ email: string }>(
         `SELECT email FROM admin_users WHERE id = $1`,
         [passwordUserId],
       );
       expect(rows[0]!.email).toBe(newEmail);
+    });
+
+    test("email-change token is single-use (replay rejected after apply)", async () => {
+      const { confirmEmailChange, AccountActionError } = await import(
+        "@lib/services/admin-user-service"
+      );
+      const { createSignedToken } = await import("@lib/admin/signed-token");
+      const token = createSignedToken(
+        {
+          purpose: "email-change",
+          userId: passwordUserId,
+          newEmail: `${PREFIX}-replayed@example.com`,
+          fromEmail: `${PREFIX}-password@example.com`,
+        },
+        60,
+      );
+      await confirmEmailChange(token);
+      // Email no longer matches fromEmail — the same token must now die.
+      await expect(confirmEmailChange(token)).rejects.toBeInstanceOf(
+        AccountActionError,
+      );
+    });
+
+    test("an email-change token cannot reset a password (purpose confusion)", async () => {
+      const { confirmPasswordReset, AccountActionError } = await import(
+        "@lib/services/admin-user-service"
+      );
+      const { createSignedToken } = await import("@lib/admin/signed-token");
+      // Both token kinds share the HMAC secret; only `purpose` separates
+      // them. This was exploitable before the purpose check existed.
+      const emailChangeToken = createSignedToken(
+        {
+          purpose: "email-change",
+          userId: passwordUserId,
+          newEmail: `${PREFIX}-evil@example.com`,
+          fromEmail: `${PREFIX}-password@example.com`,
+        },
+        60,
+      );
+      await expect(
+        confirmPasswordReset(emailChangeToken, "attacker-password-123"),
+      ).rejects.toBeInstanceOf(AccountActionError);
+      // Legacy shape without purpose must also be rejected.
+      const legacyToken = createSignedToken({ userId: passwordUserId }, 60);
+      await expect(
+        confirmPasswordReset(legacyToken, "attacker-password-123"),
+      ).rejects.toBeInstanceOf(AccountActionError);
+    });
+
+    test("password-reset token is single-use (fingerprint invalidated by the reset)", async () => {
+      const { confirmPasswordReset, AccountActionError } = await import(
+        "@lib/services/admin-user-service"
+      );
+      const { createSignedToken } = await import("@lib/admin/signed-token");
+      const { createHash } = await import("crypto");
+
+      const { rows } = await client.query<{ password_hash: string }>(
+        `SELECT password_hash FROM admin_users WHERE id = $1`,
+        [passwordUserId],
+      );
+      const pwFp = createHash("sha256")
+        .update(rows[0]!.password_hash)
+        .digest("hex")
+        .slice(0, 16);
+      const token = createSignedToken(
+        { purpose: "password-reset", userId: passwordUserId, pwFp },
+        60,
+      );
+
+      await confirmPasswordReset(token, "brand-new-password-123");
+      // Hash changed → fingerprint mismatch → replay dies.
+      await expect(
+        confirmPasswordReset(token, "second-password-456"),
+      ).rejects.toBeInstanceOf(AccountActionError);
+
+      const after = await client.query<{ password_hash: string }>(
+        `SELECT password_hash FROM admin_users WHERE id = $1`,
+        [passwordUserId],
+      );
+      expect(
+        await bcrypt.compare(
+          "brand-new-password-123",
+          after.rows[0]!.password_hash,
+        ),
+      ).toBe(true);
     });
 
     test("linkGoogleIdentity rejects an identity already linked to another account", async () => {

--- a/integration/services/contributor-link.integration.test.ts
+++ b/integration/services/contributor-link.integration.test.ts
@@ -39,6 +39,7 @@ describeIntegration("linkOrCreateContributorFromSupabase (#456)", () => {
     const user = await linkOrCreateContributorFromSupabase({
       id: SUPABASE_ID_NEW,
       email: EMAIL_NEW,
+      emailConfirmed: true,
       name: "E2E Google User",
     });
     expect(user).not.toBeNull();
@@ -60,10 +61,12 @@ describeIntegration("linkOrCreateContributorFromSupabase (#456)", () => {
     const first = await linkOrCreateContributorFromSupabase({
       id: SUPABASE_ID_NEW,
       email: EMAIL_NEW,
+      emailConfirmed: true,
     });
     const second = await linkOrCreateContributorFromSupabase({
       id: SUPABASE_ID_NEW,
       email: EMAIL_NEW,
+      emailConfirmed: true,
     });
     expect(second?.id).toBe(first?.id ?? -1);
   });
@@ -80,6 +83,7 @@ describeIntegration("linkOrCreateContributorFromSupabase (#456)", () => {
     const user = await linkOrCreateContributorFromSupabase({
       id: SUPABASE_ID_LINK,
       email: EMAIL_LINK.toUpperCase(),
+      emailConfirmed: true,
     });
     expect(user?.username).toBe("e2e-google-link");
     expect(user?.role).toBe("editor");
@@ -89,5 +93,49 @@ describeIntegration("linkOrCreateContributorFromSupabase (#456)", () => {
       [EMAIL_LINK],
     );
     expect(rows[0]?.supabase_user_id).toBe(SUPABASE_ID_LINK);
+  });
+
+  test("unverified email never links to an existing account nor gets stored", async () => {
+    const unverifiedId = "00000000-0000-4000-8000-00000000e2e3";
+    const existingEmail = "e2e-google-unverified@example.com";
+    await client.query(
+      `DELETE FROM admin_users WHERE email = $1 OR supabase_user_id = $2 OR username LIKE 'e2e-google-unverified%'`,
+      [existingEmail, unverifiedId],
+    );
+    await client.query(
+      `INSERT INTO admin_users (username, display_name, password_hash, role, email, is_active)
+       VALUES ('e2e-google-unverified-victim', 'Victim Admin', 'x', 'admin', $1, true)`,
+      [existingEmail],
+    );
+    const { linkOrCreateContributorFromSupabase } = await import(
+      "@lib/services/admin-user-service"
+    );
+    try {
+      const user = await linkOrCreateContributorFromSupabase({
+        id: unverifiedId,
+        email: existingEmail,
+        emailConfirmed: false,
+      });
+      // Must NOT resolve to the existing admin row.
+      expect(user?.role).toBe("contributor");
+      expect(user?.username).not.toBe("e2e-google-unverified-victim");
+
+      const { rows } = await client.query(
+        `SELECT email, supabase_user_id FROM admin_users WHERE supabase_user_id = $1`,
+        [unverifiedId],
+      );
+      // New account stores no unverified email.
+      expect(rows[0]?.email).toBeNull();
+
+      const victim = await client.query(
+        `SELECT supabase_user_id FROM admin_users WHERE username = 'e2e-google-unverified-victim'`,
+      );
+      expect(victim.rows[0]?.supabase_user_id).toBeNull();
+    } finally {
+      await client.query(
+        `DELETE FROM admin_users WHERE email = $1 OR supabase_user_id = $2 OR username LIKE 'e2e-google-unverified%'`,
+        [existingEmail, unverifiedId],
+      );
+    }
   });
 });

--- a/integration/services/history.integration.test.ts
+++ b/integration/services/history.integration.test.ts
@@ -124,7 +124,9 @@ describeIntegration("editor history revert integration", () => {
       "e2e-admin",
     );
     expect(cleanup?.code).toBe(originalCode);
-  });
+    // Four sequential writes against the remote E2E DB routinely brush past
+    // bun's 5s default; give the round-trips room like merge tests do.
+  }, 30_000);
 
   test("revert with stale expectedVersion throws EditConflictError", async () => {
     const { EditConflictError } = await import("@lib/services/admin-service");

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from "crypto";
-import { ADMIN_PASSWORD, ADMIN_SESSION_SECRET } from "astro:env/server";
+import { ADMIN_SESSION_SECRET } from "astro:env/server";
 import type { AdminRole } from "./roles";
 export type { AdminRole } from "./roles";
 export { canPublishDirectly, canReviewProposals } from "./roles";
@@ -16,10 +16,12 @@ type SessionPayload = SessionUser & { exp: number };
 const COOKIE_NAME = "admin_session";
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
 
+// No ADMIN_PASSWORD fallback: the login password must never double as the
+// key that signs sessions and reset tokens (knowing it would let anyone
+// forge a session for any user).
 function signingSecret(): string {
   if (ADMIN_SESSION_SECRET) return ADMIN_SESSION_SECRET;
-  if (ADMIN_PASSWORD) return ADMIN_PASSWORD;
-  throw new Error("ADMIN_SESSION_SECRET or ADMIN_PASSWORD must be configured");
+  throw new Error("ADMIN_SESSION_SECRET must be configured");
 }
 
 function signBody(body: string): string {

--- a/src/lib/admin/entity-merge-route.ts
+++ b/src/lib/admin/entity-merge-route.ts
@@ -39,7 +39,9 @@ export function createEntityMergeRoute<TEntity>(options: {
   merge: MergeHandler<TEntity>;
 }): APIRoute {
   return async ({ cookies, params, request }) => {
-    const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+    const auth = await editorSessionOrUnauthorized(cookies, {
+      requirePublish: true,
+    });
     if (auth instanceof Response) return auth;
 
     const sourceId = parseInt(params["id"] ?? "");

--- a/src/lib/admin/require-editor.test.ts
+++ b/src/lib/admin/require-editor.test.ts
@@ -4,6 +4,9 @@ import type { AstroCookies } from "astro";
 mock.module("astro:env/server", () => ({
   ADMIN_PASSWORD: "test-password",
   ADMIN_SESSION_SECRET: "test-secret-key-for-tests",
+  // require-editor pulls in @lib/db for session revalidation; the pg Pool
+  // is lazy, so an empty URL is fine — these tests never reach a query.
+  DATABASE_URL: "",
 }));
 
 const { editorSessionOrUnauthorized } = await import("./require-editor");
@@ -21,16 +24,16 @@ function mockCookies(value?: string): AstroCookies {
 }
 
 describe("editorSessionOrUnauthorized", () => {
-  test("returns 401 when no session cookie is present", () => {
-    const result = editorSessionOrUnauthorized(mockCookies());
+  test("returns 401 when no session cookie is present", async () => {
+    const result = await editorSessionOrUnauthorized(mockCookies());
     expect(result).toBeInstanceOf(Response);
     if (result instanceof Response) {
       expect(result.status).toBe(401);
     }
   });
 
-  test("returns 401 for malformed session tokens", () => {
-    const result = editorSessionOrUnauthorized(
+  test("returns 401 for malformed session tokens", async () => {
+    const result = await editorSessionOrUnauthorized(
       mockCookies("not-a-valid-token"),
     );
     expect(result).toBeInstanceOf(Response);

--- a/src/lib/admin/require-editor.ts
+++ b/src/lib/admin/require-editor.ts
@@ -1,4 +1,7 @@
 import type { AstroCookies } from "astro";
+import { and, eq } from "drizzle-orm";
+import { adminUsersTable } from "@drizzle/schema";
+import { db } from "@lib/db";
 import {
   ADMIN_COOKIE_NAME,
   canPublishDirectly,
@@ -20,11 +23,52 @@ type EditorSessionOptions = {
   requireAdmin?: boolean;
 };
 
-export function editorSessionOrUnauthorized(
+/**
+ * Re-check the stateless cookie against the DB so deactivation/demotion
+ * takes effect immediately instead of after cookie expiry (7 days). One
+ * primary-key lookup per privileged request; returns the CURRENT role.
+ */
+async function revalidateSession(
+  session: SessionUser,
+): Promise<SessionUser | null> {
+  try {
+    const [row] = await db
+      .select({
+        role: adminUsersTable.role,
+        displayName: adminUsersTable.displayName,
+      })
+      .from(adminUsersTable)
+      .where(
+        and(
+          eq(adminUsersTable.id, session.id),
+          eq(adminUsersTable.isActive, true),
+        ),
+      )
+      .limit(1);
+    if (!row) return null;
+    return {
+      ...session,
+      displayName: row.displayName ?? session.displayName,
+      role: row.role ?? session.role,
+    };
+  } catch (error) {
+    // DB down: fail closed for privileged routes.
+    console.error("Session revalidation failed:", error);
+    return null;
+  }
+}
+
+export async function editorSessionOrUnauthorized(
   cookies: AstroCookies,
   options: EditorSessionOptions = {},
-): { session: SessionUser; editedBy: string; role: AdminRole } | Response {
-  const session = getEditorSession(cookies);
+): Promise<
+  { session: SessionUser; editedBy: string; role: AdminRole } | Response
+> {
+  const cookieSession = getEditorSession(cookies);
+  if (!cookieSession) {
+    return unauthorized();
+  }
+  const session = await revalidateSession(cookieSession);
   if (!session) {
     return unauthorized();
   }

--- a/src/lib/admin/signed-token.ts
+++ b/src/lib/admin/signed-token.ts
@@ -1,13 +1,13 @@
-import { ADMIN_PASSWORD, ADMIN_SESSION_SECRET } from "astro:env/server";
+import { ADMIN_SESSION_SECRET } from "astro:env/server";
 import {
   createSignedToken as createSignedTokenCore,
   verifySignedToken as verifySignedTokenCore,
 } from "./signed-token-core";
 
+// No ADMIN_PASSWORD fallback — see signingSecret() in ./auth.ts.
 function signingSecret(): string {
   if (ADMIN_SESSION_SECRET) return ADMIN_SESSION_SECRET;
-  if (ADMIN_PASSWORD) return ADMIN_PASSWORD;
-  throw new Error("ADMIN_SESSION_SECRET or ADMIN_PASSWORD must be configured");
+  throw new Error("ADMIN_SESSION_SECRET must be configured");
 }
 
 export function createSignedToken<T extends Record<string, unknown>>(

--- a/src/lib/proposals/diff.test.ts
+++ b/src/lib/proposals/diff.test.ts
@@ -55,13 +55,33 @@ describe("buildFieldDiffs", () => {
     ]);
   });
 
-  test("skips bundled rooms and event locations keys", () => {
+  test("skips bundled rooms (own summary) but renders event locations", () => {
     const diffs = buildFieldDiffs(null, {
       rooms: [{ roomCode: "A" }],
       locations: [{ label: "gate" }],
       title: "Fair",
     });
-    expect(diffs.map((d) => d.field)).toEqual(["title"]);
+    expect(diffs.map((d) => d.field)).toEqual(["locations", "title"]);
+  });
+
+  test("summarizes event locations as label (lat, lon) lists", () => {
+    const diffs = buildFieldDiffs(
+      { locations: [{ label: "Old gate", lat: 14.16, lon: 121.24 }] },
+      {
+        locations: [
+          { label: "Main gate", lat: 14.16723, lon: 121.24341 },
+          { label: "", lat: null, lon: null },
+        ],
+      },
+    );
+    expect(diffs).toEqual([
+      {
+        field: "locations",
+        label: "Locations",
+        before: "Old gate (14.16000, 121.24000)",
+        after: "Main gate (14.16723, 121.24341); Unnamed",
+      },
+    ]);
   });
 
   test("treats empty strings as unset", () => {

--- a/src/lib/proposals/diff.ts
+++ b/src/lib/proposals/diff.ts
@@ -25,6 +25,7 @@ export const FIELD_LABELS: Record<string, string> = {
   imageUrl: "Image",
   recurrence: "Recurrence",
   rooms: "Bundled rooms",
+  locations: "Locations",
 };
 
 export type FieldDiff = {
@@ -35,8 +36,29 @@ export type FieldDiff = {
   after: string | null;
 };
 
-// Keys with their own review summaries (bundled rooms, event locations).
-const SKIPPED_KEYS = new Set(["rooms", "locations"]);
+// Keys with their own review summary (create_building bundled rooms).
+const SKIPPED_KEYS = new Set(["rooms"]);
+
+/** One-line summary per event location so reviewers see what changes. */
+function formatLocations(value: unknown): string | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  return value
+    .map((item) => {
+      const loc = item as {
+        label?: unknown;
+        lat?: unknown;
+        lon?: unknown;
+      };
+      const name =
+        typeof loc.label === "string" && loc.label.trim()
+          ? loc.label.trim()
+          : "Unnamed";
+      return typeof loc.lat === "number" && typeof loc.lon === "number"
+        ? `${name} (${loc.lat.toFixed(5)}, ${loc.lon.toFixed(5)})`
+        : name;
+    })
+    .join("; ");
+}
 
 function formatValue(value: unknown): string | null {
   if (value === null || value === undefined) return null;
@@ -62,8 +84,9 @@ export function buildFieldDiffs(
   const diffs: FieldDiff[] = [];
   for (const [field, proposed] of Object.entries(patch)) {
     if (SKIPPED_KEYS.has(field)) continue;
-    const before = current ? formatValue(current[field]) : null;
-    const after = formatValue(proposed);
+    const format = field === "locations" ? formatLocations : formatValue;
+    const before = current ? format(current[field]) : null;
+    const after = format(proposed);
     if (current && before === after) continue;
     diffs.push({
       field,

--- a/src/lib/r2-upload.ts
+++ b/src/lib/r2-upload.ts
@@ -19,6 +19,7 @@ export {
   buildUploadKey,
   detectImageContentType,
   parseEventImageUrl,
+  parseImageUrl,
   sanitizeUploadPrefix,
 } from "./r2-upload-core";
 

--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import bcrypt from "bcrypt";
 import { and, desc, eq, ne, sql } from "drizzle-orm";
 import { ADMIN_PASSWORD } from "astro:env/server";
@@ -91,6 +92,7 @@ export async function getAdminUserBySupabaseId(
 export type SupabaseIdentity = {
   id: string;
   email: string | null;
+  emailConfirmed: boolean;
   name?: string | null;
 };
 
@@ -98,6 +100,11 @@ export type SupabaseIdentity = {
  * Resolve an OAuth (e.g. Google) Supabase user to an `admin_users` row.
  * Links by supabase id, then by email (existing account without a link),
  * else creates a new `contributor` account (#456).
+ *
+ * Email matching/storage only happens for provider-verified emails —
+ * otherwise a provider that passes unverified emails would let anyone
+ * claim an existing account (including admin rows) by registering its
+ * email address at that provider.
  */
 export async function linkOrCreateContributorFromSupabase(
   identity: SupabaseIdentity,
@@ -105,7 +112,9 @@ export async function linkOrCreateContributorFromSupabase(
   const linked = await getAdminUserBySupabaseId(identity.id);
   if (linked) return linked;
 
-  const email = identity.email?.trim().toLowerCase() ?? null;
+  const email = identity.emailConfirmed
+    ? (identity.email?.trim().toLowerCase() ?? null)
+    : null;
 
   if (email) {
     const [byEmail] = await db
@@ -333,7 +342,16 @@ export async function changePassword(
     .where(eq(adminUsersTable.id, userId));
 }
 
-type EmailChangeTokenPayload = { userId: number; newEmail: string };
+// `purpose` stops cross-endpoint replay (an email-change token must never
+// pass as a password-reset token — both are signed with the same secret).
+// Binding to the current email/password state makes each token single-use:
+// once the change applies, the state no longer matches and replays die.
+type EmailChangeTokenPayload = {
+  purpose: "email-change";
+  userId: number;
+  newEmail: string;
+  fromEmail: string | null;
+};
 
 export async function requestEmailChange(
   userId: number,
@@ -355,8 +373,20 @@ export async function requestEmailChange(
     throw new AccountActionError("That email is already in use.", 409);
   }
 
+  const [self] = await db
+    .select({ email: adminUsersTable.email })
+    .from(adminUsersTable)
+    .where(eq(adminUsersTable.id, userId))
+    .limit(1);
+  if (!self) throw new AccountActionError("Account not found.", 404);
+
   const token = createSignedToken<EmailChangeTokenPayload>(
-    { userId, newEmail: normalized },
+    {
+      purpose: "email-change",
+      userId,
+      newEmail: normalized,
+      fromEmail: self.email,
+    },
     EMAIL_CHANGE_TOKEN_TTL_SECONDS,
   );
   const confirmUrl = `${SITE_URL}/api/account/confirm-email-change?token=${encodeURIComponent(token)}`;
@@ -374,7 +404,17 @@ export async function requestEmailChange(
   });
 }
 
-type PasswordResetTokenPayload = { userId: number };
+type PasswordResetTokenPayload = {
+  purpose: "password-reset";
+  userId: number;
+  /** Fingerprint of the password hash the token was issued against. */
+  pwFp: string;
+};
+
+/** Short non-reversible fingerprint of the stored password hash. */
+function passwordHashFingerprint(passwordHash: string): string {
+  return createHash("sha256").update(passwordHash).digest("hex").slice(0, 16);
+}
 
 /**
  * Request a password-reset email. Always resolves without error, whether or
@@ -390,6 +430,7 @@ export async function requestPasswordReset(login: string): Promise<void> {
       id: adminUsersTable.id,
       email: adminUsersTable.email,
       isActive: adminUsersTable.isActive,
+      passwordHash: adminUsersTable.passwordHash,
     })
     .from(adminUsersTable)
     .where(
@@ -405,7 +446,11 @@ export async function requestPasswordReset(login: string): Promise<void> {
   if (!user?.isActive || !user.email) return;
 
   const token = createSignedToken<PasswordResetTokenPayload>(
-    { userId: user.id },
+    {
+      purpose: "password-reset",
+      userId: user.id,
+      pwFp: passwordHashFingerprint(user.passwordHash),
+    },
     EMAIL_CHANGE_TOKEN_TTL_SECONDS,
   );
   const resetUrl = `${SITE_URL}/reset-password?token=${encodeURIComponent(token)}`;
@@ -433,9 +478,26 @@ export async function confirmPasswordReset(
     );
   }
   const payload = verifySignedToken<PasswordResetTokenPayload>(token);
-  if (!payload || !Number.isInteger(payload.userId)) {
+  if (
+    !payload ||
+    payload.purpose !== "password-reset" ||
+    !Number.isInteger(payload.userId) ||
+    typeof payload.pwFp !== "string"
+  ) {
     throw new AccountActionError("This link is invalid or has expired.", 400);
   }
+
+  const [row] = await db
+    .select({ passwordHash: adminUsersTable.passwordHash })
+    .from(adminUsersTable)
+    .where(eq(adminUsersTable.id, payload.userId))
+    .limit(1);
+  // Fingerprint mismatch = password already changed since the token was
+  // issued (including by this very token) — single-use enforcement.
+  if (!row || passwordHashFingerprint(row.passwordHash) !== payload.pwFp) {
+    throw new AccountActionError("This link is invalid or has expired.", 400);
+  }
+
   const passwordHash = await bcrypt.hash(newPassword, 12);
   await db
     .update(adminUsersTable)
@@ -445,13 +507,31 @@ export async function confirmPasswordReset(
 
 export async function confirmEmailChange(token: string): Promise<void> {
   const payload = verifySignedToken<EmailChangeTokenPayload>(token);
-  if (!payload || !Number.isInteger(payload.userId) || !payload.newEmail) {
+  if (
+    !payload ||
+    payload.purpose !== "email-change" ||
+    !Number.isInteger(payload.userId) ||
+    !payload.newEmail
+  ) {
     throw new AccountActionError("This link is invalid or has expired.", 400);
   }
-  await db
+  // Guarding on the issued-against email makes the token single-use and
+  // drops stale tokens if the email changed some other way meanwhile.
+  const updated = await db
     .update(adminUsersTable)
     .set({ email: payload.newEmail, updatedAt: sql`now()` })
-    .where(eq(adminUsersTable.id, payload.userId));
+    .where(
+      and(
+        eq(adminUsersTable.id, payload.userId),
+        payload.fromEmail === null
+          ? sql`email IS NULL`
+          : sql`lower(email) = ${payload.fromEmail.toLowerCase()}`,
+      ),
+    )
+    .returning({ id: adminUsersTable.id });
+  if (updated.length === 0) {
+    throw new AccountActionError("This link is invalid or has expired.", 400);
+  }
 }
 
 export async function linkGoogleIdentity(
@@ -653,8 +733,13 @@ export async function createAdminUser(
   }
 }
 
-async function countActiveAdmins(excludingUserId?: number): Promise<number> {
-  const rows = await db
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+async function countActiveAdmins(
+  tx: Tx | typeof db,
+  excludingUserId?: number,
+): Promise<number> {
+  const rows = await tx
     .select({ c: sql<number>`count(*)` })
     .from(adminUsersTable)
     .where(
@@ -678,55 +763,65 @@ export async function updateManagedUser(
   targetUserId: number,
   input: UpdateManagedUserInput,
 ): Promise<AdminManagedUser> {
-  const [target] = await db
-    .select({
-      id: adminUsersTable.id,
-      role: adminUsersTable.role,
-      isActive: adminUsersTable.isActive,
-    })
-    .from(adminUsersTable)
-    .where(eq(adminUsersTable.id, targetUserId))
-    .limit(1);
-  if (!target) throw new AccountActionError("Account not found.", 404);
+  // Transaction + advisory lock serializes admin role/active changes so two
+  // concurrent demotions can't both pass the last-admin check and leave
+  // zero active admins. Lock is xact-scoped: released on commit/rollback.
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('admin_users:last-admin-guard'))`,
+    );
 
-  const demotingFromAdmin =
-    target.role === "admin" &&
-    input.role !== undefined &&
-    input.role !== "admin";
-  const deactivatingAdmin =
-    target.role === "admin" && input.isActive === false && target.isActive;
+    const [target] = await tx
+      .select({
+        id: adminUsersTable.id,
+        role: adminUsersTable.role,
+        isActive: adminUsersTable.isActive,
+      })
+      .from(adminUsersTable)
+      .where(eq(adminUsersTable.id, targetUserId))
+      .limit(1);
+    if (!target) throw new AccountActionError("Account not found.", 404);
 
-  if (demotingFromAdmin || deactivatingAdmin) {
-    const remaining = await countActiveAdmins(targetUserId);
-    if (remaining < 1) {
-      throw new AccountActionError(
-        "Cannot remove the last remaining admin.",
-        400,
-      );
+    const demotingFromAdmin =
+      target.role === "admin" &&
+      input.role !== undefined &&
+      input.role !== "admin";
+    const deactivatingAdmin =
+      target.role === "admin" && input.isActive === false && target.isActive;
+
+    if (demotingFromAdmin || deactivatingAdmin) {
+      const remaining = await countActiveAdmins(tx, targetUserId);
+      if (remaining < 1) {
+        throw new AccountActionError(
+          "Cannot remove the last remaining admin.",
+          400,
+        );
+      }
     }
-  }
 
-  const updates: Record<string, unknown> = { updatedAt: sql`now()` };
-  if (input.role !== undefined) updates["role"] = input.role;
-  if (input.isActive !== undefined) updates["isActive"] = input.isActive;
+    const updates: Record<string, unknown> = { updatedAt: sql`now()` };
+    if (input.role !== undefined) updates["role"] = input.role;
+    if (input.isActive !== undefined) updates["isActive"] = input.isActive;
 
-  const [updated] = await db
-    .update(adminUsersTable)
-    .set(updates)
-    .where(eq(adminUsersTable.id, targetUserId))
-    .returning({
-      id: adminUsersTable.id,
-      username: adminUsersTable.username,
-      displayName: adminUsersTable.displayName,
-      email: adminUsersTable.email,
-      role: adminUsersTable.role,
-      isActive: adminUsersTable.isActive,
-      createdAt: adminUsersTable.createdAt,
-    });
-  if (!updated) throw new AccountActionError("Failed to update account.", 500);
-  return {
-    ...updated,
-    displayName: updated.displayName ?? updated.username,
-    role: updated.role ?? "editor",
-  };
+    const [updated] = await tx
+      .update(adminUsersTable)
+      .set(updates)
+      .where(eq(adminUsersTable.id, targetUserId))
+      .returning({
+        id: adminUsersTable.id,
+        username: adminUsersTable.username,
+        displayName: adminUsersTable.displayName,
+        email: adminUsersTable.email,
+        role: adminUsersTable.role,
+        isActive: adminUsersTable.isActive,
+        createdAt: adminUsersTable.createdAt,
+      });
+    if (!updated)
+      throw new AccountActionError("Failed to update account.", 500);
+    return {
+      ...updated,
+      displayName: updated.displayName ?? updated.username,
+      role: updated.role ?? "editor",
+    };
+  });
 }

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -48,8 +48,22 @@ export async function getEntityHistory(
 // Fields that can be restored from a snapshot. Anything else in the snapshot
 // (id, version, updatedAt, joined labels) must never be written back.
 const REVERTABLE_FIELDS: Record<string, string[]> = {
-  building: ["buildingName", "lat", "lon", "buildingType", "directions"],
-  room: ["roomCode", "directions", "buildingId", "collegeId", "divisionId"],
+  building: [
+    "buildingName",
+    "lat",
+    "lon",
+    "buildingType",
+    "directions",
+    "imageUrl",
+  ],
+  room: [
+    "roomCode",
+    "directions",
+    "buildingId",
+    "collegeId",
+    "divisionId",
+    "imageUrl",
+  ],
   college: ["collegeName"],
   division: ["divisionName", "collegeId"],
   dorm: [
@@ -68,6 +82,7 @@ const REVERTABLE_FIELDS: Record<string, string[]> = {
     "priceRange",
     "contactPhone",
     "facebookLink",
+    "imageUrl",
   ],
   // Scalar fields only; locations/routes restore is out of scope for v1.
   event: [

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -5,6 +5,7 @@ import {
   divisionsTable,
   dormsTable,
   editProposalsTable,
+  eventLocationsTable,
   eventsTable,
   roomsTable,
 } from "@drizzle/schema";
@@ -12,7 +13,7 @@ import { db } from "@lib/db";
 import { validateSubmitterName } from "@constants/proposals";
 import { type SessionUser } from "@lib/admin/auth";
 import { recordProposalContribution } from "./contribution-service";
-import { parseEventImageUrl } from "@lib/r2-upload";
+import { parseImageUrl } from "@lib/r2-upload";
 import { R2_PUBLIC_URL } from "astro:env/server";
 import {
   canViewProposalSubmitterDetails,
@@ -384,14 +385,29 @@ export async function getCurrentEntityValues(
         .limit(1);
       return row ?? null;
     }
-    case "event":
-    case "event_locations": {
+    case "event": {
       const [row] = await db
         .select()
         .from(eventsTable)
         .where(eq(eventsTable.id, entityId))
         .limit(1);
       return row ?? null;
+    }
+    case "event_locations": {
+      const [row] = await db
+        .select()
+        .from(eventsTable)
+        .where(eq(eventsTable.id, entityId))
+        .limit(1);
+      if (!row) return null;
+      // Patch key is `locations`; include the published ones so the review
+      // queue renders a real before/after instead of a blank diff.
+      const locations = await db
+        .select()
+        .from(eventLocationsTable)
+        .where(eq(eventLocationsTable.eventId, entityId))
+        .orderBy(eventLocationsTable.sortOrder, eventLocationsTable.id);
+      return { ...row, locations };
     }
   }
 }
@@ -620,9 +636,12 @@ export class ProposalActionError extends Error {
   }
 }
 
-function validateProposalImageUrl(patch: Record<string, unknown>) {
+function validateProposalImageUrl(
+  patch: Record<string, unknown>,
+  label: string,
+) {
   if (!("imageUrl" in patch)) return;
-  const parsed = parseEventImageUrl(patch.imageUrl, R2_PUBLIC_URL);
+  const parsed = parseImageUrl(patch.imageUrl, R2_PUBLIC_URL, label);
   if (!parsed.ok) {
     throw new ProposalActionError(parsed.error);
   }
@@ -631,21 +650,22 @@ function validateProposalImageUrl(patch: Record<string, unknown>) {
   }
 }
 
-const IMAGE_PATCH_ENTITY_TYPES: ReadonlySet<string> = new Set([
-  "create_event",
-  "event",
-  "building",
-  "room",
-  "dorm",
-  "create_dorm",
-]);
+const IMAGE_PATCH_ENTITY_LABELS: Readonly<Record<string, string>> = {
+  create_event: "Event image",
+  event: "Event image",
+  building: "Building image",
+  room: "Room image",
+  dorm: "Dorm image",
+  create_dorm: "Dorm image",
+};
 
 async function applyProposalPatch(proposal: EditProposalRow, editedBy: string) {
   const patch = proposal.proposedPatch as Record<string, unknown>;
   const entityType = proposal.entityType as ProposalEntityType;
 
-  if (IMAGE_PATCH_ENTITY_TYPES.has(entityType)) {
-    validateProposalImageUrl(patch);
+  const imageLabel = IMAGE_PATCH_ENTITY_LABELS[entityType];
+  if (imageLabel) {
+    validateProposalImageUrl(patch, imageLabel);
   }
 
   if (isCreateProposalType(entityType)) {

--- a/src/pages/api/account/change-password.ts
+++ b/src/pages/api/account/change-password.ts
@@ -15,7 +15,7 @@ export const prerender = false;
 const LIMIT = { max: 8, windowMs: 30 * 1000 };
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   const rate = checkRateLimit(

--- a/src/pages/api/account/delete.ts
+++ b/src/pages/api/account/delete.ts
@@ -16,7 +16,7 @@ export const prerender = false;
 const LIMIT = { max: 5, windowMs: 60 * 1000 };
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   const rate = checkRateLimit(

--- a/src/pages/api/account/export.ts
+++ b/src/pages/api/account/export.ts
@@ -5,7 +5,7 @@ import { exportAccountData } from "@lib/services/admin-user-service";
 export const prerender = false;
 
 export const GET: APIRoute = async ({ cookies }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   const data = await exportAccountData(auth.session.id);

--- a/src/pages/api/account/me.ts
+++ b/src/pages/api/account/me.ts
@@ -9,7 +9,7 @@ import {
 export const prerender = false;
 
 export const GET: APIRoute = async ({ cookies }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   const profile = await getAccountProfile(auth.session.id);
@@ -18,7 +18,7 @@ export const GET: APIRoute = async ({ cookies }) => {
 };
 
 export const PATCH: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   let body: { displayName?: string };

--- a/src/pages/api/account/request-email-change.ts
+++ b/src/pages/api/account/request-email-change.ts
@@ -15,7 +15,7 @@ export const prerender = false;
 const LIMIT = { max: 5, windowMs: 60 * 1000 };
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   const rate = checkRateLimit(

--- a/src/pages/api/account/unlink-google.ts
+++ b/src/pages/api/account/unlink-google.ts
@@ -8,7 +8,7 @@ import {
 export const prerender = false;
 
 export const POST: APIRoute = async ({ cookies }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   try {

--- a/src/pages/api/admin/aliases/index.ts
+++ b/src/pages/api/admin/aliases/index.ts
@@ -17,7 +17,7 @@ function json(data: unknown, status = 200) {
 
 /** List aliases with optional search. */
 export const GET: APIRoute = async ({ cookies, url }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   const q = url.searchParams.get("q")?.trim() ?? "";
@@ -42,7 +42,9 @@ export const GET: APIRoute = async ({ cookies, url }) => {
 
 /** Create a new alias. */
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   let body: Record<string, unknown>;
@@ -94,7 +96,9 @@ export const POST: APIRoute = async ({ cookies, request }) => {
 
 /** Bulk-delete aliases by IDs. */
 export const DELETE: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   let body: Record<string, unknown>;

--- a/src/pages/api/admin/auth.ts
+++ b/src/pages/api/admin/auth.ts
@@ -107,17 +107,25 @@ export const POST: APIRoute = async ({ request, cookies }) => {
         cookies,
       });
       const SUPABASE_LOGIN_TIMEOUT_MS = 5000;
-      const { data, error } = await Promise.race([
-        supabase.auth.signInWithPassword({ email: username, password }),
-        new Promise<never>((_, reject) =>
-          setTimeout(
-            () => reject(new Error("Supabase sign-in timed out")),
-            SUPABASE_LOGIN_TIMEOUT_MS,
-          ),
-        ),
-      ]);
-      if (data.user && !error) {
-        user = await getAdminUserBySupabaseId(data.user.id);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const { data, error } = await Promise.race([
+          supabase.auth.signInWithPassword({ email: username, password }),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error("Supabase sign-in timed out")),
+              SUPABASE_LOGIN_TIMEOUT_MS,
+            );
+          }),
+        ]);
+        if (data.user && !error) {
+          user = await getAdminUserBySupabaseId(data.user.id);
+        }
+      } finally {
+        // Always clear the timer so a fast response doesn't leave a live
+        // handle behind. The losing signInWithPassword call can't be
+        // aborted (supabase-js takes no signal); it settles unobserved.
+        clearTimeout(timer);
       }
     } catch {
       // Supabase not configured or unavailable → fall through to bcrypt

--- a/src/pages/api/admin/buildings/[id].ts
+++ b/src/pages/api/admin/buildings/[id].ts
@@ -22,7 +22,9 @@ type BuildingPatchBody = {
 };
 
 export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = parseInt(params["id"] ?? "");

--- a/src/pages/api/admin/buildings/index.ts
+++ b/src/pages/api/admin/buildings/index.ts
@@ -12,7 +12,9 @@ function json(data: unknown, status = 200) {
 }
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   let body: Record<string, unknown>;

--- a/src/pages/api/admin/colleges/[id].ts
+++ b/src/pages/api/admin/colleges/[id].ts
@@ -15,7 +15,9 @@ type CollegePatchBody = {
 };
 
 export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = parseInt(params["id"] ?? "");

--- a/src/pages/api/admin/colleges/index.ts
+++ b/src/pages/api/admin/colleges/index.ts
@@ -12,7 +12,9 @@ function json(data: unknown, status = 200) {
 }
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   let body: Record<string, unknown>;

--- a/src/pages/api/admin/divisions/[id].ts
+++ b/src/pages/api/admin/divisions/[id].ts
@@ -28,7 +28,9 @@ function invalidCollegeId(value: unknown) {
 }
 
 export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = parseInt(params["id"] ?? "");

--- a/src/pages/api/admin/divisions/index.ts
+++ b/src/pages/api/admin/divisions/index.ts
@@ -12,7 +12,9 @@ function json(data: unknown, status = 200) {
 }
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   let body: Record<string, unknown>;

--- a/src/pages/api/admin/dorms/[id].ts
+++ b/src/pages/api/admin/dorms/[id].ts
@@ -32,7 +32,9 @@ type DormPatchBody = {
 };
 
 export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = parseInt(params["id"] ?? "");

--- a/src/pages/api/admin/dorms/index.ts
+++ b/src/pages/api/admin/dorms/index.ts
@@ -12,7 +12,9 @@ function json(data: unknown, status = 200) {
 }
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   let body: Record<string, unknown>;

--- a/src/pages/api/admin/events/[id].ts
+++ b/src/pages/api/admin/events/[id].ts
@@ -18,7 +18,9 @@ type EventPatchBody = EventWriteInput & {
 };
 
 export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = parseEventId(params.id);
@@ -68,7 +70,9 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
 };
 
 export const DELETE: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = parseEventId(params.id);

--- a/src/pages/api/admin/events/[id]/locations.ts
+++ b/src/pages/api/admin/events/[id]/locations.ts
@@ -15,7 +15,9 @@ type LocationsPatchBody = {
 };
 
 export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = Number(params.id);

--- a/src/pages/api/admin/events/[id]/routes.ts
+++ b/src/pages/api/admin/events/[id]/routes.ts
@@ -15,7 +15,9 @@ type RoutesPatchBody = {
 };
 
 export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = Number(params.id);

--- a/src/pages/api/admin/events/index.ts
+++ b/src/pages/api/admin/events/index.ts
@@ -12,7 +12,9 @@ import { slugifySegment } from "@lib/site";
 export const prerender = false;
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   let body: Record<string, unknown>;

--- a/src/pages/api/admin/history/[id]/revert.ts
+++ b/src/pages/api/admin/history/[id]/revert.ts
@@ -12,7 +12,9 @@ import {
 export const prerender = false;
 
 export const POST: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const historyId = Number(params.id);

--- a/src/pages/api/admin/history/index.ts
+++ b/src/pages/api/admin/history/index.ts
@@ -5,7 +5,9 @@ import { getEntityHistory } from "@lib/services/history-service";
 export const prerender = false;
 
 export const GET: APIRoute = async ({ cookies, url }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const entityType = url.searchParams.get("entityType") ?? "";

--- a/src/pages/api/admin/proposals/[id]/approve.ts
+++ b/src/pages/api/admin/proposals/[id]/approve.ts
@@ -12,7 +12,9 @@ import {
 export const prerender = false;
 
 export const POST: APIRoute = async ({ cookies, params }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requireReview: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requireReview: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = Number(params.id);

--- a/src/pages/api/admin/proposals/[id]/reject.ts
+++ b/src/pages/api/admin/proposals/[id]/reject.ts
@@ -14,7 +14,9 @@ export const prerender = false;
 type RejectBody = { note?: string };
 
 export const POST: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requireReview: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requireReview: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = Number(params.id);

--- a/src/pages/api/admin/proposals/[id]/request-changes.ts
+++ b/src/pages/api/admin/proposals/[id]/request-changes.ts
@@ -15,7 +15,9 @@ export const prerender = false;
 type RequestChangesBody = { note?: string };
 
 export const POST: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requireReview: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requireReview: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = Number(params.id);

--- a/src/pages/api/admin/proposals/index.ts
+++ b/src/pages/api/admin/proposals/index.ts
@@ -8,7 +8,9 @@ import {
 export const prerender = false;
 
 export const GET: APIRoute = async ({ cookies }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requireReview: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requireReview: true,
+  });
   if (auth instanceof Response) return auth;
 
   const [proposals, pendingCount] = await Promise.all([

--- a/src/pages/api/admin/rooms/[id].ts
+++ b/src/pages/api/admin/rooms/[id].ts
@@ -47,7 +47,9 @@ function invalidPosition(value: unknown) {
 }
 
 export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = parseInt(params["id"] ?? "");

--- a/src/pages/api/admin/rooms/[id]/merge.ts
+++ b/src/pages/api/admin/rooms/[id]/merge.ts
@@ -22,7 +22,9 @@ function json(data: unknown, status = 200) {
 }
 
 export const POST: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   const sourceId = parseInt(params["id"] ?? "");

--- a/src/pages/api/admin/rooms/index.ts
+++ b/src/pages/api/admin/rooms/index.ts
@@ -16,7 +16,9 @@ function json(data: unknown, status = 200) {
 }
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requirePublish: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requirePublish: true,
+  });
   if (auth instanceof Response) return auth;
 
   let body: Record<string, unknown>;

--- a/src/pages/api/admin/upload.ts
+++ b/src/pages/api/admin/upload.ts
@@ -23,7 +23,7 @@ export const prerender = false;
 const UPLOAD_LIMIT = { max: 30, windowMs: 10 * 60 * 1000 };
 
 export const GET: APIRoute = async ({ cookies }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   return json({
@@ -34,7 +34,7 @@ export const GET: APIRoute = async ({ cookies }) => {
 };
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
   const ip = clientIp(request);

--- a/src/pages/api/admin/users/[id].ts
+++ b/src/pages/api/admin/users/[id].ts
@@ -8,7 +8,9 @@ import {
 export const prerender = false;
 
 export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requireAdmin: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requireAdmin: true,
+  });
   if (auth instanceof Response) return auth;
 
   const id = parseInt(params["id"] ?? "");

--- a/src/pages/api/admin/users/index.ts
+++ b/src/pages/api/admin/users/index.ts
@@ -9,7 +9,9 @@ import {
 export const prerender = false;
 
 export const GET: APIRoute = async ({ cookies }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requireAdmin: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requireAdmin: true,
+  });
   if (auth instanceof Response) return auth;
 
   const users = await listAllAdminUsers();
@@ -17,7 +19,9 @@ export const GET: APIRoute = async ({ cookies }) => {
 };
 
 export const POST: APIRoute = async ({ cookies, request }) => {
-  const auth = editorSessionOrUnauthorized(cookies, { requireAdmin: true });
+  const auth = await editorSessionOrUnauthorized(cookies, {
+    requireAdmin: true,
+  });
   if (auth instanceof Response) return auth;
 
   let body: {

--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -31,6 +31,7 @@ export const GET: APIRoute = async ({ url, request, cookies }) => {
     const user = await linkOrCreateContributorFromSupabase({
       id: data.user.id,
       email: data.user.email ?? null,
+      emailConfirmed: Boolean(data.user.email_confirmed_at),
       name: meta?.full_name ?? meta?.name ?? null,
     });
     if (!user) return fail("account_unavailable");

--- a/src/pages/api/auth/link-callback.ts
+++ b/src/pages/api/auth/link-callback.ts
@@ -17,7 +17,7 @@ export const GET: APIRoute = async ({ url, request, cookies }) => {
       headers: { Location: `/?account_error=${encodeURIComponent(reason)}` },
     });
 
-  const auth = editorSessionOrUnauthorized(cookies);
+  const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return fail("not_logged_in");
 
   const code = url.searchParams.get("code");

--- a/src/pages/api/contributor-progress.ts
+++ b/src/pages/api/contributor-progress.ts
@@ -32,7 +32,7 @@ export const GET: APIRoute = async ({ url, cookies }) => {
   const buildingIdRaw = url.searchParams.get("buildingId");
 
   if (scope === "mine") {
-    const auth = editorSessionOrUnauthorized(cookies);
+    const auth = await editorSessionOrUnauthorized(cookies);
     if (auth instanceof Response) return auth;
     return json(await fetchMineProgress(sessionEditedBy(auth.session)));
   }


### PR DESCRIPTION
## Summary

Fixes all 10 confirmed findings from the post-release code review of the shipped account-management, Turnstile, entity-image, proposal-diff, and version-history work.

### Security
1. **Token purpose confusion (account takeover)** — signed tokens now carry `purpose: "password-reset" | "email-change"`; `confirmPasswordReset` rejects anything else, so an email-change link can no longer reset a password.
2. **Single-use tokens** — password-reset tokens embed a SHA-256 fingerprint of the password hash they were issued against (any change invalidates them, including their own use); email-change tokens embed the issued-against email and apply via a conditional `UPDATE ... WHERE email matches`.
3. **HMAC secret hardening** — removed the ADMIN_PASSWORD fallback; `ADMIN_SESSION_SECRET` is now required (verified set in Production + Preview/staging on Vercel).
4. **OAuth link guard** — email auto-linking requires `email_confirmed_at`; unverified provider emails are never matched against existing accounts nor stored.
5. **Immediate revocation** — `editorSessionOrUnauthorized` revalidates the cookie against the DB (isActive + current role) on every privileged request, so deactivating/demoting a user takes effect immediately instead of at 7-day cookie expiry. One PK lookup per privileged call; fails closed on DB errors.
6. **Last-admin race** — `updateManagedUser` runs in a transaction under `pg_advisory_xact_lock`, so concurrent demotions can't leave zero active admins.

### Correctness
7. History revert now restores `imageUrl` for buildings, rooms, and dorms (was silently skipped).
8. `event_locations` proposals render a real before/after diff (label + coordinates per location) in the review queue instead of a blank changes list; current locations are included in `currentValues`.
9. Supabase login timeout clears its timer via `finally` (no leaked handle per timed-out login).
10. Building/room/dorm image validation errors now say "Building/Room/Dorm image ..." via the generic `parseImageUrl`, not "Event image ...".

## Tests
- New integration regressions: purpose-confusion rejection (incl. legacy tokens without purpose), email-change replay rejection, password-reset replay rejection, unverified-email link refusal.
- Updated: diff tests (locations now render), require-editor tests (async), contributor-link tests (emailConfirmed).
- `bun run test` 183 pass, `bun run test:components` 56 pass, `bun run build` green. Integration suite runs in CI (needs E2E DB).

## Notes
- Old email-change/password-reset links issued before this deploy become invalid (missing purpose). TTL is 30 min, so blast radius is near zero.
- Feature-branch Vercel previews without `ADMIN_SESSION_SECRET` will return a clear 503 on editor login (staging + prod have the secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, session signing, password/email tokens, OAuth account linking, and live session enforcement on every privileged API call—misconfiguration (e.g. missing `ADMIN_SESSION_SECRET`) or a bug could lock out editors or weaken account security.
> 
> **Overview**
> Hardens **admin auth and account flows** after a security review: signed tokens and sessions no longer fall back to `ADMIN_PASSWORD`; email/password-reset links carry a **`purpose`** and state bindings so they are single-use and cannot be cross-used; OAuth linking only trusts **verified** emails; privileged routes **revalidate** the session cookie against the DB on every request; and **last-admin** demotions run under a transaction advisory lock.
> 
> **Editor/review behavior** also improves: history revert includes **`imageUrl`** for buildings, rooms, and dorms; **`event_locations`** proposals get real before/after diffs and published locations in `currentValues`; proposal image validation uses entity-specific labels via **`parseImageUrl`**.
> 
> All **`editorSessionOrUnauthorized`** call sites are updated to **`await`** the new async guard. Tests and E2E assertions are extended for token replay, purpose confusion, unverified OAuth email, and login error UI (`#admin-login-error`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec296f1004850c83619fe0dc0df1ca51f4156d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->