### PR TITLE
feat: batch-approve selected proposals (#9)

### DIFF
--- a/src/components/svelte/ProposalReviewPanel.component.test.ts
+++ b/src/components/svelte/ProposalReviewPanel.component.test.ts
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/svelte";
-import { beforeEach, describe, expect, test } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import ProposalReviewPanelHost from "@test/components/ProposalReviewPanelHost.svelte";
 import { adminAuthStore, proposalsStore } from "@lib/store.svelte";
 import { mountAtWidth } from "@test/layout-assertions";
@@ -62,5 +62,55 @@ describe("ProposalReviewPanel diffs", () => {
     render(ProposalReviewPanelHost);
     expect(screen.getByText("New entry")).toBeVisible();
     expect(screen.getByText("CEM 203")).toBeVisible();
+  });
+});
+
+describe("ProposalReviewPanel batch approve", () => {
+  beforeEach(() => {
+    adminAuthStore.isLoggedIn = true;
+    adminAuthStore.canReview = true;
+    proposalsStore.loading = false;
+    proposalsStore.pendingCount = 2;
+    proposalsStore.refresh = vi.fn(() => Promise.resolve());
+    proposalsStore.proposals = [
+      { ...baseProposal(), id: 7, entityLabel: "Old Hall" },
+      { ...baseProposal(), id: 8, entityLabel: "New Hall" },
+    ];
+  });
+
+  test("select all then approve posts an approve for every selected proposal", async () => {
+    // Response omits proposal.entityType so approveOne skips the
+    // published-entity side effects (no app-context dependency in the test).
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(ProposalReviewPanelHost);
+
+    const approveBtn = screen.getByRole("button", {
+      name: /approve 0 selected/i,
+    });
+    expect(approveBtn).toBeDisabled();
+
+    await fireEvent.click(screen.getByLabelText(/select all/i));
+    expect(
+      screen.getByRole("button", { name: /approve 2 selected/i }),
+    ).toBeEnabled();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /approve 2 selected/i }),
+    );
+
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls).toContain("/api/admin/proposals/7/approve");
+      expect(urls).toContain("/api/admin/proposals/8/approve");
+    });
+
+    vi.unstubAllGlobals();
   });
 });

--- a/src/components/svelte/ProposalReviewPanel.svelte
+++ b/src/components/svelte/ProposalReviewPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { SvelteSet } from "svelte/reactivity";
   import {
     adminAuthStore,
     proposalsStore,
@@ -28,6 +29,41 @@
 
   let noteById = $state<Record<number, string>>({});
   let actingId = $state<number | null>(null);
+  const selectedIds = new SvelteSet<number>();
+  let batchRunning = $state(false);
+
+  // Approve a single proposal: POST + apply the published entity to local
+  // state. No toast/refresh — callers (single action, batch) decide those.
+  async function approveOne(id: number): Promise<{ ok: boolean; error?: string }> {
+    const res = await fetch(`/api/admin/proposals/${id}/approve`, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ note: noteById[id] ?? "" }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: (data as { error?: string }).error };
+    }
+    const published = (data as { published?: unknown }).published;
+    const entityType = (data as { proposal?: { entityType?: string } }).proposal
+      ?.entityType;
+    if (entityType) {
+      afterProposalPublished(
+        appActions,
+        appData,
+        entityType as ProposalEntityType,
+        published,
+      );
+      syncOpenEntityQueryAfterPublish(
+        appData,
+        entityType as ProposalEntityType,
+        published,
+      );
+    }
+    noteById[id] = "";
+    return { ok: true };
+  }
 
   async function runAction(
     id: number,
@@ -35,8 +71,22 @@
   ) {
     actingId = id;
     try {
-      const suffix = action === "request-changes" ? "request-changes" : action;
-      const res = await fetch(`/api/admin/proposals/${id}/${suffix}`, {
+      if (action === "approve") {
+        const result = await approveOne(id);
+        if (!result.ok) {
+          toastStore.show(
+            result.error ?? `Could not approve proposal #${id}.`,
+            "error",
+          );
+          return;
+        }
+        selectedIds.delete(id);
+        toastStore.show("Proposal approved and published.", "success");
+        await proposalsStore.refresh();
+        return;
+      }
+
+      const res = await fetch(`/api/admin/proposals/${id}/${action}`, {
         method: "POST",
         credentials: "same-origin",
         headers: { "content-type": "application/json" },
@@ -51,30 +101,11 @@
         );
         return;
       }
-      if (action === "approve") {
-        const published = (data as { published?: unknown }).published;
-        const entityType = (data as { proposal?: { entityType?: string } })
-          .proposal?.entityType;
-        if (entityType) {
-          afterProposalPublished(
-            appActions,
-            appData,
-            entityType as ProposalEntityType,
-            published,
-          );
-          syncOpenEntityQueryAfterPublish(
-            appData,
-            entityType as ProposalEntityType,
-            published,
-          );
-        }
-      }
+      selectedIds.delete(id);
       toastStore.show(
-        action === "approve"
-          ? "Proposal approved and published."
-          : action === "reject"
-            ? "Proposal rejected."
-            : "Sent back to contributor with notes.",
+        action === "reject"
+          ? "Proposal rejected."
+          : "Sent back to contributor with notes.",
         "success",
       );
       noteById[id] = "";
@@ -82,6 +113,55 @@
     } finally {
       actingId = null;
     }
+  }
+
+  function toggleSelected(id: number) {
+    if (selectedIds.has(id)) selectedIds.delete(id);
+    else selectedIds.add(id);
+  }
+
+  const allSelected = $derived(
+    proposalsStore.proposals.length > 0 &&
+      proposalsStore.proposals.every((p) => selectedIds.has(p.id)),
+  );
+
+  function toggleSelectAll() {
+    if (allSelected) {
+      selectedIds.clear();
+    } else {
+      for (const p of proposalsStore.proposals) selectedIds.add(p.id);
+    }
+  }
+
+  // Approve every selected proposal in turn. Each approve can conflict (409)
+  // independently, so aggregate outcomes and report a summary rather than
+  // failing the whole batch on the first error.
+  async function runBatchApprove() {
+    const ids = [...selectedIds];
+    if (ids.length === 0 || batchRunning) return;
+    batchRunning = true;
+    let approved = 0;
+    let failed = 0;
+    try {
+      for (const id of ids) {
+        const result = await approveOne(id);
+        if (result.ok) {
+          approved += 1;
+          selectedIds.delete(id);
+        } else {
+          failed += 1;
+        }
+      }
+    } finally {
+      batchRunning = false;
+      await proposalsStore.refresh();
+    }
+    toastStore.show(
+      failed === 0
+        ? `Approved ${approved} proposal${approved === 1 ? "" : "s"}.`
+        : `Approved ${approved}, ${failed} failed (likely conflicts) — review the rest.`,
+      failed === 0 ? "success" : "error",
+    );
   }
 </script>
 
@@ -101,10 +181,38 @@
     {:else if proposalsStore.proposals.length === 0}
       <p class="entity-review-empty">No pending suggestions.</p>
     {:else}
+      <div class="entity-review-batch">
+        <label class="entity-review-select-all">
+          <input
+            type="checkbox"
+            checked={allSelected}
+            onchange={toggleSelectAll}
+          />
+          Select all
+        </label>
+        <button
+          type="button"
+          class="entity-review-batch-approve"
+          disabled={selectedIds.size === 0 || batchRunning}
+          onclick={runBatchApprove}
+        >
+          {batchRunning
+            ? "Approving…"
+            : `Approve ${selectedIds.size} selected`}
+        </button>
+      </div>
       <ul class="entity-review-list">
         {#each proposalsStore.proposals as proposal (proposal.id)}
           <li class="entity-review-item">
             <div class="entity-review-meta">
+              <label class="entity-review-select">
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(proposal.id)}
+                  onchange={() => toggleSelected(proposal.id)}
+                  aria-label={`Select ${proposal.entityLabel} for batch approve`}
+                />
+              </label>
               <span class="entity-review-entity">
                 {proposal.entityLabel}
                 <small>({proposal.entityType})</small>
@@ -182,6 +290,50 @@
 <style>
   @import "./editor/review-panel.css";
   @import "./editor/entity-editor.css";
+
+  .entity-review-batch {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 8px;
+    background: hsl(0, 0%, 98%);
+  }
+
+  .entity-review-select-all {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 30%);
+    cursor: pointer;
+  }
+
+  .entity-review-batch-approve {
+    padding: 0.3rem 0.75rem;
+    border: 1px solid hsl(140, 45%, 38%);
+    border-radius: 999px;
+    background: hsl(140, 45%, 38%);
+    color: white;
+    font-size: 0.8rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .entity-review-batch-approve:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .entity-review-select {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 0.375rem;
+  }
 
   .entity-review-bundled {
     margin: 0.35rem 0 0;


### PR DESCRIPTION
Reviewers could only approve suggested edits one at a time. This adds batch approve to the review queue (`ProposalReviewPanel`).

## What's new
- Checkbox per proposal + a "Select all" toggle.
- "Approve N selected" button: approves each selected proposal in turn, reusing the existing per-id `/approve` endpoint + published-entity apply, then shows a summary toast.
- Partial failures (e.g. 409 conflicts) are counted and left selected — the batch doesn't abort on the first error.
- No new server endpoint: reuses the tested single-approve path (`approveOne` extracted from `runAction`).

## Tests
- `ProposalReviewPanel.component.test.ts`: select-all enables the batch button and posts an approve for every selected proposal (4/4). Full component 74/74, unit 251/251.

## CI note
`e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret; `verify` + `bundle` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the admin publish/apply path for multiple proposals in one action; failures are handled per-item but successful batch runs can apply several published entities to local state in sequence.
> 
> **Overview**
> Reviewers can **batch-approve** pending suggestions from the proposal review queue instead of approving one at a time.
> 
> **`ProposalReviewPanel`** adds per-proposal checkboxes, a **Select all** control, and an **Approve N selected** action that runs sequential `POST` calls to the existing `/api/admin/proposals/:id/approve` route. Approve logic is pulled into **`approveOne`** (shared by single and batch flows); batch mode tallies successes and failures, keeps failed items selected, refreshes the queue once, and shows a summary toast. Reject/request-changes paths unchanged aside from clearing selection when those actions succeed.
> 
> A component test covers select-all → batch approve and asserts both proposal approve URLs are requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d9a53f914220b37643f4842d0b30290e7fd4fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->