### PR TITLE
release: offline orgs/places directory sync (#18a)

### DIFF
--- a/src/lib/local/data/campus-directory-sync.test.ts
+++ b/src/lib/local/data/campus-directory-sync.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Record which sync functions the offline directory download invokes.
+const calls: string[] = [];
+
+const emptyLoad = () => Promise.resolve({ rows: [], source: "local" as const });
+const oneRowLoad = () =>
+  Promise.resolve({ rows: [{ id: 1 }], source: "remote" as const });
+const syncSpy = (name: string) => () => {
+  calls.push(name);
+  return Promise.resolve();
+};
+
+mock.module("./utils", () => ({
+  getBuildings: emptyLoad,
+  getColleges: emptyLoad,
+  getDivisions: emptyLoad,
+  getDorms: emptyLoad,
+  // Non-empty so the org/place sync branches actually run.
+  getOrganizations: oneRowLoad,
+  getPlaces: oneRowLoad,
+  getBuildingRooms: emptyLoad,
+  getCollegeRooms: emptyLoad,
+  getDivisionRooms: emptyLoad,
+}));
+
+mock.module("./sync", () => ({
+  localTableSyncCheck: () => Promise.resolve({ newKey: "k", localKey: null }),
+  checkLocalBuildingRoom: () => Promise.resolve(false),
+  checkLocalCollegeRoom: () => Promise.resolve(false),
+  checkLocalDivisionRoom: () => Promise.resolve(false),
+  syncAliasCache: syncSpy("aliases"),
+  syncBuildingRooms: syncSpy("buildingRooms"),
+  syncBuildings: syncSpy("buildings"),
+  syncCollegeRooms: syncSpy("collegeRooms"),
+  syncColleges: syncSpy("colleges"),
+  syncDivisionRooms: syncSpy("divisionRooms"),
+  syncDivisions: syncSpy("divisions"),
+  syncDorms: syncSpy("dorms"),
+  syncOrganizations: syncSpy("organizations"),
+  syncPlaces: syncSpy("places"),
+}));
+
+const { syncCampusDirectoryForOffline } = await import(
+  "./campus-directory-sync"
+);
+
+describe("syncCampusDirectoryForOffline", () => {
+  beforeEach(() => {
+    calls.length = 0;
+    globalThis.localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } as unknown as Storage;
+  });
+
+  afterEach(() => {
+    calls.length = 0;
+  });
+
+  test("downloads organizations and places for offline use", async () => {
+    const result = await syncCampusDirectoryForOffline();
+    expect(result.ok).toBe(true);
+    // The whole point of #14: orgs/places must be part of the offline directory.
+    expect(calls).toContain("organizations");
+    expect(calls).toContain("places");
+  });
+});

--- a/src/lib/local/data/campus-directory-sync.ts
+++ b/src/lib/local/data/campus-directory-sync.ts
@@ -4,6 +4,8 @@ import {
   getColleges,
   getDivisions,
   getDorms,
+  getOrganizations,
+  getPlaces,
   getBuildingRooms,
   getCollegeRooms,
   getDivisionRooms,
@@ -21,6 +23,8 @@ import {
   syncDivisionRooms,
   syncDivisions,
   syncDorms,
+  syncOrganizations,
+  syncPlaces,
 } from "./sync";
 
 export const OFFLINE_DIRECTORY_SYNCED_AT_KEY = "offline-directory-synced-at";
@@ -40,21 +44,37 @@ export async function syncCampusDirectoryForOffline(options?: {
   };
 
   try {
-    const [buildingCheck, collegeCheck, divisionCheck, dormCheck] =
-      await Promise.all([
-        localTableSyncCheck("buildings"),
-        localTableSyncCheck("colleges"),
-        localTableSyncCheck("divisions"),
-        localTableSyncCheck("dorms"),
-      ]);
+    const [
+      buildingCheck,
+      collegeCheck,
+      divisionCheck,
+      dormCheck,
+      organizationCheck,
+      placeCheck,
+    ] = await Promise.all([
+      localTableSyncCheck("buildings"),
+      localTableSyncCheck("colleges"),
+      localTableSyncCheck("divisions"),
+      localTableSyncCheck("dorms"),
+      localTableSyncCheck("organizations"),
+      localTableSyncCheck("places"),
+    ]);
 
-    const [buildingLoad, collegeLoad, divisionLoad, dormLoad] =
-      await Promise.all([
-        getBuildings(buildingCheck),
-        getColleges(collegeCheck),
-        getDivisions(divisionCheck),
-        getDorms(dormCheck),
-      ]);
+    const [
+      buildingLoad,
+      collegeLoad,
+      divisionLoad,
+      dormLoad,
+      organizationLoad,
+      placeLoad,
+    ] = await Promise.all([
+      getBuildings(buildingCheck),
+      getColleges(collegeCheck),
+      getDivisions(divisionCheck),
+      getDorms(dormCheck),
+      getOrganizations(organizationCheck),
+      getPlaces(placeCheck),
+    ]);
 
     report({
       phase: "entities",
@@ -79,6 +99,12 @@ export async function syncCampusDirectoryForOffline(options?: {
       divisionLoad.source === "remote",
     );
     await syncDorms(dormCheck, dormLoad.rows, dormLoad.source === "remote");
+    await syncOrganizations(
+      organizationCheck,
+      organizationLoad.rows,
+      organizationLoad.source === "remote",
+    );
+    await syncPlaces(placeCheck, placeLoad.rows, placeLoad.source === "remote");
 
     const roomTargets: Array<{
       kind: "building" | "college" | "division";


### PR DESCRIPTION
Promotes offline directory sync for orgs/places (#567) to production. The "Download campus directory" button now includes organizations + places, so the directory and place search work offline.

CI: `verify` + `bundle` + Vercel green. `e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive wiring of existing sync helpers into the offline flow; no auth or API surface changes beyond richer local cache.
> 
> **Overview**
> **Offline campus directory download** now syncs **organizations** and **places** alongside buildings, colleges, divisions, and dorms, so directory and place search can work without network.
> 
> `syncCampusDirectoryForOffline` runs `localTableSyncCheck` and `getOrganizations` / `getPlaces`, then calls existing `syncOrganizations` and `syncPlaces` in the entities phase. A new Bun test mocks dependencies and asserts those sync paths run when org/place data is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51767dc3323e13fabcc080da8bd2852ada356b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->