### PR TITLE
feat(planner): color legend for block types

### DIFF
--- a/src/components/svelte/planner/PlannerGrid.svelte
+++ b/src/components/svelte/planner/PlannerGrid.svelte
@@ -268,6 +268,30 @@
     ((endMin - startMin) / TOTAL_MIN) * 100;
 </script>
 
+<div class="planner-legend" aria-label="Block colors">
+  <span class="planner-legend__item">
+    <span
+      class="planner-legend__dot"
+      style:background-color={getPlannerBlockColor("LEC")}
+    ></span>
+    Lecture
+  </span>
+  <span class="planner-legend__item">
+    <span
+      class="planner-legend__dot"
+      style:background-color={getPlannerBlockColor("LAB")}
+    ></span>
+    Lab
+  </span>
+  <span class="planner-legend__item">
+    <span
+      class="planner-legend__dot"
+      style:background-color={getPlannerBlockColor("RCT")}
+    ></span>
+    Recitation
+  </span>
+</div>
+
 <div class="planner-grid-scroll">
   <div class="planner-grid" class:planner-grid--dragging={drag}>
     <div class="planner-grid__time" aria-hidden="true">
@@ -361,6 +385,29 @@
 {/if}
 
 <style>
+  .planner-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 1rem;
+    padding: 0.375rem 0.125rem;
+    font-size: 0.75rem;
+    color: hsl(0, 0%, 35%);
+  }
+
+  .planner-legend__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-weight: 600;
+  }
+
+  .planner-legend__dot {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 0.1875rem;
+    flex: 0 0 auto;
+  }
+
   .planner-grid-scroll {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Legend above the grid: Lecture (blue) / Lab (green) / Recitation (amber), driven by getPlannerBlockColor so it stays in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational UI only in the planner grid; no logic, data, or auth changes.
> 
> **Overview**
> Adds a **color legend** above the planner weekly grid so users can see what Lecture, Lab, and Recitation blocks mean without guessing from the tiles alone.
> 
> Each legend swatch uses **`getPlannerBlockColor`** with the same type codes (`LEC`, `LAB`, `RCT`) as the grid blocks, so legend colors stay aligned if the palette changes. The legend is a compact flex row with an `aria-label` for accessibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8161c443784f989a3732b010a096a23663a4ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->