### PR TITLE
ci(release): auto-merge the version-sync PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,16 @@ jobs:
             CHANGELOG.md
             package.json
 
+      - name: Auto-merge version sync PR
+        if: steps.pkg.outputs.published == 'true' && steps.sync_pr.outputs.pull-request-number
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ steps.sync_pr.outputs.pull-request-number }}" \
+            --repo "${{ github.repository }}" --squash --auto \
+          || echo "::warning::Could not enable auto-merge on the sync PR — merge it manually, and enable repo Settings > General > Pull Requests > 'Allow auto-merge'."
+
       - name: Version sync PR failed
         if: steps.pkg.outputs.published == 'true' && steps.sync_pr.outcome == 'failure'
         run: |


### PR DESCRIPTION
Closes the version-drift loop: with Actions now allowed to create PRs, enable auto-merge on the chore(release) sync PR so package.json (and the footer) self-sync each release. Needs repo 'Allow auto-merge' enabled; degrades to manual merge otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the release workflow; no application or auth logic, with graceful fallback if auto-merge is unavailable.
> 
> **Overview**
> After semantic-release opens the **chore(release)** PR that syncs `package.json` and `CHANGELOG.md`, the release workflow now runs **`gh pr merge … --squash --auto`** so that PR can merge itself once checks pass (when the repo allows auto-merge).
> 
> The step only runs when a release was published and the sync PR was created; failures are non-blocking (`continue-on-error`) and emit a workflow warning pointing at manual merge and enabling **Allow auto-merge** in repo settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 630914a42a8cda9aae0352d8479c70700a798169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->