### PR TITLE
feat(rooms): room purpose categories (#537 Phase 1)

### DIFF
--- a/drizzle/0023_add_room_category.sql
+++ b/drizzle/0023_add_room_category.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "rooms" ADD COLUMN IF NOT EXISTS "category" varchar(24);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -280,6 +280,7 @@ export const roomsTable = pgTable(
     collegeId: integer("college_id"),
     divisionId: integer("division_id"),
     imageUrl: text("image_url"),
+    category: varchar({ length: 24 }),
     version: integer().default(1).notNull(),
     updatedAt: timestamp("updated_at", { mode: "string" })
       .defaultNow()

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -48,6 +48,7 @@ const E2E_MIGRATION_FILES = [
   "0020_add_admin_user_email.sql",
   "0021_account_management.sql",
   "0022_history_summary_index.sql",
+  "0023_add_room_category.sql",
 ] as const;
 
 async function applyE2eMigrations(client: pg.Client) {

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -38,6 +38,11 @@
   import { getRoomShareUrl } from "@lib/share-links";
   import { ROOM_SCHEDULE_SCOPE_NOTE } from "@lib/amis/room-scheduled-types";
   import { fetchFinalExams, FINALS_SCOPE_NOTE } from "@lib/final-exams";
+  import {
+    ROOM_CATEGORIES,
+    ROOM_CATEGORY_LABELS,
+    roomCategoryLabel,
+  } from "@constants/room-categories";
   import type { FinalExamRow, RoomData } from "@lib/types";
   import Classes from "./Classes.svelte";
   import FinalExamsList from "./FinalExamsList.svelte";
@@ -48,7 +53,8 @@
     | "buildingId"
     | "collegeId"
     | "divisionId"
-    | "imageUrl";
+    | "imageUrl"
+    | "category";
 
   const appData = getAppData();
   const app = $derived(appData());
@@ -63,6 +69,7 @@
     collegeId: "College",
     divisionId: "Division",
     imageUrl: "Room photo",
+    category: "Room category",
   };
 
   let draftRoomId = $state<number | null>(null);
@@ -73,6 +80,7 @@
   let collegeDraft = $state("");
   let divisionDraft = $state("");
   let imageDraft = $state<string | null>(null);
+  let categoryDraft = $state("");
   let savingField = $state<RoomEditableField | null>(null);
   let savedField = $state<RoomEditableField | null>(null);
   let fieldError = $state<string | null>(null);
@@ -143,6 +151,7 @@
     collegeDraft = room.collegeId === null ? "" : String(room.collegeId);
     divisionDraft = room.divisionId === null ? "" : String(room.divisionId);
     imageDraft = room.imageUrl ?? null;
+    categoryDraft = room.category ?? "";
     savedField = null;
     fieldError = null;
     mergePrompt = null;
@@ -218,6 +227,7 @@
       collegeId?: number | null;
       divisionId?: number | null;
       imageUrl?: string | null;
+      category?: string | null;
     } = { version: room.version };
 
     if (field === "roomCode") {
@@ -237,6 +247,8 @@
       body.divisionId = selectValueToId(divisionDraft);
     } else if (field === "imageUrl") {
       body.imageUrl = imageDraft || null;
+    } else if (field === "category") {
+      body.category = categoryDraft || null;
     }
 
     savingField = field;
@@ -390,7 +402,8 @@
       directionsDraft.trim() === (room.directions ?? "") &&
       buildingDraft === String(room.buildingId ?? "") &&
       collegeDraft === String(room.collegeId ?? "") &&
-      divisionDraft === String(room.divisionId ?? "")
+      divisionDraft === String(room.divisionId ?? "") &&
+      categoryDraft === (room.category ?? "")
     );
   });
 
@@ -418,6 +431,9 @@
     }
     if (divisionDraft !== String(room.divisionId ?? "")) {
       patch.divisionId = selectValueToId(divisionDraft);
+    }
+    if (categoryDraft !== (room.category ?? "")) {
+      patch.category = categoryDraft || null;
     }
 
     savingField = "roomCode" as RoomEditableField;
@@ -489,6 +505,12 @@
       {/if}
 
       <h2 class="entity-header__title">{currentRoom.value.code}</h2>
+
+      {#if roomCategoryLabel(currentRoom.value.category)}
+        <span class="room-category-badge"
+          >{roomCategoryLabel(currentRoom.value.category)}</span
+        >
+      {/if}
 
       {#if currentRoom.value.collegeName}
         <p class="entity-header__context">
@@ -598,6 +620,29 @@
                 bind:value={directionsDraft}
                 disabled={savingField !== null}
                 rows="3"></textarea>
+            {/snippet}
+          </EntityEditorField>
+
+          <EntityEditorField
+            label="Room category"
+            inputId="room-category-editor"
+            {canPublish}
+            disabled={savingField !== null}
+            fieldSaving={savingField === "category"}
+            unchanged={categoryDraft === (currentRoom.value.category ?? "")}
+            onsave={() => saveField("category")}
+          >
+            {#snippet control()}
+              <select
+                id="room-category-editor"
+                bind:value={categoryDraft}
+                disabled={savingField !== null}
+              >
+                <option value="">Untagged (classroom)</option>
+                {#each ROOM_CATEGORIES as cat (cat)}
+                  <option value={cat}>{ROOM_CATEGORY_LABELS[cat]}</option>
+                {/each}
+              </select>
             {/snippet}
           </EntityEditorField>
 
@@ -856,6 +901,17 @@
   @import "../controls/entity-detail.css";
   @import "../editor/entity-editor.css";
   @import "../map-chrome/map-chrome.css";
+
+  .room-category-badge {
+    display: inline-block;
+    align-self: flex-start;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    background: hsl(5, 40%, 94%);
+    color: #7b1113;
+    font-size: 0.6875rem;
+    font-weight: 600;
+  }
 
   .merge-prompt {
     display: flex;

--- a/src/constants/room-categories.test.ts
+++ b/src/constants/room-categories.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ROOM_CATEGORIES,
+  normalizeRoomCategory,
+  roomCategoryLabel,
+} from "./room-categories.js";
+
+describe("normalizeRoomCategory", () => {
+  test("accepts known categories, case/space-insensitively", () => {
+    expect(normalizeRoomCategory("office")).toBe("office");
+    expect(normalizeRoomCategory(" Org-Tambayan ")).toBe("org-tambayan");
+    expect(normalizeRoomCategory("EVENT-VENUE")).toBe("event-venue");
+  });
+
+  test("rejects unknown/empty/non-string as null", () => {
+    expect(normalizeRoomCategory("dorm")).toBeNull();
+    expect(normalizeRoomCategory("")).toBeNull();
+    expect(normalizeRoomCategory(null)).toBeNull();
+    expect(normalizeRoomCategory(42)).toBeNull();
+  });
+
+  test("every listed category round-trips and has a label", () => {
+    for (const c of ROOM_CATEGORIES) {
+      expect(normalizeRoomCategory(c)).toBe(c);
+      expect(roomCategoryLabel(c)).toBeTruthy();
+    }
+  });
+
+  test("roomCategoryLabel returns null for untagged", () => {
+    expect(roomCategoryLabel(null)).toBeNull();
+    expect(roomCategoryLabel("nonsense")).toBeNull();
+  });
+});

--- a/src/constants/room-categories.ts
+++ b/src/constants/room-categories.ts
@@ -1,0 +1,38 @@
+/**
+ * Room purpose categories (#537). Independent of the LEC/LAB *class* type — a
+ * room is a physical space that may be a classroom, an office, an org tambayan,
+ * an event venue, etc. `null`/absent means untagged (treated as a classroom).
+ */
+export const ROOM_CATEGORIES = [
+  "classroom",
+  "laboratory",
+  "office",
+  "org-tambayan",
+  "event-venue",
+  "facility",
+] as const;
+
+export type RoomCategory = (typeof ROOM_CATEGORIES)[number];
+
+const ROOM_CATEGORY_SET = new Set<string>(ROOM_CATEGORIES);
+
+export const ROOM_CATEGORY_LABELS: Record<RoomCategory, string> = {
+  classroom: "Classroom",
+  laboratory: "Laboratory",
+  office: "Office",
+  "org-tambayan": "Org Tambayan",
+  "event-venue": "Event Venue",
+  facility: "Facility",
+};
+
+/** Normalize an arbitrary stored value to a known category, else null. */
+export function normalizeRoomCategory(value: unknown): RoomCategory | null {
+  if (typeof value !== "string") return null;
+  const v = value.trim().toLowerCase();
+  return ROOM_CATEGORY_SET.has(v) ? (v as RoomCategory) : null;
+}
+
+export function roomCategoryLabel(value: unknown): string | null {
+  const c = normalizeRoomCategory(value);
+  return c ? ROOM_CATEGORY_LABELS[c] : null;
+}

--- a/src/lib/local/data/pgliteDB.ts
+++ b/src/lib/local/data/pgliteDB.ts
@@ -90,6 +90,7 @@ export async function initPGLiteDB(db: PGlite) {
    	"building_id" integer,
    	"college_id" integer,
    	"division_id" integer,
+    "category" varchar(24),
     "version" integer NOT NULL DEFAULT 1,
     "updated_at" text NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "classes_fetched" boolean NOT NULL DEFAULT false
@@ -203,6 +204,9 @@ export async function initPGLiteDB(db: PGlite) {
 
     ALTER TABLE rooms
     ADD COLUMN IF NOT EXISTS "image_url" text;
+
+    ALTER TABLE rooms
+    ADD COLUMN IF NOT EXISTS "category" varchar(24);
 
     ALTER TABLE dorms
     ADD COLUMN IF NOT EXISTS "image_url" text;

--- a/src/lib/local/data/sync.ts
+++ b/src/lib/local/data/sync.ts
@@ -502,6 +502,7 @@ export async function getLocalBuildingRooms(id: number) {
     r.building_id as "buildingId",
     r.college_id as "collegeId",
     r.division_id as "divisionId",
+    r.category as category,
     r.version,
     r.updated_at as "updatedAt",
     rp.floor
@@ -568,8 +569,8 @@ export async function syncBuildingRooms(
     try {
       await localDB.query(
         `
-            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at, category)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT (id) DO UPDATE SET
             id = EXCLUDED.id,
             room_code = EXCLUDED.room_code,
@@ -579,7 +580,8 @@ export async function syncBuildingRooms(
             division_id = EXCLUDED.division_id,
             image_url = EXCLUDED.image_url,
             version = EXCLUDED.version,
-            updated_at = EXCLUDED.updated_at;
+            updated_at = EXCLUDED.updated_at,
+            category = EXCLUDED.category;
             `,
         [
           room.id,
@@ -591,6 +593,7 @@ export async function syncBuildingRooms(
           room.imageUrl ?? null,
           room.version,
           room.updatedAt,
+          room.category ?? null,
         ],
       );
     } catch (e) {
@@ -696,8 +699,8 @@ export async function syncCollegeRooms(
     try {
       await localDB.query(
         `
-            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at, category)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT (id) DO UPDATE SET
             id = EXCLUDED.id,
             room_code = EXCLUDED.room_code,
@@ -707,7 +710,8 @@ export async function syncCollegeRooms(
             division_id = EXCLUDED.division_id,
             image_url = EXCLUDED.image_url,
             version = EXCLUDED.version,
-            updated_at = EXCLUDED.updated_at;
+            updated_at = EXCLUDED.updated_at,
+            category = EXCLUDED.category;
             `,
         [
           room.id,
@@ -719,6 +723,7 @@ export async function syncCollegeRooms(
           room.imageUrl ?? null,
           room.version,
           room.updatedAt,
+          room.category ?? null,
         ],
       );
     } catch (e) {
@@ -824,8 +829,8 @@ export async function syncDivisionRooms(
     try {
       await localDB.query(
         `
-            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at, category)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT (id) DO UPDATE SET
             id = EXCLUDED.id,
             room_code = EXCLUDED.room_code,
@@ -835,7 +840,8 @@ export async function syncDivisionRooms(
             division_id = EXCLUDED.division_id,
             image_url = EXCLUDED.image_url,
             version = EXCLUDED.version,
-            updated_at = EXCLUDED.updated_at;
+            updated_at = EXCLUDED.updated_at,
+            category = EXCLUDED.category;
             `,
         [
           room.id,
@@ -847,6 +853,7 @@ export async function syncDivisionRooms(
           room.imageUrl ?? null,
           room.version,
           room.updatedAt,
+          room.category ?? null,
         ],
       );
     } catch (e) {

--- a/src/lib/local/data/utils.ts
+++ b/src/lib/local/data/utils.ts
@@ -217,6 +217,7 @@ export async function getLocalRoomByCode(code: string) {
             r.college_id as "collegeId",
             r.division_id as "divisionId",
             r.image_url as "imageUrl",
+            r.category as category,
             r.version,
             r.updated_at as "updatedAt"
             FROM rooms AS r
@@ -253,6 +254,7 @@ export async function getLocalRoomById(id: number) {
             r.college_id as "collegeId",
             r.division_id as "divisionId",
             r.image_url as "imageUrl",
+            r.category as category,
             r.version,
             r.updated_at as "updatedAt"
             FROM rooms AS r

--- a/src/lib/services/admin-service.ts
+++ b/src/lib/services/admin-service.ts
@@ -15,6 +15,7 @@ import {
   updateTable,
 } from "@drizzle/schema";
 import { normalizeEntityName } from "@lib/entity-names";
+import { normalizeRoomCategory } from "@constants/room-categories";
 import { db } from "@lib/db";
 import {
   buildingIsrPath,
@@ -190,6 +191,7 @@ export type RoomUpdateInput = {
   collegeId?: number | null;
   divisionId?: number | null;
   imageUrl?: string | null;
+  category?: string | null;
 };
 
 export async function findRoomMergeCandidate(
@@ -321,6 +323,8 @@ export async function updateRoom(
   if (input.divisionId !== undefined)
     updates.divisionId = input.divisionId ?? null;
   if (input.imageUrl !== undefined) updates.imageUrl = input.imageUrl;
+  if (input.category !== undefined)
+    updates.category = normalizeRoomCategory(input.category);
 
   if (Object.keys(updates).length > 0) {
     if (input.roomCode !== undefined) {

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -54,6 +54,7 @@ export async function getAllRoomsCached(): Promise<RoomData[]> {
       collegeId: roomsTable.collegeId,
       divisionId: roomsTable.divisionId,
       imageUrl: roomsTable.imageUrl,
+      category: roomsTable.category,
       version: roomsTable.version,
       updatedAt: roomsTable.updatedAt,
     })
@@ -119,6 +120,7 @@ export async function getAllRooms(): Promise<RoomData[]> {
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
         imageUrl: roomsTable.imageUrl,
+        category: roomsTable.category,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })
@@ -153,6 +155,7 @@ export async function getRoomByCode(code: string) {
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
         imageUrl: roomsTable.imageUrl,
+        category: roomsTable.category,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })
@@ -211,6 +214,7 @@ export async function getBuildingRooms(
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
         imageUrl: roomsTable.imageUrl,
+        category: roomsTable.category,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })
@@ -244,6 +248,7 @@ export async function getCollegeRooms(collegeId: number): Promise<RoomData[]> {
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
         imageUrl: roomsTable.imageUrl,
+        category: roomsTable.category,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })
@@ -279,6 +284,7 @@ export async function getDivisionRooms(
         collegeId: roomsTable.collegeId,
         divisionId: roomsTable.divisionId,
         imageUrl: roomsTable.imageUrl,
+        category: roomsTable.category,
         version: roomsTable.version,
         updatedAt: roomsTable.updatedAt,
       })

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -58,6 +58,8 @@ type RoomData = {
   collegeName: string | null;
   divisionName: string | null;
   imageUrl?: string | null;
+  /** Room purpose category (#537): classroom | office | org-tambayan | … | null. */
+  category?: string | null;
   version: number;
   updatedAt: string;
   floor?: number | null;


### PR DESCRIPTION
First slice of the map-integrated campus directory (#537).

Adds a nullable `rooms.category` column: **classroom | laboratory | office | org-tambayan | event-venue | facility**, independent of the LEC/LAB *class* type. A room can now be tagged as an org tambayan, office, or event venue.

Full vertical, following the dorm/room field pattern:
- Migration `0023_add_room_category.sql` (+ e2e-reset-db list, + PGlite offline schema & ADD COLUMN)
- `drizzle/schema.ts`, `RoomData` type
- Sync write + offline read (`sync.ts`, `utils.ts`), `map-data-service` fetch
- `updateRoom` with `normalizeRoomCategory` validation; flows through the existing room proposal path
- `RoomResult`: category badge in the detail header + inline editable `<select>` via the existing propose/review flow

Verified: `bun run test` (234), `bun run test:components` (73), `bun run build` all green; new `room-categories.test.ts` (4).

Next slices: admin-building data tagging (type already exists), then Places POI layer, then the org/office Directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive nullable column and UI with server-side category normalization; no auth or breaking API changes.
> 
> **Overview**
> Introduces **room purpose categories** (#537) as a nullable `rooms.category` column, separate from LEC/LAB class types. Allowed values are **classroom, laboratory, office, org-tambayan, event-venue, facility**; empty/null is treated as untagged (default classroom behavior).
> 
> The change is wired **end-to-end**: migration `0023_add_room_category.sql`, Drizzle schema, `RoomData` typing, **map-data-service** room queries, PGlite schema/sync/read paths, and E2E migration list. **`updateRoom`** accepts `category` and normalizes via `normalizeRoomCategory` (new `room-categories` constants + tests).
> 
> **RoomResult** shows a header badge when tagged and adds an editable category **select** in the existing propose/publish editor flow (per-field and bulk save).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a98410aef34eec91449b7a817c84d0162bc2302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->