### PR TITLE
fix: read one-shot URL params before EntityUrlSync strips them

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -62,6 +62,14 @@
   const updateData = (queryHistory: RecentSearch[]) => {
     localStorage.setItem("recent-search", JSON.stringify(queryHistory));
   };
+
+  // Capture one-shot URL params (editor=login, auth_error, account, share
+  // codes) at script init. Child components like EntityUrlSync normalize the
+  // URL in their onMount, which fires before this parent component's onMount,
+  // so reading window.location.search there would see an already-stripped URL.
+  const initialUrlSearch =
+    typeof window !== "undefined" ? window.location.search : "";
+
   onMount(() => {
     const recentSearchesLS = localStorage.getItem("recent-search");
     try {
@@ -83,7 +91,7 @@
       });
     }
 
-    const urlParams = new URLSearchParams(window.location.search);
+    const urlParams = new URLSearchParams(initialUrlSearch);
 
     if (urlParams.get("editor") === "login") {
       adminAuthStore.openLogin();


### PR DESCRIPTION
## Regression (self-caused, on prod via #562)
Removing the `termStore.init()` gate around EntityUrlSync's controller made its `init()` run synchronously in onMount. EntityUrlSync is a **child** of Entry, so its onMount fires **before** Entry's onMount — and `init()`'s `replaceState` (via `withTermQuery`, term param only) stripped `?editor=login`, `?auth_error`, `?account`, `?contribute`, and `?plan` share codes before Entry read them. Result: the sign-in dialog and share-plan import silently stopped opening from those links.

## Fix
Capture `window.location.search` at Entry's **script init** (runs before any child component exists) and read the one-shot params from that snapshot.

## Test
- Fixes `e2e/smoke/redirects.spec.ts` "/?editor=login opens login dialog" (was failing consistently, now `redirects` 7/7 green).

## CI note
`e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret; `verify` + `bundle` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bootstrap timing fix with no auth or data-model changes; restores intended deep-link behavior.
> 
> **Overview**
> Fixes a regression where deep links with one-shot query params (`?editor=login`, `?auth_error`, account events, `?contribute=1`, `?plan=…`) stopped opening the login dialog, account toasts, suggest-addition panel, and shared plan import.
> 
> **`Entry.svelte`** now stores `window.location.search` at **script init** in `initialUrlSearch` (SSR-safe) and builds `URLSearchParams` from that snapshot in `onMount` instead of the live URL. Child **`EntityUrlSync`** still normalizes the address bar in its own `onMount`, which runs before the parent’s, so reading `window.location.search` only in `onMount` could already be missing those params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e496cdb9a41bd5d65a4de27ef2eef08979b830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->