### PR TITLE
fix(e2e): unbreak post-#503 e2e — boot races + buried drawer handle

### DIFF
--- a/e2e/smoke/entity-pages.spec.ts
+++ b/e2e/smoke/entity-pages.spec.ts
@@ -12,14 +12,21 @@ test.describe("entity pages", () => {
     const res = await page.goto(buildingPagePath());
     expect(res?.status()).toBeLessThan(400);
     await expect(page.locator("body")).toContainText(E2E_FIXTURES.buildingName);
-    await expect(page.locator("body")).toContainText("3D view");
+    // Panel content renders only after the client app boots.
+    await waitForAppBoot(page);
+    await expect(page.locator("body")).toContainText("3D view", {
+      timeout: 30_000,
+    });
   });
 
   test("seeded room page 200", async ({ page }) => {
     const res = await page.goto(roomPagePath());
     expect(res?.status()).toBeLessThan(400);
     await expect(page.locator("body")).toContainText(E2E_FIXTURES.roomCode);
-    await expect(page.locator("body")).toContainText("Move in 3D");
+    await waitForAppBoot(page);
+    await expect(page.locator("body")).toContainText("Move in 3D", {
+      timeout: 30_000,
+    });
   });
 
   test("seeded event page 200", async ({ page }) => {

--- a/e2e/smoke/zoom-levels.spec.ts
+++ b/e2e/smoke/zoom-levels.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from "@playwright/test";
+import { campusSearchBox, waitForAppBoot } from "../helpers/app";
 
 test("Layout remains functional at 150% zoom", async ({ page }) => {
   await page.goto("/");
+  await waitForAppBoot(page);
 
   // Simulate 150% zoom (accessibility test)
   await page.evaluate(() => {
@@ -10,9 +12,7 @@ test("Layout remains functional at 150% zoom", async ({ page }) => {
   });
 
   // Check if main UI elements are still accessible
-  await expect(
-    page.locator("button.map-chrome-chip", { hasText: "Search" }),
-  ).toBeVisible();
+  await expect(campusSearchBox(page)).toBeVisible();
   await expect(page.locator("button.app-menu__trigger")).toBeVisible();
 
   // Open sidebar to ensure it doesn't break

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -258,7 +258,6 @@
     color: #7b1113;
     cursor: pointer;
     box-shadow: var(--map-chrome-shadow);
-    z-index: -1;
   }
   .drawer-handle:hover,
   .drawer-handle:focus-visible {


### PR DESCRIPTION
Every e2e run since #503 merged fails the same tests (see #505/#530 runs). #503 bundled UI commits and new e2e specs that never ran on CI (the `run/e2e` label was never applied to it).

Three fixes:
1. **zoom-levels.spec.ts** (new in #503): asserted a `button.map-chrome-chip` with text "Search" that doesn't exist (search is a searchbox), and raced app boot. Now waits for boot and asserts the real searchbox.
2. **entity-pages.spec.ts**: the new "3D view"/"Move in 3D" assertions race client boot with default 5s timeouts. Now `waitForAppBoot` first.
3. **MainControls.svelte**: #503 added `z-index: -1` to `.drawer-handle`, burying the collapse handle behind `.drawer-sheet` — unclickable on mobile Chrome, so every pin-drag/undo-redo test timed out at 4.5m. Removed; desktop drawer verified visually.

Verified locally against a CI-equivalent stack (node-adapter build, seeded e2e Postgres in podman): all previously-failing specs green on desktop-chrome + mobile-chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness and a small CSS stacking fix; no auth, data, or API behavior changes.
> 
> **Overview**
> Restores CI e2e stability after regressions from #503 by aligning tests with client boot timing, correcting search UI locators, and fixing a mobile drawer handle that could not receive clicks.
> 
> **E2E:** Building and room entity-page specs now call `waitForAppBoot` before asserting panel copy like **3D view** / **Move in 3D**, with a 30s timeout so assertions run after the Svelte shell finishes. The zoom-level smoke test waits for boot and targets the campus **searchbox** via `campusSearchBox` instead of a non-existent Search chip button.
> 
> **UI:** Removes `z-index: -1` from `.drawer-handle` in `MainControls.svelte` so the collapse control stays above the drawer sheet and remains clickable on mobile Chrome (unblocking pin-drag and undo/redo flows that were timing out).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ffe62a96fe4fdfe90e9c8a2a85b365fe4f63a31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->