### PR TITLE
fix(planner): color by type, fix stale-on-add, remove lec+lab together

### DIFF
--- a/src/components/svelte/planner/PlannerGrid.svelte
+++ b/src/components/svelte/planner/PlannerGrid.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getColorForCourse } from "@lib/schedule-renderer";
+  import { getPlannerBlockColor } from "@lib/schedule-renderer";
   import { sectionBlocks } from "@lib/planner/conflicts";
   import { alternativeOfferings } from "@lib/planner/alternatives";
   import type { Conflict, ScheduleBlock } from "@lib/planner/conflicts";
@@ -274,7 +274,7 @@
               class:planner-block--dragging={drag?.fromKey === block.key}
               style:top="{topPct(block.startMin)}%"
               style:height="{heightPct(block.startMin, block.endMin)}%"
-              style:background-color={getColorForCourse(block.courseCode)}
+              style:background-color={getPlannerBlockColor(block.type)}
             >
               <button
                 type="button"
@@ -324,7 +324,6 @@
                 style:height="{heightPct(ghost.startMin, ghost.endMin)}%"
                 style:left="calc({(ghost.col / ghost.colCount) * 100}% + 1px)"
                 style:width="calc({100 / ghost.colCount}% - 2px)"
-                style:border-color={getColorForCourse(drag.courseCode)}
               >
                 <span class="planner-ghost__label">{ghost.ghostKey}</span>
               </div>

--- a/src/components/svelte/planner/PlannerScreen.svelte
+++ b/src/components/svelte/planner/PlannerScreen.svelte
@@ -28,6 +28,9 @@
   let finals = $state<FinalExamRow[]>([]);
   let courseRows = $state<ClassMapValue[]>([]);
   let lastRefreshKey = $state<string | null>(null);
+  // Monotonic id so an out-of-order fetch (older, fewer courses) can't overwrite
+  // a newer one and wrongly flag just-added sections as "no longer offered".
+  let refreshSeq = 0;
 
   const plan = $derived(plannerStore.activePlan);
   const offerings = $derived.by(() => {
@@ -146,6 +149,7 @@
     if (refreshKey === lastRefreshKey) return;
     lastRefreshKey = refreshKey;
 
+    const seq = ++refreshSeq;
     Promise.all(
       courseCodes.map((code) =>
         fetchClassPage({
@@ -153,14 +157,19 @@
           courseCodePrefix: code,
           limit: 100,
         }).then(
-          (page) => page.rows,
-          () => [],
+          (page) => ({ code, rows: page.rows, ok: true }),
+          () => ({ code, rows: [] as ClassMapValue[], ok: false }),
         ),
       ),
-    ).then((pages) => {
-      const rows = pages.flat();
+    ).then((results) => {
+      if (seq !== refreshSeq) return; // superseded by a newer refresh
+      const okResults = results.filter((r) => r.ok);
+      const rows = okResults.flatMap((r) => r.rows);
+      const fetchedCourses = new Set(okResults.map((r) => r.code));
       courseRows = rows;
-      if (rows.length > 0) plannerStore.refreshActivePlan(rows);
+      if (fetchedCourses.size > 0) {
+        plannerStore.refreshActivePlan(rows, fetchedCourses);
+      }
     });
 
     Promise.all(

--- a/src/lib/schedule-renderer.test.ts
+++ b/src/lib/schedule-renderer.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from "bun:test";
-import { parseDays, parseScheduleTime } from "@lib/schedule-renderer";
+import {
+  getPlannerBlockColor,
+  parseDays,
+  parseScheduleTime,
+} from "@lib/schedule-renderer";
+
+describe("getPlannerBlockColor", () => {
+  it("colors by component type, not course", () => {
+    expect(getPlannerBlockColor("LEC")).toBe("#1565C0");
+    expect(getPlannerBlockColor("lab")).toBe("#2E7D32");
+    expect(getPlannerBlockColor("RCT")).toBe("#EF6C00");
+  });
+  it("falls back to a neutral color for other/unknown types", () => {
+    expect(getPlannerBlockColor("CPT")).toBe("#546E7A");
+    expect(getPlannerBlockColor(null)).toBe("#546E7A");
+  });
+});
 
 describe("parseScheduleTime", () => {
   it("parses AMIS-style compact times", () => {

--- a/src/lib/schedule-renderer.ts
+++ b/src/lib/schedule-renderer.ts
@@ -360,3 +360,22 @@ export function getColorForCourse(courseCode: string) {
   }
   return courseColors[Math.abs(hash) % courseColors.length];
 }
+
+/**
+ * Planner grid block color keyed on component type, not course: lectures,
+ * labs, and recitations each read as one consistent kind at a glance (a hashed
+ * per-course palette collided — different courses shared a color). Room-view
+ * coloring still uses getColorForCourse.
+ */
+export function getPlannerBlockColor(type: string | null | undefined): string {
+  switch ((type ?? "").trim().toUpperCase()) {
+    case "LEC":
+      return "#1565C0"; // blue — lecture
+    case "LAB":
+      return "#2E7D32"; // green — lab
+    case "RCT":
+      return "#EF6C00"; // amber — recitation
+    default:
+      return "#546E7A"; // slate — other (e.g. CPT)
+  }
+}

--- a/src/lib/stores/planner-store.svelte.ts
+++ b/src/lib/stores/planner-store.svelte.ts
@@ -1,5 +1,8 @@
 import { dismissEphemeralOverlays } from "../overlay-stack.js";
-import { offeringGroupKey } from "../class-offering-groups.js";
+import {
+  offeringGroupKey,
+  parentLectureSection,
+} from "../class-offering-groups.js";
 import { findConflicts } from "../planner/conflicts.js";
 import {
   mergePlannerState,
@@ -125,9 +128,14 @@ export class PlannerStore {
   removeOffering = (courseCode: string, section: string) => {
     const plan = this.activePlan;
     if (!plan) return;
-    const key = offeringGroupKey(courseCode, section);
+    // A lecture and its lab/recit are one enrollment unit — removing any
+    // component removes the whole unit. Resolve each section to its lecture
+    // (itself if it is the lecture, else the parent encoded in a child section
+    // like "C-4L" -> "C") and drop everything in that unit for the course.
+    const unitOf = (s: string) => parentLectureSection({ section: s }) ?? s;
+    const targetUnit = unitOf(section);
     plan.sections = plan.sections.filter(
-      (s) => offeringGroupKey(s.courseCode, s.section) !== key,
+      (s) => s.courseCode !== courseCode || unitOf(s.section) !== targetUnit,
     );
     this.persist();
   };
@@ -166,7 +174,10 @@ export class PlannerStore {
   };
 
   /** Overwrite matching sections with fresh rows; mark unresolved ones stale. */
-  refreshActivePlan = (rows: ClassMapValue[]) => {
+  refreshActivePlan = (
+    rows: ClassMapValue[],
+    fetchedCourses?: Set<string>,
+  ) => {
     const plan = this.activePlan;
     if (!plan) return;
     const fresh = new Map(
@@ -177,7 +188,14 @@ export class PlannerStore {
     );
     plan.sections = plan.sections.map((section) => {
       const updated = fresh.get(sectionNaturalKey(section));
-      return updated ?? { ...section, stale: true };
+      if (updated) return updated;
+      // Only mark "no longer offered" when this course was actually fetched
+      // successfully and the section is genuinely gone — never on a failed or
+      // not-yet-loaded fetch, which would flag a just-added section.
+      if (fetchedCourses && !fetchedCourses.has(section.courseCode)) {
+        return section;
+      }
+      return { ...section, stale: true };
     });
     this.persist();
   };

--- a/src/lib/stores/planner.store.test.ts
+++ b/src/lib/stores/planner.store.test.ts
@@ -49,6 +49,42 @@ describe("PlannerStore", () => {
     expect(store.addedKeys.size).toBe(0);
   });
 
+  test("removing the lab also removes its paired lecture (one enrollment unit)", () => {
+    const store = makeStore();
+    store.addOffering([
+      row({ id: 1, section: "AB", type: "LEC" }),
+      row({ id: 2, section: "AB-1L", type: "LAB" }),
+    ]);
+    // Remove via the lab; the lecture "AB" must go with it.
+    store.removeOffering("CMSC 128", "AB-1L");
+    expect(store.activePlan?.sections).toEqual([]);
+  });
+
+  test("removing the lecture also removes its lab", () => {
+    const store = makeStore();
+    store.addOffering([
+      row({ id: 1, section: "AB", type: "LEC" }),
+      row({ id: 2, section: "AB-1L", type: "LAB" }),
+    ]);
+    store.removeOffering("CMSC 128", "AB");
+    expect(store.activePlan?.sections).toEqual([]);
+  });
+
+  test("refreshActivePlan does NOT stale a section whose course was not fetched", () => {
+    const store = makeStore();
+    store.addOffering([row({ id: 1, section: "AB", type: "LEC" })]);
+    // Fetched a different course only — the just-added CMSC 128 must not flag.
+    store.refreshActivePlan([], new Set(["OTHER 1"]));
+    expect(store.activePlan?.sections.every((s) => !s.stale)).toBe(true);
+  });
+
+  test("refreshActivePlan stales a section only when its fetched course dropped it", () => {
+    const store = makeStore();
+    store.addOffering([row({ id: 1, section: "AB", type: "LEC" })]);
+    store.refreshActivePlan([], new Set(["CMSC 128"]));
+    expect(store.activePlan?.sections.every((s) => s.stale)).toBe(true);
+  });
+
   test("removeSections removes exact linked lecture and lab rows", () => {
     const store = makeStore();
     const rows = [


### PR DESCRIPTION
Three planner fixes: (A) grid colors by LEC/LAB/RCT type instead of a colliding per-course hash; (B) 'no longer offered' no longer flags just-added sections (request sequencing + don't stale on failed/pending fetch); (D) removing a lab removes its paired lecture (one enrollment unit). Tests: +2 bun (color), +4 vitest (store). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Planner-only UX and local plan state; no auth or API contract changes beyond safer client-side refresh handling.
> 
> **Overview**
> Fixes three planner bugs: **grid coloring**, **false “no longer offered”** warnings, and **partial removal** of linked lecture/lab units.
> 
> **Colors** now use a new `getPlannerBlockColor` keyed on component type (LEC/LAB/RCT, with a neutral fallback) instead of the per-course hash that could collide; room views still use `getColorForCourse`. Drag ghosts no longer tint borders by course.
> 
> **Stale sections** are only set when a course’s fetch **succeeded** and that section is missing from the response. `PlannerScreen` sequences refreshes with a monotonic `refreshSeq` and passes a `fetchedCourses` set into `refreshActivePlan`, so failed or superseded/out-of-order fetches do not mark just-added rows stale.
> 
> **Remove** treats lecture + lab/recit as one enrollment unit via `parentLectureSection`: removing either component drops every planned row in that unit for the course.
> 
> Tests cover block colors (bun) and store refresh/remove behavior (vitest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90be7b93d518779725de1a8f55c63f11b307577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->