### PR TITLE
feat: drag the mobile details sheet handle to expand/collapse (#4)

### DIFF
--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -19,6 +19,7 @@
   import ChevronUp from "@lucide/svelte/icons/chevron-up";
   import X from "@lucide/svelte/icons/x";
   import { JEEPNEY_ROUTES } from "@constants/jeepney-routes";
+  import { resolveDrawerDragIntent } from "@lib/drawer-drag";
   import { MediaQuery } from "svelte/reactivity";
 
   const mobile = new MediaQuery("max-width:48rem");
@@ -71,6 +72,40 @@
     sidePanelStore.collapsed = !sidePanelStore.collapsed;
   }
 
+  // Drag-to-resize the mobile sheet: drag the handle down to collapse, up to
+  // expand. Small movements fall through to the click handler as a tap toggle.
+  let dragStartY: number | null = null;
+  let dragMoved = false;
+
+  function onHandlePointerDown(event: PointerEvent) {
+    if (!mobile.current || event.pointerType === "mouse") return;
+    dragStartY = event.clientY;
+    dragMoved = false;
+    (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+  }
+
+  function onHandlePointerMove(event: PointerEvent) {
+    if (dragStartY === null) return;
+    if (Math.abs(event.clientY - dragStartY) > 6) dragMoved = true;
+  }
+
+  function onHandlePointerUp(event: PointerEvent) {
+    if (dragStartY === null) return;
+    const intent = resolveDrawerDragIntent(event.clientY - dragStartY);
+    dragStartY = null;
+    if (intent === "expand") sidePanelStore.expand();
+    else if (intent === "collapse") sidePanelStore.collapse();
+  }
+
+  function onHandleClick() {
+    // Swallow the click that fires after a drag so it doesn't re-toggle.
+    if (dragMoved) {
+      dragMoved = false;
+      return;
+    }
+    togglePanel();
+  }
+
   function closeSelection() {
     if (jeepneyStore.selectedStopIndex !== null) {
       jeepneyStore.closeStop();
@@ -95,7 +130,10 @@
                 aria-controls="side-panel-details"
                 aria-label={toggleLabel}
                 title={toggleLabel}
-                onclick={togglePanel}
+                onclick={onHandleClick}
+                onpointerdown={onHandlePointerDown}
+                onpointermove={onHandlePointerMove}
+                onpointerup={onHandlePointerUp}
               >
                 <span class="drawer-peek-label">{peekLabel}</span>
                 <ChevronUp size={16} aria-hidden="true" />
@@ -118,7 +156,10 @@
               aria-controls="side-panel-details"
               aria-label={toggleLabel}
               title={toggleLabel}
-              onclick={togglePanel}
+              onclick={onHandleClick}
+              onpointerdown={onHandlePointerDown}
+              onpointermove={onHandlePointerMove}
+              onpointerup={onHandlePointerUp}
             >
               {#if mobile.current}
                 <span class="drawer-grab" aria-hidden="true"></span>
@@ -372,6 +413,7 @@
       background: transparent;
       color: #18181b;
       cursor: pointer;
+      touch-action: none;
     }
 
     .drawer-peek-expand:hover,
@@ -496,7 +538,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      cursor: pointer;
+      cursor: grab;
+      /* Let the handle own vertical drags instead of scrolling the page. */
+      touch-action: none;
     }
 
     .drawer-grab {

--- a/src/lib/drawer-drag.test.ts
+++ b/src/lib/drawer-drag.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { resolveDrawerDragIntent } from "./drawer-drag";
+
+describe("resolveDrawerDragIntent", () => {
+  test("dragging down past the threshold collapses", () => {
+    expect(resolveDrawerDragIntent(60)).toBe("collapse");
+    expect(resolveDrawerDragIntent(40)).toBe("collapse");
+  });
+
+  test("dragging up past the threshold expands", () => {
+    expect(resolveDrawerDragIntent(-60)).toBe("expand");
+    expect(resolveDrawerDragIntent(-40)).toBe("expand");
+  });
+
+  test("small movements are taps, not swipes", () => {
+    expect(resolveDrawerDragIntent(0)).toBe("none");
+    expect(resolveDrawerDragIntent(10)).toBe("none");
+    expect(resolveDrawerDragIntent(-30)).toBe("none");
+  });
+
+  test("honors a custom threshold", () => {
+    expect(resolveDrawerDragIntent(20, 15)).toBe("collapse");
+    expect(resolveDrawerDragIntent(20, 25)).toBe("none");
+  });
+});

--- a/src/lib/drawer-drag.ts
+++ b/src/lib/drawer-drag.ts
@@ -1,0 +1,18 @@
+export type DrawerDragIntent = "expand" | "collapse" | "none";
+
+/** Drags shorter than this (px) are treated as taps, not swipes. */
+export const DRAWER_DRAG_THRESHOLD = 40;
+
+/**
+ * Interpret a vertical drag on the drawer handle. Positive deltaY means the
+ * pointer moved down (collapse the sheet); negative means up (expand it).
+ * Movements under the threshold return "none" so a tap still toggles via click.
+ */
+export function resolveDrawerDragIntent(
+  deltaY: number,
+  threshold: number = DRAWER_DRAG_THRESHOLD,
+): DrawerDragIntent {
+  if (deltaY >= threshold) return "collapse";
+  if (deltaY <= -threshold) return "expand";
+  return "none";
+}


### PR DESCRIPTION
The mobile details sheet handle only toggled on tap. This adds a drag gesture.

## What's new
- Drag the handle (or the collapsed peek) **down to collapse, up to expand**; a tap still toggles.
- Pointer events + pointer capture + `touch-action: none` so the drag owns the vertical gesture instead of scrolling the page.
- Drags under a small threshold fall through to the tap toggle (no accidental collapse on tap).

## Tests
- `drawer-drag.test.ts`: `resolveDrawerDragIntent` maps drag delta → expand/collapse/none with a threshold. Unit 261/261, component 78/78, build clean.

## CI note
`e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret; `verify` + `bundle` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile UI interaction and a pure helper; no auth, data, or API changes.
> 
> **Overview**
> On mobile, the details sheet **handle** and **collapsed peek** now support **drag up to expand** and **drag down to collapse**, while a short tap still toggles like before.
> 
> `MainControls.svelte` wires **pointer capture** on touch pointers only (not mouse), uses `resolveDrawerDragIntent` on release, and **suppresses the follow-up click** after a real drag so the panel doesn’t double-toggle. **`touch-action: none`** on the peek/handle keeps vertical drags from scrolling the page.
> 
> New **`drawer-drag.ts`** centralizes the **40px** swipe threshold (`expand` / `collapse` / `none`); **`drawer-drag.test.ts`** covers threshold behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e6441d3d81340c9c8af41aa3b67ecc9c82927f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->