### PR TITLE
release: searchable places (POIs) (#14 discovery)

### DIFF
--- a/e2e/browse/campus-directory.spec.ts
+++ b/e2e/browse/campus-directory.spec.ts
@@ -1,11 +1,21 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { waitForAppBoot, campusSearchBox } from "../helpers/app";
 import { searchSuggestions } from "../helpers/search";
 import { E2E_FIXTURES } from "../../scripts/e2e-reset-db";
 
 const orgPattern = new RegExp(E2E_FIXTURES.orgName, "i");
+const placePattern = new RegExp(E2E_FIXTURES.placeName, "i");
 
-test.describe("campus directory (orgs & offices)", () => {
+// The entity name also appears as a map-pin button, so scope directory
+// interactions to the browse list rows (button.entity-list-row) specifically.
+function directoryRow(page: Page, pattern: RegExp) {
+  return page
+    .locator("button.entity-list-row")
+    .filter({ hasText: pattern })
+    .first();
+}
+
+test.describe("campus directory (orgs, offices, places)", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     await waitForAppBoot(page);
@@ -18,7 +28,7 @@ test.describe("campus directory (orgs & offices)", () => {
     await expect(
       page.getByRole("heading", { name: /Orgs & Offices/i }),
     ).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByRole("button", { name: orgPattern })).toBeVisible({
+    await expect(directoryRow(page, orgPattern)).toBeVisible({
       timeout: 10_000,
     });
   });
@@ -27,7 +37,7 @@ test.describe("campus directory (orgs & offices)", () => {
     page,
   }) => {
     await page.getByRole("button", { name: "Browse orgs" }).click();
-    await page.getByRole("button", { name: orgPattern }).first().click();
+    await directoryRow(page, orgPattern).click({ timeout: 15_000 });
     await expect(
       page.getByRole("heading", { name: E2E_FIXTURES.orgName }),
     ).toBeVisible({ timeout: 10_000 });
@@ -45,6 +55,21 @@ test.describe("campus directory (orgs & offices)", () => {
     await suggestion.click({ timeout: 15_000 });
     await expect(
       page.getByRole("heading", { name: E2E_FIXTURES.orgName }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("searching a place name surfaces a suggestion that selects it", async ({
+    page,
+  }) => {
+    await campusSearchBox(page).fill(E2E_FIXTURES.placeName);
+    const suggestion = searchSuggestions(page)
+      .locator("button.suggestion")
+      .filter({ hasText: placePattern })
+      .first();
+    await suggestion.waitFor({ state: "visible", timeout: 30_000 });
+    await suggestion.click({ timeout: 15_000 });
+    await expect(
+      page.getByRole("heading", { name: E2E_FIXTURES.placeName }),
     ).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/e2e/smoke/planner-route.spec.ts
+++ b/e2e/smoke/planner-route.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+import { suppressLandingModal } from "../helpers/app";
+
+// /planner is a deep link that must open the Class Planner overlay directly.
+// Without a blocking e2e this route silently breaks (cf. app-menu regressions).
+// The planner is a full-screen dialog that covers the map chrome, so we wait on
+// the loading shell detaching rather than waitForAppBoot (which needs the map).
+async function waitForPlannerBoot(page: import("@playwright/test").Page) {
+  const shell = page.locator("#app-loading-shell");
+  if ((await shell.count()) > 0) {
+    await shell.waitFor({ state: "detached", timeout: 120_000 });
+  }
+}
+
+test.describe("planner route", () => {
+  test("/planner opens the Class Planner with the change-of-matriculation disclaimer", async ({
+    page,
+  }) => {
+    await suppressLandingModal(page);
+    await page.goto("/planner");
+    await waitForPlannerBoot(page);
+
+    const planner = page.getByRole("dialog", { name: "Class Planner" });
+    await expect(planner).toBeVisible();
+    await expect(planner.getByText(/change of matriculation/i)).toBeVisible();
+  });
+
+  test("/planner?term still opens the planner", async ({ page }) => {
+    await suppressLandingModal(page);
+    await page.goto("/planner?term=1252");
+    await waitForPlannerBoot(page);
+
+    await expect(
+      page.getByRole("dialog", { name: "Class Planner" }),
+    ).toBeVisible();
+  });
+});

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -17,6 +17,7 @@ export const E2E_FIXTURES = {
   buildingName: "E2E Test Hall",
   dormName: "E2E Test Dorm",
   orgName: "E2E Test Office",
+  placeName: "E2E Test Cafe",
   roomCode: "E2E-101",
   eventSlug: "e2e-test-event",
   eventTitle: "E2E Test Event",
@@ -102,6 +103,8 @@ async function main() {
         room_positions,
         rooms,
         aliases,
+        organizations,
+        places,
         buildings,
         dorms,
         divisions,
@@ -161,6 +164,18 @@ async function main() {
     const orgId = organization.rows[0]?.id;
     if (!orgId) throw new Error("Failed to seed organization");
 
+    const place = await client.query<{ id: number }>(
+      `INSERT INTO places (name, category, lat, lon, description, version)
+       VALUES ($1, 'food', $2, $3, 'E2E seeded place', 1) RETURNING id`,
+      [
+        E2E_FIXTURES.placeName,
+        E2E_FIXTURES.buildingLat,
+        E2E_FIXTURES.buildingLon,
+      ],
+    );
+    const placeId = place.rows[0]?.id;
+    if (!placeId) throw new Error("Failed to seed place");
+
     await client.query(
       `INSERT INTO events (slug, title, description, category, starts_at, ends_at, timezone, recurrence, is_active, include_in_seo, version)
        VALUES ($1, $2, 'E2E event', 'other', NOW() + interval '1 day', NOW() + interval '2 days', 'Asia/Manila', 'none', true, true, 1)`,
@@ -208,6 +223,7 @@ async function main() {
       "classes",
       "terms",
       "organizations",
+      "places",
     ]) {
       await client.query(
         `INSERT INTO update (table_name, sync_key) VALUES ($1, gen_random_uuid())
@@ -225,6 +241,7 @@ async function main() {
         collegeId,
         divisionId,
         orgId,
+        placeId,
       }),
     );
   } finally {

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -57,6 +57,7 @@
   type MetadataProps = {
     initialSearch?: InitialSearchState;
     suppressLandingModal?: boolean;
+    openPlanner?: boolean;
   };
   const metadata: MetadataProps = $props();
 
@@ -502,4 +503,5 @@
 <Entry
   initialSearch={metadata.initialSearch}
   suppressLandingModal={metadata.suppressLandingModal ?? false}
+  openPlanner={metadata.openPlanner ?? false}
 />

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -50,9 +50,14 @@
   type Props = {
     initialSearch?: InitialSearchState;
     suppressLandingModal?: boolean;
+    openPlanner?: boolean;
   };
 
-  const { initialSearch, suppressLandingModal = false }: Props = $props();
+  const {
+    initialSearch,
+    suppressLandingModal = false,
+    openPlanner = false,
+  }: Props = $props();
 
   const updateData = (queryHistory: RecentSearch[]) => {
     localStorage.setItem("recent-search", JSON.stringify(queryHistory));
@@ -129,6 +134,15 @@
     }
 
     plannerStore.init();
+
+    // /planner deep link (prop set by the planner.astro page). Driven by a prop,
+    // not window.location, because the SPA URL router normalizes the path to "/"
+    // on boot before this runs. ?term still flows through termStore.
+    if (openPlanner) {
+      void termStore.init();
+      plannerStore.openPlanner();
+    }
+
     const planParam = urlParams.get("plan");
     if (planParam) {
       window.history.replaceState({}, "", window.location.pathname);

--- a/src/components/svelte/planner/PlannerScreen.svelte
+++ b/src/components/svelte/planner/PlannerScreen.svelte
@@ -10,6 +10,7 @@
     toastStore,
   } from "@lib/store.svelte";
   import { fetchClassPage } from "@lib/classes-api";
+  import { COURSE_CHANGE_DISCLAIMER } from "@lib/amis/room-scheduled-types";
   import { fetchFinalExams, FINALS_SCOPE_NOTE } from "@lib/final-exams";
   import { isUnscheduled } from "@lib/planner/conflicts";
   import { buildPlanIcs } from "@lib/planner/ics";
@@ -209,6 +210,8 @@
         </button>
       {/if}
     </header>
+
+    <p class="planner-disclaimer" role="note">{COURSE_CHANGE_DISCLAIMER}</p>
 
     <div class="planner-tabs" role="tablist" aria-label="Plans">
       {#each plannerStore.plansForTerm as tabPlan (tabPlan.id)}
@@ -438,6 +441,18 @@
   .planner-action:hover,
   .planner-action:focus-visible {
     background: hsl(5, 53%, 96%);
+  }
+
+  .planner-disclaimer {
+    flex-shrink: 0;
+    margin: 0;
+    padding: 0.4375rem 0.75rem;
+    background: hsl(38, 92%, 95%);
+    border-bottom: 1px solid hsl(38, 70%, 85%);
+    color: hsl(32, 60%, 30%);
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1.35;
   }
 
   .planner-tabs {

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -20,8 +20,16 @@
   import Suggestion from "./Suggestion.svelte";
 
   const appData = getAppData();
-  const { buildings, colleges, divisions, dorms, events, organizations, loaded } =
-    $derived(appData());
+  const {
+    buildings,
+    colleges,
+    divisions,
+    dorms,
+    events,
+    organizations,
+    places,
+    loaded,
+  } = $derived(appData());
 
   const filteredDorms = $derived.by(() => {
     if (!loaded) return [];
@@ -49,6 +57,7 @@
       divisions,
       events,
       organizations,
+      places,
     }),
   );
 

--- a/src/lib/amis/room-scheduled-types.ts
+++ b/src/lib/amis/room-scheduled-types.ts
@@ -32,6 +32,14 @@ export const NON_ROOM_CLASS_TYPES: Readonly<
 export const ROOM_SCHEDULE_SCOPE_NOTE =
   "Schedules list lecture and lab sections with assigned rooms. Thesis, special problem, dissertation, and similar sections usually are not tied to a room in AMIS, so they do not appear here.";
 
+/**
+ * Disclaimer for course/section data during enrollment. Offerings are not final
+ * until the last day of change of matriculation. Kept date-free on purpose so it
+ * stays correct across terms.
+ */
+export const COURSE_CHANGE_DISCLAIMER =
+  "Course offerings may still change up to the last day of change of matriculation.";
+
 export function isRoomScheduledClassType(type: string | null | undefined) {
   if (!type) return false;
   return ROOM_SCHEDULED_CLASS_TYPES.has(type.trim().toUpperCase());

--- a/src/lib/search-suggestions.ts
+++ b/src/lib/search-suggestions.ts
@@ -1,4 +1,10 @@
-import type { BuildingData, DormData, EventData, OrgData } from "./types";
+import type {
+  BuildingData,
+  DormData,
+  EventData,
+  OrgData,
+  PlaceData,
+} from "./types";
 import type { QueryStoreState } from "./store.svelte";
 
 type Suggestion = {
@@ -36,6 +42,7 @@ export function buildEntitySuggestions(
     divisions: { divisionName: string }[];
     events: EventData[];
     organizations: OrgData[];
+    places: PlaceData[];
   },
 ): Suggestion[] {
   const needle = searchString.trim().toLowerCase();
@@ -82,6 +89,13 @@ export function buildEntitySuggestions(
         name.toLowerCase().includes(needle) ||
         Boolean(description?.toLowerCase().includes(needle)),
       ({ name }) => ({ value: name, category: "organization" }),
+    ),
+    ...takeMatches(
+      data.places,
+      ({ name, description }) =>
+        name.toLowerCase().includes(needle) ||
+        Boolean(description?.toLowerCase().includes(needle)),
+      ({ name }) => ({ value: name, category: "place" }),
     ),
   ];
 

--- a/src/pages/planner.astro
+++ b/src/pages/planner.astro
@@ -1,0 +1,33 @@
+---
+import AppRoot from "@ui/AppRoot.svelte";
+import Layout from "@layouts/Layout.astro";
+import {
+  breadcrumbSchema,
+  jsonLd,
+  webpageSchema,
+  websiteSchema,
+} from "@lib/site";
+
+// Deep link to the class planner: /planner?term=<crs_id>. Entry.svelte opens
+// the planner on this path; the term comes from ?term via termStore.
+const title = "Class Planner | Room TBA";
+const description =
+  "Plan your UPLB class schedule: add sections by term, spot conflicts, and export to your calendar.";
+const structuredData = jsonLd(
+  websiteSchema(),
+  webpageSchema({ title, description, path: "/planner" }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Class Planner", path: "/planner" },
+  ]),
+);
+---
+
+<Layout
+  title={title}
+  description={description}
+  canonicalPath="/planner"
+  structuredData={structuredData}
+>
+  <AppRoot client:only="svelte" openPlanner suppressLandingModal />
+</Layout>


### PR DESCRIPTION
Promotes searchable places (#565) to production. Places now appear in search suggestions (by name/description) and open the existing PlaceResult panel.

CI: `verify` + `bundle` green. `e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret (breaks CI DB reset); verified locally against the real E2E DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly search UX, a dedicated planner page, informational copy, and test/seed updates; no auth or data-model changes beyond E2E fixtures.
> 
> **Overview**
> **Searchable places (POIs)** now appear in campus search suggestions when name or description matches, using the existing `place` result flow. `Suggestions.svelte` passes `places` into `buildEntitySuggestions`, which adds a `place` category alongside orgs and events.
> 
> **`/planner` deep link:** New `planner.astro` renders the app with `openPlanner` and `suppressLandingModal`. `AppRoot` → `Entry` opens the Class Planner on mount via that prop (not `window.location`, since the SPA normalizes to `/` before boot). `?term` still goes through `termStore`.
> 
> **Class Planner** shows a shared **change-of-matriculation** disclaimer (`COURSE_CHANGE_DISCLAIMER`) at the top of the planner UI.
> 
> **E2E:** E2E DB reset seeds a test place and includes `places`/`organizations` in truncate/sync. Campus directory tests target `button.entity-list-row` so org names don’t collide with map-pin buttons; new coverage for place search suggestions. New smoke spec asserts `/planner` and `/planner?term` open the Class Planner dialog and show the disclaimer text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de7fc015ec9368e271a1affb59f877f92b8a113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->