### PR TITLE
feat(planner): reflect planner state in the /planner URL

### DIFF
--- a/e2e/smoke/planner-route.spec.ts
+++ b/e2e/smoke/planner-route.spec.ts
@@ -34,4 +34,19 @@ test.describe("planner route", () => {
       page.getByRole("dialog", { name: "Class Planner" }),
     ).toBeVisible();
   });
+
+  test("opening the planner from the map updates the URL to /planner", async ({
+    page,
+  }) => {
+    await suppressLandingModal(page);
+    await page.goto("/");
+    await waitForPlannerBoot(page);
+
+    // click() auto-waits for the chrome button to be actionable.
+    await page
+      .getByRole("button", { name: "Open course planner" })
+      .click({ timeout: 60_000 });
+    await expect(page.getByRole("dialog", { name: "Class Planner" })).toBeVisible();
+    await expect(page).toHaveURL(/\/planner(\?|$)/);
+  });
 });

--- a/src/components/svelte/EntityUrlSync.svelte
+++ b/src/components/svelte/EntityUrlSync.svelte
@@ -13,6 +13,7 @@
   import {
     currentRoom,
     mapEditStore,
+    plannerStore,
     queryStore,
     termStore,
   } from "@lib/store.svelte";
@@ -40,6 +41,10 @@
         value: queryStore.queryValue,
         eventSlug: queryStore.selectedEventSlug ?? undefined,
       }),
+      setPlannerOpen: (open) => {
+        if (open) plannerStore.openPlanner();
+        else plannerStore.close();
+      },
     });
 
     controller.init();
@@ -63,6 +68,7 @@
       editMode: mapEditStore.enabled,
       termId: termStore.activeTermId,
       defaultTermId: termStore.defaultTermId,
+      plannerOpen: plannerStore.open,
     });
   });
 

--- a/src/lib/entity-url-sync.ts
+++ b/src/lib/entity-url-sync.ts
@@ -22,6 +22,8 @@ export type EntityUrlSyncContext = {
   hydrateQuery: (query: RoutableQueryState) => void;
   clearQuery: () => void;
   getQuerySnapshot: () => RoutableQueryState;
+  /** Open/close the planner in response to /planner navigations (back/forward). */
+  setPlannerOpen: (open: boolean) => void;
 };
 
 export type EntityUrlSyncSnapshot = RoutableQueryState & {
@@ -29,9 +31,11 @@ export type EntityUrlSyncSnapshot = RoutableQueryState & {
   editMode: boolean;
   termId: number | null;
   defaultTermId: number | null;
+  plannerOpen: boolean;
 };
 
 const HOME_PATH = "/";
+const PLANNER_PATH = "/planner";
 
 export function createEntityUrlSync(context: EntityUrlSyncContext) {
   let applyingFromHistory = false;
@@ -123,6 +127,8 @@ export function createEntityUrlSync(context: EntityUrlSyncContext) {
     applyingFromHistory = true;
     try {
       termStore.applyFromUrl();
+      // Back/forward into or out of /planner toggles the planner overlay.
+      context.setPlannerOpen(currentPathname() === PLANNER_PATH);
       const state = (event.state ?? null) as EntityHistoryState | null;
       if (state?.query) {
         context.hydrateQuery(state.query);
@@ -171,6 +177,41 @@ export function createEntityUrlSync(context: EntityUrlSyncContext) {
 
   function syncFromQuery(snapshot: EntityUrlSyncSnapshot) {
     if (!initialized || applyingFromHistory || snapshot.editMode) return;
+
+    // Planner takes over the URL while open, so clicking "Class Planner" moves
+    // to /planner (shareable, refreshable). Closing falls through to the
+    // entity/home logic below and restores the prior path.
+    if (snapshot.plannerOpen) {
+      const plannerPath = withTermQuery(
+        PLANNER_PATH,
+        snapshot.termId,
+        snapshot.defaultTermId,
+      );
+      const plannerPathname = plannerPath.split("?")[0] ?? PLANNER_PATH;
+      const plannerSearch = plannerPath.includes("?")
+        ? plannerPath.slice(plannerPath.indexOf("?"))
+        : "";
+      if (
+        currentPathname() !== plannerPathname ||
+        window.location.search !== plannerSearch
+      ) {
+        const carried =
+          snapshot.type === "result" && snapshot.category !== null
+            ? {
+                type: "result" as const,
+                category: snapshot.category,
+                value: snapshot.value,
+                eventSlug: snapshot.eventSlug,
+              }
+            : null;
+        window.history.pushState(
+          buildHistoryState(carried, HOME_PATH),
+          "",
+          plannerPath,
+        );
+      }
+      return;
+    }
 
     if (snapshot.type !== "result" || snapshot.category === null) {
       const pathname = currentPathname();


### PR DESCRIPTION
Clicking Class Planner (or opening /planner) now shows /planner in the URL — shareable & refreshable; close/back restore the prior path. Blocking e2e added (3 planner-route tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared history/URL sync behavior for a major overlay; mistakes could break deep links, back/forward, or entity URLs while the planner is open.
> 
> **Overview**
> **Class Planner** now drives the browser URL: when the overlay is open, history moves to **`/planner`** (with the usual term query), so the route is shareable and survives refresh. Closing the planner lets the existing entity/home URL logic run again and restore the prior path.
> 
> **`createEntityUrlSync`** gains **`plannerOpen`** on its snapshot and **`setPlannerOpen`** on context. **`syncFromQuery`** short-circuits to **`pushState`** on `/planner` while open, stashing any active entity query in history state. **`popstate`** opens or closes the planner when navigating into or out of `/planner`. **`EntityUrlSync.svelte`** wires this to **`plannerStore`**.
> 
> A Playwright smoke test asserts that opening the planner from the map leaves the URL at **`/planner`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c9cb8fbf33259b940fc6b902b3d502faa2960a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->