### PR TITLE
chore(release): sync app version to 1.40.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-room",
   "type": "module",
-  "version": "1.31.1",
+  "version": "1.40.0",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Footer stuck at 1.31.1; latest release is v1.40.0. Chore bump to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field in package.json with no runtime or dependency changes.
> 
> **Overview**
> Updates the **`version`** field in `package.json` from **1.31.1** to **1.40.0** so the displayed app version (e.g. footer) matches **v1.40.0** on GitHub.
> 
> This is a manual sync when the automated post-release version PR did not land or was out of date; no application logic or dependencies change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d191dfe468ac7c47c52fbd6ee239051d6fe45633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->