### PR TITLE
release: App-menu how-it-works entry (#6)

### DIFF
--- a/src/components/svelte/status-bar/AppMenu.component.test.ts
+++ b/src/components/svelte/status-bar/AppMenu.component.test.ts
@@ -39,3 +39,21 @@ describe("AppMenu review entry", () => {
     ).toBeNull();
   });
 });
+
+describe("AppMenu help entry", () => {
+  beforeEach(() => {
+    modalStore.closeModal();
+    adminAuthStore.canReview = false;
+  });
+
+  test("'How Room TBA works' opens the landing modal on the welcome tab", async () => {
+    render(AppMenu, { props: { onSignOut: () => {} } });
+    await fireEvent.click(screen.getByRole("button", { name: /app menu/i }));
+    await fireEvent.click(
+      screen.getByRole("button", { name: /how room tba works/i }),
+    );
+    expect(modalStore.open).toBe(true);
+    expect(modalStore.type).toBe("landing");
+    expect(modalStore.landingTab).toBe("welcome");
+  });
+});

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -2,6 +2,7 @@
   import Menu from "@lucide/svelte/icons/menu";
   import Keyboard from "@lucide/svelte/icons/keyboard";
   import FileText from "@lucide/svelte/icons/file-text";
+  import LifeBuoy from "@lucide/svelte/icons/life-buoy";
   import Inbox from "@lucide/svelte/icons/inbox";
   import { onMount } from "svelte";
   import { formatCatalogUpdatedDate } from "@constants/data-catalog";
@@ -152,6 +153,11 @@
     modalStore.openModal("changelog");
   }
 
+  function handleHowItWorks() {
+    closePanel();
+    modalStore.openModal("landing", { landingTab: "welcome" });
+  }
+
   function handleReview() {
     closePanel();
     modalStore.openModal("review");
@@ -248,6 +254,14 @@
         aria-labelledby="app-menu-help-heading"
       >
         <h3 id="app-menu-help-heading" class="app-menu__heading">Help</h3>
+        <button
+          type="button"
+          class="app-menu__action map-chrome-chip"
+          onclick={handleHowItWorks}
+        >
+          <LifeBuoy size={14} aria-hidden="true" />
+          <span>How Room TBA works</span>
+        </button>
         <button
           type="button"
           class="app-menu__action map-chrome-chip"


### PR DESCRIPTION
Promotes #6. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI addition reusing existing modal navigation; no auth, data, or API changes.
> 
> **Overview**
> Adds a **Help** entry in the status-bar app menu so users can reopen onboarding without hunting for the first-run flow.
> 
> **How Room TBA works** closes the menu and opens the existing landing modal on the **`welcome`** tab (same `modalStore.openModal("landing", { landingTab: "welcome" })` pattern as other menu links). A **LifeBuoy** icon labels the control.
> 
> Component test coverage asserts the menu click sets `modalStore.open`, `type: "landing"`, and `landingTab: "welcome"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18c804701e3bc7b2e47941f9a823fd5d74006f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->