### PR TITLE
release: fix ?editor=login / share-code URL param race

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -62,6 +62,14 @@
   const updateData = (queryHistory: RecentSearch[]) => {
     localStorage.setItem("recent-search", JSON.stringify(queryHistory));
   };
+
+  // Capture one-shot URL params (editor=login, auth_error, account, share
+  // codes) at script init. Child components like EntityUrlSync normalize the
+  // URL in their onMount, which fires before this parent component's onMount,
+  // so reading window.location.search there would see an already-stripped URL.
+  const initialUrlSearch =
+    typeof window !== "undefined" ? window.location.search : "";
+
   onMount(() => {
     const recentSearchesLS = localStorage.getItem("recent-search");
     try {
@@ -83,7 +91,7 @@
       });
     }
 
-    const urlParams = new URLSearchParams(window.location.search);
+    const urlParams = new URLSearchParams(initialUrlSearch);
 
     if (urlParams.get("editor") === "login") {
       adminAuthStore.openLogin();


### PR DESCRIPTION
Promotes the Entry URL-param race fix (#570) to production. Restores `?editor=login` (sign-in dialog), `?auth_error`, `?account`, `?contribute`, and `?plan` share-code handling, which a synchronous EntityUrlSync.init() had begun stripping before Entry read them.

CI: `verify` + `bundle` + Vercel green. `e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized timing fix in Entry URL bootstrap; no auth or data-model changes beyond restoring intended deep-link behavior.
> 
> **Overview**
> Fixes a **mount-order race** where `EntityUrlSync` normalizes the URL in its `onMount` before `Entry`’s `onMount` runs, so one-shot query params were already gone when `Entry` read `window.location.search`.
> 
> **`Entry.svelte`** now captures `initialUrlSearch` at **script init** (with an SSR-safe `typeof window` guard) and parses that snapshot in `onMount` instead of the live search string. That restores handling for `?editor=login`, `?auth_error`, account events/errors, `?contribute=1`, and `?plan` share links without changing when the URL is cleaned up afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c37f01d707be992600958a2b12811323bf8bed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->