### PR TITLE
release: pending-review modal (#10)

### DIFF
--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -12,6 +12,7 @@
   import ScheduleModal from "./ScheduleModal.svelte";
   import LeaderboardModal from "./LeaderboardModal.svelte";
   import ChangelogModal from "../ChangelogModal.svelte";
+  import ProposalReviewPanel from "../ProposalReviewPanel.svelte";
   import X from "@lucide/svelte/icons/x";
 
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
@@ -36,6 +37,7 @@
     if (modalStore.type === "schedule-expand") return "Room schedule";
     if (modalStore.type === "leaderboard") return "Contributor leaderboard";
     if (modalStore.type === "changelog") return "What's new";
+    if (modalStore.type === "review") return "Review suggested edits";
     return "Dialog";
   });
 
@@ -116,6 +118,18 @@
           <X size={20} aria-hidden="true" />
         </button>
         <ChangelogModal />
+      {:else if modalStore.type === "review"}
+        <button
+          type="button"
+          class="modal-content__close-icon"
+          aria-label="Close review"
+          onclick={closeDialog}
+        >
+          <X size={20} aria-hidden="true" />
+        </button>
+        <div class="review-modal-scroll">
+          <ProposalReviewPanel />
+        </div>
       {/if}
     </div>
   </div>
@@ -146,6 +160,13 @@
     box-sizing: border-box;
     pointer-events: auto;
   }
+  .review-modal-scroll {
+    min-height: 0;
+    max-height: min(70vh, 40rem);
+    overflow-y: auto;
+    padding: 0.5rem 0.75rem 0.25rem;
+  }
+
   .modal-content {
     position: relative;
     flex: 0 1 64rem;

--- a/src/components/svelte/status-bar/AppMenu.component.test.ts
+++ b/src/components/svelte/status-bar/AppMenu.component.test.ts
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test } from "vitest";
+import AppMenu from "./AppMenu.svelte";
+import { adminAuthStore, modalStore, proposalsStore } from "@lib/store.svelte";
+
+describe("AppMenu review entry", () => {
+  beforeEach(() => {
+    modalStore.closeModal();
+    adminAuthStore.canReview = false;
+    proposalsStore.pendingCount = 0;
+  });
+
+  test("reviewers get a review entry that opens the review modal with the pending count", async () => {
+    adminAuthStore.canReview = true;
+    proposalsStore.pendingCount = 3;
+    render(AppMenu, { props: { onSignOut: () => {} } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /app menu/i }));
+
+    const reviewBtn = screen.getByRole("button", {
+      name: /review suggested edits/i,
+    });
+    expect(reviewBtn).toBeVisible();
+    expect(reviewBtn.textContent).toContain("3");
+
+    await fireEvent.click(reviewBtn);
+    expect(modalStore.open).toBe(true);
+    expect(modalStore.type).toBe("review");
+  });
+
+  test("non-reviewers do not see the review entry", async () => {
+    adminAuthStore.canReview = false;
+    render(AppMenu, { props: { onSignOut: () => {} } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /app menu/i }));
+
+    expect(
+      screen.queryByRole("button", { name: /review suggested edits/i }),
+    ).toBeNull();
+  });
+});

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -2,6 +2,7 @@
   import Menu from "@lucide/svelte/icons/menu";
   import Keyboard from "@lucide/svelte/icons/keyboard";
   import FileText from "@lucide/svelte/icons/file-text";
+  import Inbox from "@lucide/svelte/icons/inbox";
   import { onMount } from "svelte";
   import { formatCatalogUpdatedDate } from "@constants/data-catalog";
   import { APP_VERSION_LABEL } from "@constants/version";
@@ -14,7 +15,12 @@
     openEphemeralOverlay,
   } from "@lib/overlay-stack";
   import { rafThrottle } from "@lib/layout-css-vars";
-  import { adminAuthStore, mapToolsStore, modalStore } from "@lib/store.svelte";
+  import {
+    adminAuthStore,
+    mapToolsStore,
+    modalStore,
+    proposalsStore,
+  } from "@lib/store.svelte";
   import OfflineMaps from "@ui/OfflineMaps.svelte";
   import SyncStatus from "@ui/SyncStatus.svelte";
   import PWAInstallPrompt from "@ui/PWAInstallPrompt.svelte";
@@ -145,6 +151,11 @@
     closePanel();
     modalStore.openModal("changelog");
   }
+
+  function handleReview() {
+    closePanel();
+    modalStore.openModal("review");
+  }
 </script>
 
 <svelte:window onpointerdown={handleDocumentPointerDown} />
@@ -187,6 +198,24 @@
             utilities
             {onSignOut}
           />
+        </section>
+      {/if}
+
+      {#if adminAuthStore.canReview}
+        <section class="app-menu__section" aria-label="Review">
+          <button
+            type="button"
+            class="app-menu__action map-chrome-chip"
+            onclick={handleReview}
+          >
+            <Inbox size={14} aria-hidden="true" />
+            <span>
+              Review suggested edits
+              {#if proposalsStore.pendingCount > 0}
+                <span class="app-menu__badge">{proposalsStore.pendingCount}</span>
+              {/if}
+            </span>
+          </button>
         </section>
       {/if}
 
@@ -279,6 +308,20 @@
   .app-menu__action {
     align-self: flex-start;
     cursor: pointer;
+  }
+
+  .app-menu__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.1rem;
+    margin-left: 0.25rem;
+    padding: 0 0.3rem;
+    border-radius: 999px;
+    background: hsl(5, 53%, 32%);
+    color: white;
+    font-size: 0.6875rem;
+    font-weight: 700;
   }
 
   .app-menu__panel {

--- a/src/constants/modal-states.ts
+++ b/src/constants/modal-states.ts
@@ -5,4 +5,5 @@ export const modalOptions = [
   "schedule-expand",
   "leaderboard",
   "changelog",
+  "review",
 ] as const;


### PR DESCRIPTION
Promotes the pending-review modal (#583) to production. Reviewers get a "Review suggested edits" entry in the App menu (with a pending-count badge) that opens the review queue — including batch-approve — in a modal.

CI: `verify` + `bundle` + Vercel green. `e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and navigation only; review UI is gated by existing `canReview` and reuses `ProposalReviewPanel` without changing auth or API logic in this diff.
> 
> **Overview**
> Ships the **review queue** in production by wiring the existing `ProposalReviewPanel` into the global modal system and exposing it from the App menu for users with review permission.
> 
> Adds a new **`review` modal type** (aria label “Review suggested edits”) that renders `ProposalReviewPanel` inside a scrollable container with the same close affordance as other modals. **Reviewers** see a **“Review suggested edits”** action in the App menu, with a **pending-count badge** when `proposalsStore.pendingCount > 0`; choosing it closes the menu and opens the review modal. Non-reviewers do not see the entry.
> 
> Includes **component tests** for the menu: badge visibility, modal open/type, and hiding when `canReview` is false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ca4a572a530ef1e84c97b8fc200ce12a7e8d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->