### PR TITLE
feat(planner): intentional mobile layout (first pass)

### DIFF
--- a/src/components/svelte/planner/PlannerCourseSearch.svelte
+++ b/src/components/svelte/planner/PlannerCourseSearch.svelte
@@ -365,4 +365,65 @@
     border-color: hsl(5, 53%, 32%);
     color: white;
   }
+
+  /* --- Mobile (phones): readable rows and ≥44px tap targets for the search
+     field, course headers, and Add/✓ toggles. --- */
+  @media (max-width: 640px) {
+    /* 1rem input avoids the iOS focus zoom; roomier field overall. */
+    .course-search__box {
+      padding: 0.625rem 0.75rem;
+    }
+
+    .course-search__box input {
+      font-size: 1rem;
+    }
+
+    .course-search__note {
+      font-size: 0.875rem;
+    }
+
+    .course-item__header {
+      min-height: 2.75rem;
+      padding: 0.75rem;
+    }
+
+    .course-item__code {
+      font-size: 0.9375rem;
+    }
+
+    .course-item__meta {
+      font-size: 0.75rem;
+    }
+
+    .course-item__title {
+      font-size: 0.8125rem;
+    }
+
+    .course-item__sections {
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem 0.75rem;
+    }
+
+    .section-row {
+      gap: 0.75rem;
+    }
+
+    .section-row__name {
+      font-size: 0.875rem;
+    }
+
+    .section-row__schedule {
+      font-size: 0.8125rem;
+    }
+
+    .section-row__toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 3.5rem;
+      min-height: 2.75rem;
+      padding: 0.5rem 0.875rem;
+      font-size: 0.875rem;
+    }
+  }
 </style>

--- a/src/components/svelte/planner/PlannerGrid.svelte
+++ b/src/components/svelte/planner/PlannerGrid.svelte
@@ -292,6 +292,8 @@
   </span>
 </div>
 
+<p class="planner-grid__scroll-hint" aria-hidden="true">Swipe to see all days →</p>
+
 <div class="planner-grid-scroll">
   <div class="planner-grid" class:planner-grid--dragging={drag}>
     <div class="planner-grid__time" aria-hidden="true">
@@ -392,6 +394,19 @@
     padding: 0.375rem 0.125rem;
     font-size: 0.75rem;
     color: hsl(0, 0%, 35%);
+  }
+
+  /* Mobile-only affordance that the week grid scrolls sideways (hidden on
+     desktop, where all six days already fit). */
+  .planner-grid__scroll-hint {
+    display: none;
+    align-items: center;
+    justify-content: flex-end;
+    margin: 0;
+    padding: 0 0.125rem 0.375rem;
+    color: hsl(0, 0%, 45%);
+    font-size: 0.75rem;
+    font-weight: 600;
   }
 
   .planner-legend__item {
@@ -615,6 +630,78 @@
   @media (prefers-reduced-motion: reduce) {
     .planner-ghost {
       transition: none;
+    }
+  }
+
+  /* --- Mobile (phones): bigger text, taller rows, wider day columns, and a
+     horizontally-scrollable week grid instead of a squeezed six-up view. --- */
+  @media (max-width: 640px) {
+    .planner-legend {
+      gap: 0.375rem 1.25rem;
+      font-size: 0.8125rem;
+    }
+
+    .planner-legend__dot {
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+
+    .planner-grid__scroll-hint {
+      display: flex;
+    }
+
+    /* Wider day columns so blocks are readable and tappable; the grid overflows
+       its scroll container and scrolls sideways on a narrow phone. */
+    .planner-grid {
+      grid-template-columns: 3.25rem repeat(6, minmax(5.25rem, 1fr));
+      min-width: 34.75rem;
+    }
+
+    /* Taller rows use the phone's vertical space and give a 1-hour block a
+       3rem (48px) height — above the 44px tap-target minimum. */
+    .planner-grid__day-body {
+      height: 39rem; /* 13 hours × 3rem */
+      background-image: repeating-linear-gradient(
+        to bottom,
+        transparent,
+        transparent calc(3rem - 1px),
+        hsl(0, 0%, 93%) calc(3rem - 1px),
+        hsl(0, 0%, 93%) 3rem
+      );
+    }
+
+    .planner-grid__day-label {
+      font-size: 0.875rem;
+    }
+
+    .planner-grid__hour {
+      font-size: 0.75rem;
+    }
+
+    .planner-block__label {
+      padding: 0.25rem 0.375rem;
+    }
+
+    .planner-block__course {
+      font-size: 0.8125rem;
+    }
+
+    .planner-block__section {
+      font-size: 0.75rem;
+    }
+
+    .planner-block__actions {
+      gap: 0.375rem;
+      padding: 0.375rem;
+    }
+
+    .planner-block__actions button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 2.75rem;
+      padding: 0.5rem 0.875rem;
+      font-size: 0.875rem;
     }
   }
 </style>

--- a/src/components/svelte/planner/PlannerScreen.svelte
+++ b/src/components/svelte/planner/PlannerScreen.svelte
@@ -755,4 +755,108 @@
     font-size: 0.6875rem;
     color: hsl(0, 0%, 50%);
   }
+
+  /* --- Mobile (phones): readable text, ≥44px tap targets, a header that wraps
+     instead of overflowing, and roomier stacked sections. --- */
+  @media (max-width: 640px) {
+    /* Share + "Add to Google Calendar" wrap onto their own row rather than
+       overflowing the top bar. */
+    .planner-header {
+      flex-wrap: wrap;
+      row-gap: 0.5rem;
+    }
+
+    .planner-back {
+      min-height: 2.75rem;
+      font-size: 1rem;
+    }
+
+    .planner-title {
+      font-size: 1.0625rem;
+    }
+
+    .planner-action {
+      flex: 1 1 45%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 2.75rem;
+      padding: 0.5rem 0.875rem;
+      font-size: 0.875rem;
+    }
+
+    .planner-disclaimer,
+    .planner-save-note {
+      font-size: 0.8125rem;
+    }
+
+    .planner-tabs {
+      gap: 0.5rem;
+    }
+
+    .planner-tab {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 2.75rem;
+      padding: 0.375rem 0.875rem;
+      font-size: 0.875rem;
+    }
+
+    .planner-tab--new {
+      min-width: 2.75rem;
+      font-size: 1.25rem;
+    }
+
+    .planner-conflict-badge {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8125rem;
+    }
+
+    .planner-delete-confirm__label {
+      font-size: 0.875rem;
+    }
+
+    .planner-body {
+      gap: 1rem;
+      padding: 0.75rem 0.75rem calc(1rem + env(safe-area-inset-bottom, 0px));
+    }
+
+    .planner-side__heading {
+      font-size: 0.9375rem;
+    }
+
+    .planner-offering {
+      padding: 0.75rem;
+    }
+
+    .planner-offering__course {
+      font-size: 0.9375rem;
+    }
+
+    .planner-offering__title,
+    .planner-offering__part {
+      font-size: 0.8125rem;
+    }
+
+    /* Obvious, tappable Remove. */
+    .planner-offering__remove {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 2.75rem;
+      padding: 0.5rem 0.875rem;
+      border: 1px solid hsl(0, 60%, 80%);
+      font-size: 0.875rem;
+    }
+
+    .planner-plain-list {
+      gap: 0.375rem;
+      font-size: 0.875rem;
+    }
+
+    .planner-finals-note {
+      font-size: 0.8125rem;
+    }
+  }
 </style>


### PR DESCRIPTION
First pass of the mobile effort, scoped to the **course planner only** (`PlannerScreen.svelte`, `PlannerGrid.svelte`, and its sibling `PlannerCourseSearch.svelte`). Goal: make the planner feel designed for a phone instead of an auto-shrunk desktop UI. **Desktop is untouched** — the whole diff is additive: `@media (max-width: 640px)` blocks plus one decorative scroll-hint `<p>`. No desktop selector or property was modified (verified: `git diff` shows zero removed lines outside headers).

## The grid (the big decision)
At ~380px the 6-column week grid is unusable if forced to fit. I kept the existing **horizontal-scroll** approach (grid already lives in an `overflow-x: auto` container) and made it intentional rather than adding a day-tabs view:

- **Wider day columns** on mobile — `minmax(5.25rem, 1fr)` (~84px) so ~3.5 days show at once and each column is a comfortable touch/read width; the grid scrolls sideways for the rest.
- **Taller rows** — `3rem`/hour (was `2.5rem`), so a 1-hour block is **48px** tall (≥44px tap target) and text is readable. Uses the phone's vertical space. The hour-line gradient and day-body height are overridden together inside the media query so the grid stays aligned.
- **Scroll affordance** — a mobile-only `Swipe to see all days →` hint above the grid (hidden on desktop, `aria-hidden` since it duplicates the visible scrollable grid).

Why not a day-focused (one-day-at-a-time) view? It needs new state + markup + JS for marginal gain over a clearly-scrollable grid; the scroll approach is the simplest thing that's genuinely usable and keeps conflicts/drag-to-swap visible across days. (Ladder: reuse the existing scroll container over building a new view mode.)

## Everything else (all ≥44px touch targets, bigger text)
- **Header** wraps (`flex-wrap`) so **Share** + **Add to Google Calendar** drop to their own row two-up instead of overflowing; back/title/term-chip stay on row 1.
- **Plan tabs / + / Delete / Cancel** → `min-height: 2.75rem`, bigger font; the `+` is a 44×44 square.
- **Grid block Remove/Room** actions, **course-search field** (1rem input to avoid iOS focus-zoom), **course headers**, **Add/✓ toggles**, and the sections-list **Remove** (now bordered + 44px, obvious) all bumped to ≥44px with larger text.
- Full course title still wraps (unchanged `overflow-wrap: anywhere`). Color legend, LEC/LAB linked list, and the change-of-matriculation note are visually bumped but structurally untouched and still render.

## Breakpoint
`@media (max-width: 640px)` as specified. Note the file already had a `48rem` (768px) single-column stack; these mobile rules layer on top for phones ≤640px. The 641–768px tablet range keeps the pre-existing single-column-but-desktop-text behavior (out of scope for this phone-first pass).

## Verification
- `npx biome check` on all three files → **passes** (exit 0). The one `info` is a pre-existing `dataset["ghost"]` literal-key lint on a line I didn't touch.
- `vitest run` planner component tests: all green **except one pre-existing failure** — `PlannerScreen.component.test.ts` `getByText("CMSC 128 · AB-1L")`. I confirmed it fails identically on clean `origin/main` (stash + rerun); it's stale from the earlier LEC/LAB linked-list markup refactor, **not caused by this CSS-only change**. Left as-is (fixing it means reasoning about that feature's intended text, out of scope here).
- **Could not visually confirm on a device / emulator** — no mobile screenshot capability in this environment. The behavior above is derived from the CSS; a real-device pass (esp. header wrap arrangement and grid scroll feel) is still worth a human check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only, scoped to mobile breakpoints in three planner components; no logic, data, or desktop layout changes.
> 
> **Overview**
> **Phone-first pass** for the course planner only (`PlannerScreen`, `PlannerGrid`, `PlannerCourseSearch`). Everything is **additive** `@media (max-width: 640px)` CSS; desktop selectors are not changed.
> 
> On **`PlannerGrid`**, the week view stays a six-day grid but is tuned for narrow screens: **wider day columns** and a higher **min-width** so the existing horizontal scroll container shows ~3.5 days at a time instead of a squeezed six-up layout. **Hour rows grow to 3rem** (48px per hour) with matching day-body height and grid lines. A mobile-only **“Swipe to see all days →”** hint appears above the grid (`aria-hidden`); legend, block labels, and **Remove/Room** actions get larger type and **2.75rem** minimum touch heights.
> 
> **`PlannerScreen`** wraps the top **header** so Share and Add to Google Calendar can sit two-up on a second row; back, tabs, delete/cancel, conflict badge, and section-list **Remove** are bumped to readable sizes and ≥44px targets, with slightly roomier body padding (including safe-area).
> 
> **`PlannerCourseSearch`** uses a **1rem** search input (iOS zoom avoidance), larger course/section copy, and bigger **Add/✓** toggles with flex-centered hit areas.
> 
> These rules layer on top of the existing **48rem** single-column stack in `PlannerScreen`; tablets between 641px and 768px keep prior behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eae950e273ba8d0cb1a8f1b85bb801ee654d8f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->