### PR TITLE
feat(account): include saved planner plans in the data export (#2)

### DIFF
--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -6,6 +6,7 @@ import {
   adminUsersTable,
   contributionsTable,
   editProposalsTable,
+  plannerPlansTable,
 } from "@drizzle/schema";
 import { db } from "@lib/db";
 import type { SessionUser } from "@lib/admin/auth";
@@ -615,6 +616,7 @@ export type AccountDataExport = {
   profile: AccountProfile;
   proposals: unknown[];
   contributions: unknown[];
+  plans: unknown;
 };
 
 export async function exportAccountData(
@@ -623,7 +625,7 @@ export async function exportAccountData(
   const profile = await getAccountProfile(userId);
   if (!profile) return null;
 
-  const [proposals, contributions] = await Promise.all([
+  const [proposals, contributions, plannerRows] = await Promise.all([
     db
       .select()
       .from(editProposalsTable)
@@ -634,9 +636,19 @@ export async function exportAccountData(
       .from(contributionsTable)
       .where(eq(contributionsTable.userId, userId))
       .orderBy(desc(contributionsTable.createdAt)),
+    db
+      .select({ data: plannerPlansTable.data })
+      .from(plannerPlansTable)
+      .where(eq(plannerPlansTable.userId, userId))
+      .limit(1),
   ]);
 
-  return { profile, proposals, contributions };
+  return {
+    profile,
+    proposals,
+    contributions,
+    plans: plannerRows[0]?.data ?? null,
+  };
 }
 
 // ── Admin-managed users (#225 follow-up: admin creates admin/editor) ──


### PR DESCRIPTION
Account data export bundled profile/proposals/contributions but omitted the user's saved planner. Include the plans blob so an export is complete (and a plan-persistence follow-through for #2).

Note: `planner_plans` is now applied to the **prod** DB, so #2 persistence is active in production.

CI: this run should show `e2e`/`migrations` **green** now that the `E2E_DATABASE_URL` secret is rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only export field with no changes to auth or write paths; depends on `planner_plans` being migrated in prod.
> 
> **Overview**
> **Account data export** now includes the user's saved planner state, not just profile, edit proposals, and contributions.
> 
> `exportAccountData` loads the `data` blob from `planner_plans` for the requesting user (at most one row) and adds it to the export as **`plans`**, or `null` when nothing is saved. The `AccountDataExport` type gains a `plans` field so the `/api/account/export` JSON response reflects the fuller payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff799af7feb0b580f3356c935b017dfb9332a867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->