### PR TITLE
chore(release): sync app version to 1.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-room",
   "type": "module",
-  "version": "1.23.0",
+  "version": "1.29.2",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Footer showed v1.23.0 because package.json was never bumped (release sync PRs aren't created — org blocks Actions from opening PRs). Bumps to match the current release line. See #569 context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version bump with no runtime or dependency changes.
> 
> **Overview**
> Updates the **`package.json` `version`** field from **1.23.0** to **1.29.2** so user-facing version text (e.g. footer) aligns with the actual release line after automated release sync PRs could not be opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0622a14db3eee9c4a1f3a2294d564b62c7235b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->