### PR TITLE
fix(pwa): denylist /planner (and siblings) with query strings

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,17 +39,19 @@ export default defineConfig({
         navigateFallback: "/",
         navigateFallbackDenylist: [
           /^\/api\//,
-          /^\/privacy(\/|$)/,
-          /^\/terms(\/|$)/,
-          /^\/changelog(\/|$)/,
+          /^\/privacy(\/|\?|$)/,
+          /^\/terms(\/|\?|$)/,
+          /^\/changelog(\/|\?|$)/,
           // /planner is its own page; without this the nav fallback serves the
           // map shell and the planner never opens for returning (SW-cached)
-          // users. Network-first; the in-app planner button covers offline.
-          /^\/planner(\/|$)/,
+          // users. The `\?` matters: workbox matches denylist against
+          // pathname+search, so /planner?term=… must be covered too (#planner).
+          // Network-first; the in-app planner button covers offline.
+          /^\/planner(\/|\?|$)/,
           // Server redirects — must hit network, not offline app shell (#471).
-          /^\/messenger(\/|$)/,
-          /^\/maintain(\/|$)/,
-          /^\/discord(\/|$)/,
+          /^\/messenger(\/|\?|$)/,
+          /^\/maintain(\/|\?|$)/,
+          /^\/discord(\/|\?|$)/,
         ],
         swDest: "dist/client/sw.js",
         // Cache third-party map resources at runtime so the campus map works


### PR DESCRIPTION
Root cause of '/planner works but /planner?term=1261 goes to base': the SW navigateFallbackDenylist regex `/^\/planner(\/|$)/` is matched against pathname+search, so the `?` broke the match → SW served the map shell instead of planner.astro. Add `\?` to all denylist entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small service-worker routing tweak with no auth or data changes; main risk is a regex mistake affecting offline navigation for a few paths.
> 
> **Overview**
> Fixes a bug where URLs like `/planner?term=1261` were handled by the PWA **navigate fallback** (map shell) instead of the real planner page.
> 
> Workbox evaluates `navigateFallbackDenylist` against **pathname + search**, so patterns that only allowed `/` or end-of-string failed when a `?` followed the path. All affected denylist regexes in `astro.config.mjs` now include `\?` after the path segment—**privacy**, **terms**, **changelog**, **planner**, and the redirect routes **messenger**, **maintain**, and **discord**—so query-string navigations stay off the offline app shell and hit the network or correct page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b0bb1039437c2262b2fd1e7e8f78f3e8c4218a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->