### PR TITLE
test(integration): isolate rate-limit test in its own IP bucket

### DIFF
--- a/integration/http/admin-auth-rate-limit.integration.test.ts
+++ b/integration/http/admin-auth-rate-limit.integration.test.ts
@@ -24,6 +24,9 @@ describeIntegration("admin auth rate limit", () => {
         previewFetchInit({
           method: "POST",
           body: form,
+          // Isolated IP bucket: the 9 failed attempts here must not consume
+          // the shared runner IP's login budget for later suite logins.
+          headers: { "X-Forwarded-For": "203.0.113.77" },
         }),
       );
       lastStatus = res.status;


### PR DESCRIPTION
The admin-auth rate-limit test's 9 failed logins consume the shared runner IP's 12-attempt budget (`LOGIN_IP_LIMIT`), so any later integration test that logs in can flake with a 429 → null session cookie. This is what failed `admin PATCH HTTP > stale version returns 409` on #505's e2e rerun.

Fix: the test sends `X-Forwarded-For: 203.0.113.77` (TEST-NET), which `clientIp` trusts, so its attempts land in an isolated IP bucket. The 429 it asserts still triggers via the per-username limit (8 < 9 attempts).

Verified locally against a CI-equivalent preview with rate limiting enabled: full integration suite 40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production behavior impact; reduces integration flake from shared IP rate limits.
> 
> **Overview**
> The admin auth rate-limit integration test now sends **`X-Forwarded-For: 203.0.113.77`** (TEST-NET) on each failed login so those nine attempts use a **dedicated IP bucket** instead of the shared CI runner IP.
> 
> The test still expects **429** after repeated failures via the **per-username** limit; it no longer drains the suite-wide **`LOGIN_IP_LIMIT`** budget and causing later login-based tests to flake with 429.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1071333041c3a50dc97d0c77dd7d1fadee1445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->