### PR TITLE
test(planner): full test pyramid, decoupled from map

### DIFF
--- a/e2e/smoke/planner-flow.spec.ts
+++ b/e2e/smoke/planner-flow.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, type Page } from "@playwright/test";
+import { suppressLandingModal } from "../helpers/app";
+
+// Planner interactions, decoupled from the map: search -> add -> remove, and the
+// conflict badge. The planner is a full-screen dialog over the map chrome, so we
+// wait on the loading shell detaching (not waitForAppBoot, which needs the map).
+async function waitForPlannerBoot(page: Page) {
+  const shell = page.locator("#app-loading-shell");
+  if ((await shell.count()) > 0) {
+    await shell.waitFor({ state: "detached", timeout: 120_000 });
+  }
+}
+
+function plannerDialog(page: Page) {
+  return page.getByRole("dialog", { name: "Class Planner" });
+}
+
+test.describe("planner interactions", () => {
+  test("searching a course adds an offering to the plan, then removes it", async ({
+    page,
+  }) => {
+    await suppressLandingModal(page);
+    await page.goto("/planner?term=1252");
+    await waitForPlannerBoot(page);
+
+    const planner = plannerDialog(page);
+    await expect(planner).toBeVisible();
+
+    // "E2E 101" is the seeded class in the default term (scripts/e2e-reset-db.ts).
+    await page.locator("#planner-course-search").fill("E2E");
+
+    const courseHeader = planner.getByRole("button", { name: /E2E 101/ });
+    await expect(courseHeader).toBeVisible({ timeout: 15_000 });
+    await courseHeader.click(); // expand the section list
+
+    await planner.getByRole("button", { name: "Add" }).first().click();
+
+    // The Sections side panel appears and lists the added offering.
+    const offering = planner.getByText(/E2E 101\s*·\s*AB/);
+    await expect(offering).toBeVisible();
+    await expect(
+      planner.getByRole("heading", { name: /Sections \(1\)/ }),
+    ).toBeVisible();
+
+    await planner.getByRole("button", { name: "Remove" }).first().click();
+    await expect(offering).toHaveCount(0);
+  });
+
+  test("two overlapping sections show the conflict badge; removing one clears it", async ({
+    page,
+  }) => {
+    await suppressLandingModal(page);
+    // Seed a plan with two overlapping sections. The schedule strings overlap on
+    // Monday 9:00-9:30, so the store derives exactly one conflict. Fake course
+    // codes return no rows from /api/classes, so refreshActivePlan leaves them
+    // intact. This exercises the badge render path deterministically, without
+    // depending on which real classes the e2e DB happens to hold.
+    await page.addInitScript(() => {
+      const plan = {
+        id: "e2e-conflict-plan",
+        label: "Plan 1",
+        termId: 1252,
+        sections: [
+          {
+            courseCode: "ZZZ 1",
+            section: "A",
+            type: "LEC",
+            schedule: ["MW 08:00AM-09:30AM"],
+            roomCode: null,
+            courseTitle: "Conflict A",
+          },
+          {
+            courseCode: "ZZZ 2",
+            section: "B",
+            type: "LEC",
+            schedule: ["M 09:00AM-10:00AM"],
+            roomCode: null,
+            courseTitle: "Conflict B",
+          },
+        ],
+      };
+      localStorage.setItem(
+        "room-tba-planner",
+        JSON.stringify({
+          v: 1,
+          plans: [plan],
+          activePlanIdByTerm: { "1252": plan.id },
+        }),
+      );
+    });
+
+    await page.goto("/planner?term=1252");
+    await waitForPlannerBoot(page);
+
+    const planner = plannerDialog(page);
+    await expect(planner).toBeVisible();
+
+    // Both seeded offerings render, and the badge reports the conflict.
+    await expect(planner.getByText(/ZZZ 1\s*·\s*A/)).toBeVisible();
+    await expect(planner.getByText(/1 conflict\b/i)).toBeVisible();
+
+    // Remove one side of the clash -> no more overlap -> "All clear".
+    await planner
+      .locator(".planner-offering", { hasText: "ZZZ 2" })
+      .getByRole("button", { name: "Remove" })
+      .click();
+
+    await expect(planner.getByText(/all clear/i)).toBeVisible();
+    await expect(planner.getByText(/\d+ conflict/i)).toHaveCount(0);
+  });
+});

--- a/src/lib/class-offering-groups.test.ts
+++ b/src/lib/class-offering-groups.test.ts
@@ -103,6 +103,18 @@ describe("groupClassesByOffering", () => {
     ]);
   });
 
+  test("keeps same-letter same-timeslot lectures (C1, C2) separate", () => {
+    // C1 and C2 are two distinct lecture sections, not a lab/recit of a "C"
+    // lecture — they must stay as separate offerings, never folded together.
+    const groups = groupClassesByOffering([
+      row({ id: 1, section: "C1", type: "LEC", schedule: ["MW 10:00AM-11:30AM"] }),
+      row({ id: 2, section: "C2", type: "LEC", schedule: ["MW 10:00AM-11:30AM"] }),
+    ]);
+
+    expect(groups.map((g) => g.section).sort()).toEqual(["C1", "C2"]);
+    expect(groups.every((g) => g.sections.length === 1)).toBe(true);
+  });
+
   test("adds the parent lecture row to each recit offering", () => {
     const groups = groupClassesByOffering([
       row({ id: 1, courseCode: "SPCM 1", section: "UV", type: "LEC" }),

--- a/src/lib/classes-api.store.test.ts
+++ b/src/lib/classes-api.store.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClassQueryPage } from "@lib/classes-api";
+
+// fetchClassPage only needs getJSONFetch (which is `fetch(url).json()`). The real
+// util transitively boots the whole Svelte-rune store graph, so mock the boundary
+// and assert the /api/classes URL fetchClassPage builds from its options.
+// (.store.test.ts so it runs under vitest, where vi.mock is hoisted + file-scoped
+// — a bun mock.module here would leak into every other test in the run.)
+const { getJSONFetch } = vi.hoisted(() => ({ getJSONFetch: vi.fn() }));
+vi.mock("@lib/local/data/utils", () => ({ getJSONFetch }));
+
+import { fetchClassPage } from "@lib/classes-api";
+
+const calledUrl = () => new URL(getJSONFetch.mock.calls[0][0], "http://x");
+
+describe("fetchClassPage", () => {
+  beforeEach(() => {
+    getJSONFetch.mockReset();
+    getJSONFetch.mockResolvedValue({ rows: [], total: 0 });
+  });
+
+  it("hits /api/classes and encodes every provided option", async () => {
+    const result: ClassQueryPage = { rows: [{ courseCode: "CMSC 128" }], total: 1 };
+    getJSONFetch.mockResolvedValueOnce(result);
+
+    const page = await fetchClassPage({
+      termId: 1252,
+      courseCodePrefix: "CMSC",
+      limit: 10,
+      offset: 20,
+    });
+
+    const url = calledUrl();
+    expect(url.pathname).toBe("/api/classes");
+    expect(url.searchParams.get("term_id")).toBe("1252");
+    expect(url.searchParams.get("course_code")).toBe("CMSC");
+    expect(url.searchParams.get("limit")).toBe("10");
+    expect(url.searchParams.get("offset")).toBe("20");
+    expect(page).toEqual(result);
+  });
+
+  it("defaults limit to 25 and offset to 0", async () => {
+    await fetchClassPage({ termId: 1252 });
+    const p = calledUrl().searchParams;
+    expect(p.get("limit")).toBe("25");
+    expect(p.get("offset")).toBe("0");
+  });
+
+  it("omits term_id when null and a blank course code", async () => {
+    await fetchClassPage({ termId: null, courseCodePrefix: "   " });
+    const p = calledUrl().searchParams;
+    expect(p.has("term_id")).toBe(false);
+    expect(p.has("course_code")).toBe(false);
+  });
+
+  it("trims a padded course code prefix", async () => {
+    await fetchClassPage({ courseCodePrefix: "  MATH 27  " });
+    expect(calledUrl().searchParams.get("course_code")).toBe("MATH 27");
+  });
+
+  it("propagates fetch errors to the caller", async () => {
+    getJSONFetch.mockRejectedValueOnce(new Error("network down"));
+    await expect(fetchClassPage({ termId: 1252 })).rejects.toThrow(
+      "network down",
+    );
+  });
+});

--- a/src/lib/planner/types.test.ts
+++ b/src/lib/planner/types.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { sectionNaturalKey } from "./types.js";
+
+describe("sectionNaturalKey", () => {
+  it("joins course code, section, and type with the :: separator", () => {
+    expect(
+      sectionNaturalKey({
+        courseCode: "CMSC 128",
+        section: "AB-1L",
+        type: "LAB",
+      }),
+    ).toBe("CMSC 128::AB-1L::LAB");
+  });
+
+  it("distinguishes LEC from LAB of the same section (dedup relies on this)", () => {
+    const base = { courseCode: "CMSC 128", section: "AB-1L" };
+    expect(sectionNaturalKey({ ...base, type: "LEC" })).not.toBe(
+      sectionNaturalKey({ ...base, type: "LAB" }),
+    );
+  });
+});


### PR DESCRIPTION
Fills the remaining gaps in the course-planner test pyramid, decoupled from the map feature (no browse-buildings filters, no map pins, no map chrome). Most planner unit tests already existed on `main`; this PR adds the pieces that were still uncovered plus a planner-interaction e2e.

## Files added / changed

### Unit — bun (`bun test src/lib …`)
- **`src/lib/planner/types.test.ts`** (new, 2 tests) — `sectionNaturalKey` format (`courseCode::section::type`) and LEC-vs-LAB key distinctness (persistence/dedup relies on it).
- **`src/lib/class-offering-groups.test.ts`** (+1 test) — same-letter same-timeslot lectures (`C1`, `C2`) stay SEPARATE, never folded into a phantom `C` lecture parent. Existing LAB/recit-linking coverage left untouched.

### Unit — vitest (`.store.test.ts`, runs under the svelte/happy-dom env)
- **`src/lib/classes-api.store.test.ts`** (new, 5 tests) — `fetchClassPage` builds `/api/classes` with the right query params (`term_id`/`course_code`/`limit`/`offset`, defaults 25/0, null/blank omission, trimming), returns the `{rows,total}` shape, and propagates fetch errors. Named `.store.test.ts` because importing `classes-api` transitively boots the Svelte-rune store graph, which plain `bun test` cannot load; `vi.mock` on the `getJSONFetch` boundary is hoisted + file-scoped (a bun `mock.module` would leak into every other test in the run).

### e2e — Playwright (`e2e/smoke/planner-flow.spec.ts`, new, 2 tests)
- Search a course code -> expand -> Add updates the Sections list -> Remove.
- Two overlapping sections show the conflict badge -> removing one clears it. Seeded via `localStorage` so it is deterministic regardless of e2e DB contents. Map-independent (waits on the loading shell, never on map chrome), mirroring `planner-route.spec.ts`.

## Verification / pass counts
- **Unit (bun):** `bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts'` -> **280 pass, 0 fail** (includes the new `types.test.ts` + `class-offering-groups` case).
- **Unit (vitest):** `vitest run` -> **27 files, 85 pass, 0 fail** (includes the new `classes-api.store.test.ts` = 5).
- **e2e:** written and validated statically + against the live API (dev server on the seeded e2e DB returns `E2E 101` for `/api/classes?term_id=1252&course_code=E2E`). **Not executed in this sandbox:** the Playwright specs need the production build, and the Astro build fails in the isolated worktree because `node_modules` is a cross-device symlink (worktree on tmpfs) that mangles Astro's rolldown compile-metadata paths; the dev-server fallback does not hydrate the planner island (the pre-existing `planner-route.spec.ts` also fails against dev), so this is an environment limit, not a spec defect. They should run under the normal `serve:e2e` (built app) CI path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior modifications.
> 
> **Overview**
> Adds **planner-focused test coverage** with no production code changes: unit tests for offering grouping, planner keys, and class API query building, plus map-independent Playwright flows.
> 
> **Unit (bun):** New `sectionNaturalKey` tests lock the `courseCode::section::type` format and LEC vs LAB distinctness for planner dedup/persistence. **`groupClassesByOffering`** gains a case that **C1/C2** same-slot lectures stay separate offerings (not merged into a phantom parent).
> 
> **Unit (vitest):** New `classes-api.store.test.ts` exercises **`fetchClassPage`** URL/query encoding (`term_id`, trimmed `course_code`, default limit/offset, omission rules) and error propagation via a mocked `getJSONFetch` boundary (`.store.test.ts` avoids bun store-graph leakage).
> 
> **e2e:** New `planner-flow.spec.ts` covers search → add → remove against seeded **E2E 101**, and conflict badge → remove → “All clear” using **localStorage**-seeded overlapping schedules; boot waits on **`#app-loading-shell`** instead of map chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4637b4f0f867744a48195d8de4f2665301aac514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->