### PR TITLE
fix(planner): pass island props explicitly so /planner opens in prod

### DIFF
--- a/e2e/smoke/planner-route.spec.ts
+++ b/e2e/smoke/planner-route.spec.ts
@@ -23,6 +23,9 @@ test.describe("planner route", () => {
     const planner = page.getByRole("dialog", { name: "Class Planner" });
     await expect(planner).toBeVisible();
     await expect(planner.getByText(/change of matriculation/i)).toBeVisible();
+    // The URL must stay /planner (regression: the prod island dropped the
+    // openPlanner prop, so the planner never opened and the path fell back to /).
+    await expect(page).toHaveURL(/\/planner(\/|\?|$)/);
   });
 
   test("/planner?term still opens the planner", async ({ page }) => {

--- a/src/lib/entity-url-sync.ts
+++ b/src/lib/entity-url-sync.ts
@@ -36,6 +36,9 @@ export type EntityUrlSyncSnapshot = RoutableQueryState & {
 
 const HOME_PATH = "/";
 const PLANNER_PATH = "/planner";
+// currentPathname() runs through normalizePathname (adds a trailing slash), so
+// compare against the normalized form, not the raw "/planner".
+const PLANNER_PATH_NORMALIZED = normalizePathname(PLANNER_PATH);
 
 export function createEntityUrlSync(context: EntityUrlSyncContext) {
   let applyingFromHistory = false;
@@ -128,7 +131,7 @@ export function createEntityUrlSync(context: EntityUrlSyncContext) {
     try {
       termStore.applyFromUrl();
       // Back/forward into or out of /planner toggles the planner overlay.
-      context.setPlannerOpen(currentPathname() === PLANNER_PATH);
+      context.setPlannerOpen(currentPathname() === PLANNER_PATH_NORMALIZED);
       const state = (event.state ?? null) as EntityHistoryState | null;
       if (state?.query) {
         context.hydrateQuery(state.query);
@@ -187,12 +190,11 @@ export function createEntityUrlSync(context: EntityUrlSyncContext) {
         snapshot.termId,
         snapshot.defaultTermId,
       );
-      const plannerPathname = plannerPath.split("?")[0] ?? PLANNER_PATH;
       const plannerSearch = plannerPath.includes("?")
         ? plannerPath.slice(plannerPath.indexOf("?"))
         : "";
       if (
-        currentPathname() !== plannerPathname ||
+        currentPathname() !== PLANNER_PATH_NORMALIZED ||
         window.location.search !== plannerSearch
       ) {
         const carried =

--- a/src/pages/planner.astro
+++ b/src/pages/planner.astro
@@ -29,5 +29,5 @@ const structuredData = jsonLd(
   canonicalPath="/planner"
   structuredData={structuredData}
 >
-  <AppRoot client:only="svelte" openPlanner suppressLandingModal />
+  <AppRoot client:only="svelte" openPlanner={true} suppressLandingModal={true} />
 </Layout>


### PR DESCRIPTION
/planner opened for nobody on prod: bare boolean props on the client:only island are dropped in the prerendered build, so openPlanner never reached the client and the URL fell back to /. Use explicit ={true} (matches the working event-page pattern). Verified in the production build; e2e now asserts URL persistence and runs against the built app. Also fixes a trailing-slash comparison bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted routing and Astro island prop fix with a trailing-slash comparison tweak; no auth, data, or payment paths touched.
> 
> **Overview**
> Fixes **`/planner`** deep links failing in production: the prerendered **`client:only`** island was not receiving **`openPlanner`** / **`suppressLandingModal`** when those props were written as bare booleans, so the app booted without opening the Class Planner and URL sync could fall back to **`/`**. **`planner.astro`** now passes **`openPlanner={true}`** and **`suppressLandingModal={true}`**, matching the explicit-prop pattern used on event pages.
> 
> **`entity-url-sync`** now compares the current path to a **normalized** planner path (**`/planner/`**) for popstate and while the planner is open, so trailing-slash handling stays consistent with **`normalizePathname`**.
> 
> E2e smoke coverage asserts the browser **stays on `/planner`** after load, guarding the prod regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b855e1f79deda60fcb1fd02bb63c0d62fe652886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->