### PR TITLE
fix: update prompt shows installed version, not stale changelog version

### DIFF
--- a/src/components/svelte/ChangelogModal.svelte
+++ b/src/components/svelte/ChangelogModal.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
   import { RefreshCw, FileText } from "@lucide/svelte";
   import { syncToastStore, modalStore } from "@lib/store.svelte";
-  import { APP_VERSION_LABEL } from "@constants/version";
-  import { parseChangelogHighlights } from "@lib/changelog-highlights";
+  import { APP_VERSION, APP_VERSION_LABEL } from "@constants/version";
+  import {
+    parseChangelogHighlights,
+    isChangelogCurrent,
+  } from "@lib/changelog-highlights";
   import changelogRaw from "../../../CHANGELOG.md?raw";
 
   const highlights = $derived(parseChangelogHighlights(changelogRaw));
   const hasUpdate = $derived(syncToastStore.needRefresh);
+  // Only show the parsed highlights when the changelog matches the installed
+  // version. A stale CHANGELOG (version bumped without regenerating it) would
+  // otherwise claim an older version than the one already running.
+  const showHighlights = $derived(
+    highlights !== null && isChangelogCurrent(highlights.version, APP_VERSION),
+  );
 
   let reloading = $state(false);
 
@@ -19,11 +28,7 @@
 
 <div class="changelog-modal">
   <p class="changelog-modal__version">
-    {#if highlights}
-      What's new in v{highlights.version}
-    {:else}
-      Room TBA {APP_VERSION_LABEL}
-    {/if}
+    Room TBA {APP_VERSION_LABEL}
   </p>
 
   {#if hasUpdate}
@@ -32,7 +37,7 @@
     </p>
   {/if}
 
-  {#if highlights && highlights.items.length > 0}
+  {#if showHighlights && highlights}
     <ul class="changelog-modal__list">
       {#each highlights.items as item (item)}
         <li>{item}</li>
@@ -44,7 +49,9 @@
       </p>
     {/if}
   {:else}
-    <p class="changelog-modal__lead">See the full changelog for details.</p>
+    <p class="changelog-modal__lead">
+      See the full changelog for what's new.
+    </p>
   {/if}
 
   <a

--- a/src/components/svelte/SyncStatus.svelte
+++ b/src/components/svelte/SyncStatus.svelte
@@ -12,8 +12,11 @@
     appBootstrapStore,
     modalStore,
   } from "@lib/store.svelte";
-  import { APP_VERSION_LABEL } from "@constants/version";
-  import { parseChangelogHighlights } from "@lib/changelog-highlights";
+  import { APP_VERSION, APP_VERSION_LABEL } from "@constants/version";
+  import {
+    parseChangelogHighlights,
+    isChangelogCurrent,
+  } from "@lib/changelog-highlights";
   import changelogRaw from "../../../CHANGELOG.md?raw";
 
   type Props = {
@@ -102,7 +105,9 @@
       showDetail &&
       !compact &&
       updateHighlights !== null &&
-      updateHighlights.items.length > 0,
+      updateHighlights.items.length > 0 &&
+      // Don't show stale changelog bullets that predate the installed version.
+      isChangelogCurrent(updateHighlights.version, APP_VERSION),
   );
 
   const statusLabel = $derived.by(() => {

--- a/src/lib/changelog-highlights.test.ts
+++ b/src/lib/changelog-highlights.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, test } from "bun:test";
-import { parseChangelogHighlights } from "./changelog-highlights";
+import {
+  parseChangelogHighlights,
+  isChangelogCurrent,
+} from "./changelog-highlights";
+
+describe("isChangelogCurrent", () => {
+  test("true when the changelog matches or leads the app version", () => {
+    expect(isChangelogCurrent("1.31.1", "1.31.1")).toBe(true);
+    expect(isChangelogCurrent("1.31.0", "1.31.0")).toBe(true);
+    expect(isChangelogCurrent("1.32.0", "1.31.1")).toBe(true);
+  });
+
+  test("false when the changelog lags the installed version (the 1.23 vs 1.31 bug)", () => {
+    expect(isChangelogCurrent("1.23.0", "1.31.1")).toBe(false);
+    expect(isChangelogCurrent("1.9.0", "1.10.0")).toBe(false);
+  });
+
+  test("tolerates a leading v and missing patch segments", () => {
+    expect(isChangelogCurrent("v1.31", "1.31.0")).toBe(true);
+    expect(isChangelogCurrent("v1.23", "v1.31.1")).toBe(false);
+  });
+});
 
 describe("parseChangelogHighlights", () => {
   test("returns top bullets for the latest version", () => {

--- a/src/lib/changelog-highlights.ts
+++ b/src/lib/changelog-highlights.ts
@@ -40,6 +40,37 @@ export function parseChangelogHighlights(
   };
 }
 
+/** Compare dotted numeric versions ("1.31.1"); returns <0, 0, or >0. */
+function compareVersions(a: string, b: string): number {
+  const parse = (v: string) =>
+    v
+      .replace(/^v/i, "")
+      .split(".")
+      .map((n) => Number.parseInt(n, 10) || 0);
+  const pa = parse(a);
+  const pb = parse(b);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * The changelog highlights are only trustworthy for the running app when the
+ * newest CHANGELOG entry is at least the app version. When package.json is
+ * bumped without regenerating CHANGELOG.md (a stale changelog), the highlights
+ * lag the real version and must not be shown as "what's new" — otherwise the
+ * update prompt claims a version older than the one already installed.
+ */
+export function isChangelogCurrent(
+  changelogVersion: string,
+  appVersion: string,
+): boolean {
+  return compareVersions(changelogVersion, appVersion) >= 0;
+}
+
 function sanitizeBullet(raw: string): string {
   return raw
     .replace(/\(\[[^\]]+\]\([^)]+\)\)/g, "")


### PR DESCRIPTION
## Bug (reported)
"Clicking the update modal still asks me to update to 1.23 even though it says I'm on 1.31."

## Root cause
On `origin/main`, `package.json` is **1.31.1** but `CHANGELOG.md`'s newest entry is **1.23.0** — semantic-release bumps the version but the changelog isn't regenerated. `parseChangelogHighlights` read the changelog's top heading (1.23) and the prompt claimed an update to a version *older* than the installed one.

## Fix
- `ChangelogModal` shows the app's own version (`APP_VERSION_LABEL`) as the source of truth — never the parsed changelog version.
- Highlights (modal + SyncStatus inline) render only when the changelog's newest entry is `>=` the installed version (`isChangelogCurrent`); a stale changelog falls back to a generic "see the full changelog" link.

**Follow-up (not code):** the real gap is the release pipeline bumping `package.json` without regenerating `CHANGELOG.md`. This change makes the UI correct regardless, but the changelog should be regenerated so real "what's new" bullets return.

## Test
- `isChangelogCurrent`: match/lead/lag + `v`-prefix/short forms. Unit 257/257, component 78/78.

## CI note
`e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret; `verify` + `bundle` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only version display and changelog gating with unit tests; no auth, data, or sync behavior changes.
> 
> **Overview**
> Fixes the update UI claiming an **older** version than the one already installed when `CHANGELOG.md` is stale (e.g. app at **1.31.1** but changelog top entry still **1.23.0**).
> 
> Adds **`isChangelogCurrent`** (semver-style compare, optional `v` prefix) so parsed highlight bullets render only when the changelog’s newest entry is **≥** **`APP_VERSION`**. **`ChangelogModal`** always titles with **`APP_VERSION_LABEL`** instead of the parsed changelog version; **`SyncStatus`** applies the same gate for inline “what’s new” bullets. When the changelog lags, users see generic copy and a link to the full changelog instead of misleading bullets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683218ab5f0117332d6c2a805b4097da17d629d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->