### PR TITLE
feat: browsable + searchable campus orgs/offices directory (#14)

### DIFF
--- a/e2e/browse/campus-directory.spec.ts
+++ b/e2e/browse/campus-directory.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+import { waitForAppBoot, campusSearchBox } from "../helpers/app";
+import { searchSuggestions } from "../helpers/search";
+import { E2E_FIXTURES } from "../../scripts/e2e-reset-db";
+
+const orgPattern = new RegExp(E2E_FIXTURES.orgName, "i");
+
+test.describe("campus directory (orgs & offices)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await waitForAppBoot(page);
+  });
+
+  test("Orgs chip opens the directory listing the seeded org", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Browse orgs" }).click();
+    await expect(
+      page.getByRole("heading", { name: /Orgs & Offices/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("button", { name: orgPattern })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("selecting an org from the directory opens its detail panel", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Browse orgs" }).click();
+    await page.getByRole("button", { name: orgPattern }).first().click();
+    await expect(
+      page.getByRole("heading", { name: E2E_FIXTURES.orgName }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("searching an org name surfaces a suggestion that selects it", async ({
+    page,
+  }) => {
+    await campusSearchBox(page).fill(E2E_FIXTURES.orgName);
+    const suggestion = searchSuggestions(page)
+      .locator("button.suggestion")
+      .filter({ hasText: orgPattern })
+      .first();
+    await suggestion.waitFor({ state: "visible", timeout: 30_000 });
+    await suggestion.click({ timeout: 15_000 });
+    await expect(
+      page.getByRole("heading", { name: E2E_FIXTURES.orgName }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -16,6 +16,7 @@ const DEFAULT_E2E_PASSWORD = "e2e-test-password-change-me";
 export const E2E_FIXTURES = {
   buildingName: "E2E Test Hall",
   dormName: "E2E Test Dorm",
+  orgName: "E2E Test Office",
   roomCode: "E2E-101",
   eventSlug: "e2e-test-event",
   eventTitle: "E2E Test Event",
@@ -152,6 +153,14 @@ async function main() {
     const roomId = room.rows[0]?.id;
     if (!roomId) throw new Error("Failed to seed room");
 
+    const organization = await client.query<{ id: number }>(
+      `INSERT INTO organizations (name, category, building_id, description, version)
+       VALUES ($1, 'office', $2, 'E2E seeded office', 1) RETURNING id`,
+      [E2E_FIXTURES.orgName, buildingId],
+    );
+    const orgId = organization.rows[0]?.id;
+    if (!orgId) throw new Error("Failed to seed organization");
+
     await client.query(
       `INSERT INTO events (slug, title, description, category, starts_at, ends_at, timezone, recurrence, is_active, include_in_seo, version)
        VALUES ($1, $2, 'E2E event', 'other', NOW() + interval '1 day', NOW() + interval '2 days', 'Asia/Manila', 'none', true, true, 1)`,
@@ -198,6 +207,7 @@ async function main() {
       "events",
       "classes",
       "terms",
+      "organizations",
     ]) {
       await client.query(
         `INSERT INTO update (table_name, sync_key) VALUES ($1, gen_random_uuid())
@@ -214,6 +224,7 @@ async function main() {
         roomId,
         collegeId,
         divisionId,
+        orgId,
       }),
     );
   } finally {

--- a/src/components/svelte/controls/CampusBrowseList.svelte
+++ b/src/components/svelte/controls/CampusBrowseList.svelte
@@ -4,16 +4,24 @@
   import EntityPanelHeader from "./EntityPanelHeader.svelte";
   import { getAppData } from "@lib/context";
   import type { CampusBrowseTab } from "@lib/browse-campus";
+  import { orgCategoryLabel } from "@constants/org-categories";
   import { queryStore } from "@lib/store.svelte";
 
   const appData = getAppData();
-  const { buildings, colleges, divisions, loaded } = $derived(appData());
+  const { buildings, colleges, divisions, organizations, loaded } =
+    $derived(appData());
 
   let filterText = $state("");
 
   const activeTab = $derived.by((): CampusBrowseTab => {
     const value = queryStore.queryValue;
-    if (value === "colleges" || value === "divisions") return value;
+    if (
+      value === "colleges" ||
+      value === "divisions" ||
+      value === "organizations"
+    ) {
+      return value;
+    }
     return "buildings";
   });
 
@@ -23,6 +31,8 @@
         return "Colleges";
       case "divisions":
         return "Divisions";
+      case "organizations":
+        return "Orgs & Offices";
       default:
         return "Buildings";
     }
@@ -41,6 +51,12 @@
           noun: "division",
           plural: "divisions",
           placeholder: "Search divisions…",
+        };
+      case "organizations":
+        return {
+          noun: "org or office",
+          plural: "orgs & offices",
+          placeholder: "Search orgs & offices…",
         };
       default:
         return {
@@ -85,11 +101,22 @@
     );
   });
 
+  const filteredOrganizations = $derived.by(() => {
+    if (!loaded || !organizations) return [];
+    const needle = filterText.trim().toLowerCase();
+    const rows = [...organizations].sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+    if (!needle) return rows;
+    return rows.filter((row) => row.name.toLowerCase().includes(needle));
+  });
+
   const visibleItems = $derived.by(() => {
     if (activeTab === "colleges") {
       return filteredColleges.map((row) => ({
         id: row.id,
         label: row.collegeName,
+        meta: null as string | null,
         open: () => openCollege(row.collegeName),
       }));
     }
@@ -97,12 +124,22 @@
       return filteredDivisions.map((row) => ({
         id: row.id,
         label: row.divisionName,
+        meta: null as string | null,
         open: () => openDivision(row.divisionName),
+      }));
+    }
+    if (activeTab === "organizations") {
+      return filteredOrganizations.map((row) => ({
+        id: row.id,
+        label: row.name,
+        meta: orgCategoryLabel(row.category),
+        open: () => openOrg(row.name),
       }));
     }
     return filteredBuildings.map((row) => ({
       id: row.id,
       label: row.buildingName,
+      meta: null as string | null,
       open: () => openBuilding(row.buildingName),
     }));
   });
@@ -142,6 +179,15 @@
   function openDivision(name: string) {
     queryStore.updateQuery({
       category: "division",
+      type: "result",
+      value: name,
+    });
+    queryStore.inputValue = name;
+  }
+
+  function openOrg(name: string) {
+    queryStore.updateQuery({
+      category: "organization",
       type: "result",
       value: name,
     });
@@ -192,6 +238,9 @@
               onclick={item.open}
             >
               <span class="entity-list-row__label">{item.label}</span>
+              {#if item.meta}
+                <span class="entity-list-row__meta">{item.meta}</span>
+              {/if}
               <ChevronRight
                 size={16}
                 aria-hidden="true"
@@ -215,6 +264,18 @@
     height: 100%;
     min-height: 0;
     font-family: inherit;
+  }
+
+  .entity-list-row__meta {
+    flex-shrink: 0;
+    margin-left: auto;
+    padding: 0.0625rem 0.4375rem;
+    border-radius: 999px;
+    background: hsl(5, 30%, 94%);
+    color: hsl(5, 40%, 34%);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    white-space: nowrap;
   }
 
 

--- a/src/components/svelte/search/CampusBrowseChips.svelte
+++ b/src/components/svelte/search/CampusBrowseChips.svelte
@@ -3,6 +3,7 @@
   import GraduationCap from "@lucide/svelte/icons/graduation-cap";
   import Landmark from "@lucide/svelte/icons/landmark";
   import University from "@lucide/svelte/icons/university";
+  import Users from "@lucide/svelte/icons/users";
   import {
     openBrowseClasses,
     openCampusBrowse,
@@ -21,6 +22,7 @@
     { id: "buildings", label: "Buildings", icon: University },
     { id: "colleges", label: "Colleges", icon: GraduationCap },
     { id: "divisions", label: "Divisions", icon: Landmark },
+    { id: "organizations", label: "Orgs", icon: Users },
     { id: "classes", label: "Classes", icon: BookText },
     // Planner is pinned as a standalone always-visible chip in Search.svelte.
   ];
@@ -30,7 +32,8 @@
     if (queryStore.category !== "browse") return null;
     if (
       queryStore.queryValue === "colleges" ||
-      queryStore.queryValue === "divisions"
+      queryStore.queryValue === "divisions" ||
+      queryStore.queryValue === "organizations"
     ) {
       return queryStore.queryValue;
     }

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -300,7 +300,7 @@
                 aria-controls="search-suggestions"
                 aria-autocomplete="list"
                 aria-haspopup="listbox"
-                placeholder="Search room, building, dorm, event, division..."
+                placeholder="Search room, building, org, event, division..."
               />
               {#if draftInput !== "" || queryStore.category !== null}
                 <button

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -20,7 +20,7 @@
   import Suggestion from "./Suggestion.svelte";
 
   const appData = getAppData();
-  const { buildings, colleges, divisions, dorms, events, loaded } =
+  const { buildings, colleges, divisions, dorms, events, organizations, loaded } =
     $derived(appData());
 
   const filteredDorms = $derived.by(() => {
@@ -48,6 +48,7 @@
       colleges,
       divisions,
       events,
+      organizations,
     }),
   );
 

--- a/src/lib/browse-campus-shared.ts
+++ b/src/lib/browse-campus-shared.ts
@@ -1,4 +1,8 @@
-export type CampusBrowseTab = "buildings" | "colleges" | "divisions";
+export type CampusBrowseTab =
+  | "buildings"
+  | "colleges"
+  | "divisions"
+  | "organizations";
 
 export function campusBrowseQuery(tab: CampusBrowseTab) {
   return {

--- a/src/lib/search-suggestions.ts
+++ b/src/lib/search-suggestions.ts
@@ -1,4 +1,4 @@
-import type { BuildingData, DormData, EventData } from "./types";
+import type { BuildingData, DormData, EventData, OrgData } from "./types";
 import type { QueryStoreState } from "./store.svelte";
 
 type Suggestion = {
@@ -35,6 +35,7 @@ export function buildEntitySuggestions(
     colleges: { collegeName: string }[];
     divisions: { divisionName: string }[];
     events: EventData[];
+    organizations: OrgData[];
   },
 ): Suggestion[] {
   const needle = searchString.trim().toLowerCase();
@@ -74,6 +75,13 @@ export function buildEntitySuggestions(
         eventSlug: e.slug,
         event: e,
       }),
+    ),
+    ...takeMatches(
+      data.organizations,
+      ({ name, description }) =>
+        name.toLowerCase().includes(needle) ||
+        Boolean(description?.toLowerCase().includes(needle)),
+      ({ name }) => ({ value: name, category: "organization" }),
     ),
   ];
 


### PR DESCRIPTION
Completes the #537 org/office directory. Orgs were previously map-pin + detail-panel only (reachable only by clicking a marker). This adds the two missing discovery surfaces, reusing the existing `category="organization"` selection wiring.

## What's new
- **Browse directory**: an "Orgs & Offices" tab in `CampusBrowseList` + an "Orgs" browse chip. Lists every org/office alphabetically with its category badge; selecting one opens the existing `OrgResult` detail panel.
- **Search**: organizations now appear in search suggestions (`buildEntitySuggestions`), matched by name or description.
- Search placeholder mentions orgs.

## Tests
- `e2e/browse/campus-directory.spec.ts` (3 tests): browse-open lists the org, list-select opens the panel, search-select opens the panel. All green.
- Full `e2e/browse` suite: 24 passed, 0 regressions.
- Component 73/73, unit 250/250, build clean.
- `e2e-reset-db` seeds an "E2E Test Office" org fixture + syncs the organizations table.

## Not in scope (follow-ups)
- Places (food/landmarks POIs) in search/browse — separate concept from the org directory.
- Map category filter toggles for org/place pins (#18b).
- Org/place creation UI + places admin write route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing discovery UI and test fixtures only; no auth, API, or data-model changes beyond E2E seeding.
> 
> **Overview**
> Adds **browse** and **search** paths for campus orgs/offices, reusing the existing `category="organization"` selection that already drives the org detail panel from map pins.
> 
> Users get an **Orgs** browse chip and an **Orgs & Offices** tab in `CampusBrowseList`: alphabetical list, in-tab filter, category badge per row, and row click opens the org result panel. `CampusBrowseTab` and chip active-state handling now include `organizations`.
> 
> **Search** includes organizations in `buildEntitySuggestions` (name and description), wires `organizations` through `Suggestions.svelte`, and updates the search placeholder to mention orgs.
> 
> E2E support seeds **E2E Test Office** in `e2e-reset-db`, syncs the `organizations` table, and adds `campus-directory.spec.ts` for browse list, selection, and search-to-panel flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a1dfd68b8c0855d91682c9b354855809ce4a9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->