### PR TITLE
fix(search): render browse chips in default state (unblocks staging-smoke)

### DIFF
--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -380,12 +380,13 @@
         </div>
       </div>
 
+      {#if chrome.showSearchSuggestions}
+        <div class="campus-browse-chips__container">
+          <CampusBrowseChips />
+        </div>
+      {/if}
+
       {#if showSearchDropdown}
-          <div class="campus-browse-chips__container">
-            {#if chrome.showSearchSuggestions}
-            <CampusBrowseChips />
-            {/if}
-          </div>
         <!-- svelte-ignore a11y_interactive_supports_focus -->
         <div
           id="search-suggestions"


### PR DESCRIPTION
Follow-up to #555. The search restructure gated the browse chips (Buildings/Colleges/Divisions/Classes + the "Browse buildings" control the staging smoke's `waitForAppBoot` depends on) behind `showSearchDropdown` (focus). That broke `staging-smoke` and regressed default-state browse access.

Now gated on `showSearchSuggestions` (renders by default); suggestions dropdown stays behind `showSearchDropdown`. Verified in-browser: "Browse buildings" visible unfocused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small layout/visibility change in search chrome only; no auth, data, or API impact.
> 
> **Overview**
> **Campus browse chips** (`CampusBrowseChips` — Buildings/Colleges/Divisions/Classes and **Browse buildings**) are no longer tied to the focused search suggestions dropdown.
> 
> They render whenever `chrome.showSearchSuggestions` is true, directly under the search bar. The **suggestions listbox** still only appears when `showSearchDropdown` is true (focused search, events/editor shelves closed).
> 
> This restores default-state browse access and unblocks **staging-smoke** / `waitForAppBoot`, which expect **Browse buildings** to be visible without focusing the input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87cbc4c269320746fd94da443637498ea444d8db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->