### PR TITLE
feat(planner): wrap full course title + show matriculation date

### DIFF
--- a/src/components/svelte/planner/PlannerScreen.svelte
+++ b/src/components/svelte/planner/PlannerScreen.svelte
@@ -11,6 +11,7 @@
   } from "@lib/store.svelte";
   import { fetchClassPage } from "@lib/classes-api";
   import { COURSE_CHANGE_DISCLAIMER } from "@lib/amis/room-scheduled-types";
+  import { changeOfMatriculationLabel } from "@lib/term-calendar";
   import { fetchFinalExams, FINALS_SCOPE_NOTE } from "@lib/final-exams";
   import { isUnscheduled } from "@lib/planner/conflicts";
   import { buildPlanIcs } from "@lib/planner/ics";
@@ -252,7 +253,11 @@
       {/if}
     </header>
 
-    <p class="planner-disclaimer" role="note">{COURSE_CHANGE_DISCLAIMER}</p>
+    <p class="planner-disclaimer" role="note">
+      {COURSE_CHANGE_DISCLAIMER}{changeOfMatriculationLabel(termStore.activeTermId)
+        ? ` (${changeOfMatriculationLabel(termStore.activeTermId)})`
+        : ""}
+    </p>
 
     <div class="planner-tabs" role="tablist" aria-label="Plans">
       {#each plannerStore.plansForTerm as tabPlan (tabPlan.id)}
@@ -709,9 +714,9 @@
   .planner-offering__title {
     font-size: 0.75rem;
     color: hsl(0, 0%, 40%);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    line-height: 1.3;
+    /* Show the full course title (its description) — wrap instead of truncate. */
+    overflow-wrap: anywhere;
   }
 
   .planner-offering__remove {

--- a/src/lib/term-calendar.test.ts
+++ b/src/lib/term-calendar.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  changeOfMatriculationLabel,
   isDateWithinTerm,
   resolveActiveTermByDate,
   resolveInitialTermId,
@@ -90,5 +91,15 @@ describe("term-calendar", () => {
         date: midyearDay,
       }),
     ).toBe(1253);
+  });
+});
+
+describe("changeOfMatriculationLabel", () => {
+  it("formats the last day for a known term", () => {
+    expect(changeOfMatriculationLabel(1261)).toBe("August 7, 2026");
+  });
+  it("returns null for unknown terms / null", () => {
+    expect(changeOfMatriculationLabel(1252)).toBeNull();
+    expect(changeOfMatriculationLabel(null)).toBeNull();
   });
 });

--- a/src/lib/term-calendar.ts
+++ b/src/lib/term-calendar.ts
@@ -26,6 +26,31 @@ export const TERM_CALENDAR_WINDOWS: Record<
   },
 };
 
+/**
+ * Last day of change of matriculation per term (Asia/Manila, date-only). Until
+ * this date, course offerings can still change — surfaced in the planner note.
+ */
+export const CHANGE_OF_MATRICULATION_ENDS: Record<number, string> = {
+  // CRS 1261 — AY 2026–2027 1st sem (classes start Aug 3).
+  1261: "2026-08-07",
+};
+
+/** Human date ("August 7, 2026") for a term's last day of change of
+ *  matriculation, or null when unknown. */
+export function changeOfMatriculationLabel(
+  termId: number | null | undefined,
+): string | null {
+  const iso = termId == null ? undefined : CHANGE_OF_MATRICULATION_ENDS[termId];
+  if (!iso) return null;
+  const [year, month, day] = iso.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString("en-PH", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 function toManilaDateKey(date: Date) {
   return date.toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
 }


### PR DESCRIPTION
Course titles in the Sections list no longer truncate (full name/description shows). The change-of-matriculation note now lists the actual date for the active term (August 7, 2026 for AY 2026-2027 1st sem). Tests + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI and display-only calendar copy changes with no auth, data, or API impact.
> 
> **Overview**
> The planner **Sections** list now **wraps full course titles** instead of single-line ellipsis truncation, via updated `.planner-offering__title` styles.
> 
> The yellow **course-change disclaimer** appends the **last day of change of matriculation** for the active term when known (e.g. `(August 7, 2026)` for term `1261`), using new `CHANGE_OF_MATRICULATION_ENDS` data and `changeOfMatriculationLabel()` in `term-calendar.ts`, with unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f33e8f1f6a5cf9b8c41d127830ce622e1c19fa62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->