### PR TITLE
fix(search): restore map term selector (unblocks active-semester smoke)

### DIFF
--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -18,6 +18,7 @@
   import EventCards from "./EventCards.svelte";
   import Suggestions from "./Suggestions.svelte";
   import BuildingTypeFilterBar from "@ui/BuildingTypeFilterBar.svelte";
+  import TermSelector from "@ui/TermSelector.svelte";
   import TransitFilterChip from "@ui/TransitFilterChip.svelte";
   import TransitRoutePanel from "@ui/TransitRoutePanel.svelte";
   import { jeepneyStore, plannerStore } from "@lib/store.svelte";
@@ -383,6 +384,7 @@
       {#if chrome.showSearchSuggestions}
         <div class="campus-browse-chips__container">
           <CampusBrowseChips />
+          <TermSelector />
         </div>
       {/if}
 


### PR DESCRIPTION
Ken's c5c98b3 dropped the TermSelector from the map chrome (kept only in RoomResult); prod still shows it and the staging smoke expects it. Re-add it to the search chrome, grouped with browse chips like prod. Keeps his RoomResult selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI placement change reusing an existing component; no auth, data, or API changes.
> 
> **Overview**
> **Restores the semester/term picker on the map search chrome** by wiring `TermSelector` back into `Search.svelte`, next to `CampusBrowseChips` inside the browse-chips row when search suggestions chrome is visible.
> 
> This matches production layout and unblocks staging smoke that expects an active-semester control on the map. The separate `TermSelector` on room detail (`RoomResult`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ad8847797c97626f54cbf8354260205b43c543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->