### PR TITLE
fix: lab/recit sections carry their parent lecture (CMSC 12 case)

### DIFF
--- a/src/lib/class-offering-groups.test.ts
+++ b/src/lib/class-offering-groups.test.ts
@@ -31,6 +31,27 @@ describe("parentLectureSection", () => {
       "A2",
     );
   });
+
+  test("maps recit section names to their parent lecture (any type)", () => {
+    // Recits use an R suffix and a multi-letter lecture prefix (UV); they are
+    // not typed "LAB" but must still resolve to their parent lecture.
+    expect(parentLectureSection(row({ section: "UV-1R", type: "REC" }))).toBe(
+      "UV",
+    );
+    expect(parentLectureSection(row({ section: "G-2R", type: "RECIT" }))).toBe(
+      "G",
+    );
+    expect(parentLectureSection(row({ section: "ST11R", type: "REC" }))).toBe(
+      "ST1",
+    );
+  });
+
+  test("returns null for standalone lecture/seminar sections", () => {
+    expect(parentLectureSection(row({ section: "G", type: "LEC" }))).toBeNull();
+    expect(
+      parentLectureSection(row({ section: "UV", type: "LEC" })),
+    ).toBeNull();
+  });
 });
 
 describe("groupClassesByOffering", () => {
@@ -50,5 +71,18 @@ describe("groupClassesByOffering", () => {
       "G",
       "G-5L",
     ]);
+  });
+
+  test("adds the parent lecture row to each recit offering", () => {
+    const groups = groupClassesByOffering([
+      row({ id: 1, courseCode: "SPCM 1", section: "UV", type: "LEC" }),
+      row({ id: 2, courseCode: "SPCM 1", section: "UV-1R", type: "REC" }),
+      row({ id: 3, courseCode: "SPCM 1", section: "UV-2R", type: "REC" }),
+    ]);
+
+    // The standalone lecture group is folded into its recits, not listed alone.
+    expect(groups.map((group) => group.section)).toEqual(["UV-1R", "UV-2R"]);
+    expect(groups[0]?.sections.map((s) => s.section)).toEqual(["UV", "UV-1R"]);
+    expect(groups[1]?.sections.map((s) => s.section)).toEqual(["UV", "UV-2R"]);
   });
 });

--- a/src/lib/class-offering-groups.ts
+++ b/src/lib/class-offering-groups.ts
@@ -19,11 +19,17 @@ function classType(row: ClassMapValue): string {
 }
 
 export function parentLectureSection(row: ClassMapValue): string | null {
-  if (classType(row) !== "LAB" || !row.section) return null;
+  if (!row.section) return null;
   const section = row.section.trim().toUpperCase();
-  const hyphenated = section.match(/^(.+)-\d+L$/);
+  // A lab or recit section encodes its parent lecture as the prefix before its
+  // numbered slot: "G-1L"/"UV-1R" (dashed) or "ST11L" (compact). Any trailing
+  // letter run marks a child (L = lab, R = recit, …), so match [A-Z]+ not just
+  // "L". The prefix is everything up to the dash/number, which preserves
+  // multi-letter lecture codes like "UV". Not gated on type: recits are not
+  // typed "LAB", and the section shape alone identifies a child.
+  const hyphenated = section.match(/^(.+)-\d+[A-Z]+$/);
   if (hyphenated?.[1]) return hyphenated[1];
-  const compact = section.match(/^(.+)\dL$/);
+  const compact = section.match(/^(.+)\d[A-Z]+$/);
   return compact?.[1] ?? null;
 }
 


### PR DESCRIPTION
## Bug
A lab/recit section encodes its parent lecture as the prefix before its numbered slot (`G-1L` → `G`, `UV-1R` → `UV`). `parentLectureSection` only handled `LAB` rows with an `L` suffix, so **recitations (`-<n>R`) never resolved to their lecture** — selecting a recit showed neither the lecture's schedule/room nor added the lecture to the planner.

## Fix (`class-offering-groups.ts`)
- Drop the `type === "LAB"` gate — a child is identified by section shape, and recits aren't typed `LAB`.
- Match any trailing letter run `[A-Z]+` instead of just `L`, covering `R` (recit) and future child types, for both dashed (`UV-1R`) and compact (`ST11R`) forms. Multi-letter lecture prefixes (`UV`) preserved.

All three consumers — room class list (`Classes.svelte`), planner search (`PlannerCourseSearch`), planner alternatives — group via `groupClassesByOffering`, so the linked lecture now renders its own schedule + room and is added alongside the child. (The AMIS `scheduleFromRowFields` fallback already builds each section's own schedule.)

## Tests
- recit → parent-lecture mapping, standalone-lecture null, and a recit offering that carries its lecture row. Unit 254/254; planner offering component test still green.

## CI note
`e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret; `verify` + `bundle` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change to section-string parsing in class offering grouping; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes recitation offerings that did not pull in their parent lecture’s schedule, room, or planner bundle because `parentLectureSection` only recognized **LAB** rows with an **`L`** section suffix.
> 
> **`parentLectureSection`** now keys off section naming only: dashed (`UV-1R`) and compact (`ST11R`) child sections match a trailing letter run (`[A-Z]+`), not just `L`, and the **`type === "LAB"`** check is removed so **REC** / **RECIT** rows resolve like labs. Standalone lectures still return null.
> 
> Tests cover recit → parent mapping, standalone lecture nulls, and **`groupClassesByOffering`** folding a lecture into each recit group (e.g. SPCM 1 `UV` + `UV-1R` / `UV-2R`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c2ffa51e456e4b1e83316bad5a1a956f1787c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->