### PR TITLE
release: batch-approve proposals in the review queue (#9)

### DIFF
--- a/src/components/svelte/ProposalReviewPanel.component.test.ts
+++ b/src/components/svelte/ProposalReviewPanel.component.test.ts
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/svelte";
-import { beforeEach, describe, expect, test } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import ProposalReviewPanelHost from "@test/components/ProposalReviewPanelHost.svelte";
 import { adminAuthStore, proposalsStore } from "@lib/store.svelte";
 import { mountAtWidth } from "@test/layout-assertions";
@@ -62,5 +62,55 @@ describe("ProposalReviewPanel diffs", () => {
     render(ProposalReviewPanelHost);
     expect(screen.getByText("New entry")).toBeVisible();
     expect(screen.getByText("CEM 203")).toBeVisible();
+  });
+});
+
+describe("ProposalReviewPanel batch approve", () => {
+  beforeEach(() => {
+    adminAuthStore.isLoggedIn = true;
+    adminAuthStore.canReview = true;
+    proposalsStore.loading = false;
+    proposalsStore.pendingCount = 2;
+    proposalsStore.refresh = vi.fn(() => Promise.resolve());
+    proposalsStore.proposals = [
+      { ...baseProposal(), id: 7, entityLabel: "Old Hall" },
+      { ...baseProposal(), id: 8, entityLabel: "New Hall" },
+    ];
+  });
+
+  test("select all then approve posts an approve for every selected proposal", async () => {
+    // Response omits proposal.entityType so approveOne skips the
+    // published-entity side effects (no app-context dependency in the test).
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(ProposalReviewPanelHost);
+
+    const approveBtn = screen.getByRole("button", {
+      name: /approve 0 selected/i,
+    });
+    expect(approveBtn).toBeDisabled();
+
+    await fireEvent.click(screen.getByLabelText(/select all/i));
+    expect(
+      screen.getByRole("button", { name: /approve 2 selected/i }),
+    ).toBeEnabled();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /approve 2 selected/i }),
+    );
+
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls).toContain("/api/admin/proposals/7/approve");
+      expect(urls).toContain("/api/admin/proposals/8/approve");
+    });
+
+    vi.unstubAllGlobals();
   });
 });

--- a/src/components/svelte/ProposalReviewPanel.svelte
+++ b/src/components/svelte/ProposalReviewPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { SvelteSet } from "svelte/reactivity";
   import {
     adminAuthStore,
     proposalsStore,
@@ -28,6 +29,41 @@
 
   let noteById = $state<Record<number, string>>({});
   let actingId = $state<number | null>(null);
+  const selectedIds = new SvelteSet<number>();
+  let batchRunning = $state(false);
+
+  // Approve a single proposal: POST + apply the published entity to local
+  // state. No toast/refresh — callers (single action, batch) decide those.
+  async function approveOne(id: number): Promise<{ ok: boolean; error?: string }> {
+    const res = await fetch(`/api/admin/proposals/${id}/approve`, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ note: noteById[id] ?? "" }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: (data as { error?: string }).error };
+    }
+    const published = (data as { published?: unknown }).published;
+    const entityType = (data as { proposal?: { entityType?: string } }).proposal
+      ?.entityType;
+    if (entityType) {
+      afterProposalPublished(
+        appActions,
+        appData,
+        entityType as ProposalEntityType,
+        published,
+      );
+      syncOpenEntityQueryAfterPublish(
+        appData,
+        entityType as ProposalEntityType,
+        published,
+      );
+    }
+    noteById[id] = "";
+    return { ok: true };
+  }
 
   async function runAction(
     id: number,
@@ -35,8 +71,22 @@
   ) {
     actingId = id;
     try {
-      const suffix = action === "request-changes" ? "request-changes" : action;
-      const res = await fetch(`/api/admin/proposals/${id}/${suffix}`, {
+      if (action === "approve") {
+        const result = await approveOne(id);
+        if (!result.ok) {
+          toastStore.show(
+            result.error ?? `Could not approve proposal #${id}.`,
+            "error",
+          );
+          return;
+        }
+        selectedIds.delete(id);
+        toastStore.show("Proposal approved and published.", "success");
+        await proposalsStore.refresh();
+        return;
+      }
+
+      const res = await fetch(`/api/admin/proposals/${id}/${action}`, {
         method: "POST",
         credentials: "same-origin",
         headers: { "content-type": "application/json" },
@@ -51,30 +101,11 @@
         );
         return;
       }
-      if (action === "approve") {
-        const published = (data as { published?: unknown }).published;
-        const entityType = (data as { proposal?: { entityType?: string } })
-          .proposal?.entityType;
-        if (entityType) {
-          afterProposalPublished(
-            appActions,
-            appData,
-            entityType as ProposalEntityType,
-            published,
-          );
-          syncOpenEntityQueryAfterPublish(
-            appData,
-            entityType as ProposalEntityType,
-            published,
-          );
-        }
-      }
+      selectedIds.delete(id);
       toastStore.show(
-        action === "approve"
-          ? "Proposal approved and published."
-          : action === "reject"
-            ? "Proposal rejected."
-            : "Sent back to contributor with notes.",
+        action === "reject"
+          ? "Proposal rejected."
+          : "Sent back to contributor with notes.",
         "success",
       );
       noteById[id] = "";
@@ -82,6 +113,55 @@
     } finally {
       actingId = null;
     }
+  }
+
+  function toggleSelected(id: number) {
+    if (selectedIds.has(id)) selectedIds.delete(id);
+    else selectedIds.add(id);
+  }
+
+  const allSelected = $derived(
+    proposalsStore.proposals.length > 0 &&
+      proposalsStore.proposals.every((p) => selectedIds.has(p.id)),
+  );
+
+  function toggleSelectAll() {
+    if (allSelected) {
+      selectedIds.clear();
+    } else {
+      for (const p of proposalsStore.proposals) selectedIds.add(p.id);
+    }
+  }
+
+  // Approve every selected proposal in turn. Each approve can conflict (409)
+  // independently, so aggregate outcomes and report a summary rather than
+  // failing the whole batch on the first error.
+  async function runBatchApprove() {
+    const ids = [...selectedIds];
+    if (ids.length === 0 || batchRunning) return;
+    batchRunning = true;
+    let approved = 0;
+    let failed = 0;
+    try {
+      for (const id of ids) {
+        const result = await approveOne(id);
+        if (result.ok) {
+          approved += 1;
+          selectedIds.delete(id);
+        } else {
+          failed += 1;
+        }
+      }
+    } finally {
+      batchRunning = false;
+      await proposalsStore.refresh();
+    }
+    toastStore.show(
+      failed === 0
+        ? `Approved ${approved} proposal${approved === 1 ? "" : "s"}.`
+        : `Approved ${approved}, ${failed} failed (likely conflicts) — review the rest.`,
+      failed === 0 ? "success" : "error",
+    );
   }
 </script>
 
@@ -101,10 +181,38 @@
     {:else if proposalsStore.proposals.length === 0}
       <p class="entity-review-empty">No pending suggestions.</p>
     {:else}
+      <div class="entity-review-batch">
+        <label class="entity-review-select-all">
+          <input
+            type="checkbox"
+            checked={allSelected}
+            onchange={toggleSelectAll}
+          />
+          Select all
+        </label>
+        <button
+          type="button"
+          class="entity-review-batch-approve"
+          disabled={selectedIds.size === 0 || batchRunning}
+          onclick={runBatchApprove}
+        >
+          {batchRunning
+            ? "Approving…"
+            : `Approve ${selectedIds.size} selected`}
+        </button>
+      </div>
       <ul class="entity-review-list">
         {#each proposalsStore.proposals as proposal (proposal.id)}
           <li class="entity-review-item">
             <div class="entity-review-meta">
+              <label class="entity-review-select">
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(proposal.id)}
+                  onchange={() => toggleSelected(proposal.id)}
+                  aria-label={`Select ${proposal.entityLabel} for batch approve`}
+                />
+              </label>
               <span class="entity-review-entity">
                 {proposal.entityLabel}
                 <small>({proposal.entityType})</small>
@@ -182,6 +290,50 @@
 <style>
   @import "./editor/review-panel.css";
   @import "./editor/entity-editor.css";
+
+  .entity-review-batch {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 8px;
+    background: hsl(0, 0%, 98%);
+  }
+
+  .entity-review-select-all {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 30%);
+    cursor: pointer;
+  }
+
+  .entity-review-batch-approve {
+    padding: 0.3rem 0.75rem;
+    border: 1px solid hsl(140, 45%, 38%);
+    border-radius: 999px;
+    background: hsl(140, 45%, 38%);
+    color: white;
+    font-size: 0.8rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .entity-review-batch-approve:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .entity-review-select {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 0.375rem;
+  }
 
   .entity-review-bundled {
     margin: 0.35rem 0 0;


### PR DESCRIPTION
Promotes batch-approve (#573) to production. Reviewers can multi-select suggested edits and approve them in one action, with a summary of successes/failures.

CI: `verify` + `bundle` + Vercel green. `e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Batch approval publishes multiple entities via existing approve endpoints; partial failures are possible but behavior matches single-approve side effects per item.
> 
> **Overview**
> Adds **batch approve** to the suggested-edits review panel so reviewers can select multiple pending proposals and approve them in one action.
> 
> **`ProposalReviewPanel`** now tracks selection with a reactive `SvelteSet`, shows **Select all** plus per-row checkboxes, and an **Approve N selected** control that stays disabled when nothing is selected or while a batch is running. Approval logic is centralized in **`approveOne`** (POST, optional publish side effects, clear note); single approve and batch both use it. Batch runs approvals **sequentially**, counts successes vs failures (e.g. conflicts), refreshes the queue once at the end, and shows a **summary toast** instead of stopping on the first error. Reject/request-changes still use the existing per-action fetch path and clear selection on success.
> 
> A component test covers **select all → approve** and asserts **`/api/admin/proposals/{id}/approve`** is called for each selected id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7858b916e9513086e27754c88275756f3843ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->