### PR TITLE
test(planner): fix section-list assertion for grouped markup

### DIFF
--- a/src/components/svelte/planner/PlannerScreen.component.test.ts
+++ b/src/components/svelte/planner/PlannerScreen.component.test.ts
@@ -59,7 +59,15 @@ describe("PlannerScreen", () => {
     render(PlannerScreen);
     // MW LEC = 2 blocks + F LAB = 1 block
     expect(document.querySelectorAll(".planner-block")).toHaveLength(3);
-    expect(screen.getByText("CMSC 128 · AB-1L")).toBeVisible();
+    // Sections list groups by course: a "CMSC 128" header + its parts.
+    expect(
+      document.querySelector(".planner-offering__course")?.textContent,
+    ).toContain("CMSC 128");
+    expect(
+      [...document.querySelectorAll(".planner-offering__part-section")].map(
+        (el) => el.textContent?.trim(),
+      ),
+    ).toContain("AB-1L");
     expect(screen.getByText("All clear")).toBeVisible();
   });
 


### PR DESCRIPTION
The grouped sections list (#613) removed the combined 'CMSC 128 · AB-1L' text; assert the course header + part instead. Was failing on main. 5/5 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code impact.
> 
> **Overview**
> Updates the **PlannerScreen** seeded-plan test so the sections sidebar matches the **course-grouped** list UI (from #613).
> 
> Instead of looking for combined text `CMSC 128 · AB-1L`, the test now checks `.planner-offering__course` for the course code and `.planner-offering__part-section` for `AB-1L`. Grid block count and “All clear” assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3205f5f3e35babf215b5cf7fcb1c69ab4fe67bf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->