### PR TITLE
fix(planner): tile same-timeslot drag ghosts into columns

### DIFF
--- a/src/components/svelte/planner/PlannerGrid.svelte
+++ b/src/components/svelte/planner/PlannerGrid.svelte
@@ -89,6 +89,8 @@
       endMin: number;
       ghostKey: string;
       roomCode: string | null;
+      col: number;
+      colCount: number;
     }[][] = DAYS.map(() => []);
     if (!drag) return byDay;
     const offerings = alternativeOfferings(
@@ -114,8 +116,28 @@
             endMin: b.endMin,
             ghostKey: offering.section,
             roomCode: row.roomCode ?? null,
+            col: 0,
+            colCount: 1,
           });
         }
+      }
+    }
+    // Sections at the same day+time (e.g. HUM 3 C1 & C2, both WF 10:00) would
+    // otherwise stack exactly and hide all but the top ghost. Split each shared
+    // slot into side-by-side columns so every alternative stays droppable.
+    for (const dayGhosts of byDay) {
+      const bySlot = new Map<string, typeof dayGhosts>();
+      for (const g of dayGhosts) {
+        const slot = `${g.startMin}-${g.endMin}`;
+        const list = bySlot.get(slot) ?? [];
+        list.push(g);
+        bySlot.set(slot, list);
+      }
+      for (const list of bySlot.values()) {
+        list.forEach((g, i) => {
+          g.col = i;
+          g.colCount = list.length;
+        });
       }
     }
     return byDay;
@@ -300,6 +322,8 @@
                 data-ghost={ghost.ghostKey}
                 style:top="{topPct(ghost.startMin)}%"
                 style:height="{heightPct(ghost.startMin, ghost.endMin)}%"
+                style:left="calc({(ghost.col / ghost.colCount) * 100}% + 1px)"
+                style:width="calc({100 / ghost.colCount}% - 2px)"
                 style:border-color={getColorForCourse(drag.courseCode)}
               >
                 <span class="planner-ghost__label">{ghost.ghostKey}</span>
@@ -490,8 +514,8 @@
 
   .planner-ghost {
     position: absolute;
-    left: 1px;
-    right: 1px;
+    /* left/width are set inline so same-slot ghosts tile into columns. */
+    box-sizing: border-box;
     z-index: 5;
     display: flex;
     align-items: center;


### PR DESCRIPTION
When switching sections by drag, alternatives sharing a timeslot (e.g. HUM 3 C1 & C2) stacked as overlapping ghosts so only one was reachable. Tile same-slot ghosts side by side. Client-only layout fix; column math unit-checked. Best verified by dragging a section that has a same-time alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, client-only layout change in PlannerGrid drag ghosts with no API, auth, or data impact.
> 
> **Overview**
> Fixes **section-switch drag ghosts** when multiple alternatives share the same day and time: they no longer stack on top of each other so only one target was reachable.
> 
> `ghostBlocksByDay` now groups ghosts by `startMin`/`endMin` per day, assigns each a **column index** and **column count**, and the ghost elements use inline `left`/`width` so same-slot alternatives render **side by side**. `.planner-ghost` drops full-width `left`/`right` in favor of `box-sizing: border-box` and those inline dimensions.
> 
> Client-only planner UI; swap behavior and `data-ghost` hit-testing are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6b34c1b6bbe9ee970e3206e2e232ae68f545d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->