### PR TITLE
feat(auth): contributor self-signup (attribution + username reservation)

### DIFF
--- a/src/components/svelte/AdminLoginModal.component.test.ts
+++ b/src/components/svelte/AdminLoginModal.component.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import { beforeEach, describe, expect, test } from "vitest";
 import AdminLoginModal from "@ui/AdminLoginModal.svelte";
 import { adminAuthStore } from "@lib/store.svelte";
@@ -23,5 +23,24 @@ describe("AdminLoginModal", () => {
     expect(
       screen.getByRole("link", { name: /Message maintainers/i }),
     ).toHaveAttribute("href", "https://m.me/j/AbZtqMU8UUTiwQfn/");
+  });
+
+  test('the "Sign up" toggle reveals the contributor signup form', async () => {
+    render(AdminLoginModal);
+    // Sign-in mode: no confirm-password field yet.
+    expect(screen.queryByLabelText("Confirm password")).toBeNull();
+
+    await fireEvent.click(screen.getByRole("button", { name: /^Sign up$/i }));
+
+    expect(screen.getByLabelText("Username")).toBeVisible();
+    expect(screen.getByLabelText("Confirm password")).toBeVisible();
+    expect(screen.getByLabelText("Email (optional)")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /Create account/i }),
+    ).toBeVisible();
+
+    // And back again.
+    await fireEvent.click(screen.getByRole("button", { name: /^Sign in$/i }));
+    expect(screen.queryByLabelText("Confirm password")).toBeNull();
   });
 });

--- a/src/components/svelte/AdminLoginModal.svelte
+++ b/src/components/svelte/AdminLoginModal.svelte
@@ -22,6 +22,7 @@
     getTurnstileSiteKey,
     isTurnstileWidgetConfigured,
   } from "@lib/turnstile-client";
+  import { MIN_CONTRIBUTOR_PASSWORD_LENGTH } from "@lib/auth/contributor-signup";
 
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
   const loginErrorId = "admin-login-error";
@@ -36,12 +37,27 @@
       "This Google account cannot be used to sign in. Contact the maintainers.",
   };
 
+  type Mode = "signin" | "signup";
+
   let loginFrameEl = $state<HTMLDivElement | null>(null);
+  let mode = $state<Mode>("signin");
   let username = $state("admin");
   let password = $state("");
+  let confirmPassword = $state("");
+  let signupEmail = $state("");
   let error: string | null = $state(null);
   let googleLoading = $state(false);
   let turnstileToken = $state<string | null>(null);
+
+  const isSignup = $derived(mode === "signup");
+
+  function switchMode(next: Mode) {
+    mode = next;
+    error = null;
+    password = "";
+    confirmPassword = "";
+    if (next === "signup") username = "";
+  }
 
   let showForgotPassword = $state(false);
   let forgotLoginDraft = $state("");
@@ -102,6 +118,30 @@
       return;
     }
     error = null;
+
+    if (isSignup) {
+      if (password !== confirmPassword) {
+        error = "Passwords do not match.";
+        return;
+      }
+      const err = await adminAuthStore.signup({
+        username,
+        password,
+        email: signupEmail,
+        turnstileToken,
+      });
+      if (err) {
+        error = err;
+        return;
+      }
+      password = "";
+      confirmPassword = "";
+      const label =
+        adminAuthStore.displayName ?? adminAuthStore.username ?? "contributor";
+      toastStore.show(`Signed in as ${label}.`, "success");
+      return;
+    }
+
     const err = await adminAuthStore.login(username, password, turnstileToken);
     if (err) {
       error = err;
@@ -117,6 +157,9 @@
     adminAuthStore.closeLogin();
     error = null;
     password = "";
+    confirmPassword = "";
+    signupEmail = "";
+    mode = "signin";
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -144,7 +187,7 @@
     <header class="login-header">
       <div class="login-title" id="admin-login-title">
         <Lock size={16} aria-hidden="true" />
-        <span>Editor login</span>
+        <span>{isSignup ? "Create contributor account" : "Editor login"}</span>
       </div>
       <button
         type="button"
@@ -157,8 +200,15 @@
     </header>
     <form class="login-body entity-editor-form" onsubmit={submit}>
       {#if !showForgotPassword}
+        {#if isSignup}
+          <p class="login-lead">
+            Create a free contributor account so your proposals are credited to
+            you and your username is reserved. Editors and admins sign in here
+            too.
+          </p>
+        {/if}
         <EntityEditorFormField
-          label="Username or email"
+          label={isSignup ? "Username" : "Username or email"}
           inputId="admin-login-username"
         >
           {#snippet control()}
@@ -166,6 +216,8 @@
               id="admin-login-username"
               type="text"
               autocomplete="username"
+              autocapitalize="none"
+              spellcheck="false"
               bind:value={username}
               required
             />
@@ -176,7 +228,8 @@
             <input
               id="admin-login-password"
               type="password"
-              autocomplete="current-password"
+              autocomplete={isSignup ? "new-password" : "current-password"}
+              minlength={isSignup ? MIN_CONTRIBUTOR_PASSWORD_LENGTH : undefined}
               bind:value={password}
               required
               aria-invalid={error ? true : undefined}
@@ -184,13 +237,46 @@
             />
           {/snippet}
         </EntityEditorFormField>
-        <button
-          type="button"
-          class="forgot-password-link"
-          onclick={() => (showForgotPassword = true)}
-        >
-          Forgot password?
-        </button>
+        {#if isSignup}
+          <EntityEditorFormField
+            label="Confirm password"
+            inputId="admin-signup-confirm"
+          >
+            {#snippet control()}
+              <input
+                id="admin-signup-confirm"
+                type="password"
+                autocomplete="new-password"
+                minlength={MIN_CONTRIBUTOR_PASSWORD_LENGTH}
+                bind:value={confirmPassword}
+                required
+              />
+            {/snippet}
+          </EntityEditorFormField>
+          <EntityEditorFormField
+            label="Email (optional)"
+            inputId="admin-signup-email"
+          >
+            {#snippet control()}
+              <input
+                id="admin-signup-email"
+                type="email"
+                autocomplete="email"
+                autocapitalize="none"
+                spellcheck="false"
+                bind:value={signupEmail}
+              />
+            {/snippet}
+          </EntityEditorFormField>
+        {:else}
+          <button
+            type="button"
+            class="forgot-password-link"
+            onclick={() => (showForgotPassword = true)}
+          >
+            Forgot password?
+          </button>
+        {/if}
       {/if}
       {#if turnstileEnabled && !showForgotPassword}
         <TurnstileWidget siteKey={turnstileSiteKey} bind:token={turnstileToken} />
@@ -205,11 +291,32 @@
       {#if !showForgotPassword}
         <EntityEditorSubmitButton
           type="submit"
-          label="Sign in"
-          savingLabel="Signing in…"
+          label={isSignup ? "Create account" : "Sign in"}
+          savingLabel={isSignup ? "Creating account…" : "Signing in…"}
           saving={adminAuthStore.loading}
           disabled={turnstileEnabled && !turnstileToken}
         />
+        <p class="login-mode-toggle">
+          {#if isSignup}
+            Already have an account?
+            <button
+              type="button"
+              class="login-mode-btn"
+              onclick={() => switchMode("signin")}
+            >
+              Sign in
+            </button>
+          {:else}
+            No account yet?
+            <button
+              type="button"
+              class="login-mode-btn"
+              onclick={() => switchMode("signup")}
+            >
+              Sign up
+            </button>
+          {/if}
+        </p>
       {/if}
       {#if showForgotPassword}
         <div class="forgot-password-panel">
@@ -363,6 +470,34 @@
   }
   .login-body :global(.entity-editor-submit) {
     width: 100%;
+  }
+  .login-lead {
+    margin: 0 0 0.25rem;
+    font-size: 0.8125rem;
+    line-height: 1.45;
+    color: hsl(0, 0%, 38%);
+  }
+  .login-mode-toggle {
+    margin: 0.25rem 0 0;
+    font-size: 0.8125rem;
+    color: hsl(0, 0%, 38%);
+    text-align: center;
+    line-height: 1.45;
+  }
+  .login-mode-btn {
+    margin-left: 0.25rem;
+    padding: 0;
+    border: none;
+    background: none;
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .login-mode-btn:hover,
+  .login-mode-btn:focus-visible {
+    color: hsl(5, 53%, 24%);
   }
   .login-footer {
     margin: 0;

--- a/src/lib/auth/contributor-signup.test.ts
+++ b/src/lib/auth/contributor-signup.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MIN_CONTRIBUTOR_PASSWORD_LENGTH,
+  validateContributorSignup,
+} from "./contributor-signup";
+
+const goodPassword = "x".repeat(MIN_CONTRIBUTOR_PASSWORD_LENGTH);
+
+describe("validateContributorSignup", () => {
+  test("accepts a valid contributor and normalizes username/email", () => {
+    const result = validateContributorSignup({
+      username: "  Jane.Doe ",
+      password: goodPassword,
+      email: "  Jane@Example.COM ",
+    });
+    expect(result).toEqual({
+      ok: true,
+      username: "jane.doe",
+      password: goodPassword,
+      email: "jane@example.com",
+      displayName: null,
+    });
+  });
+
+  test("email is optional", () => {
+    const result = validateContributorSignup({
+      username: "jane",
+      password: goodPassword,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.email).toBeNull();
+  });
+
+  test("blank email is treated as omitted", () => {
+    const result = validateContributorSignup({
+      username: "jane",
+      password: goodPassword,
+      email: "   ",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.email).toBeNull();
+  });
+
+  test.each([
+    ["missing username", { password: goodPassword }],
+    ["missing password", { username: "jane" }],
+    ["too short", { username: "ab", password: goodPassword }],
+    ["too long", { username: "a".repeat(33), password: goodPassword }],
+    ["leading symbol", { username: "-jane", password: goodPassword }],
+    ["illegal chars", { username: "jane doe!", password: goodPassword }],
+  ])("rejects %s", (_label, input) => {
+    const result = validateContributorSignup(input);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(400);
+  });
+
+  test("rejects a weak (too short) password", () => {
+    const result = validateContributorSignup({
+      username: "jane",
+      password: "x".repeat(MIN_CONTRIBUTOR_PASSWORD_LENGTH - 1),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/at least/i);
+  });
+
+  test("rejects a malformed email", () => {
+    const result = validateContributorSignup({
+      username: "jane",
+      password: goodPassword,
+      email: "not-an-email",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("uppercase in the username is folded, not rejected", () => {
+    const result = validateContributorSignup({
+      username: "JANE",
+      password: goodPassword,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.username).toBe("jane");
+  });
+});

--- a/src/lib/auth/contributor-signup.ts
+++ b/src/lib/auth/contributor-signup.ts
@@ -1,0 +1,83 @@
+// Pure validation for contributor self-signup (attribution + username
+// reservation). No DB/env imports so it runs under `bun test` and can be
+// shared with the client modal for the same rules.
+
+export const MIN_CONTRIBUTOR_PASSWORD_LENGTH = 10;
+export const USERNAME_MIN_LENGTH = 3;
+export const USERNAME_MAX_LENGTH = 32;
+
+// Same charset the OAuth path derives usernames from
+// (linkOrCreateContributorFromSupabase): lowercase letters, digits, `. _ -`.
+// Must start alphanumeric so usernames stay legible and @-mentionable.
+const USERNAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type SignupInput = {
+  username?: unknown;
+  password?: unknown;
+  email?: unknown;
+  displayName?: unknown;
+};
+
+export type SignupValid = {
+  ok: true;
+  username: string;
+  password: string;
+  email: string | null;
+  displayName: string | null;
+};
+
+export type SignupInvalid = { ok: false; error: string; status: number };
+
+export function validateContributorSignup(
+  input: SignupInput,
+): SignupValid | SignupInvalid {
+  const fail = (error: string, status = 400): SignupInvalid => ({
+    ok: false,
+    error,
+    status,
+  });
+
+  if (
+    typeof input.username !== "string" ||
+    typeof input.password !== "string"
+  ) {
+    return fail("Username and password are required.");
+  }
+
+  const username = input.username.trim().toLowerCase();
+  if (
+    username.length < USERNAME_MIN_LENGTH ||
+    username.length > USERNAME_MAX_LENGTH ||
+    !USERNAME_PATTERN.test(username)
+  ) {
+    return fail(
+      `Username must be ${USERNAME_MIN_LENGTH}–${USERNAME_MAX_LENGTH} characters: lowercase letters, numbers, and . _ - (starting with a letter or number).`,
+    );
+  }
+
+  const password = input.password;
+  if (password.length < MIN_CONTRIBUTOR_PASSWORD_LENGTH) {
+    return fail(
+      `Password must be at least ${MIN_CONTRIBUTOR_PASSWORD_LENGTH} characters.`,
+    );
+  }
+
+  let email: string | null = null;
+  if (input.email != null && String(input.email).trim() !== "") {
+    email = String(input.email).trim().toLowerCase();
+    if (!EMAIL_PATTERN.test(email) || email.length > 255) {
+      return fail("Enter a valid email address, or leave it blank.");
+    }
+  }
+
+  let displayName: string | null = null;
+  if (input.displayName != null && String(input.displayName).trim() !== "") {
+    displayName = String(input.displayName).trim();
+    if (displayName.length > 100) {
+      return fail("Display name must be 100 characters or fewer.");
+    }
+  }
+
+  return { ok: true, username, password, email, displayName };
+}

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -480,6 +480,69 @@ class AdminAuthStore {
     }
   };
 
+  /** Self-signup a contributor account (attribution + username reservation).
+   * Logs the new account in on success. Resolves to an error message or null. */
+  signup = async (input: {
+    username: string;
+    password: string;
+    email?: string;
+    displayName?: string;
+    turnstileToken?: string | null;
+  }): Promise<string | null> => {
+    this.loading = true;
+    try {
+      const res = await fetch("/api/auth/signup", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: input.username.trim(),
+          password: input.password,
+          email: input.email?.trim() || undefined,
+          displayName: input.displayName?.trim() || undefined,
+          turnstileToken: input.turnstileToken ?? undefined,
+        }),
+      });
+      const data = await res.json().catch(
+        () =>
+          ({}) as {
+            error?: string;
+            username?: string;
+            displayName?: string;
+            role?: "admin" | "editor" | "contributor";
+            canPublish?: boolean;
+            canReview?: boolean;
+          },
+      );
+      if (!res.ok) {
+        return (
+          data.error ??
+          (res.status === 409
+            ? "That username is already taken. Try another."
+            : res.status === 429
+              ? "Too many sign-up attempts. Wait about a minute and try again."
+              : res.status >= 500
+                ? "Sign-up failed on our side. Try again later."
+                : "Could not create your account. Check the form and try again.")
+        );
+      }
+      this.applySession({
+        loggedIn: true,
+        username: data.username ?? input.username.trim().toLowerCase(),
+        displayName: data.displayName,
+        role: data.role ?? "contributor",
+        canPublish: data.canPublish,
+        canReview: data.canReview,
+      });
+      this.loginOpen = false;
+      return null;
+    } catch {
+      return "Network error. Try again.";
+    } finally {
+      this.loading = false;
+    }
+  };
+
   /** Start Google OAuth (#456); resolves to an error message or redirects away. */
   loginWithGoogle = async (): Promise<string | null> => {
     try {

--- a/src/pages/api/auth/signup.ts
+++ b/src/pages/api/auth/signup.ts
@@ -1,0 +1,140 @@
+import type { APIRoute } from "astro";
+import {
+  canPublishDirectly,
+  canReviewProposals,
+  createSessionToken,
+  setSessionCookie,
+} from "@lib/admin/auth";
+import {
+  type SignupInput,
+  validateContributorSignup,
+} from "@lib/auth/contributor-signup";
+import {
+  checkRateLimit,
+  clientIp,
+  rateLimitResponse,
+} from "@lib/api/rate-limit";
+import {
+  AccountActionError,
+  createAdminUser,
+} from "@lib/services/admin-user-service";
+import { verifyTurnstileToken } from "@lib/turnstile";
+
+export const prerender = false;
+
+const SIGNUP_IP_LIMIT = { max: 5, windowMs: 60 * 1000 };
+const SIGNUP_RATE_LIMIT_MESSAGE =
+  "Too many sign-up attempts. Wait about a minute and try again.";
+
+/**
+ * Contributor self-signup (#456 follow-up). Creates a *contributor-role*
+ * account only — never admin/editor — so proposals get attributed to a
+ * verified account and the username is reserved from anonymous submitters.
+ * Guarded by IP rate limit + Turnstile like the login path.
+ */
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const ip = clientIp(request);
+    const skipRateLimit = process.env.ASTRO_E2E_SKIP_LOGIN_RATE_LIMIT === "1";
+    if (!skipRateLimit) {
+      const rate = checkRateLimit(
+        `contributor-signup:ip:${ip}`,
+        SIGNUP_IP_LIMIT.max,
+        SIGNUP_IP_LIMIT.windowMs,
+      );
+      if (!rate.allowed) {
+        return rateLimitResponse(rate.resetAt, SIGNUP_RATE_LIMIT_MESSAGE);
+      }
+    }
+
+    let body: SignupInput & { turnstileToken?: unknown };
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const turnstileOk = await verifyTurnstileToken(
+      typeof body.turnstileToken === "string" ? body.turnstileToken : null,
+      ip,
+    );
+    if (!turnstileOk) {
+      return json(
+        { error: "Verification failed. Refresh the page and try again." },
+        400,
+      );
+    }
+
+    const valid = validateContributorSignup(body);
+    if (!valid.ok) return json({ error: valid.error }, valid.status);
+
+    // Reuses the admin-user insert (bcrypt + atomic username-unique guard),
+    // but the role is hard-coded here so this public endpoint can never mint
+    // an admin/editor. A taken username surfaces as AccountActionError(409).
+    let user: Awaited<ReturnType<typeof createAdminUser>>;
+    try {
+      user = await createAdminUser({
+        username: valid.username,
+        displayName: valid.displayName ?? undefined,
+        email: valid.email ?? undefined,
+        password: valid.password,
+        role: "contributor",
+      });
+    } catch (error) {
+      if (error instanceof AccountActionError) {
+        return json({ error: error.message }, error.status);
+      }
+      throw error;
+    }
+
+    let token: string;
+    try {
+      token = createSessionToken({
+        id: user.id,
+        username: user.username,
+        displayName: user.displayName,
+        role: user.role,
+      });
+    } catch (error) {
+      console.error("Signup session signing misconfigured:", error);
+      return json(
+        {
+          error:
+            "Sign-up is not configured on this server. Contact the site maintainer.",
+        },
+        503,
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        username: user.username,
+        displayName: user.displayName,
+        role: user.role,
+        canPublish: canPublishDirectly(user.role),
+        canReview: canReviewProposals(user.role),
+      }),
+      {
+        status: 201,
+        headers: {
+          "Content-Type": "application/json",
+          "Set-Cookie": setSessionCookie(token),
+        },
+      },
+    );
+  } catch (error) {
+    console.error("Contributor signup failed:", error);
+    return json(
+      { error: "Sign-up is temporarily unavailable. Try again in a moment." },
+      503,
+    );
+  }
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
## What

A lower-privilege **contributor self-signup** flow. Contributors can now claim a verified account for two reasons:

- **Attribution** — proposals tie to the account instead of anonymous browser state.
- **Username reservation** — once a signed-in user holds a username, anonymous submitters can't reuse it.

Editors/admins stay admin-created — unchanged. This endpoint can **never** mint an admin/editor.

## How

- **`POST /api/auth/signup`** (`prerender=false`): IP rate limit + Turnstile-verify like the login path, pure validation, then inserts a **contributor-role** row. Role is hard-coded `"contributor"`. Reuses `createAdminUser` for bcrypt hashing + the atomic username-unique guard (a taken username → typed **409**). Sets the same `admin_session` cookie login uses, so the new account is signed in on success. Typed JSON errors throughout.
- **`src/lib/auth/contributor-signup.ts`** — pure validator: username charset (`[a-z0-9][a-z0-9._-]*`, 3–32 chars, folded to lowercase), password min length (10, matching the existing policy), optional email. No DB/env imports, so it runs under `bun test` and is shared with the modal for the same rules.
- **`AdminLoginModal.svelte`** — "No account yet? Sign up" toggle opens a signup form (username, password, confirm, optional email). Handles empty fields, password mismatch, taken username (409), weak password, loading/spinner (disabled submit), server + network errors, and success (close + signed-in toast). Reuses existing form fields + the Turnstile widget + Google button.
- **`adminAuthStore.signup()`** — posts, maps typed errors (409 / 429 / 5xx / network), logs the account in on success.

## Schema / role decision

**No migration.** The `contributor` value already exists in `admin_role`, the `email` column already exists on `admin_users`, and the `admin_users_username_unique` index already enforces reservation. Everything is reuse.

## Tests

- `bun test src/lib src/constants` — **296 pass / 0 fail** (incl. 12 new validator cases: charset/length, optional/blank email, weak password, taken-username status).
- `vitest run AdminLoginModal.component.test.ts` — **2 pass** (added a test that the "Sign up" toggle reveals the confirm-password + optional-email fields and back).
- `npx biome check` on all changed files — clean.

## Not verified here

- Full e2e / live DB round-trip (no DB or Turnstile secret in this environment) — the endpoint's DB insert + session cookie path is exercised only through the reused, already-tested `createAdminUser` + `createSessionToken`.
- `astro check` carries one pre-existing `ts(4111)` on `process.env.ASTRO_E2E_SKIP_LOGIN_RATE_LIMIT` — **identical to the existing `src/pages/api/admin/auth.ts` on main**; it's the repo's accepted resolution of biome `useLiteralKeys` vs tsconfig `noPropertyAccessFromIndexSignature` (biome is the enforced `lint` gate and is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new public account-creation and session-issuance path in auth, though role is fixed to contributor and the flow mirrors existing login protections (rate limit, Turnstile, reused user insert).
> 
> **Overview**
> Adds **public contributor self-signup** so users can create low-privilege accounts for proposal attribution and username reservation, without changing how editors/admins are provisioned.
> 
> A new **`POST /api/auth/signup`** path applies the same **IP rate limiting and Turnstile** checks as login, runs shared **`validateContributorSignup`** rules, inserts users via **`createAdminUser`** with **`role` hard-coded to `contributor`**, and returns the usual session cookie so signup signs the user in immediately. **`adminAuthStore.signup()`** posts to that endpoint and maps 409/429/network errors into UI messages.
> 
> **`AdminLoginModal`** gains a sign-in / sign-up toggle: signup adds confirm password, optional email, client-side password match, and min-length aligned with the shared validator; sign-in behavior (forgot password, Google) is unchanged.
> 
> New **`contributor-signup.ts`** (plus unit tests) centralizes username/password/email validation for both API and modal; a component test covers the signup toggle UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f22283722285cc55f27d628e480d030a214bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->