### PR TITLE
test(e2e): plan persistence API round-trip (#2)

### DIFF
--- a/e2e/admin/plan-persistence.spec.ts
+++ b/e2e/admin/plan-persistence.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+import { loginAsEditor } from "../helpers/users";
+import { E2E_FIXTURES } from "../../scripts/e2e-reset-db";
+
+test.describe("plan persistence (#2)", () => {
+  test("unauthenticated requests are rejected", async ({ page }) => {
+    const res = await page.request.get("/api/account/plans");
+    expect(res.status()).toBe(401);
+  });
+
+  test("a signed-in user's planner blob round-trips through the account", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await loginAsEditor(page);
+
+    const blob = {
+      v: 1,
+      plans: [
+        {
+          id: "e2e-plan-1",
+          label: "E2E Plan",
+          termId: E2E_FIXTURES.termId,
+          sections: [],
+        },
+      ],
+      activePlanIdByTerm: {},
+    };
+
+    // Use in-page fetch so the httpOnly admin_session cookie is sent.
+    const put = await page.evaluate(async (data) => {
+      const res = await fetch("/api/account/plans", {
+        method: "PUT",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ data }),
+      });
+      return { ok: res.ok, status: res.status };
+    }, blob);
+    expect(put.ok, `PUT returned ${put.status}`).toBeTruthy();
+
+    const body = (await page.evaluate(async () => {
+      const res = await fetch("/api/account/plans", {
+        credentials: "same-origin",
+      });
+      return res.json();
+    })) as { data?: { plans?: { id?: string }[] } };
+    expect(body.data?.plans?.[0]?.id).toBe("e2e-plan-1");
+  });
+});


### PR DESCRIPTION
Adds e2e coverage for #2: /api/account/plans rejects anon (401) and round-trips a signed-in user's planner blob. Passes locally (2/2). Runs in CI once the E2E_DATABASE_URL secret is set to the pooler form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition; no application or API implementation changes in this diff.
> 
> **Overview**
> Adds Playwright coverage in **`e2e/admin/plan-persistence.spec.ts`** for issue **#2** against **`/api/account/plans`**.
> 
> One test asserts **GET** without a session returns **401**. The other signs in via **`loginAsEditor`**, **PUT**s a v1 planner blob (using **`E2E_FIXTURES.termId`**), then **GET**s and checks the first plan id is **`e2e-plan-1`**. Authenticated calls use in-page **`fetch`** with **`credentials: "same-origin"`** so the httpOnly **`admin_session`** cookie is sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 586f1dc228417b57e719a366f5f9174220986f05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->