### PR TITLE
fix(planner): exclude /planner from PWA navigate fallback

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,6 +42,10 @@ export default defineConfig({
           /^\/privacy(\/|$)/,
           /^\/terms(\/|$)/,
           /^\/changelog(\/|$)/,
+          // /planner is its own page; without this the nav fallback serves the
+          // map shell and the planner never opens for returning (SW-cached)
+          // users. Network-first; the in-app planner button covers offline.
+          /^\/planner(\/|$)/,
           // Server redirects — must hit network, not offline app shell (#471).
           /^\/messenger(\/|$)/,
           /^\/maintain(\/|$)/,


### PR DESCRIPTION
## Problem
`/planner` opens for first-time visitors but not for returning (service-worker-cached) users. The workbox `navigateFallback: "/"` serves the precached map shell for every navigation; `/planner` was not in `navigateFallbackDenylist`, so the SW served the map instead of `planner.astro` and the planner never auto-opened.

## Fix
Add `/^\/planner(\/|$)/` to `navigateFallbackDenylist`, mirroring `/privacy`, `/terms`, `/changelog`. `/planner` now hits the network → `planner.astro` → planner opens. In-app planner button still covers offline.

## Note
Returning users pick up the new service worker via the existing refresh prompt (or a hard reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single PWA routing denylist entry with no changes to auth, APIs, or data handling; users need the updated service worker to pick up the fix.
> 
> **Overview**
> Fixes a regression where **returning users with an active service worker** navigated to `/planner` but saw the precached map shell instead of the dedicated planner route, so the Class Planner deep link never auto-opened.
> 
> Adds `/^\/planner(\/|$)/` to Workbox **`navigateFallbackDenylist`** in `astro.config.mjs`, same pattern as `/privacy`, `/terms`, and `/changelog`. Those navigations now go to the network and load `planner.astro`; offline use is still covered by the in-app planner entry point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6c0c88a39ee1cf82352c300ee479ef17709b63a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->