### PR TITLE
batch: lectures in room view, term AY label, org/place pin toggles, contributor avatars, deploy docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,14 @@ When the user asks to **ship** a feature or fix, they mean the **full integratio
 
 Direct commit + push to `staging` without a PR is fine for solo touch-ups ([§ Push to staging directly](#push-to-staging-directly)): but that is **not** “shipped” until stage 2 (`staging` → `main`) is also reviewed, built, and merged.
 
+### Minimize deploys — the Vercel free tier has a daily cap
+
+Every push to `staging` or `main` (and every PR preview) triggers a Vercel deployment, and the free tier caps deployments per day ("Deployment rate limited — retry in 24 hours"). Hitting the cap **freezes all prod deploys for ~24h**.
+
+- **Batch features into one release.** When several fixes/features are ready, land them all on `staging`, then do **one** `staging` → `main` release — not a release per feature. One-PR-per-feature releases burned the cap once already.
+- Don't open/refresh PRs just to re-trigger builds; don't push trivial follow-up commits that each redeploy.
+- If the cap is hit, further merges only queue undeployed commits — wait for the reset or upgrade the Vercel plan; don't keep merging.
+
 **Merge the release PR with a merge commit, not squash** — semantic-release reads the individual conventional commits to build the changelog; a squash collapses them to one message.
 
 **Release-step (`main`) gotchas — semantic-release.** Pushing to `main` runs `bunx semantic-release` (`.github/workflows/release.yml`). Two failure modes seen in practice:

--- a/src/components/svelte/Avatar.svelte
+++ b/src/components/svelte/Avatar.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { nameInitials, nameColor } from "@lib/avatar";
+
+  type Props = {
+    name: string;
+    size?: number;
+  };
+
+  let { name, size = 28 }: Props = $props();
+
+  const initials = $derived(nameInitials(name));
+  const background = $derived(nameColor(name));
+</script>
+
+<span
+  class="avatar"
+  style:width={`${size}px`}
+  style:height={`${size}px`}
+  style:background={background}
+  style:font-size={`${Math.round(size * 0.4)}px`}
+  role="img"
+  aria-label={name}
+  title={name}
+>
+  {initials}
+</span>
+
+<style>
+  .avatar {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    color: white;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0.02em;
+    user-select: none;
+  }
+</style>

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -141,7 +141,7 @@
   // the building they sit in. Orgs without any resolvable location are dropped
   // from the map (they still appear in the directory list).
   const filteredOrganizations = $derived.by(() => {
-    if (!loaded) return [];
+    if (!loaded || !mapViewStore.showOrgs) return [];
     return organizations
       .map((org) => {
         let lat = org.lat;
@@ -161,7 +161,7 @@
       );
   });
   const filteredPlaces = $derived.by(() => {
-    if (!loaded) return [];
+    if (!loaded || !mapViewStore.showPlaces) return [];
     return places.filter((place) => place.lat != null && place.lon != null);
   });
 

--- a/src/components/svelte/MapLegend.svelte
+++ b/src/components/svelte/MapLegend.svelte
@@ -174,6 +174,42 @@
             {/each}
           </div>
         </section>
+
+        <section class="legend-section" aria-labelledby="legend-layers">
+          <h3 id="legend-layers" class="legend-section-title">Layers</h3>
+          <div class="legend-list">
+            <button
+              type="button"
+              class="legend-item legend-toggle"
+              class:legend-toggle--off={!mapViewStore.showOrgs}
+              aria-pressed={mapViewStore.showOrgs}
+              onclick={() => mapViewStore.toggleOrgs()}
+            >
+              <span class="legend-swatch organization" aria-hidden="true"></span>
+              <span class="legend-copy">
+                <span class="legend-label">Orgs &amp; offices</span>
+                <span class="legend-description">
+                  {mapViewStore.showOrgs ? "Shown" : "Hidden"} — tap to toggle.
+                </span>
+              </span>
+            </button>
+            <button
+              type="button"
+              class="legend-item legend-toggle"
+              class:legend-toggle--off={!mapViewStore.showPlaces}
+              aria-pressed={mapViewStore.showPlaces}
+              onclick={() => mapViewStore.togglePlaces()}
+            >
+              <span class="legend-swatch place" aria-hidden="true"></span>
+              <span class="legend-copy">
+                <span class="legend-label">Places</span>
+                <span class="legend-description">
+                  {mapViewStore.showPlaces ? "Shown" : "Hidden"} — tap to toggle.
+                </span>
+              </span>
+            </button>
+          </div>
+        </section>
       </div>
     </div>
   {/if}
@@ -397,6 +433,41 @@
 
   .legend-swatch.location {
     background-color: #4285f4;
+  }
+
+  .legend-swatch.organization {
+    background-color: hsl(262, 52%, 47%);
+  }
+
+  .legend-swatch.place {
+    background-color: hsl(28, 80%, 45%);
+  }
+
+  .legend-toggle {
+    all: unset;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    min-width: 0;
+    max-width: 100%;
+    border-radius: 0.625rem;
+    background-color: hsl(0, 0%, 98%);
+    padding: 0.45rem 0.625rem;
+    cursor: pointer;
+  }
+
+  .legend-toggle:hover,
+  .legend-toggle:focus-visible {
+    background-color: hsl(5, 30%, 95%);
+  }
+
+  .legend-toggle--off {
+    opacity: 0.55;
+  }
+
+  .legend-toggle--off .legend-swatch {
+    filter: grayscale(1);
   }
 
   .legend-swatch.jeepney-stop {

--- a/src/components/svelte/ProposalReviewPanel.svelte
+++ b/src/components/svelte/ProposalReviewPanel.svelte
@@ -13,6 +13,7 @@
   import { parseBundledRooms } from "@lib/proposals/create-proposal-validation";
   import EntityEditorFormField from "@ui/editor/EntityEditorFormField.svelte";
   import EntityReviewActions from "@ui/editor/EntityReviewActions.svelte";
+  import Avatar from "@ui/Avatar.svelte";
 
   const appActions = getAppActions();
   const appData = getAppData();
@@ -217,9 +218,10 @@
                 {proposal.entityLabel}
                 <small>({proposal.entityType})</small>
               </span>
-              <span class="entity-review-submitter"
-                >{proposal.submitterName}</span
-              >
+              <span class="entity-review-submitter">
+                <Avatar name={proposal.submitterName} size={20} />
+                {proposal.submitterName}
+              </span>
             </div>
             {#if proposal.currentVersion != null && proposal.currentVersion !== proposal.baseVersion}
               <p class="entity-review-stale" role="alert">
@@ -333,6 +335,12 @@
     display: inline-flex;
     align-items: center;
     margin-right: 0.375rem;
+  }
+
+  .entity-review-submitter {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
   }
 
   .entity-review-bundled {

--- a/src/components/svelte/TermSelector.svelte
+++ b/src/components/svelte/TermSelector.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import GraduationCap from "@lucide/svelte/icons/graduation-cap";
-  import { termChipLabel } from "@lib/term-label";
+  import { termFullLabel } from "@lib/term-label";
   import { formatTermDateRange } from "@lib/term-calendar";
   import { trapFocus } from "@lib/focus-trap";
   import { portal } from "@lib/portal";
@@ -42,7 +42,7 @@
 
   const active = $derived(termStore.activeTerm);
 
-  const activeChipLabel = $derived(active ? termChipLabel(active) : "Term");
+  const activeChipLabel = $derived(active ? termFullLabel(active) : "Term");
 
   const activeDateRange = $derived(active ? formatTermDateRange(active) : null);
 

--- a/src/lib/avatar.test.ts
+++ b/src/lib/avatar.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { nameInitials, nameColor } from "./avatar";
+
+describe("nameInitials", () => {
+  test("first + last initial for multi-word names", () => {
+    expect(nameInitials("Juan Dela Cruz")).toBe("JC");
+    expect(nameInitials("Ada Lovelace")).toBe("AL");
+  });
+
+  test("first two letters for a single word", () => {
+    expect(nameInitials("stimmie")).toBe("ST");
+  });
+
+  test("falls back to ? for empty/blank", () => {
+    expect(nameInitials("")).toBe("?");
+    expect(nameInitials("   ")).toBe("?");
+  });
+});
+
+describe("nameColor", () => {
+  test("is deterministic for the same name", () => {
+    expect(nameColor("Ada Lovelace")).toBe(nameColor("Ada Lovelace"));
+  });
+
+  test("returns an hsl color", () => {
+    expect(nameColor("someone")).toMatch(/^hsl\(\d+, 45%, 42%\)$/);
+  });
+});

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -1,0 +1,24 @@
+/** Up to two uppercase initials from a display name ("Juan Dela Cruz" -> "JD"). */
+export function nameInitials(name: string): string {
+  const words = name
+    .trim()
+    .split(/\s+/)
+    .filter((w) => /[a-z0-9]/i.test(w));
+  if (words.length === 0) return "?";
+  if (words.length === 1) {
+    return (words[0]?.slice(0, 2) ?? "?").toUpperCase();
+  }
+  const first = words[0]?.[0] ?? "";
+  const last = words[words.length - 1]?.[0] ?? "";
+  return (first + last).toUpperCase() || "?";
+}
+
+/** Deterministic HSL background for a name, so the same person keeps one color. */
+export function nameColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 45%, 42%)`;
+}

--- a/src/lib/class-offering-groups.test.ts
+++ b/src/lib/class-offering-groups.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   groupClassesByOffering,
   parentLectureSection,
+  missingParentLectures,
 } from "./class-offering-groups.js";
 import type { ClassMapValue } from "@lib/types";
 
@@ -51,6 +52,35 @@ describe("parentLectureSection", () => {
     expect(
       parentLectureSection(row({ section: "UV", type: "LEC" })),
     ).toBeNull();
+  });
+});
+
+describe("missingParentLectures", () => {
+  test("reports a lab's parent lecture when it's not in the set (other room)", () => {
+    const result = missingParentLectures([
+      row({ id: 2, section: "G-1L", type: "LAB", roomCode: "ICS PC2" }),
+    ]);
+    expect(result).toEqual([{ courseCode: "CMSC 12", section: "G" }]);
+  });
+
+  test("reports nothing when the parent lecture is already present", () => {
+    const result = missingParentLectures([
+      row({ id: 1, section: "G", type: "LEC" }),
+      row({ id: 2, section: "G-1L", type: "LAB" }),
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  test("dedupes across multiple labs sharing a lecture", () => {
+    const result = missingParentLectures([
+      row({ id: 2, section: "G-1L", type: "LAB" }),
+      row({ id: 3, section: "G-5L", type: "LAB" }),
+      row({ id: 4, section: "UV-1R", type: "REC", courseCode: "SPCM 1" }),
+    ]);
+    expect(result).toEqual([
+      { courseCode: "CMSC 12", section: "G" },
+      { courseCode: "SPCM 1", section: "UV" },
+    ]);
   });
 });
 

--- a/src/lib/class-offering-groups.ts
+++ b/src/lib/class-offering-groups.ts
@@ -41,6 +41,36 @@ export function offeringGroupKey(
   return `${courseCode}::${section}`;
 }
 
+/**
+ * Parent-lecture (courseCode, section) pairs that a lab/recit in `classes`
+ * points to but that aren't present — e.g. in a room view, the lecture meets
+ * in a different room so it isn't in that room's class list. Callers fetch
+ * these and merge them in so groupClassesByOffering can attach the lecture.
+ */
+export function missingParentLectures(
+  classes: ClassMapValue[],
+): { courseCode: string; section: string }[] {
+  const presentLectures = new Set(
+    classes
+      .filter((row) => classType(row) === "LEC")
+      .map(
+        (row) =>
+          `${row.courseCode}::${(row.section ?? "").trim().toUpperCase()}`,
+      ),
+  );
+  const seen = new Set<string>();
+  const out: { courseCode: string; section: string }[] = [];
+  for (const row of classes) {
+    const section = parentLectureSection(row);
+    if (!section || !row.courseCode) continue;
+    const key = `${row.courseCode}::${section}`;
+    if (presentLectures.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    out.push({ courseCode: row.courseCode, section });
+  }
+  return out;
+}
+
 /** Group LEC/LAB/SEM rows that share course code + section (#301). */
 export function groupClassesByOffering(
   classes: ClassMapValue[],

--- a/src/lib/stores/data-stores.svelte.ts
+++ b/src/lib/stores/data-stores.svelte.ts
@@ -8,6 +8,8 @@ import {
   resolveInitialTermId,
 } from "../term-calendar.js";
 import type { TermWithCount } from "@lib/types";
+import { missingParentLectures } from "../class-offering-groups.js";
+import { fetchClassPage } from "../classes-api.js";
 import { ACTIVE_TERM_LS_KEY } from "./store-types.js";
 
 export class TermStore {
@@ -113,14 +115,62 @@ export class RoomClassesStore {
       const data = await getJSONFetch<ClassMapValue[]>(
         `/api/classes?${params.toString()}`,
       );
-      this._cache.set(key, data);
-      if (this._requestKey === key) this.classes = data;
+      // A lab/recit's parent lecture usually meets in a different room, so it
+      // isn't in this room's list. Fetch those lectures so the offering
+      // grouping can show each lab/recit alongside its lecture (#301).
+      const withParents = await this.#addParentLectures(data, termId);
+      this._cache.set(key, withParents);
+      if (this._requestKey === key) this.classes = withParents;
     } catch (e) {
       console.error("Failed to load room classes:", e);
       if (this._requestKey === key) this.classes = [];
     } finally {
       if (this._requestKey === key) this.loading = false;
     }
+  };
+
+  // Fetch the parent lectures referenced by labs/recits in `roomClasses` that
+  // aren't already present (they meet in other rooms) and merge them in.
+  #addParentLectures = async (
+    roomClasses: ClassMapValue[],
+    termId: number | null,
+  ): Promise<ClassMapValue[]> => {
+    const missing = missingParentLectures(roomClasses);
+    if (missing.length === 0) return roomClasses;
+
+    const sectionsByCourse = new Map<string, Set<string>>();
+    for (const { courseCode, section } of missing) {
+      const set = sectionsByCourse.get(courseCode) ?? new Set<string>();
+      set.add(section);
+      sectionsByCourse.set(courseCode, set);
+    }
+
+    const haveIds = new Set(roomClasses.map((row) => row.id));
+    const extra: ClassMapValue[] = [];
+    await Promise.all(
+      [...sectionsByCourse].map(async ([courseCode, sections]) => {
+        try {
+          const page = await fetchClassPage({
+            termId,
+            courseCodePrefix: courseCode,
+            limit: 100,
+          });
+          for (const row of page.rows) {
+            if (row.courseCode !== courseCode) continue;
+            const section = (row.section ?? "").trim().toUpperCase();
+            if (sections.has(section) && !haveIds.has(row.id)) {
+              haveIds.add(row.id);
+              extra.push(row);
+            }
+          }
+        } catch {
+          // Best effort — if a course fetch fails, omit that lecture rather
+          // than failing the whole room load.
+        }
+      }),
+    );
+
+    return extra.length > 0 ? [...roomClasses, ...extra] : roomClasses;
   };
 
   clear = () => {

--- a/src/lib/stores/map-stores.store.test.ts
+++ b/src/lib/stores/map-stores.store.test.ts
@@ -64,6 +64,26 @@ describe("MapViewStore", () => {
     store.showAll();
     expect(store.eventsOnly).toBe(false);
   });
+
+  test("org and place layers default on and toggle independently", () => {
+    const store = new MapViewStore();
+    expect(store.showOrgs).toBe(true);
+    expect(store.showPlaces).toBe(true);
+    store.toggleOrgs();
+    expect(store.showOrgs).toBe(false);
+    expect(store.showPlaces).toBe(true);
+    store.togglePlaces();
+    expect(store.showPlaces).toBe(false);
+  });
+
+  test("showAll restores hidden pin layers", () => {
+    const store = new MapViewStore();
+    store.toggleOrgs();
+    store.togglePlaces();
+    store.showAll();
+    expect(store.showOrgs).toBe(true);
+    expect(store.showPlaces).toBe(true);
+  });
 });
 
 describe("Building3DStore", () => {

--- a/src/lib/stores/map-stores.svelte.ts
+++ b/src/lib/stores/map-stores.svelte.ts
@@ -10,13 +10,27 @@ export class MapStore {
 
 export class MapViewStore {
   eventsOnly: boolean = $state(false);
+  // Org/office and place (POI) pin layers — on by default, toggled from the
+  // map legend so users can declutter the map (#18b).
+  showOrgs: boolean = $state(true);
+  showPlaces: boolean = $state(true);
 
   toggleEventsOnly = () => {
     this.eventsOnly = !this.eventsOnly;
   };
 
+  toggleOrgs = () => {
+    this.showOrgs = !this.showOrgs;
+  };
+
+  togglePlaces = () => {
+    this.showPlaces = !this.showPlaces;
+  };
+
   showAll = () => {
     this.eventsOnly = false;
+    this.showOrgs = true;
+    this.showPlaces = true;
   };
 }
 

--- a/src/lib/term-label.test.ts
+++ b/src/lib/term-label.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { termChipLabel, termFullLabel } from "./term-label";
+
+const term = (over: Partial<Parameters<typeof termFullLabel>[0]>) => ({
+  label: "AY 2026-2027 1st sem",
+  semester: "1",
+  schoolYear: "2026-2027",
+  ...over,
+});
+
+describe("termFullLabel", () => {
+  test("appends the academic year with spaced dash", () => {
+    expect(termFullLabel(term({}))).toBe("1st sem AY 2026 - 2027");
+    expect(termFullLabel(term({ semester: "2" }))).toBe(
+      "2nd sem AY 2026 - 2027",
+    );
+    expect(termFullLabel(term({ semester: "midyear" }))).toBe(
+      "Midyear AY 2026 - 2027",
+    );
+  });
+
+  test("falls back to the semester alone when the school year is missing", () => {
+    expect(termFullLabel(term({ schoolYear: null }))).toBe("1st sem");
+  });
+});
+
+describe("termChipLabel", () => {
+  test("stays the short semester label", () => {
+    expect(termChipLabel(term({}))).toBe("1st sem");
+  });
+});

--- a/src/lib/term-label.ts
+++ b/src/lib/term-label.ts
@@ -7,6 +7,16 @@ export function termChipLabel(term: Pick<Term, "label" | "semester">) {
   return term.label.replace(/^AY \d{4}-\d{4} /, "");
 }
 
+/** "1st sem AY 2026 - 2027" — semester plus academic year for the term picker. */
+export function termFullLabel(
+  term: Pick<Term, "label" | "semester" | "schoolYear">,
+) {
+  const semester = termChipLabel(term);
+  if (!term.schoolYear) return semester;
+  const ay = `AY ${term.schoolYear.replace("-", " - ")}`;
+  return `${semester} ${ay}`;
+}
+
 export function termSeoPhrase(term: Pick<Term, "label">) {
   return term.label;
 }


### PR DESCRIPTION
Batched release (one deploy, per the new AGENTS.md deploy-minimization note).

- **fix(room):** a lab/recit's parent lecture now shows in the room view even when the lecture meets in another room (RoomClassesStore fetches the missing parent lectures). Fixes "lecture classes don't appear."
- **fix(term):** term selector shows "1st sem AY 2026 - 2027", not just "1st sem".
- **feat(#18b):** toggle org/office + place pin layers from the map legend (also adds the previously-missing legend entries).
- **feat(#7):** initials avatars for contributors in the review queue (no external Gravatar dependency).
- **docs:** AGENTS.md — minimize deploys / batch releases to respect the Vercel free-tier cap.

Supersedes PR #591 (its #18b commit is included here).

## Tests
Unit 272/272, component 80/80, build clean. New: missingParentLectures, termFullLabel, avatar helpers, MapViewStore layer toggles.

## CI note
`e2e`/`migrations` red only due to the stale `E2E_DATABASE_URL` secret; `verify` + `bundle` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI and supplemental class fetches with graceful failure; room load adds extra API calls per room view but does not change auth or schema.
> 
> **Overview**
> Batched release spanning **room schedules**, **map UX**, **term chrome**, **review UI**, and **agent docs**.
> 
> **Room view (#301):** When a room lists only labs/recits, the store now detects missing parent lectures and **fetches those LEC rows** (other rooms) so offering groups can show lecture + lab together. Adds `missingParentLectures` and best-effort merge in `RoomClassesStore`.
> 
> **Map (#18b):** `MapViewStore` gains **org and place layer flags** (on by default). The map legend gets a **Layers** section to toggle org/office and POI pins; `Map.svelte` hides those marker sets when layers are off. `showAll` turns both back on.
> 
> **Term picker:** Chip label uses new **`termFullLabel`** — e.g. `1st sem AY 2026 - 2027` instead of semester-only.
> 
> **Review queue (#7):** New **`Avatar`** (initials + deterministic color, no Gravatar) beside submitter names in `ProposalReviewPanel`.
> 
> **Docs:** `AGENTS.md` adds guidance to **batch releases** and avoid burning the Vercel free-tier daily deploy cap.
> 
> Unit tests cover avatar helpers, `termFullLabel`, `missingParentLectures`, and layer toggle store behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc434b244c8934a33c459984d4c661f57748819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->