### PR TITLE
fix(terms): correct term-picker class count pluralization

### DIFF
--- a/src/components/svelte/TermSelector.svelte
+++ b/src/components/svelte/TermSelector.svelte
@@ -247,7 +247,7 @@
                 {/if}
               </span>
               {#if term.classCount > 0}
-                <span class="term-picker-option__count">{term.classCount} {term.classCount === 1 ? "classes" : "class"}</span>
+                <span class="term-picker-option__count">{term.classCount} {term.classCount === 1 ? "class" : "classes"}</span>
               {/if}
             </button>
           {/each}


### PR DESCRIPTION
Inverted ternary showed '4670 class' / '1 classes'. Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line copy fix in UI text with no logic, API, or data changes.
> 
> **Overview**
> Fixes **inverted pluralization** in the chip-style term picker dropdown (`TermSelector.svelte`): each option’s class count now shows **“1 class”** vs **“N classes”** instead of the reversed strings.
> 
> The change is limited to the `term.classCount === 1 ? "class" : "classes"` ternary on `term-picker-option__count`; no behavior or data flow changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9dec899ece6866121f5d1c6543cde8756790e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->