### PR TITLE
chore(release): sync app version to 1.31.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-room",
   "type": "module",
-  "version": "1.29.2",
+  "version": "1.31.1",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Footer stuck at 1.29.2 while releases reached v1.31.1 (version-sync PRs never created — org blocks Actions from opening PRs). Chore-only bump. Permanent fix tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version bump with no logic, auth, or data changes.
> 
> **Overview**
> Bumps the root **`package.json` `version`** from **1.29.2** to **1.31.1** so the displayed app label matches current releases.
> 
> `APP_VERSION_LABEL` in `src/constants/version.ts` reads that field, so the status bar / menu footer version string updates to **v1.31.1** on the next build—no other code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6564d374b8cfa986cc3f4f7c199605dff9f0e5f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->