### PR TITLE
fix(amis): import parent lectures embedded in child sections

### DIFF
--- a/src/lib/amis/normalize-class.test.ts
+++ b/src/lib/amis/normalize-class.test.ts
@@ -15,6 +15,59 @@ describe("amis normalize", () => {
     expect(rows).toHaveLength(1);
   });
 
+  it("surfaces the parent lecture embedded in a child section", () => {
+    const rows = extractClassRows({
+      classes: {
+        data: [
+          {
+            id: 2,
+            course_code: "CMSC 100",
+            section: "D-1L",
+            type: "LAB",
+            parent_class_id: 1,
+            parent: {
+              id: 1,
+              section: "D",
+              type: "LEC",
+              facility_id: "SMA LH",
+              class_dates: [
+                { date: "WF", start_time: "12:00 PM", end_time: "01:00 PM" },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    // lab + its previously-missing parent lecture
+    expect(rows).toHaveLength(2);
+    const lec = rows.find((r) => r.section === "D");
+    expect(lec?.type).toBe("LEC");
+    // parent lacked course_code; it must inherit from the child
+    expect(lec?.course_code).toBe("CMSC 100");
+    const normalized = normalizeAmisClass(lec!, 1261);
+    expect(normalized?.schedule).toEqual(["WF 12:00PM-01:00PM"]);
+    expect(normalized?.facilityCode).toBe("SMA LH");
+  });
+
+  it("does not duplicate a parent already present as a top-level row", () => {
+    const rows = extractClassRows({
+      classes: {
+        data: [
+          { id: 1, course_code: "X 1", section: "A", type: "LEC" },
+          {
+            id: 2,
+            course_code: "X 1",
+            section: "A-1L",
+            type: "LAB",
+            parent_class_id: 1,
+            parent: { id: 1, section: "A", type: "LEC" },
+          },
+        ],
+      },
+    });
+    expect(rows).toHaveLength(2);
+  });
+
   it("maps legacy AMIS export rows", () => {
     const normalized = normalizeAmisClass(
       {

--- a/src/lib/amis/normalize-class.ts
+++ b/src/lib/amis/normalize-class.ts
@@ -17,11 +17,10 @@ function asString(value: unknown): string | null {
   return null;
 }
 
-/** Unwrap paginated / nested AMIS responses into flat class rows. */
-export function extractClassRows(payload: unknown): AmisClassRow[] {
+function extractRawClassRows(payload: unknown): AmisClassRow[] {
   if (payload == null) return [];
   if (Array.isArray(payload)) {
-    return payload.flatMap((entry) => extractClassRows(entry));
+    return payload.flatMap((entry) => extractRawClassRows(entry));
   }
 
   const obj = asRecord(payload);
@@ -36,6 +35,37 @@ export function extractClassRows(payload: unknown): AmisClassRow[] {
   if (Array.isArray(obj.classes)) return obj.classes as AmisClassRow[];
 
   return [];
+}
+
+/**
+ * AMIS lists child sections (LAB/RCT/CPT) but omits their parent LEC as its own
+ * list row — the lecture only appears embedded in each child's `parent` field.
+ * Surface those parents (deduped by id, skipping any already listed) so lectures
+ * actually import. The embedded parent lacks course_code/course, so inherit them
+ * from the child that carried it.
+ */
+function withEmbeddedParents(rows: AmisClassRow[]): AmisClassRow[] {
+  const existingIds = new Set(rows.map((r) => r.id).filter((id) => id != null));
+  const parents = new Map<unknown, AmisClassRow>();
+  for (const row of rows) {
+    const parent = asRecord(row.parent);
+    if (!parent) continue;
+    const pid = parent.id;
+    if (pid == null || existingIds.has(pid) || parents.has(pid)) continue;
+    parents.set(pid, {
+      ...parent,
+      course_code: parent.course_code ?? row.course_code,
+      course: parent.course ?? row.course,
+      parent: undefined,
+    });
+  }
+  return parents.size > 0 ? [...rows, ...parents.values()] : rows;
+}
+
+/** Unwrap paginated / nested AMIS responses into flat class rows, including the
+ *  parent lectures AMIS only embeds inside child sections. */
+export function extractClassRows(payload: unknown): AmisClassRow[] {
+  return withEmbeddedParents(extractRawClassRows(payload));
 }
 
 function normalizeTimeToken(value: unknown) {


### PR DESCRIPTION
Every lab/recit course imported without its lecture: AMIS omits the parent LEC from the class list and only embeds it in each child's `parent` field (100% of ~1500 child sections/term). extractClassRows now surfaces those parents (deduped, inheriting course_code). Data re-imported across all 9 terms (staging + prod). Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the set of rows produced on every AMIS class fetch/import path; incorrect deduping or inheritance could add wrong or duplicate sections until data is re-imported.
> 
> **Overview**
> **Fixes missing parent lecture (LEC) rows** when importing AMIS class lists: child sections (LAB/RCT/CPT) often include a `parent` object, but AMIS does not list that lecture as its own row.
> 
> `extractClassRows` now runs unwrapping via `extractRawClassRows`, then **`withEmbeddedParents`** appends deduplicated parent rows (by `id`, skipping parents already in the list). Embedded parents **inherit `course_code` and `course` from the child** when absent, and nested `parent` is cleared on the synthesized row so imports normalize schedule and facility like other lectures.
> 
> Tests cover surfacing an embedded parent (including normalization), and **no duplicate** when the LEC is already a top-level row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 165af5e6a6ef7916a184bed5f8362180f5205877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->