### PR TITLE
Merge Config files, Styling changes from 'staging' to 'main' 

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 // drizzle.config.ts
 
 import { defineConfig } from "drizzle-kit";
-import { loadEnv } from "./load-env";
+import { loadEnv } from "./scripts/load-env";
 
 loadEnv();
 

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -572,16 +572,6 @@
     min-height: 2.75rem;
     padding: 0.125rem;
     pointer-events: auto;
-    background-color: var(--map-chrome-surface, hsl(5 20% 97%));
-    backdrop-filter: blur(10px);
-    border: 1px solid var(--map-chrome-border, hsl(5 10% 68%));
-    border-radius: var(--map-chrome-radius, 1rem);
-    box-shadow: var(
-      --map-chrome-panel-shadow,
-      0 0 0 1px hsla(15, 8%, 20%, 0.16),
-      0 2px 8px hsla(0, 0%, 0%, 0.14),
-      0 8px 20px hsla(0, 0%, 0%, 0.18)
-    );
   }
 
   .bottom-band::before {
@@ -656,7 +646,6 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    width: calc(var(--map-chrome-toggle-size, 2rem) + 0.375rem);
     box-sizing: border-box;
     gap: 0.125rem;
     padding: 0.1875rem;
@@ -673,9 +662,9 @@
   }
 
   .camera-controls-card__divider {
-    height: 1px;
-    margin: 0 0.125rem;
-    background-color: var(--map-chrome-divider, hsl(5 12% 88%));
+    height: 2px;
+    margin: .5rem 0.125rem;
+    background-color: var(--map-chrome-divider, hsl(5 12% 70%));
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/components/svelte/MapToolsFlyout.svelte
+++ b/src/components/svelte/MapToolsFlyout.svelte
@@ -54,7 +54,7 @@
     ariaLabel="Map tools"
     onclick={() => mapToolsStore.toggle()}
   >
-    <Layers size={20} aria-hidden="true" />
+    <Layers size={16} aria-hidden="true" />
   </MapChromeFabTrigger>
 
   {#if mapToolsStore.open}

--- a/src/components/svelte/MapViewControls.svelte
+++ b/src/components/svelte/MapViewControls.svelte
@@ -204,7 +204,7 @@
         aria-label="Decrease map tilt"
         disabled={pitch <= 0}
       >
-        <ChevronDown size={16} aria-hidden="true" />
+        <ChevronUp size={16} aria-hidden="true" />
       </button>
       <button
         type="button"
@@ -214,7 +214,7 @@
         aria-label="Increase map tilt"
         disabled={pitch >= MAX_PITCH}
       >
-        <ChevronUp size={16} aria-hidden="true" />
+        <ChevronDown size={16} aria-hidden="true" />
       </button>
     </div>
   {/if}

--- a/src/components/svelte/controls/entity-detail.css
+++ b/src/components/svelte/controls/entity-detail.css
@@ -574,7 +574,7 @@
   justify-content: center;
   gap: 0.25rem;
   min-height: 2rem;
-  padding: 0.375rem 0.75rem;
+  padding: 0.125rem 0.75rem;
   border: 1px solid #d8b9ba;
   border-radius: 0.625rem;
   background: #fffafa;

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -373,8 +373,7 @@ button.map-chrome-chip:disabled {
 .map-chrome-fab-trigger {
   display: flex;
   flex-shrink: 0;
-  width: 3rem;
-  height: 3rem;
+  padding:.75rem;
   align-items: center;
   justify-content: center;
   border: 1.5px solid var(--map-chrome-border-accent, hsl(5, 40%, 42%));

--- a/src/components/svelte/planner/PlannerGrid.svelte
+++ b/src/components/svelte/planner/PlannerGrid.svelte
@@ -262,115 +262,117 @@
   const hourLabel = (hour: number) =>
     `${hour > 12 ? hour - 12 : hour}${hour >= 12 ? "PM" : "AM"}`;
 
-  const topPct = (min: number) =>
-    ((min - START_HOUR * 60) / TOTAL_MIN) * 100;
+  const topPct = (min: number) => ((min - START_HOUR * 60) / TOTAL_MIN) * 100;
   const heightPct = (startMin: number, endMin: number) =>
     ((endMin - startMin) / TOTAL_MIN) * 100;
 </script>
 
-<div class="planner-legend" aria-label="Block colors">
-  <span class="planner-legend__item">
-    <span
-      class="planner-legend__dot"
-      style:background-color={getPlannerBlockColor("LEC")}
-    ></span>
-    Lecture
-  </span>
-  <span class="planner-legend__item">
-    <span
-      class="planner-legend__dot"
-      style:background-color={getPlannerBlockColor("LAB")}
-    ></span>
-    Lab
-  </span>
-  <span class="planner-legend__item">
-    <span
-      class="planner-legend__dot"
-      style:background-color={getPlannerBlockColor("RCT")}
-    ></span>
-    Recitation
-  </span>
-</div>
+<div>
+  <div class="planner-legend" aria-label="Block colors">
+    <span class="planner-legend__item">
+      <span
+        class="planner-legend__dot"
+        style:background-color={getPlannerBlockColor("LEC")}
+      ></span>
+      Lecture
+    </span>
+    <span class="planner-legend__item">
+      <span
+        class="planner-legend__dot"
+        style:background-color={getPlannerBlockColor("LAB")}
+      ></span>
+      Lab
+    </span>
+    <span class="planner-legend__item">
+      <span
+        class="planner-legend__dot"
+        style:background-color={getPlannerBlockColor("RCT")}
+      ></span>
+      Recitation
+    </span>
+  </div>
 
-<p class="planner-grid__scroll-hint" aria-hidden="true">Swipe to see all days →</p>
-
-<div class="planner-grid-scroll">
-  <div class="planner-grid" class:planner-grid--dragging={drag}>
-    <div class="planner-grid__time" aria-hidden="true">
-      {#each HOURS as hour (hour)}
-        <div class="planner-grid__hour">{hourLabel(hour)}</div>
-      {/each}
-    </div>
-    {#each DAYS as day, dayIndex (day)}
-      <div class="planner-grid__day">
-        <div class="planner-grid__day-label">{day}</div>
-        <div class="planner-grid__day-body">
-          {#each blocksByDay[dayIndex] as block (block.key)}
-            <div
-              class="planner-block"
-              class:planner-block--conflict={block.conflicted}
-              class:planner-block--selected={selectedKey === block.key}
-              class:planner-block--dragging={drag?.fromKey === block.key}
-              style:top="{topPct(block.startMin)}%"
-              style:height="{heightPct(block.startMin, block.endMin)}%"
-              style:background-color={getPlannerBlockColor(block.type)}
-            >
-              <button
-                type="button"
-                class="planner-block__label"
-                title="{block.courseCode} {block.type} {block.section}{block.roomCode
-                  ? ` · ${block.roomCode}`
-                  : ''} — drag to switch section"
-                onclick={() => onBlockClick(block)}
-                onpointerdown={(e) => onBlockPointerDown(e, block)}
-                onpointermove={onBlockPointerMove}
-                onpointerup={onBlockPointerUp}
-                onpointercancel={cleanup}
+  <p class="planner-grid__scroll-hint" aria-hidden="true">
+    Swipe to see all days →
+  </p>
+  <div class="planner-grid-scroll">
+    <div class="planner-grid" class:planner-grid--dragging={drag}>
+      <div class="planner-grid__time" aria-hidden="true">
+        {#each HOURS as hour (hour)}
+          <div class="planner-grid__hour">{hourLabel(hour)}</div>
+        {/each}
+      </div>
+      {#each DAYS as day, dayIndex (day)}
+        <div class="planner-grid__day">
+          <div class="planner-grid__day-label">{day}</div>
+          <div class="planner-grid__day-body">
+            {#each blocksByDay[dayIndex] as block (block.key)}
+              <div
+                class="planner-block"
+                class:planner-block--conflict={block.conflicted}
+                class:planner-block--selected={selectedKey === block.key}
+                class:planner-block--dragging={drag?.fromKey === block.key}
+                style:top="{topPct(block.startMin)}%"
+                style:height="{heightPct(block.startMin, block.endMin)}%"
+                style:background-color={getPlannerBlockColor(block.type)}
               >
-                <span class="planner-block__course">{block.courseCode}</span>
-                <span class="planner-block__section">
-                  {block.type} · {block.section}
-                </span>
-              </button>
-              {#if selectedKey === block.key}
-                <div class="planner-block__actions">
-                  <button
-                    type="button"
-                    onclick={() => onremove(block.courseCode, block.section)}
-                  >
-                    Remove
-                  </button>
-                  {#if block.roomCode}
+                <button
+                  type="button"
+                  class="planner-block__label"
+                  title="{block.courseCode} {block.type} {block.section}{block.roomCode
+                    ? ` · ${block.roomCode}`
+                    : ''} — drag to switch section"
+                  onclick={() => onBlockClick(block)}
+                  onpointerdown={(e) => onBlockPointerDown(e, block)}
+                  onpointermove={onBlockPointerMove}
+                  onpointerup={onBlockPointerUp}
+                  onpointercancel={cleanup}
+                >
+                  <span class="planner-block__course">{block.courseCode}</span>
+                  <span class="planner-block__section">
+                    {block.type} · {block.section}
+                  </span>
+                </button>
+                {#if selectedKey === block.key}
+                  <div class="planner-block__actions">
                     <button
                       type="button"
-                      onclick={() => onopenroom(block.roomCode ?? "")}
+                      onclick={() => onremove(block.courseCode, block.section)}
                     >
-                      Room
+                      Remove
                     </button>
-                  {/if}
-                </div>
-              {/if}
-            </div>
-          {/each}
-
-          {#if drag}
-            {#each ghostBlocksByDay[dayIndex] as ghost (ghost.ghostKey + ghost.startMin)}
-              <div
-                class="planner-ghost"
-                class:planner-ghost--hover={hoverGhost === ghost.ghostKey}
-                data-ghost={ghost.ghostKey}
-                style:top="{topPct(ghost.startMin)}%"
-                style:height="{heightPct(ghost.startMin, ghost.endMin)}%"
-                style:left="calc({(ghost.col / ghost.colCount) * 100}% + 1px)"
-                style:width="calc({100 / ghost.colCount}% - 2px)"
-              >
-                <span class="planner-ghost__label">{ghost.ghostKey}</span>
+                    {#if block.roomCode}
+                      <button
+                        type="button"
+                        onclick={() => onopenroom(block.roomCode ?? "")}
+                      >
+                        Room
+                      </button>
+                    {/if}
+                  </div>
+                {/if}
               </div>
             {/each}
-          {/if}
+
+            {#if drag}
+              {#each ghostBlocksByDay[dayIndex] as ghost (ghost.ghostKey + ghost.startMin)}
+                <div
+                  class="planner-ghost"
+                  class:planner-ghost--hover={hoverGhost === ghost.ghostKey}
+                  data-ghost={ghost.ghostKey}
+                  style:top="{topPct(ghost.startMin)}%"
+                  style:height="{heightPct(ghost.startMin, ghost.endMin)}%"
+                  style:left="calc({(ghost.col / ghost.colCount) * 100}% + 1px)"
+                  style:width="calc({100 / ghost.colCount}% - 2px)"
+                >
+                  <span class="planner-ghost__label">{ghost.ghostKey}</span>
+                </div>
+              {/each}
+            {/if}
+          </div>
         </div>
-      </div>
-    {/each}
+      {/each}
+    </div>
   </div>
 </div>
 

--- a/src/components/svelte/planner/PlannerScreen.svelte
+++ b/src/components/svelte/planner/PlannerScreen.svelte
@@ -605,14 +605,14 @@
     overscroll-behavior: contain;
     padding: 0.625rem 0.625rem calc(0.75rem + env(safe-area-inset-bottom, 0px));
     display: grid;
-    grid-template-columns: 17rem minmax(0, 1fr) 18rem;
+    grid-template-columns: 17rem auto 18rem;
     gap: 0.75rem;
     align-content: start;
     -webkit-overflow-scrolling: touch;
   }
 
   .planner-body--no-side {
-    grid-template-columns: 17rem minmax(0, 1fr);
+    grid-template-columns: 17rem minmax(auto, 80rem);
   }
 
   @media (max-width: 48rem) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
       "@constants/*": ["./src/constants/*"],
       "@lib/*": ["./src/lib/*"],
       "@drizzle/*": ["./drizzle/*"],
-      "@layouts/*": ["./src/layouts/*"]
+      "@layouts/*": ["./src/layouts/*"],
+      "@test/*": ["./src/test/*"]
     }
   }
 }


### PR DESCRIPTION
## Who are you?

- [ ] **Campus / data / QA only:** no code in this PR? Comment on the issue and skip the rest.
- [ ] **Developer:** code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.

## Summary

<!, What changed and why (1–3 sentences)., >

**Linked issues:** Closes # / Refs #

## Developer checklist

- [ ] `bun test src`
- [ ] `bun run lint` (or Biome format on touched files)
- [ ] Linked issue commented with this PR URL
- [ ] **Heavy CI:** PR marked ready for review (or `run/e2e` label) before merge: integration + E2E are gated ([testing.md § Heavy CI gating](docs/testing.md#heavy-ci-gating-prs))

## QA Summary (code changes)

Automated:

- [ ] Biome format passed: `bunx biome format.` (PR CI)
- [ ] Unit tests passed: `bun test src` (PR CI)
- [ ] E2E + integration passed: mark PR ready or add `run/e2e` label ([testing.md](docs/testing.md#heavy-ci-gating-prs))
- [ ] Full lint passed (local): `bun run lint`
- [ ] Build passed (local): `bun run build` (needs `DATABASE_URL`; not run in PR CI)

If auth, routing, or schema changed:

- [ ] Admin redirects verified: `/admin`, `/admin/login`
- [ ] Migration applied on Supabase (if `drizzle/` changed)

If map chrome, editor, or side panel changed:

- [ ] Verified at 320px and/or 768px per [map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md)
- [ ] Editor/login/drag-save flows (see [editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md))

Known gaps:

- <!, Anything not tested and why, >

Follow-up:

- <!, Issues or PRs to file next, >

## Issues updated (maintainers / detailed specs)

- [ ] Linked issue(s) commented with this PR
- [ ] Acceptance criteria / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
- [ ] `Last verified against staging:` date set on linked issues

## Test plan

<!, Optional: steps a reviewer can run locally., >
