### PR TITLE
feat(help): App-menu entry to reopen the how-it-works guide (#6)

### DIFF
--- a/src/components/svelte/status-bar/AppMenu.component.test.ts
+++ b/src/components/svelte/status-bar/AppMenu.component.test.ts
@@ -39,3 +39,21 @@ describe("AppMenu review entry", () => {
     ).toBeNull();
   });
 });
+
+describe("AppMenu help entry", () => {
+  beforeEach(() => {
+    modalStore.closeModal();
+    adminAuthStore.canReview = false;
+  });
+
+  test("'How Room TBA works' opens the landing modal on the welcome tab", async () => {
+    render(AppMenu, { props: { onSignOut: () => {} } });
+    await fireEvent.click(screen.getByRole("button", { name: /app menu/i }));
+    await fireEvent.click(
+      screen.getByRole("button", { name: /how room tba works/i }),
+    );
+    expect(modalStore.open).toBe(true);
+    expect(modalStore.type).toBe("landing");
+    expect(modalStore.landingTab).toBe("welcome");
+  });
+});

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -2,6 +2,7 @@
   import Menu from "@lucide/svelte/icons/menu";
   import Keyboard from "@lucide/svelte/icons/keyboard";
   import FileText from "@lucide/svelte/icons/file-text";
+  import LifeBuoy from "@lucide/svelte/icons/life-buoy";
   import Inbox from "@lucide/svelte/icons/inbox";
   import { onMount } from "svelte";
   import { formatCatalogUpdatedDate } from "@constants/data-catalog";
@@ -152,6 +153,11 @@
     modalStore.openModal("changelog");
   }
 
+  function handleHowItWorks() {
+    closePanel();
+    modalStore.openModal("landing", { landingTab: "welcome" });
+  }
+
   function handleReview() {
     closePanel();
     modalStore.openModal("review");
@@ -248,6 +254,14 @@
         aria-labelledby="app-menu-help-heading"
       >
         <h3 id="app-menu-help-heading" class="app-menu__heading">Help</h3>
+        <button
+          type="button"
+          class="app-menu__action map-chrome-chip"
+          onclick={handleHowItWorks}
+        >
+          <LifeBuoy size={14} aria-hidden="true" />
+          <span>How Room TBA works</span>
+        </button>
         <button
           type="button"
           class="app-menu__action map-chrome-chip"


### PR DESCRIPTION
My judgment on the remaining backlog:
- **#6 (this PR):** the landing modal's welcome tab is the how-to guide; add an App-menu 'How Room TBA works' entry to reopen it anytime. Tested.
- **#16 jeepney click delay:** traced the select path 3× — geometry is a synchronous static import, no code delay; the only latency is the intentional camera fit/fly animation. Not shipping a speculative change that could break it; needs a concrete repro.
- **#11 featured plans:** needs a curation model + real content (which plans) — building infra without content ships an empty feature.
- **#15 jeepney editing:** routes live in a constants file; runtime editing means migrating the whole route dataset to DB + admin CRUD — a core data-model change I won't do hastily without sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI addition that reuses existing modal navigation; no auth, data, or API changes.
> 
> **Overview**
> Adds a **Help** menu action **How Room TBA works** so users can reopen the onboarding guide after dismissing the first-run landing modal.
> 
> The new control closes the app menu and calls `modalStore.openModal("landing", { landingTab: "welcome" })`, matching the existing pattern used for other landing tabs (e.g. Contributors → `campus`). A component test asserts the landing modal opens on the welcome tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7776919b1d603e84dd0655bed2635da5cf589b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->