### PR TITLE
release: plan persistence per account (#2) + term-selector AY layout

### DIFF
--- a/drizzle/0026_add_planner_plans.sql
+++ b/drizzle/0026_add_planner_plans.sql
@@ -1,0 +1,8 @@
+-- #2 plan persistence: a signed-in user's saved course planner.
+-- One row per user; `data` holds the PlannerPersisted blob
+-- ({ v, plans, activePlanIdByTerm }) so the client codec round-trips it.
+CREATE TABLE IF NOT EXISTS planner_plans (
+  user_id integer PRIMARY KEY REFERENCES admin_users(id) ON DELETE CASCADE,
+  data jsonb NOT NULL,
+  updated_at timestamp DEFAULT now() NOT NULL
+);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -448,6 +448,19 @@ export const contributionsTable = pgTable("contributions", {
   createdAt: timestamp("created_at", { mode: "string" }).defaultNow().notNull(),
 });
 
+/**
+ * A signed-in user's saved course planner (#2). One row per user holding the
+ * whole PlannerPersisted blob ({ v, plans, activePlanIdByTerm }) as jsonb, so
+ * the existing serialize/parsePlanner codec round-trips it unchanged.
+ */
+export const plannerPlansTable = pgTable("planner_plans", {
+  userId: integer("user_id")
+    .primaryKey()
+    .references(() => adminUsersTable.id, { onDelete: "cascade" }),
+  data: jsonb().notNull(),
+  updatedAt: timestamp("updated_at", { mode: "string" }).defaultNow().notNull(),
+});
+
 export const eventsTable = pgTable(
   "events",
   {

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -53,6 +53,7 @@ const E2E_MIGRATION_FILES = [
   "0023_add_room_category.sql",
   "0024_add_places.sql",
   "0025_add_organizations.sql",
+  "0026_add_planner_plans.sql",
 ] as const;
 
 async function applyE2eMigrations(client: pg.Client) {
@@ -91,6 +92,7 @@ async function main() {
 
     await client.query(`
       TRUNCATE TABLE
+        planner_plans,
         editor_history,
         contributions,
         edit_proposals,

--- a/src/components/svelte/TermSelector.svelte
+++ b/src/components/svelte/TermSelector.svelte
@@ -262,7 +262,7 @@
     position: relative;
     flex: 0 0 auto;
     min-width: 0;
-    max-width: min(100%, 11rem);
+    max-width: min(100%, 15rem);
     margin-top: 0vh;
   }
 
@@ -277,7 +277,7 @@
   }
 
   .term-filter-chip__label {
-    max-width: 5.5rem;
+    max-width: 11rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -384,6 +384,8 @@
       {#if chrome.showSearchSuggestions}
         <div class="campus-browse-chips__container">
           <CampusBrowseChips />
+        </div>
+        <div class="campus-browse-chips__term">
           <TermSelector />
         </div>
       {/if}
@@ -491,6 +493,9 @@
     .campus-browse-chips__container {
         padding: .5rem .75rem;
     }
+  .campus-browse-chips__term {
+    padding: 0 0.75rem 0.5rem;
+  }
   .sr-only {
     position: absolute;
     width: 1px;

--- a/src/lib/planner/persist.test.ts
+++ b/src/lib/planner/persist.test.ts
@@ -1,6 +1,53 @@
 import { describe, expect, it } from "bun:test";
-import { parsePlanner, serializePlanner } from "./persist.js";
+import {
+  mergePlannerState,
+  parsePlanner,
+  serializePlanner,
+} from "./persist.js";
 import type { PlannerPlan } from "./types.js";
+
+const makePlan = (id: string, termId = 1252): PlannerPlan => ({
+  id,
+  label: id,
+  termId,
+  sections: [],
+});
+
+describe("mergePlannerState", () => {
+  it("unions local-only and remote-only plans", () => {
+    const merged = mergePlannerState(
+      { plans: [makePlan("local")], activePlanIdByTerm: {} },
+      { plans: [makePlan("remote")], activePlanIdByTerm: {} },
+    );
+    expect(merged.plans.map((p) => p.id).sort()).toEqual(["local", "remote"]);
+  });
+
+  it("remote wins on a shared plan id", () => {
+    const merged = mergePlannerState(
+      {
+        plans: [{ ...makePlan("p1"), label: "local" }],
+        activePlanIdByTerm: {},
+      },
+      {
+        plans: [{ ...makePlan("p1"), label: "remote" }],
+        activePlanIdByTerm: {},
+      },
+    );
+    expect(merged.plans).toHaveLength(1);
+    expect(merged.plans[0]?.label).toBe("remote");
+  });
+
+  it("keeps active-plan choices only for plans that survive the merge", () => {
+    const merged = mergePlannerState(
+      { plans: [makePlan("local")], activePlanIdByTerm: { "1252": "local" } },
+      {
+        plans: [makePlan("remote")],
+        activePlanIdByTerm: { "1253": "gone" },
+      },
+    );
+    expect(merged.activePlanIdByTerm).toEqual({ "1252": "local" });
+  });
+});
 
 const plan: PlannerPlan = {
   id: "p1",

--- a/src/lib/planner/persist.ts
+++ b/src/lib/planner/persist.ts
@@ -33,6 +33,33 @@ export function serializePlanner(
   } satisfies PlannerPersisted);
 }
 
+/**
+ * Union two planner states for account sync: keep every plan from both, with
+ * the remote (account) version winning on a shared plan id. Prevents losing
+ * local-only plans when a user signs in on a device that already has plans,
+ * while treating the account copy as authoritative for plans it also has.
+ */
+export function mergePlannerState(
+  local: Pick<PlannerPersisted, "plans" | "activePlanIdByTerm">,
+  remote: Pick<PlannerPersisted, "plans" | "activePlanIdByTerm">,
+): PlannerPersisted {
+  const byId = new Map<string, PlannerPlan>();
+  for (const plan of remote.plans) byId.set(plan.id, plan);
+  for (const plan of local.plans)
+    if (!byId.has(plan.id)) byId.set(plan.id, plan);
+  const plans = [...byId.values()];
+  const planIds = new Set(plans.map((p) => p.id));
+  // Remote's active-plan choices win; keep local's for terms remote doesn't set.
+  const activePlanIdByTerm: Record<string, string> = {};
+  for (const [termId, planId] of Object.entries({
+    ...local.activePlanIdByTerm,
+    ...remote.activePlanIdByTerm,
+  })) {
+    if (planIds.has(planId)) activePlanIdByTerm[termId] = planId;
+  }
+  return { v: 1, plans, activePlanIdByTerm };
+}
+
 /** Parse persisted planner state; invalid plans/sections are dropped, never fatal. */
 export function parsePlanner(raw: string | null): PlannerPersisted {
   if (!raw) return { ...EMPTY_PLANNER };

--- a/src/lib/services/planner-service.ts
+++ b/src/lib/services/planner-service.ts
@@ -1,0 +1,28 @@
+import { eq } from "drizzle-orm";
+import { plannerPlansTable } from "@drizzle/schema";
+import { db } from "@lib/db";
+
+/** The stored planner blob for a user, or null if they've never saved one. */
+export async function getPlannerData(userId: number): Promise<unknown | null> {
+  const rows = await db
+    .select({ data: plannerPlansTable.data })
+    .from(plannerPlansTable)
+    .where(eq(plannerPlansTable.userId, userId))
+    .limit(1);
+  return rows[0]?.data ?? null;
+}
+
+/** Upsert the user's planner blob (one row per user). */
+export async function savePlannerData(
+  userId: number,
+  data: unknown,
+): Promise<void> {
+  const updatedAt = new Date().toISOString();
+  await db
+    .insert(plannerPlansTable)
+    .values({ userId, data, updatedAt })
+    .onConflictDoUpdate({
+      target: plannerPlansTable.userId,
+      set: { data, updatedAt },
+    });
+}

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -387,6 +387,8 @@ class AdminAuthStore {
     this.canPublish = data.canPublish ?? false;
     this.canReview = data.canReview ?? false;
     if (data.canReview) void proposalsStore.refresh();
+    if (this.isLoggedIn) void plannerStore.enableAccountSync();
+    else plannerStore.disableAccountSync();
   }
 
   hydrate = async () => {
@@ -547,6 +549,7 @@ class AdminAuthStore {
     this.canReview = false;
     proposalsStore.pendingCount = 0;
     proposalsStore.proposals = [];
+    plannerStore.disableAccountSync();
   };
 
   openLogin = () => {

--- a/src/lib/stores/planner-store.svelte.ts
+++ b/src/lib/stores/planner-store.svelte.ts
@@ -1,7 +1,11 @@
 import { dismissEphemeralOverlays } from "../overlay-stack.js";
 import { offeringGroupKey } from "../class-offering-groups.js";
 import { findConflicts } from "../planner/conflicts.js";
-import { parsePlanner, serializePlanner } from "../planner/persist.js";
+import {
+  mergePlannerState,
+  parsePlanner,
+  serializePlanner,
+} from "../planner/persist.js";
 import { sectionNaturalKey } from "../planner/types.js";
 import type { PlannedSection, PlannerPlan } from "../planner/types.js";
 import type { ClassMapValue } from "@lib/types";
@@ -220,5 +224,71 @@ export class PlannerStore {
       // localStorage may be unavailable (private mode); plan still works
       // for the current session.
     }
+    this.#pushToAccount();
   }
+
+  // --- Account sync (#2) --------------------------------------------------
+  // When signed in, plans persist to the account so they follow the user
+  // across devices; localStorage stays the offline/anon cache.
+  #accountSync = false;
+  #saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Called on sign-in: pull the account's plans, merge, and start syncing. */
+  enableAccountSync = async () => {
+    if (this.#accountSync) return;
+    this.#accountSync = true;
+    await this.#hydrateFromAccount();
+  };
+
+  /** Called on sign-out: stop pushing to the account (localStorage remains). */
+  disableAccountSync = () => {
+    this.#accountSync = false;
+    if (this.#saveTimer) {
+      clearTimeout(this.#saveTimer);
+      this.#saveTimer = null;
+    }
+  };
+
+  #hydrateFromAccount = async () => {
+    try {
+      const res = await fetch("/api/account/plans", {
+        credentials: "same-origin",
+      });
+      if (!res.ok) return;
+      const { data } = (await res.json()) as { data: unknown };
+      const remote = parsePlanner(data ? JSON.stringify(data) : null);
+      const merged = mergePlannerState(
+        { plans: this.plans, activePlanIdByTerm: this.activePlanIdByTerm },
+        remote,
+      );
+      this.plans = merged.plans;
+      this.activePlanIdByTerm = merged.activePlanIdByTerm;
+      // Writes local cache and pushes the merged union back to the account.
+      this.persist();
+    } catch {
+      // Offline or request failed — keep the local plans as-is.
+    }
+  };
+
+  #pushToAccount = () => {
+    if (!this.#accountSync || typeof fetch === "undefined") return;
+    if (this.#saveTimer) clearTimeout(this.#saveTimer);
+    this.#saveTimer = setTimeout(() => {
+      this.#saveTimer = null;
+      const data = JSON.parse(
+        serializePlanner({
+          plans: this.plans,
+          activePlanIdByTerm: this.activePlanIdByTerm,
+        }),
+      );
+      void fetch("/api/account/plans", {
+        method: "PUT",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ data }),
+      }).catch(() => {
+        // Best effort; localStorage already holds the change.
+      });
+    }, 1200);
+  };
 }

--- a/src/pages/api/account/plans.ts
+++ b/src/pages/api/account/plans.ts
@@ -9,8 +9,15 @@ export const GET: APIRoute = async ({ cookies }) => {
   const auth = await editorSessionOrUnauthorized(cookies);
   if (auth instanceof Response) return auth;
 
-  const data = await getPlannerData(auth.session.id);
-  return json({ data });
+  try {
+    const data = await getPlannerData(auth.session.id);
+    return json({ data });
+  } catch (error) {
+    // Degrade gracefully if the table isn't present yet (migration pending):
+    // the client keeps its localStorage plans instead of erroring.
+    console.error("Load planner failed:", error);
+    return json({ data: null });
+  }
 };
 
 // Upsert the user's planner blob. Body: { data: PlannerPersisted }.

--- a/src/pages/api/account/plans.ts
+++ b/src/pages/api/account/plans.ts
@@ -1,0 +1,50 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import { getPlannerData, savePlannerData } from "@lib/services/planner-service";
+
+export const prerender = false;
+
+// Return the signed-in user's saved planner blob (any logged-in role).
+export const GET: APIRoute = async ({ cookies }) => {
+  const auth = await editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return auth;
+
+  const data = await getPlannerData(auth.session.id);
+  return json({ data });
+};
+
+// Upsert the user's planner blob. Body: { data: PlannerPersisted }.
+export const PUT: APIRoute = async ({ cookies, request }) => {
+  const auth = await editorSessionOrUnauthorized(cookies);
+  if (auth instanceof Response) return auth;
+
+  let body: { data?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const data = body.data;
+  if (data == null || typeof data !== "object") {
+    return json({ error: "data (planner blob) is required." }, 400);
+  }
+  if (!Array.isArray((data as { plans?: unknown }).plans)) {
+    return json({ error: "data.plans must be an array." }, 400);
+  }
+
+  try {
+    await savePlannerData(auth.session.id, data);
+    return json({ success: true });
+  } catch (error) {
+    console.error("Save planner failed:", error);
+    return json({ error: "Failed to save planner." }, 500);
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
Promotes #595. Ships plan persistence to signed-in accounts (#2) and the term-selector own-row AY label fix.

⚠ **DB migration:** `0026_add_planner_plans.sql` must be applied to the prod Supabase DB to activate plan persistence. The code degrades gracefully (localStorage fallback) if the table is absent, so this deploy is safe either way — but persistence stays inactive until the migration runs.

CI: `verify` + `bundle` + Vercel green. `e2e`/`migrations` red only on the stale `E2E_DATABASE_URL` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated API and user-scoped jsonb storage with a required prod migration; behavior degrades safely without the table, but wrong merge/sync edge cases could affect planner data across devices.
> 
> **Overview**
> Adds **per-account course planner persistence** so signed-in users can sync plans across devices while **localStorage** remains the offline/anonymous cache.
> 
> A new **`planner_plans`** table (migration `0026`) stores one **jsonb** blob per user (`PlannerPersisted`). **`GET`/`PUT` `/api/account/plans`** load and upsert that blob for any logged-in session; **GET** returns `{ data: null }** on DB errors so clients keep local plans until the migration runs. **`planner-service`** handles read/upsert; E2E reset applies the migration and truncates the table.
> 
> On the client, **`mergePlannerState`** unions local and remote plans (remote wins on duplicate ids, prunes invalid active-plan pointers). **`plannerStore`** enables sync on login: pull → merge → persist locally and debounced **PUT** (~1.2s); disables on logout. **`adminAuthStore`** wires login/logout to that sync.
> 
> **Search chrome:** **`TermSelector`** moves to its own row under campus browse chips, with wider chip/label max-widths for full academic-year labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae90b9645e0e1472657be2a6d3501b2bf5148029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->