### PR TITLE
fix(ci): unbreak pwa-legal guardrail (verify red on main)

### DIFF
--- a/scripts/check-pwa-legal-routes.ts
+++ b/scripts/check-pwa-legal-routes.ts
@@ -16,13 +16,16 @@ const requiredPrecache = [
   "changelog/index.html",
 ];
 
-const requiredDenylist = [
-  String.raw`/^\/privacy(\/|$)/`,
-  String.raw`/^\/terms(\/|$)/`,
-  String.raw`/^\/changelog(\/|$)/`,
-  String.raw`/^\/messenger(\/|$)/`,
-  String.raw`/^\/maintain(\/|$)/`,
-  String.raw`/^\/discord(\/|$)/`,
+// Match the anchored route stem only, not the trailing boundary group — the
+// group varies (e.g. `(\/|$)` vs `(\/|\?|$)` once search strings are covered)
+// and hard-coding it made this guardrail break on unrelated denylist edits.
+const requiredDenylistRoutes = [
+  "privacy",
+  "terms",
+  "changelog",
+  "messenger",
+  "maintain",
+  "discord",
 ];
 
 let failed = false;
@@ -34,9 +37,10 @@ for (const pattern of requiredPrecache) {
   }
 }
 
-for (const pattern of requiredDenylist) {
-  if (!source.includes(pattern)) {
-    console.error(`Missing navigateFallbackDenylist entry: ${pattern}`);
+for (const route of requiredDenylistRoutes) {
+  const anchored = String.raw`/^\/${route}(`;
+  if (!source.includes(anchored)) {
+    console.error(`Missing navigateFallbackDenylist entry for /${route}`);
     failed = true;
   }
 }


### PR DESCRIPTION
Second hidden-on-main verify break (after #624's format drift).

`check:pwa-legal` matched the **full literal** denylist regex `/^\/privacy(\/|$)/`. The planner `?term` fix widened every boundary group to `(\/|\?|$)`, so the literal match failed for all 6 legal routes. It stayed hidden because biome (an earlier verify step) was failing first.

Fix: match the anchored route stem `/^\/<route>(` — still asserts each legal route is denylisted, tolerant of boundary-group edits.

Ran the full verify chain locally on this branch off main: biome ✓, unit 284 ✓, component 90 ✓, pwa-legal ✓. (Build proven green by Vercel's own deploy on #623.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI guardrail-only change; no runtime PWA or routing behavior is modified.
> 
> **Overview**
> **`check:pwa-legal`** was failing because it required **exact** `navigateFallbackDenylist` regex literals (e.g. `/^\/privacy(\/|$)/`). After denylist boundaries were widened to `(\/|\?|$)` for query strings, those literals no longer appeared in `astro.config.mjs` even though the routes were still denylisted.
> 
> The script now checks **route stems** only: for each required path (`privacy`, `terms`, `changelog`, `messenger`, `maintain`, `discord`) it asserts `astro.config.mjs` contains `/^\/<route>(`. Precache glob checks and the `navigateFallback: "/"` assertion are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49793371930934f213bb7814ec4dc0001f824ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->