### PR TITLE
feat: pending-review modal reviewers can open directly (#10)

### DIFF
--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -12,6 +12,7 @@
   import ScheduleModal from "./ScheduleModal.svelte";
   import LeaderboardModal from "./LeaderboardModal.svelte";
   import ChangelogModal from "../ChangelogModal.svelte";
+  import ProposalReviewPanel from "../ProposalReviewPanel.svelte";
   import X from "@lucide/svelte/icons/x";
 
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
@@ -36,6 +37,7 @@
     if (modalStore.type === "schedule-expand") return "Room schedule";
     if (modalStore.type === "leaderboard") return "Contributor leaderboard";
     if (modalStore.type === "changelog") return "What's new";
+    if (modalStore.type === "review") return "Review suggested edits";
     return "Dialog";
   });
 
@@ -116,6 +118,18 @@
           <X size={20} aria-hidden="true" />
         </button>
         <ChangelogModal />
+      {:else if modalStore.type === "review"}
+        <button
+          type="button"
+          class="modal-content__close-icon"
+          aria-label="Close review"
+          onclick={closeDialog}
+        >
+          <X size={20} aria-hidden="true" />
+        </button>
+        <div class="review-modal-scroll">
+          <ProposalReviewPanel />
+        </div>
       {/if}
     </div>
   </div>
@@ -146,6 +160,13 @@
     box-sizing: border-box;
     pointer-events: auto;
   }
+  .review-modal-scroll {
+    min-height: 0;
+    max-height: min(70vh, 40rem);
+    overflow-y: auto;
+    padding: 0.5rem 0.75rem 0.25rem;
+  }
+
   .modal-content {
     position: relative;
     flex: 0 1 64rem;

--- a/src/components/svelte/status-bar/AppMenu.component.test.ts
+++ b/src/components/svelte/status-bar/AppMenu.component.test.ts
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test } from "vitest";
+import AppMenu from "./AppMenu.svelte";
+import { adminAuthStore, modalStore, proposalsStore } from "@lib/store.svelte";
+
+describe("AppMenu review entry", () => {
+  beforeEach(() => {
+    modalStore.closeModal();
+    adminAuthStore.canReview = false;
+    proposalsStore.pendingCount = 0;
+  });
+
+  test("reviewers get a review entry that opens the review modal with the pending count", async () => {
+    adminAuthStore.canReview = true;
+    proposalsStore.pendingCount = 3;
+    render(AppMenu, { props: { onSignOut: () => {} } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /app menu/i }));
+
+    const reviewBtn = screen.getByRole("button", {
+      name: /review suggested edits/i,
+    });
+    expect(reviewBtn).toBeVisible();
+    expect(reviewBtn.textContent).toContain("3");
+
+    await fireEvent.click(reviewBtn);
+    expect(modalStore.open).toBe(true);
+    expect(modalStore.type).toBe("review");
+  });
+
+  test("non-reviewers do not see the review entry", async () => {
+    adminAuthStore.canReview = false;
+    render(AppMenu, { props: { onSignOut: () => {} } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /app menu/i }));
+
+    expect(
+      screen.queryByRole("button", { name: /review suggested edits/i }),
+    ).toBeNull();
+  });
+});

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -2,6 +2,7 @@
   import Menu from "@lucide/svelte/icons/menu";
   import Keyboard from "@lucide/svelte/icons/keyboard";
   import FileText from "@lucide/svelte/icons/file-text";
+  import Inbox from "@lucide/svelte/icons/inbox";
   import { onMount } from "svelte";
   import { formatCatalogUpdatedDate } from "@constants/data-catalog";
   import { APP_VERSION_LABEL } from "@constants/version";
@@ -14,7 +15,12 @@
     openEphemeralOverlay,
   } from "@lib/overlay-stack";
   import { rafThrottle } from "@lib/layout-css-vars";
-  import { adminAuthStore, mapToolsStore, modalStore } from "@lib/store.svelte";
+  import {
+    adminAuthStore,
+    mapToolsStore,
+    modalStore,
+    proposalsStore,
+  } from "@lib/store.svelte";
   import OfflineMaps from "@ui/OfflineMaps.svelte";
   import SyncStatus from "@ui/SyncStatus.svelte";
   import PWAInstallPrompt from "@ui/PWAInstallPrompt.svelte";
@@ -145,6 +151,11 @@
     closePanel();
     modalStore.openModal("changelog");
   }
+
+  function handleReview() {
+    closePanel();
+    modalStore.openModal("review");
+  }
 </script>
 
 <svelte:window onpointerdown={handleDocumentPointerDown} />
@@ -187,6 +198,24 @@
             utilities
             {onSignOut}
           />
+        </section>
+      {/if}
+
+      {#if adminAuthStore.canReview}
+        <section class="app-menu__section" aria-label="Review">
+          <button
+            type="button"
+            class="app-menu__action map-chrome-chip"
+            onclick={handleReview}
+          >
+            <Inbox size={14} aria-hidden="true" />
+            <span>
+              Review suggested edits
+              {#if proposalsStore.pendingCount > 0}
+                <span class="app-menu__badge">{proposalsStore.pendingCount}</span>
+              {/if}
+            </span>
+          </button>
         </section>
       {/if}
 
@@ -279,6 +308,20 @@
   .app-menu__action {
     align-self: flex-start;
     cursor: pointer;
+  }
+
+  .app-menu__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.1rem;
+    margin-left: 0.25rem;
+    padding: 0 0.3rem;
+    border-radius: 999px;
+    background: hsl(5, 53%, 32%);
+    color: white;
+    font-size: 0.6875rem;
+    font-weight: 700;
   }
 
   .app-menu__panel {

--- a/src/constants/modal-states.ts
+++ b/src/constants/modal-states.ts
@@ -5,4 +5,5 @@ export const modalOptions = [
   "schedule-expand",
   "leaderboard",
   "changelog",
+  "review",
 ] as const;


### PR DESCRIPTION
Reviewing suggested edits required opening the editor-tools shelf. This adds a dedicated **"Review suggested edits"** entry to the App menu (reviewers only) with a pending-count badge, opening the review queue — including the batch-approve from #9 — in a modal.

## What's new
- New `review` modal type; renders the existing `ProposalReviewPanel` (scrollable) in `Modal.svelte`.
- App-menu entry gated on `adminAuthStore.canReview`, with a `pendingCount` badge.

## Tests
- `AppMenu.component.test.ts`: reviewers see the entry + count and it opens the review modal; non-reviewers don't see it. Component 78/78, unit 254/254.

## CI note
`e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret; `verify` + `bundle` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and navigation only; reuses existing review panel and existing auth gating with no new server or data paths.
> 
> **Overview**
> Reviewers can open the **suggested-edits review queue** from the status-bar **App menu** instead of going through editor tools.
> 
> A new **`review` modal** type wires `Modal.svelte` to the existing `ProposalReviewPanel` inside a scrollable region, with dialog labeling and a close control consistent with other modals. **`modalOptions`** gains `"review"` so `modalStore.openModal("review")` is valid.
> 
> The menu shows **Review suggested edits** only when `adminAuthStore.canReview` is true, displays **`proposalsStore.pendingCount`** in a badge when nonzero, and closes the panel before opening the modal. Component tests cover visibility, badge text, and modal type for reviewers vs non-reviewers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55cc07d24f63a513c2e11134c4c748e590b5cb22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->