### PR TITLE
release: include planner plans in account export (#2)

### DIFF
--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -6,6 +6,7 @@ import {
   adminUsersTable,
   contributionsTable,
   editProposalsTable,
+  plannerPlansTable,
 } from "@drizzle/schema";
 import { db } from "@lib/db";
 import type { SessionUser } from "@lib/admin/auth";
@@ -615,6 +616,7 @@ export type AccountDataExport = {
   profile: AccountProfile;
   proposals: unknown[];
   contributions: unknown[];
+  plans: unknown;
 };
 
 export async function exportAccountData(
@@ -623,7 +625,7 @@ export async function exportAccountData(
   const profile = await getAccountProfile(userId);
   if (!profile) return null;
 
-  const [proposals, contributions] = await Promise.all([
+  const [proposals, contributions, plannerRows] = await Promise.all([
     db
       .select()
       .from(editProposalsTable)
@@ -634,9 +636,19 @@ export async function exportAccountData(
       .from(contributionsTable)
       .where(eq(contributionsTable.userId, userId))
       .orderBy(desc(contributionsTable.createdAt)),
+    db
+      .select({ data: plannerPlansTable.data })
+      .from(plannerPlansTable)
+      .where(eq(plannerPlansTable.userId, userId))
+      .limit(1),
   ]);
 
-  return { profile, proposals, contributions };
+  return {
+    profile,
+    proposals,
+    contributions,
+    plans: plannerRows[0]?.data ?? null,
+  };
 }
 
 // ── Admin-managed users (#225 follow-up: admin creates admin/editor) ──


### PR DESCRIPTION
Promotes #599. Account export now includes the user's saved planner. #2 migration already applied to prod DB. verify/bundle/Vercel green; e2e/migrations red only on the E2E_DATABASE_URL secret (set to direct form — needs the pooler form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change to self-service export; no auth or write-path changes, though exported JSON now carries planner data.
> 
> **Overview**
> **Account data export** now includes the user’s saved planner payload alongside profile, edit proposals, and contributions.
> 
> `exportAccountData` loads the `data` column from `planner_plans` for the requesting user (at most one row) and adds it to the export as **`plans`**, or `null` when none exists. The `/api/account/export` response JSON gains this field automatically because it serializes the full export object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5585b940c8fed277bf10a5e587a31062033b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->