### PR TITLE
fix(offline-maps): keep the popover inside the viewport

### DIFF
--- a/src/components/svelte/OfflineMaps.svelte
+++ b/src/components/svelte/OfflineMaps.svelte
@@ -32,7 +32,10 @@
     if (!open || !triggerEl) return;
     const rect = triggerEl.getBoundingClientRect();
     const width = Math.min(288, window.innerWidth - 16);
-    const right = Math.max(8, window.innerWidth - rect.right);
+    // Anchor to the trigger's right edge, but never let the left edge overflow
+    // the viewport (happens when the trigger sits left / on narrow screens).
+    const maxRight = window.innerWidth - width - 8;
+    const right = Math.min(Math.max(8, window.innerWidth - rect.right), maxRight);
     const bottom = Math.max(8, window.innerHeight - rect.top + 8);
     popoverStyle = `right: ${right}px; bottom: ${bottom}px; width: ${width}px;`;
   }


### PR DESCRIPTION
The offline download popover overflowed the left edge (screenshot) because positioning only clamped the right gap, not the left. Clamps `right` so the left edge stays on-screen. Same pattern as TermSelector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI positioning tweak in OfflineMaps with no auth, data, or API impact.
> 
> **Overview**
> Fixes the offline downloads popover clipping off the **left** side of the screen when the trigger is far left or the viewport is narrow.
> 
> `updatePopoverPosition` still aligns to the trigger’s right edge with a minimum 8px margin, but now also caps `right` at `window.innerWidth - width - 8` so the popover’s left edge stays on-screen. Matches the clamping approach used in TermSelector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9b87ac0cb43d257507d4997e0041dac763c889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->