### PR TITLE
fix: changelog + confirm on update; open changelog anytime

### DIFF
--- a/src/components/svelte/ChangelogModal.component.test.ts
+++ b/src/components/svelte/ChangelogModal.component.test.ts
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import ChangelogModal from "@ui/ChangelogModal.svelte";
+import { syncToastStore } from "@lib/store.svelte";
+
+describe("ChangelogModal", () => {
+  beforeEach(() => {
+    syncToastStore.needRefresh = false;
+  });
+
+  test("without a pending update: shows Close and the full-changelog link, no reload", () => {
+    syncToastStore.needRefresh = false;
+    render(ChangelogModal);
+    expect(screen.getByRole("button", { name: /close/i })).toBeVisible();
+    expect(screen.getByRole("link", { name: /full changelog/i })).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /reload to update/i }),
+    ).toBeNull();
+  });
+
+  test("with a pending update: confirming reload calls syncToastStore.reload", async () => {
+    syncToastStore.needRefresh = true;
+    const reloadSpy = vi
+      .spyOn(syncToastStore, "reload")
+      .mockImplementation(() => {});
+    render(ChangelogModal);
+
+    const reloadBtn = screen.getByRole("button", { name: /reload to update/i });
+    expect(reloadBtn).toBeVisible();
+    // Reload must be an explicit confirm, not automatic on open.
+    expect(reloadSpy).not.toHaveBeenCalled();
+
+    await fireEvent.click(reloadBtn);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    reloadSpy.mockRestore();
+  });
+});

--- a/src/components/svelte/ChangelogModal.svelte
+++ b/src/components/svelte/ChangelogModal.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  import { RefreshCw, FileText } from "@lucide/svelte";
+  import { syncToastStore, modalStore } from "@lib/store.svelte";
+  import { APP_VERSION_LABEL } from "@constants/version";
+  import { parseChangelogHighlights } from "@lib/changelog-highlights";
+  import changelogRaw from "../../../CHANGELOG.md?raw";
+
+  const highlights = $derived(parseChangelogHighlights(changelogRaw));
+  const hasUpdate = $derived(syncToastStore.needRefresh);
+
+  let reloading = $state(false);
+
+  function confirmReload() {
+    reloading = true;
+    // Applies the waiting service worker and reloads to the new version.
+    syncToastStore.reload();
+  }
+</script>
+
+<div class="changelog-modal">
+  <p class="changelog-modal__version">
+    {#if highlights}
+      What's new in v{highlights.version}
+    {:else}
+      Room TBA {APP_VERSION_LABEL}
+    {/if}
+  </p>
+
+  {#if hasUpdate}
+    <p class="changelog-modal__lead">
+      A new version is ready. Review what changed, then reload to update.
+    </p>
+  {/if}
+
+  {#if highlights && highlights.items.length > 0}
+    <ul class="changelog-modal__list">
+      {#each highlights.items as item (item)}
+        <li>{item}</li>
+      {/each}
+    </ul>
+    {#if highlights.totalCount > highlights.items.length}
+      <p class="changelog-modal__more">
+        + {highlights.totalCount - highlights.items.length} more in the full changelog
+      </p>
+    {/if}
+  {:else}
+    <p class="changelog-modal__lead">See the full changelog for details.</p>
+  {/if}
+
+  <a
+    class="changelog-modal__full-link"
+    href="/changelog"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <FileText size={14} aria-hidden="true" />
+    Full changelog
+  </a>
+
+  <div class="changelog-modal__actions">
+    {#if hasUpdate}
+      <button
+        type="button"
+        class="changelog-modal__btn changelog-modal__btn--secondary"
+        onclick={() => modalStore.closeModal()}
+      >
+        Later
+      </button>
+      <button
+        type="button"
+        class="changelog-modal__btn changelog-modal__btn--primary"
+        onclick={confirmReload}
+        disabled={reloading}
+      >
+        <RefreshCw
+          size={14}
+          class={reloading ? "loading-icon" : ""}
+          aria-hidden="true"
+        />
+        {reloading ? "Reloading…" : "Reload to update"}
+      </button>
+    {:else}
+      <button
+        type="button"
+        class="changelog-modal__btn changelog-modal__btn--primary"
+        onclick={() => modalStore.closeModal()}
+      >
+        Close
+      </button>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .changelog-modal {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    padding: 0.25rem 0.25rem 0;
+    max-width: 26rem;
+  }
+
+  .changelog-modal__version {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+    color: hsl(0, 0%, 15%);
+  }
+
+  .changelog-modal__lead {
+    margin: 0;
+    font-size: 0.875rem;
+    color: hsl(0, 0%, 30%);
+    line-height: 1.4;
+  }
+
+  .changelog-modal__list {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+    color: hsl(0, 0%, 22%);
+    line-height: 1.4;
+    list-style: disc;
+  }
+
+  .changelog-modal__more {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: hsl(0, 0%, 45%);
+  }
+
+  .changelog-modal__full-link {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.625rem;
+    border: 1px solid hsl(5, 34%, 82%);
+    border-radius: 0.5rem;
+    color: hsl(5, 53%, 32%);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .changelog-modal__full-link:hover,
+  .changelog-modal__full-link:focus-visible {
+    background: hsl(5, 20%, 96%);
+  }
+
+  .changelog-modal__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .changelog-modal__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-height: 2.25rem;
+    padding: 0.4rem 1rem;
+    border-radius: 0.625rem;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .changelog-modal__btn--primary {
+    border: 1px solid hsl(5, 53%, 32%);
+    background: hsl(5, 53%, 32%);
+    color: white;
+  }
+
+  .changelog-modal__btn--primary:hover:not(:disabled) {
+    background: hsl(5, 53%, 38%);
+  }
+
+  .changelog-modal__btn--primary:disabled {
+    cursor: progress;
+    opacity: 0.7;
+  }
+
+  .changelog-modal__btn--secondary {
+    border: 1px solid hsl(0, 0%, 80%);
+    background: transparent;
+    color: hsl(0, 0%, 30%);
+  }
+
+  .changelog-modal__btn--secondary:hover {
+    background: hsl(0, 0%, 96%);
+  }
+
+  :global(.loading-icon) {
+    animation: changelog-spin 0.75s linear infinite;
+  }
+
+  @keyframes changelog-spin {
+    from {
+      rotate: 0deg;
+    }
+    to {
+      rotate: 360deg;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.loading-icon) {
+      animation: none;
+    }
+  }
+</style>

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -10,6 +10,7 @@
     syncToastStore,
     adminAuthStore,
     toastStore,
+    modalStore,
   } from "@lib/store.svelte";
   import AppMenu from "./status-bar/AppMenu.svelte";
   import "./status-bar/status-bar.css";
@@ -45,7 +46,13 @@
       };
     }
     if (syncToastStore.needRefresh) {
-      return { kind: "update", label: "Update", action: () => syncToastStore.reload() };
+      // Show the changelog + require an explicit confirm before reloading,
+      // instead of reloading immediately on click.
+      return {
+        kind: "update",
+        label: "Update",
+        action: () => modalStore.openModal("changelog"),
+      };
     }
     if (syncToastStore.isSyncing) {
       return { kind: "syncing", label: "Syncing", action: null };

--- a/src/components/svelte/SyncStatus.svelte
+++ b/src/components/svelte/SyncStatus.svelte
@@ -7,7 +7,11 @@
     X,
     FileText,
   } from "@lucide/svelte";
-  import { syncToastStore, appBootstrapStore } from "@lib/store.svelte";
+  import {
+    syncToastStore,
+    appBootstrapStore,
+    modalStore,
+  } from "@lib/store.svelte";
   import { APP_VERSION_LABEL } from "@constants/version";
   import { parseChangelogHighlights } from "@lib/changelog-highlights";
   import changelogRaw from "../../../CHANGELOG.md?raw";
@@ -24,7 +28,6 @@
   let { compact = false, expanded = false, inline = false }: Props = $props();
 
   let manualClosed = $state<boolean>(false);
-  let reloading = $state<boolean>(false);
   let retrying = $state<boolean>(false);
 
   const LABEL_HOLD_MS = 650;
@@ -292,15 +295,10 @@
         <button
           class="sync-action reload-button"
           type="button"
-          onclick={() => syncToastStore.reload()}
-          disabled={reloading}
+          onclick={() => modalStore.openModal("changelog")}
         >
-          <RefreshCw
-            size={14}
-            class={reloading ? "loading-icon" : ""}
-            aria-hidden="true"
-          />
-          {reloading ? "Reloading…" : "Reload"}
+          <RefreshCw size={14} aria-hidden="true" />
+          Update
         </button>
       {/if}
       {#if showDismiss}

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -11,6 +11,7 @@
   import LandingModal from "./LandingModal.svelte";
   import ScheduleModal from "./ScheduleModal.svelte";
   import LeaderboardModal from "./LeaderboardModal.svelte";
+  import ChangelogModal from "../ChangelogModal.svelte";
   import X from "@lucide/svelte/icons/x";
 
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
@@ -34,6 +35,7 @@
     if (modalStore.type === "landing") return undefined;
     if (modalStore.type === "schedule-expand") return "Room schedule";
     if (modalStore.type === "leaderboard") return "Contributor leaderboard";
+    if (modalStore.type === "changelog") return "What's new";
     return "Dialog";
   });
 
@@ -104,6 +106,16 @@
           <X size={20} aria-hidden="true" />
         </button>
         <LeaderboardModal />
+      {:else if modalStore.type === "changelog"}
+        <button
+          type="button"
+          class="modal-content__close-icon"
+          aria-label="Close changelog"
+          onclick={closeDialog}
+        >
+          <X size={20} aria-hidden="true" />
+        </button>
+        <ChangelogModal />
       {/if}
     </div>
   </div>

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Menu from "@lucide/svelte/icons/menu";
   import Keyboard from "@lucide/svelte/icons/keyboard";
+  import FileText from "@lucide/svelte/icons/file-text";
   import { onMount } from "svelte";
   import { formatCatalogUpdatedDate } from "@constants/data-catalog";
   import { APP_VERSION_LABEL } from "@constants/version";
@@ -139,6 +140,11 @@
     closePanel();
     openShortcutsHelp();
   }
+
+  function handleWhatsNew() {
+    closePanel();
+    modalStore.openModal("changelog");
+  }
 </script>
 
 <svelte:window onpointerdown={handleDocumentPointerDown} />
@@ -213,6 +219,14 @@
         aria-labelledby="app-menu-help-heading"
       >
         <h3 id="app-menu-help-heading" class="app-menu__heading">Help</h3>
+        <button
+          type="button"
+          class="app-menu__action map-chrome-chip"
+          onclick={handleWhatsNew}
+        >
+          <FileText size={14} aria-hidden="true" />
+          <span>What's new</span>
+        </button>
         <button
           type="button"
           class="app-menu__action map-chrome-chip"

--- a/src/constants/modal-states.ts
+++ b/src/constants/modal-states.ts
@@ -4,4 +4,5 @@ export const modalOptions = [
   "landing",
   "schedule-expand",
   "leaderboard",
+  "changelog",
 ] as const;


### PR DESCRIPTION
## Hotfix
1. **Update button reloaded immediately** with no changelog and no confirm. Both update triggers (status-bar "Update" button + SyncStatus "Reload") now open a new `ChangelogModal` showing what changed, with an explicit **"Reload to update"** confirm and a "Later" escape.
2. **Changelog reachable anytime:** a "What's new" entry in the App-menu Help section opens the same modal even when no update is pending (alongside the existing `/changelog` page link).

## Details
- New `ChangelogModal` reuses `parseChangelogHighlights(CHANGELOG.md)`; shows highlights + "+N more" + a full-changelog link. Reload confirm renders only when `syncToastStore.needRefresh`.
- New modal type `changelog`; rendered in `Modal.svelte`.

## Test
- `ChangelogModal.component.test.ts`: no-update → Close only (no reload); update → reload happens only on explicit click. Component 76/76, unit 251/251.

## CI note
`e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret; `verify` + `bundle` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to PWA update UX; reload still goes through the existing syncToastStore handler after user confirmation.
> 
> **Overview**
> **Update flows no longer reload the app on first click.** The status-bar **Update** pill and SyncStatus **Update** button now open a new **`changelog`** modal instead of calling `syncToastStore.reload()` immediately.
> 
> The new **`ChangelogModal`** surfaces parsed `CHANGELOG.md` highlights, a link to the full changelog, and—only when `syncToastStore.needRefresh`—**Later** plus an explicit **Reload to update** that triggers reload (not on open). Without a pending update, the modal shows **Close** only.
> 
> **Changelog is available anytime** via **What's new** under App menu → Help, wired through `modalStore.openModal("changelog")` and `Modal.svelte`. Component tests cover both no-update and confirm-reload paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb3bebc5d39de17f60df541a3f812710c45a9f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->