### PR TITLE
fix(planner): refetch drag alternatives when a course is added

### DIFF
--- a/src/components/svelte/planner/PlannerScreen.svelte
+++ b/src/components/svelte/planner/PlannerScreen.svelte
@@ -138,11 +138,14 @@
   // Re-resolve natural keys and load finals once per plan per open (#planner).
   $effect(() => {
     if (!plannerStore.open || !plan || plan.sections.length === 0) return;
-    const refreshKey = `${plan.id}::${plan.termId}`;
+    // Key on the course set too: adding a course to the plan must refetch its
+    // sections, otherwise dragging a newly added block has no alternatives to
+    // drop onto (drag "doesn't work" for just-added courses).
+    const courseCodes = [...new Set(plan.sections.map((s) => s.courseCode))].sort();
+    const refreshKey = `${plan.id}::${plan.termId}::${courseCodes.join(",")}`;
     if (refreshKey === lastRefreshKey) return;
     lastRefreshKey = refreshKey;
 
-    const courseCodes = [...new Set(plan.sections.map((s) => s.courseCode))];
     Promise.all(
       courseCodes.map((code) =>
         fetchClassPage({


### PR DESCRIPTION
Dragging a just-added course's block did nothing: drag targets (courseRows/alternatives) are fetched by an effect keyed on plan.id::termId, which doesn't change when you add a course → no refetch → no alternatives → no drop targets. Key on the course set too. Pure client-logic fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side change to when class/final data is refetched; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes **drag-and-drop doing nothing** for blocks from a course you just added to the plan.
> 
> The planner effect that loads section rows (`courseRows` → `PlannerGrid` **alternatives**) and finals was gated by `refreshKey = plan.id::termId`, so adding a course did not trigger a refetch and new courses had **no drop targets**. The key now includes the **sorted set of course codes** on the plan; `courseCodes` is derived once at the top of the effect (same fetch loop as before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a2108bf202aa2f10a2fa7c526b61b712af600bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->