### PR TITLE
feat: toggle org/place pin layers from the map legend (#18b)

### DIFF
--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -141,7 +141,7 @@
   // the building they sit in. Orgs without any resolvable location are dropped
   // from the map (they still appear in the directory list).
   const filteredOrganizations = $derived.by(() => {
-    if (!loaded) return [];
+    if (!loaded || !mapViewStore.showOrgs) return [];
     return organizations
       .map((org) => {
         let lat = org.lat;
@@ -161,7 +161,7 @@
       );
   });
   const filteredPlaces = $derived.by(() => {
-    if (!loaded) return [];
+    if (!loaded || !mapViewStore.showPlaces) return [];
     return places.filter((place) => place.lat != null && place.lon != null);
   });
 

--- a/src/components/svelte/MapLegend.svelte
+++ b/src/components/svelte/MapLegend.svelte
@@ -174,6 +174,42 @@
             {/each}
           </div>
         </section>
+
+        <section class="legend-section" aria-labelledby="legend-layers">
+          <h3 id="legend-layers" class="legend-section-title">Layers</h3>
+          <div class="legend-list">
+            <button
+              type="button"
+              class="legend-item legend-toggle"
+              class:legend-toggle--off={!mapViewStore.showOrgs}
+              aria-pressed={mapViewStore.showOrgs}
+              onclick={() => mapViewStore.toggleOrgs()}
+            >
+              <span class="legend-swatch organization" aria-hidden="true"></span>
+              <span class="legend-copy">
+                <span class="legend-label">Orgs &amp; offices</span>
+                <span class="legend-description">
+                  {mapViewStore.showOrgs ? "Shown" : "Hidden"} — tap to toggle.
+                </span>
+              </span>
+            </button>
+            <button
+              type="button"
+              class="legend-item legend-toggle"
+              class:legend-toggle--off={!mapViewStore.showPlaces}
+              aria-pressed={mapViewStore.showPlaces}
+              onclick={() => mapViewStore.togglePlaces()}
+            >
+              <span class="legend-swatch place" aria-hidden="true"></span>
+              <span class="legend-copy">
+                <span class="legend-label">Places</span>
+                <span class="legend-description">
+                  {mapViewStore.showPlaces ? "Shown" : "Hidden"} — tap to toggle.
+                </span>
+              </span>
+            </button>
+          </div>
+        </section>
       </div>
     </div>
   {/if}
@@ -397,6 +433,41 @@
 
   .legend-swatch.location {
     background-color: #4285f4;
+  }
+
+  .legend-swatch.organization {
+    background-color: hsl(262, 52%, 47%);
+  }
+
+  .legend-swatch.place {
+    background-color: hsl(28, 80%, 45%);
+  }
+
+  .legend-toggle {
+    all: unset;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    min-width: 0;
+    max-width: 100%;
+    border-radius: 0.625rem;
+    background-color: hsl(0, 0%, 98%);
+    padding: 0.45rem 0.625rem;
+    cursor: pointer;
+  }
+
+  .legend-toggle:hover,
+  .legend-toggle:focus-visible {
+    background-color: hsl(5, 30%, 95%);
+  }
+
+  .legend-toggle--off {
+    opacity: 0.55;
+  }
+
+  .legend-toggle--off .legend-swatch {
+    filter: grayscale(1);
   }
 
   .legend-swatch.jeepney-stop {

--- a/src/lib/stores/map-stores.store.test.ts
+++ b/src/lib/stores/map-stores.store.test.ts
@@ -64,6 +64,26 @@ describe("MapViewStore", () => {
     store.showAll();
     expect(store.eventsOnly).toBe(false);
   });
+
+  test("org and place layers default on and toggle independently", () => {
+    const store = new MapViewStore();
+    expect(store.showOrgs).toBe(true);
+    expect(store.showPlaces).toBe(true);
+    store.toggleOrgs();
+    expect(store.showOrgs).toBe(false);
+    expect(store.showPlaces).toBe(true);
+    store.togglePlaces();
+    expect(store.showPlaces).toBe(false);
+  });
+
+  test("showAll restores hidden pin layers", () => {
+    const store = new MapViewStore();
+    store.toggleOrgs();
+    store.togglePlaces();
+    store.showAll();
+    expect(store.showOrgs).toBe(true);
+    expect(store.showPlaces).toBe(true);
+  });
 });
 
 describe("Building3DStore", () => {

--- a/src/lib/stores/map-stores.svelte.ts
+++ b/src/lib/stores/map-stores.svelte.ts
@@ -10,13 +10,27 @@ export class MapStore {
 
 export class MapViewStore {
   eventsOnly: boolean = $state(false);
+  // Org/office and place (POI) pin layers — on by default, toggled from the
+  // map legend so users can declutter the map (#18b).
+  showOrgs: boolean = $state(true);
+  showPlaces: boolean = $state(true);
 
   toggleEventsOnly = () => {
     this.eventsOnly = !this.eventsOnly;
   };
 
+  toggleOrgs = () => {
+    this.showOrgs = !this.showOrgs;
+  };
+
+  togglePlaces = () => {
+    this.showPlaces = !this.showPlaces;
+  };
+
   showAll = () => {
     this.eventsOnly = false;
+    this.showOrgs = true;
+    this.showPlaces = true;
   };
 }
 


### PR DESCRIPTION
Org and place pins always rendered and weren't even listed in the legend. This adds a **Layers** section to the map legend with toggles for orgs/offices and places (on by default), so users can declutter the map.

- `mapViewStore.showOrgs` / `showPlaces` (+ toggles), restored by `showAll()`.
- `Map` gates the org/place marker sets on those flags.
- Legend "Layers" rows show current state + tap to toggle.

## Tests
- MapViewStore: layers default on, toggle independently, restored by `showAll()`. Component/store 80/80, unit 261/261, build clean.

## Held for batched deploy
Not releasing to main yet — Vercel deploy limit is active. This will ship in the next batched staging→main release once deploys are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only map display toggles with safe defaults; directory data is unchanged and tests cover store behavior.
> 
> **Overview**
> Adds **user-controlled visibility** for organization/office and place (POI) map pins, which were always on and not represented in the legend.
> 
> `MapViewStore` gains **`showOrgs`** and **`showPlaces`** (default **on**), **`toggleOrgs`** / **`togglePlaces`**, and **`showAll()`** now turns both layers back on alongside clearing events-only mode. **`Map`** empty-lists org and place marker data when the corresponding flag is off.
> 
> The map legend gets a **Layers** section with accessible toggle rows (shown/hidden state, swatches, dimmed styling when off) wired to that store. Unit tests cover defaults, independent toggles, and **`showAll()`** restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9e153e8144af3166d167d0d818553b3a43b6cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->