### PR TITLE
release: lab/recit sections carry their parent lecture

### DIFF
--- a/src/lib/class-offering-groups.test.ts
+++ b/src/lib/class-offering-groups.test.ts
@@ -31,6 +31,27 @@ describe("parentLectureSection", () => {
       "A2",
     );
   });
+
+  test("maps recit section names to their parent lecture (any type)", () => {
+    // Recits use an R suffix and a multi-letter lecture prefix (UV); they are
+    // not typed "LAB" but must still resolve to their parent lecture.
+    expect(parentLectureSection(row({ section: "UV-1R", type: "REC" }))).toBe(
+      "UV",
+    );
+    expect(parentLectureSection(row({ section: "G-2R", type: "RECIT" }))).toBe(
+      "G",
+    );
+    expect(parentLectureSection(row({ section: "ST11R", type: "REC" }))).toBe(
+      "ST1",
+    );
+  });
+
+  test("returns null for standalone lecture/seminar sections", () => {
+    expect(parentLectureSection(row({ section: "G", type: "LEC" }))).toBeNull();
+    expect(
+      parentLectureSection(row({ section: "UV", type: "LEC" })),
+    ).toBeNull();
+  });
 });
 
 describe("groupClassesByOffering", () => {
@@ -50,5 +71,18 @@ describe("groupClassesByOffering", () => {
       "G",
       "G-5L",
     ]);
+  });
+
+  test("adds the parent lecture row to each recit offering", () => {
+    const groups = groupClassesByOffering([
+      row({ id: 1, courseCode: "SPCM 1", section: "UV", type: "LEC" }),
+      row({ id: 2, courseCode: "SPCM 1", section: "UV-1R", type: "REC" }),
+      row({ id: 3, courseCode: "SPCM 1", section: "UV-2R", type: "REC" }),
+    ]);
+
+    // The standalone lecture group is folded into its recits, not listed alone.
+    expect(groups.map((group) => group.section)).toEqual(["UV-1R", "UV-2R"]);
+    expect(groups[0]?.sections.map((s) => s.section)).toEqual(["UV", "UV-1R"]);
+    expect(groups[1]?.sections.map((s) => s.section)).toEqual(["UV", "UV-2R"]);
   });
 });

--- a/src/lib/class-offering-groups.ts
+++ b/src/lib/class-offering-groups.ts
@@ -19,11 +19,17 @@ function classType(row: ClassMapValue): string {
 }
 
 export function parentLectureSection(row: ClassMapValue): string | null {
-  if (classType(row) !== "LAB" || !row.section) return null;
+  if (!row.section) return null;
   const section = row.section.trim().toUpperCase();
-  const hyphenated = section.match(/^(.+)-\d+L$/);
+  // A lab or recit section encodes its parent lecture as the prefix before its
+  // numbered slot: "G-1L"/"UV-1R" (dashed) or "ST11L" (compact). Any trailing
+  // letter run marks a child (L = lab, R = recit, …), so match [A-Z]+ not just
+  // "L". The prefix is everything up to the dash/number, which preserves
+  // multi-letter lecture codes like "UV". Not gated on type: recits are not
+  // typed "LAB", and the section shape alone identifies a child.
+  const hyphenated = section.match(/^(.+)-\d+[A-Z]+$/);
   if (hyphenated?.[1]) return hyphenated[1];
-  const compact = section.match(/^(.+)\dL$/);
+  const compact = section.match(/^(.+)\d[A-Z]+$/);
   return compact?.[1] ?? null;
 }
 


### PR DESCRIPTION
Promotes the lab/recit parent-lecture fix (#581) to production. Selecting a lab or recitation now shows its parent lecture's schedule + room and adds the lecture to the planner (recits previously never resolved to their lecture).

CI: `verify` + `bundle` + Vercel green. `e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core class-grouping logic used by the planner and room UI; wrong parsing could mis-attach lectures or hide standalone lecture groups, but scope is limited and well-covered by new unit tests.
> 
> **Overview**
> **`parentLectureSection`** no longer requires `LAB` type and instead infers the parent lecture from section naming (`G-1L`, `UV-1R`, `ST11L`, etc.) using `\d+[A-Z]+` suffix patterns instead of lab-only `\d+L`.
> 
> **`groupClassesByOffering`** therefore attaches the parent lecture row to recitation offerings the same way it already did for labs, and folds standalone lecture groups into those recit groups instead of listing the lecture alone.
> 
> Tests cover recit mapping, multi-letter prefixes like `UV`, and null for bare lecture sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bbf75291a2b07248299720b41fd67bac56e218c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->