### PR TITLE
style: fix biome format drift (verify red on main)

### DIFF
--- a/e2e/smoke/planner-route.spec.ts
+++ b/e2e/smoke/planner-route.spec.ts
@@ -49,7 +49,9 @@ test.describe("planner route", () => {
     await page
       .getByRole("button", { name: "Open course planner" })
       .click({ timeout: 60_000 });
-    await expect(page.getByRole("dialog", { name: "Class Planner" })).toBeVisible();
+    await expect(
+      page.getByRole("dialog", { name: "Class Planner" }),
+    ).toBeVisible();
     await expect(page).toHaveURL(/\/planner(\?|$)/);
   });
 });

--- a/src/lib/class-offering-groups.test.ts
+++ b/src/lib/class-offering-groups.test.ts
@@ -107,8 +107,18 @@ describe("groupClassesByOffering", () => {
     // C1 and C2 are two distinct lecture sections, not a lab/recit of a "C"
     // lecture — they must stay as separate offerings, never folded together.
     const groups = groupClassesByOffering([
-      row({ id: 1, section: "C1", type: "LEC", schedule: ["MW 10:00AM-11:30AM"] }),
-      row({ id: 2, section: "C2", type: "LEC", schedule: ["MW 10:00AM-11:30AM"] }),
+      row({
+        id: 1,
+        section: "C1",
+        type: "LEC",
+        schedule: ["MW 10:00AM-11:30AM"],
+      }),
+      row({
+        id: 2,
+        section: "C2",
+        type: "LEC",
+        schedule: ["MW 10:00AM-11:30AM"],
+      }),
     ]);
 
     expect(groups.map((g) => g.section).sort()).toEqual(["C1", "C2"]);

--- a/src/lib/classes-api.store.test.ts
+++ b/src/lib/classes-api.store.test.ts
@@ -20,7 +20,10 @@ describe("fetchClassPage", () => {
   });
 
   it("hits /api/classes and encodes every provided option", async () => {
-    const result: ClassQueryPage = { rows: [{ courseCode: "CMSC 128" }], total: 1 };
+    const result: ClassQueryPage = {
+      rows: [{ courseCode: "CMSC 128" }],
+      total: 1,
+    };
     getJSONFetch.mockResolvedValueOnce(result);
 
     const page = await fetchClassPage({

--- a/src/lib/stores/planner-store.svelte.ts
+++ b/src/lib/stores/planner-store.svelte.ts
@@ -174,10 +174,7 @@ export class PlannerStore {
   };
 
   /** Overwrite matching sections with fresh rows; mark unresolved ones stale. */
-  refreshActivePlan = (
-    rows: ClassMapValue[],
-    fetchedCourses?: Set<string>,
-  ) => {
+  refreshActivePlan = (rows: ClassMapValue[], fetchedCourses?: Set<string>) => {
     const plan = this.activePlan;
     if (!plan) return;
     const fresh = new Map(


### PR DESCRIPTION
`verify` (biome check + format) has been **red on main** and every open PR.

**Root cause:** #606 (test pyramid) and the offerings fixes were formatted under a biome newer than the locked `2.5.2`, so their line-wrapping differs from what 2.5.2 produces.

**Fix:** `biome check --write` (2.5.2) on the 4 drifted files. Format-only — `git diff -w` shows only line re-wrapping, no logic change. Full `biome check` now clean (633 files, 0 errors).

Unblocks verify on main and every open PR (incl. #623).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Format-only rewrites with no logic, API, or runtime changes.
> 
> **Overview**
> Re-applies **Biome 2.5.2** formatting on four files that had drifted after earlier edits were saved with a newer formatter, which was leaving **`biome check`** (verify) red on main and open PRs.
> 
> Changes are **line wrapping only** (e.g. multi-line `expect(...)` in `planner-route.spec.ts`, expanded `row({...})` fixtures in tests, single-line `refreshActivePlan` signature in `planner-store.svelte.ts`). **`git diff -w`** shows no behavioral change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3bebb05a70cf8ee71b726a3b3c5bd2148555fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->