### PR TITLE
feat(planner): duplicate/rename/image-export/all-sections + student-org modal + signup entry

### DIFF
--- a/src/components/svelte/AdminLoginModal.svelte
+++ b/src/components/svelte/AdminLoginModal.svelte
@@ -99,6 +99,16 @@
     }
   });
 
+  // Each time the modal opens, land on the tab the entry point requested
+  // (the "Sign up" menu entry opens straight into signup).
+  let wasOpen = false;
+  $effect(() => {
+    if (adminAuthStore.loginOpen && !wasOpen) {
+      switchMode(adminAuthStore.loginInitialMode);
+    }
+    wasOpen = adminAuthStore.loginOpen;
+  });
+
   async function signInWithGoogle() {
     error = null;
     adminAuthStore.oauthError = null;

--- a/src/components/svelte/controls/OrgResult.svelte
+++ b/src/components/svelte/controls/OrgResult.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
-  import { adminAuthStore, queryStore, toastStore } from "@lib/store.svelte";
+  import {
+    adminAuthStore,
+    modalStore,
+    queryStore,
+    toastStore,
+  } from "@lib/store.svelte";
   import { getAppActions, getAppData } from "@lib/context";
   import Users from "@lucide/svelte/icons/users";
   import Mail from "@lucide/svelte/icons/mail";
+  import Info from "@lucide/svelte/icons/info";
   import Building2 from "@lucide/svelte/icons/building-2";
   import EntityGoogleMapsLink from "./EntityGoogleMapsLink.svelte";
   import EntityDirectionsChip from "./EntityDirectionsChip.svelte";
@@ -166,6 +172,15 @@
     <header class="entity-header">
       <div class="entity-header__title-row">
         <h2 class="entity-header__title">{org.name}</h2>
+        <button
+          type="button"
+          class="org-info-btn"
+          onclick={() => modalStore.openModal("student-orgs")}
+          aria-label="About student organization listings"
+          title="About student organization listings"
+        >
+          <Info size={16} aria-hidden="true" />
+        </button>
       </div>
 
       <div class="entity-meta-row">
@@ -356,6 +371,29 @@
   @import "./entity-detail.css";
   @import "../editor/entity-editor.css";
   @import "../map-chrome/map-chrome.css";
+
+  .entity-header__title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .org-info-btn {
+    all: unset;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 999px;
+    color: hsl(265, 45%, 45%);
+    cursor: pointer;
+  }
+
+  .org-info-btn:hover,
+  .org-info-btn:focus-visible {
+    background-color: hsl(265, 45%, 94%);
+  }
 
   .org-badge {
     background-color: hsl(265, 45%, 92%);

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -373,7 +373,7 @@ button.map-chrome-chip:disabled {
 .map-chrome-fab-trigger {
   display: flex;
   flex-shrink: 0;
-  padding:.75rem;
+  padding: 0.75rem;
   align-items: center;
   justify-content: center;
   border: 1.5px solid var(--map-chrome-border-accent, hsl(5, 40%, 42%));

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -13,6 +13,7 @@
   import LeaderboardModal from "./LeaderboardModal.svelte";
   import ChangelogModal from "../ChangelogModal.svelte";
   import ProposalReviewPanel from "../ProposalReviewPanel.svelte";
+  import StudentOrgsModal from "./StudentOrgsModal.svelte";
   import X from "@lucide/svelte/icons/x";
 
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
@@ -38,6 +39,7 @@
     if (modalStore.type === "leaderboard") return "Contributor leaderboard";
     if (modalStore.type === "changelog") return "What's new";
     if (modalStore.type === "review") return "Review suggested edits";
+    if (modalStore.type === "student-orgs") return "Student organizations";
     return "Dialog";
   });
 
@@ -130,6 +132,16 @@
         <div class="review-modal-scroll">
           <ProposalReviewPanel />
         </div>
+      {:else if modalStore.type === "student-orgs"}
+        <button
+          type="button"
+          class="modal-content__close-icon"
+          aria-label="Close student organizations"
+          onclick={closeDialog}
+        >
+          <X size={20} aria-hidden="true" />
+        </button>
+        <StudentOrgsModal />
       {/if}
     </div>
   </div>

--- a/src/components/svelte/modal/StudentOrgsModal.svelte
+++ b/src/components/svelte/modal/StudentOrgsModal.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  import Users from "@lucide/svelte/icons/users";
+  import Building2 from "@lucide/svelte/icons/building-2";
+  import Pencil from "@lucide/svelte/icons/pencil";
+  import {
+    adminAuthStore,
+    modalStore,
+    queryStore,
+    sidePanelStore,
+  } from "@lib/store.svelte";
+  import { openCampusBrowse } from "@lib/browse-campus";
+
+  function browseOrganizations() {
+    openCampusBrowse(queryStore, sidePanelStore, "organizations");
+    modalStore.closeModal();
+  }
+
+  function signUp() {
+    modalStore.closeModal();
+    adminAuthStore.openLogin("signup");
+  }
+</script>
+
+<div class="orgs-modal map-chrome-scroll">
+  <header class="orgs-modal__header">
+    <h2 id="student-orgs-modal-title">Student organizations</h2>
+    <p class="orgs-modal__lead">
+      Room TBA lists UPLB student organizations and their tambayans so you can
+      find where an org is based and how to reach it.
+    </p>
+  </header>
+
+  <ul class="orgs-modal__points">
+    <li>
+      <Users size={18} aria-hidden="true" />
+      <span>
+        <strong>Find an org.</strong> Search its name, or browse the Orgs
+        category. Each listing shows its category, host building, and contact
+        links.
+      </span>
+    </li>
+    <li>
+      <Building2 size={18} aria-hidden="true" />
+      <span>
+        <strong>Locate the tambayan.</strong> Listings pin to the org's own
+        location when known, otherwise to its host building, so directions
+        always resolve.
+      </span>
+    </li>
+    <li>
+      <Pencil size={18} aria-hidden="true" />
+      <span>
+        <strong>Keep it accurate.</strong> Open any listing and hit
+        <em>Edit</em> to suggest a fix. Signed-in contributors have their
+        suggestions credited to them.
+      </span>
+    </li>
+  </ul>
+
+  <div class="orgs-modal__actions">
+    <button type="button" class="orgs-modal__btn orgs-modal__btn--primary" onclick={browseOrganizations}>
+      Browse organizations
+    </button>
+    {#if !adminAuthStore.isLoggedIn}
+      <button type="button" class="orgs-modal__btn" onclick={signUp}>
+        Sign up to contribute
+      </button>
+    {/if}
+  </div>
+</div>
+
+<style>
+  @import "../map-chrome/map-chrome.css";
+
+  .orgs-modal {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.5rem;
+    max-height: calc(100vh - 4rem);
+  }
+
+  .orgs-modal__header h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+    font-weight: 700;
+  }
+
+  .orgs-modal__lead {
+    margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    color: hsl(0, 0%, 35%);
+  }
+
+  .orgs-modal__points {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
+  }
+
+  .orgs-modal__points li {
+    display: flex;
+    gap: 0.625rem;
+    align-items: flex-start;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: hsl(0, 0%, 25%);
+  }
+
+  .orgs-modal__points :global(svg) {
+    flex: 0 0 auto;
+    margin-top: 0.125rem;
+    color: hsl(265, 45%, 48%);
+  }
+
+  .orgs-modal__points strong {
+    color: hsl(0, 0%, 12%);
+  }
+
+  .orgs-modal__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .orgs-modal__btn {
+    flex: 1 1 auto;
+    padding: 0.5rem 1rem;
+    border: 1px solid hsl(265, 45%, 80%);
+    border-radius: 0.5rem;
+    background: white;
+    color: hsl(265, 45%, 40%);
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .orgs-modal__btn:hover,
+  .orgs-modal__btn:focus-visible {
+    background: hsl(265, 45%, 97%);
+  }
+
+  .orgs-modal__btn--primary {
+    background: hsl(265, 45%, 48%);
+    border-color: hsl(265, 45%, 48%);
+    color: white;
+  }
+
+  .orgs-modal__btn--primary:hover,
+  .orgs-modal__btn--primary:focus-visible {
+    background: hsl(265, 45%, 42%);
+  }
+</style>

--- a/src/components/svelte/planner/PlannerCourseSearch.svelte
+++ b/src/components/svelte/planner/PlannerCourseSearch.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Search from "@lucide/svelte/icons/search";
   import { SvelteSet } from "svelte/reactivity";
-  import { fetchClassPage } from "@lib/classes-api";
+  import { fetchClassPage, fetchAllClasses } from "@lib/classes-api";
   import {
     groupClassesByOffering,
     offeringGroupKey,
@@ -26,11 +26,12 @@
     const timer = setTimeout(
       () => {
         loading = true;
-        fetchClassPage({
-          termId: t,
-          courseCodePrefix: q || undefined,
-          limit: 100,
-        })
+        // With a course code typed, pull every section (HK 12 has 147, past the
+        // 100/page cap). Browsing the whole term stays a single capped page.
+        const request = q
+          ? fetchAllClasses({ termId: t, courseCodePrefix: q })
+          : fetchClassPage({ termId: t, limit: 100 });
+        request
           .then((page) => {
             rows = page.rows;
             total = page.total;

--- a/src/components/svelte/planner/PlannerScreen.svelte
+++ b/src/components/svelte/planner/PlannerScreen.svelte
@@ -9,12 +9,13 @@
     termStore,
     toastStore,
   } from "@lib/store.svelte";
-  import { fetchClassPage } from "@lib/classes-api";
+  import { fetchAllClasses } from "@lib/classes-api";
   import { COURSE_CHANGE_DISCLAIMER } from "@lib/amis/room-scheduled-types";
   import { changeOfMatriculationLabel } from "@lib/term-calendar";
   import { fetchFinalExams, FINALS_SCOPE_NOTE } from "@lib/final-exams";
   import { isUnscheduled } from "@lib/planner/conflicts";
   import { buildPlanIcs } from "@lib/planner/ics";
+  import { renderPlanToPng } from "@lib/planner/plan-image";
   import { encodeSharePlan } from "@lib/planner/share-codec";
   import FinalExamsList from "@ui/room/FinalExamsList.svelte";
   import TermSelector from "@ui/TermSelector.svelte";
@@ -123,7 +124,7 @@
   }
 
   async function copyShareLink() {
-    if (!plan) return;
+    if (!plan || !hasSchedule) return;
     const url = `${location.origin}/?plan=${encodeSharePlan(plan)}`;
     try {
       await navigator.clipboard.writeText(url);
@@ -134,7 +135,7 @@
   }
 
   function downloadIcs() {
-    if (!plan) return;
+    if (!plan || !hasSchedule) return;
     const term = termStore.activeTerm;
     const ics = buildPlanIcs(
       plan,
@@ -144,10 +145,42 @@
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = `${plan.label.toLowerCase().replaceAll(" ", "-")}-${plan.termId}.ics`;
+    link.download = `${planFileSlug(plan.label)}-${plan.termId}.ics`;
     link.click();
     URL.revokeObjectURL(url);
   }
+
+  let exportingImage = $state(false);
+
+  async function saveAsImage() {
+    if (!plan || !hasSchedule || exportingImage) return;
+    exportingImage = true;
+    try {
+      const blob = await renderPlanToPng(plan, {
+        termLabel: termStore.activeTerm?.label ?? null,
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${planFileSlug(plan.label)}-${plan.termId}.png`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      toastStore.show("Could not create the image", "error");
+    } finally {
+      exportingImage = false;
+    }
+  }
+
+  function planFileSlug(label: string): string {
+    return label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "plan";
+  }
+
+  // Share / calendar / image only make sense once something is scheduled; the
+  // buttons stay visible but disabled before then so the affordance is known.
+  const hasSchedule = $derived(
+    (plan?.sections ?? []).some((s) => !s.stale && !isUnscheduled(s)),
+  );
 
   let confirmingDelete = $state(false);
 
@@ -157,10 +190,38 @@
     confirmingDelete = false;
   }
 
-  // Switching plans cancels a pending delete confirmation.
+  // --- Rename -------------------------------------------------------------
+  let renaming = $state(false);
+  let renameDraft = $state("");
+
+  function startRename() {
+    if (!plan) return;
+    renameDraft = plan.label;
+    renaming = true;
+  }
+
+  function commitRename() {
+    if (!plan) return;
+    plannerStore.renamePlan(plan.id, renameDraft);
+    renaming = false;
+  }
+
+  function onRenameKeydown(event: KeyboardEvent) {
+    if (event.key === "Enter") commitRename();
+    else if (event.key === "Escape") renaming = false;
+  }
+
+  // Focus + select the rename field the moment it appears.
+  function autofocus(node: HTMLInputElement) {
+    node.focus();
+    node.select();
+  }
+
+  // Switching plans cancels a pending delete confirmation or rename.
   $effect(() => {
     void plan?.id;
     confirmingDelete = false;
+    renaming = false;
   });
 
   $effect(() => {
@@ -182,10 +243,11 @@
     const seq = ++refreshSeq;
     Promise.all(
       courseCodes.map((code) =>
-        fetchClassPage({
+        // fetchAllClasses (not a single 100-cap page) so a big course like
+        // HK 12 (147 sections) surfaces every drag alternative, not just 100.
+        fetchAllClasses({
           termId: plan.termId,
           courseCodePrefix: code,
-          limit: 100,
         }).then(
           (page) => ({ code, rows: page.rows, ok: true }),
           () => ({ code, rows: [] as ClassMapValue[], ok: false }),
@@ -238,17 +300,39 @@
       {#if termStore.terms.length > 0}
         <TermSelector variant="chip" />
       {/if}
-      {#if plan && plan.sections.length > 0}
-        <button type="button" class="planner-action" onclick={copyShareLink}>
+      {#if plan}
+        <button
+          type="button"
+          class="planner-action"
+          onclick={copyShareLink}
+          disabled={!hasSchedule}
+          title={hasSchedule
+            ? "Copy a link that reopens this plan"
+            : "Add a scheduled class first"}
+        >
           Share
         </button>
         <button
           type="button"
           class="planner-action"
           onclick={downloadIcs}
-          title="Downloads an .ics file you can import into Google Calendar, Apple Calendar, or Outlook"
+          disabled={!hasSchedule}
+          title={hasSchedule
+            ? "Downloads an .ics file you can import into Google Calendar, Apple Calendar, or Outlook"
+            : "Add a scheduled class first"}
         >
           Add to Google Calendar
+        </button>
+        <button
+          type="button"
+          class="planner-action"
+          onclick={saveAsImage}
+          disabled={!hasSchedule || exportingImage}
+          title={hasSchedule
+            ? "Download the timetable as an image"
+            : "Add a scheduled class first"}
+        >
+          {exportingImage ? "Saving…" : "Save image"}
         </button>
       {/if}
     </header>
@@ -261,16 +345,30 @@
 
     <div class="planner-tabs" role="tablist" aria-label="Plans">
       {#each plannerStore.plansForTerm as tabPlan (tabPlan.id)}
-        <button
-          type="button"
-          role="tab"
-          class="planner-tab"
-          class:planner-tab--active={tabPlan.id === plan?.id}
-          aria-selected={tabPlan.id === plan?.id}
-          onclick={() => plannerStore.selectPlan(tabPlan.id)}
-        >
-          {tabPlan.label}
-        </button>
+        {#if renaming && tabPlan.id === plan?.id}
+          <input
+            class="planner-tab planner-tab--rename"
+            bind:value={renameDraft}
+            onkeydown={onRenameKeydown}
+            onblur={commitRename}
+            use:autofocus
+            aria-label="Rename plan"
+            maxlength="40"
+          />
+        {:else}
+          <button
+            type="button"
+            role="tab"
+            class="planner-tab"
+            class:planner-tab--active={tabPlan.id === plan?.id}
+            aria-selected={tabPlan.id === plan?.id}
+            onclick={() => plannerStore.selectPlan(tabPlan.id)}
+            ondblclick={() =>
+              tabPlan.id === plan?.id ? startRename() : undefined}
+          >
+            {tabPlan.label}
+          </button>
+        {/if}
       {/each}
       <button
         type="button"
@@ -280,6 +378,24 @@
       >
         +
       </button>
+      {#if plan && !renaming}
+        <button
+          type="button"
+          class="planner-tab"
+          onclick={startRename}
+          aria-label="Rename {plan.label}"
+        >
+          Rename
+        </button>
+        <button
+          type="button"
+          class="planner-tab"
+          onclick={() => plannerStore.duplicatePlan(plan.id)}
+          aria-label="Duplicate {plan.label}"
+        >
+          Duplicate
+        </button>
+      {/if}
       {#if plan}
         {#if confirmingDelete}
           <span class="planner-delete-confirm" role="group" aria-label="Confirm delete plan">
@@ -501,9 +617,16 @@
     cursor: pointer;
   }
 
-  .planner-action:hover,
-  .planner-action:focus-visible {
+  .planner-action:hover:not(:disabled),
+  .planner-action:focus-visible:not(:disabled) {
     background: hsl(5, 53%, 96%);
+  }
+
+  .planner-action:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    border-color: hsl(0, 0%, 82%);
+    color: hsl(0, 0%, 55%);
   }
 
   .planner-disclaimer {
@@ -555,10 +678,30 @@
     cursor: pointer;
   }
 
+  .planner-tab:hover,
+  .planner-tab:focus-visible {
+    border-color: hsl(5, 53%, 55%);
+    background: hsl(5, 53%, 97%);
+    color: hsl(5, 53%, 28%);
+  }
+
   .planner-tab--active {
     background: hsl(5, 53%, 32%);
     border-color: hsl(5, 53%, 32%);
     color: white;
+  }
+
+  .planner-tab--active:hover {
+    background: hsl(5, 53%, 28%);
+    color: white;
+  }
+
+  .planner-tab--rename {
+    min-width: 7rem;
+    background: white;
+    border-color: hsl(5, 53%, 50%);
+    color: hsl(0, 0%, 15%);
+    text-align: left;
   }
 
   .planner-tab--delete {

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -128,7 +128,9 @@
     closePanel();
   }
 
-  function handleNavAction(id: "contributors" | "editor-login" | "leaderboard") {
+  function handleNavAction(
+    id: "contributors" | "editor-login" | "leaderboard" | "sign-up",
+  ) {
     if (id === "contributors") {
       modalStore.openModal("landing", { landingTab: "campus" });
       closePanel();
@@ -139,7 +141,7 @@
       closePanel();
       return;
     }
-    adminAuthStore.openLogin();
+    adminAuthStore.openLogin(id === "sign-up" ? "signup" : "signin");
     closePanel();
   }
 

--- a/src/constants/modal-states.ts
+++ b/src/constants/modal-states.ts
@@ -6,4 +6,5 @@ export const modalOptions = [
   "leaderboard",
   "changelog",
   "review",
+  "student-orgs",
 ] as const;

--- a/src/constants/status-bar-links.ts
+++ b/src/constants/status-bar-links.ts
@@ -20,7 +20,7 @@ export type StatusBarLinkItem = {
 
 export type StatusBarActionItem = {
   kind: "action";
-  id: "contributors" | "editor-login" | "leaderboard";
+  id: "contributors" | "editor-login" | "leaderboard" | "sign-up";
   label: string;
 };
 
@@ -66,6 +66,7 @@ export const STATUS_BAR_COMMUNITY_GROUP: StatusBarNavGroup = {
 export const STATUS_BAR_APP_ACTIONS: StatusBarActionItem[] = [
   { kind: "action", id: "contributors", label: "Contributors" },
   { kind: "action", id: "leaderboard", label: "Leaderboard" },
+  { kind: "action", id: "sign-up", label: "Sign up to contribute" },
   { kind: "action", id: "editor-login", label: "Editor sign in" },
 ];
 
@@ -136,6 +137,7 @@ export function statusBarNavGroups(options: {
     action("leaderboard"),
     ...(options.showEditorLogin
       ? [
+          action("sign-up"),
           action("editor-login"),
           {
             kind: "link" as const,

--- a/src/lib/classes-api.ts
+++ b/src/lib/classes-api.ts
@@ -24,3 +24,35 @@ export async function fetchClassPage(options: {
 
   return getJSONFetch<ClassQueryPage>(`/api/classes?${params.toString()}`);
 }
+
+// The /api/classes endpoint caps `limit` at 100, so a course with more sections
+// than that (e.g. HK 12 with 147) never fits in one page. Walk the offsets to
+// `total` so callers get every section.
+const PAGE_SIZE = 100;
+// ponytail: safety cap so a bad `total` can't loop forever; 20 pages = 2000
+// sections, far above any real course. Raise if a course ever exceeds it.
+const MAX_PAGES = 20;
+
+export async function fetchAllClasses(options: {
+  termId?: number | null;
+  courseCodePrefix?: string;
+}): Promise<ClassQueryPage> {
+  const first = await fetchClassPage({
+    ...options,
+    limit: PAGE_SIZE,
+    offset: 0,
+  });
+  const rows = first.rows.slice();
+  let pages = 1;
+  while (rows.length < first.total && pages < MAX_PAGES) {
+    const next = await fetchClassPage({
+      ...options,
+      limit: PAGE_SIZE,
+      offset: rows.length,
+    });
+    if (next.rows.length === 0) break;
+    rows.push(...next.rows);
+    pages++;
+  }
+  return { rows, total: first.total };
+}

--- a/src/lib/planner/import-shared.ts
+++ b/src/lib/planner/import-shared.ts
@@ -1,4 +1,4 @@
-import { fetchClassPage } from "@lib/classes-api";
+import { fetchAllClasses } from "@lib/classes-api";
 import type { DecodedSharePlan } from "./share-codec.js";
 import { sectionNaturalKey, type PlannedSection } from "./types.js";
 
@@ -13,10 +13,9 @@ export async function resolveSharedPlan(decoded: DecodedSharePlan): Promise<{
   const courseCodes = [...new Set(decoded.refs.map((ref) => ref.courseCode))];
   const pages = await Promise.all(
     courseCodes.map((code) =>
-      fetchClassPage({
+      fetchAllClasses({
         termId: decoded.termId,
         courseCodePrefix: code,
-        limit: 100,
       }).then(
         (page) => page.rows,
         () => [],

--- a/src/lib/planner/plan-image.test.ts
+++ b/src/lib/planner/plan-image.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { packColumns, type PlanBlock } from "./plan-image";
+
+function block(start: number, end: number): PlanBlock {
+  return {
+    day: 0,
+    start,
+    end,
+    code: "X",
+    section: "1",
+    type: "LEC",
+    room: null,
+    color: "#000",
+  };
+}
+
+describe("packColumns", () => {
+  test("non-overlapping blocks share one column", () => {
+    const a = block(600, 660);
+    const b = block(660, 720); // starts exactly when a ends — no overlap
+    const { columns, columnOf } = packColumns([a, b]);
+    expect(columns).toBe(1);
+    expect(columnOf.get(a)).toBe(0);
+    expect(columnOf.get(b)).toBe(0);
+  });
+
+  test("two overlapping blocks take two columns", () => {
+    const a = block(600, 720);
+    const b = block(660, 780);
+    const { columns } = packColumns([a, b]);
+    expect(columns).toBe(2);
+  });
+
+  test("three mutually overlapping blocks take three columns", () => {
+    const { columns } = packColumns([
+      block(600, 700),
+      block(620, 720),
+      block(640, 740),
+    ]);
+    expect(columns).toBe(3);
+  });
+
+  test("a later non-overlapping block reuses a freed column", () => {
+    const a = block(600, 660);
+    const b = block(600, 660); // overlaps a -> forces 2 columns
+    const c = block(700, 760); // after both -> reuses column 0
+    const { columns, columnOf } = packColumns([a, b, c]);
+    expect(columns).toBe(2);
+    expect(columnOf.get(c)).toBe(0);
+  });
+
+  test("empty day yields one column", () => {
+    expect(packColumns([]).columns).toBe(1);
+  });
+});

--- a/src/lib/planner/plan-image.ts
+++ b/src/lib/planner/plan-image.ts
@@ -1,0 +1,258 @@
+// Render a plan's weekly timetable to a PNG from the plan data itself — no DOM
+// screenshot library. Reuses the same schedule parsers and block colors as the
+// live grid, so the image matches what the planner shows and needs no new dep.
+
+import {
+  getPlannerBlockColor,
+  parseDays,
+  parseScheduleTime,
+} from "@lib/schedule-renderer";
+import type { PlannerPlan } from "./types";
+
+export type PlanBlock = {
+  day: number; // 0 = Mon … 5 = Sat
+  start: number; // minutes since midnight
+  end: number;
+  code: string;
+  section: string;
+  type: string;
+  room: string | null;
+  color: string;
+};
+
+const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/** Flatten a plan's scheduled sections into per-day/time blocks. */
+export function planToBlocks(plan: PlannerPlan): PlanBlock[] {
+  const blocks: PlanBlock[] = [];
+  for (const s of plan.sections) {
+    if (s.stale) continue;
+    for (const entry of s.schedule ?? []) {
+      const parsed = parseScheduleTime(entry);
+      if (!parsed) continue;
+      for (const day of parseDays(parsed.days ?? "")) {
+        blocks.push({
+          day,
+          start: parsed.startMinutes,
+          end: parsed.endMinutes,
+          code: s.courseCode,
+          section: s.section,
+          type: s.type,
+          room: s.roomCode,
+          color: getPlannerBlockColor(s.type),
+        });
+      }
+    }
+  }
+  return blocks;
+}
+
+/**
+ * Pack overlapping blocks in one day into side-by-side columns so nothing draws
+ * on top of anything else. Greedy interval colouring: each block takes the first
+ * column whose last block already ended. Returns each block's column index and
+ * the total column count for that day. Pure — this is the testable bit.
+ */
+export function packColumns(dayBlocks: PlanBlock[]): {
+  columnOf: Map<PlanBlock, number>;
+  columns: number;
+} {
+  const sorted = [...dayBlocks].sort(
+    (a, b) => a.start - b.start || a.end - b.end,
+  );
+  const columnEnds: number[] = []; // end time of the last block in each column
+  const columnOf = new Map<PlanBlock, number>();
+  for (const block of sorted) {
+    let col = columnEnds.findIndex((end) => end <= block.start);
+    if (col === -1) {
+      col = columnEnds.length;
+      columnEnds.push(block.end);
+    } else {
+      columnEnds[col] = block.end;
+    }
+    columnOf.set(block, col);
+  }
+  return { columnOf, columns: Math.max(1, columnEnds.length) };
+}
+
+/** Render the plan timetable to a PNG Blob (2× for retina). Browser-only. */
+export async function renderPlanToPng(
+  plan: PlannerPlan,
+  opts: { termLabel?: string | null } = {},
+): Promise<Blob> {
+  const blocks = planToBlocks(plan);
+
+  const usedDays = blocks.map((b) => b.day);
+  const dayCount = Math.max(
+    5,
+    (usedDays.length ? Math.max(...usedDays) : 4) + 1,
+  );
+
+  let startHour = 7;
+  let endHour = 19;
+  if (blocks.length) {
+    startHour = Math.min(
+      7,
+      Math.floor(Math.min(...blocks.map((b) => b.start)) / 60),
+    );
+    endHour = Math.max(
+      18,
+      Math.ceil(Math.max(...blocks.map((b) => b.end)) / 60),
+    );
+  }
+  const hours = Math.max(1, endHour - startHour);
+
+  // Geometry (CSS px; scaled up on the canvas for crispness).
+  const scale = 2;
+  const pad = 24;
+  const titleH = 56;
+  const headerH = 32;
+  const gutterW = 56;
+  const colW = 150;
+  const hourH = 56;
+  const width = pad * 2 + gutterW + colW * dayCount;
+  const height = pad * 2 + titleH + headerH + hourH * hours;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width * scale;
+  canvas.height = height * scale;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D context unavailable");
+  ctx.scale(scale, scale);
+
+  // Background.
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, width, height);
+
+  // Title.
+  ctx.fillStyle = "#1a1a1a";
+  ctx.font = "700 22px system-ui, -apple-system, sans-serif";
+  ctx.textBaseline = "top";
+  ctx.fillText(plan.label, pad, pad);
+  if (opts.termLabel) {
+    ctx.fillStyle = "#6b6b6b";
+    ctx.font = "500 14px system-ui, -apple-system, sans-serif";
+    ctx.fillText(`${opts.termLabel} · Room TBA`, pad, pad + 28);
+  } else {
+    ctx.fillStyle = "#6b6b6b";
+    ctx.font = "500 14px system-ui, -apple-system, sans-serif";
+    ctx.fillText("Room TBA", pad, pad + 28);
+  }
+
+  const gridTop = pad + titleH;
+  const gridLeft = pad + gutterW;
+
+  // Day headers.
+  ctx.textAlign = "center";
+  ctx.font = "600 14px system-ui, -apple-system, sans-serif";
+  ctx.fillStyle = "#333";
+  for (let d = 0; d < dayCount; d++) {
+    ctx.fillText(
+      DAY_NAMES[d] ?? "",
+      gridLeft + colW * d + colW / 2,
+      gridTop + 8,
+    );
+  }
+
+  const bodyTop = gridTop + headerH;
+
+  // Hour rows + labels.
+  ctx.strokeStyle = "#e6e6e6";
+  ctx.lineWidth = 1;
+  ctx.textAlign = "right";
+  ctx.font = "500 12px system-ui, -apple-system, sans-serif";
+  for (let h = 0; h <= hours; h++) {
+    const y = bodyTop + hourH * h;
+    ctx.beginPath();
+    ctx.moveTo(gridLeft, y);
+    ctx.lineTo(gridLeft + colW * dayCount, y);
+    ctx.stroke();
+    if (h < hours) {
+      const hour24 = startHour + h;
+      const label = `${((hour24 + 11) % 12) + 1} ${hour24 < 12 ? "AM" : "PM"}`;
+      ctx.fillStyle = "#8a8a8a";
+      ctx.fillText(label, gridLeft - 8, y + 4);
+    }
+  }
+  // Vertical day separators.
+  for (let d = 0; d <= dayCount; d++) {
+    const x = gridLeft + colW * d;
+    ctx.beginPath();
+    ctx.moveTo(x, bodyTop);
+    ctx.lineTo(x, bodyTop + hourH * hours);
+    ctx.stroke();
+  }
+
+  // Blocks, packed per day so overlaps sit side by side.
+  const minY = startHour * 60;
+  ctx.textAlign = "left";
+  for (let d = 0; d < dayCount; d++) {
+    const dayBlocks = blocks.filter((b) => b.day === d);
+    const { columnOf, columns } = packColumns(dayBlocks);
+    const subW = colW / columns;
+    for (const block of dayBlocks) {
+      const col = columnOf.get(block) ?? 0;
+      const x = gridLeft + colW * d + subW * col + 2;
+      const y = bodyTop + ((block.start - minY) / 60) * hourH + 1;
+      const w = subW - 4;
+      const bh = Math.max(18, ((block.end - block.start) / 60) * hourH - 2);
+
+      ctx.fillStyle = block.color;
+      roundRect(ctx, x, y, w, bh, 6);
+      ctx.fill();
+
+      ctx.fillStyle = "#ffffff";
+      ctx.font = "700 12px system-ui, -apple-system, sans-serif";
+      clipText(ctx, `${block.code}`, x + 6, y + 5, w - 8);
+      ctx.font = "500 11px system-ui, -apple-system, sans-serif";
+      clipText(ctx, `${block.type} ${block.section}`, x + 6, y + 20, w - 8);
+      if (block.room && bh > 48) {
+        clipText(ctx, block.room, x + 6, y + 34, w - 8);
+      }
+    }
+  }
+
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error("toBlob failed"))),
+      "image/png",
+    );
+  });
+}
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+) {
+  const radius = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + w, y, x + w, y + h, radius);
+  ctx.arcTo(x + w, y + h, x, y + h, radius);
+  ctx.arcTo(x, y + h, x, y, radius);
+  ctx.arcTo(x, y, x + w, y, radius);
+  ctx.closePath();
+}
+
+/** Draw text truncated with an ellipsis to fit maxWidth. */
+function clipText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+) {
+  if (ctx.measureText(text).width <= maxWidth) {
+    ctx.fillText(text, x, y);
+    return;
+  }
+  let t = text;
+  while (t.length > 1 && ctx.measureText(`${t}…`).width > maxWidth) {
+    t = t.slice(0, -1);
+  }
+  ctx.fillText(`${t}…`, x, y);
+}

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -365,6 +365,9 @@ class AdminAuthStore {
   canReview: boolean = $state(false);
   loading: boolean = $state(false);
   loginOpen: boolean = $state(false);
+  /** Which tab the login modal opens on — "signup" from the "create account"
+   * entry points, "signin" everywhere else. */
+  loginInitialMode: "signin" | "signup" = $state("signin");
   /** Error code from a failed OAuth redirect (`?auth_error=`). */
   oauthError: string | null = $state(null);
   accountSettingsOpen: boolean = $state(false);
@@ -615,9 +618,10 @@ class AdminAuthStore {
     plannerStore.disableAccountSync();
   };
 
-  openLogin = () => {
+  openLogin = (mode: "signin" | "signup" = "signin") => {
     dismissEphemeralOverlays();
     modalStore.closeModal();
+    this.loginInitialMode = mode;
     this.loginOpen = true;
   };
 

--- a/src/lib/stores/planner-store.svelte.ts
+++ b/src/lib/stores/planner-store.svelte.ts
@@ -163,6 +163,32 @@ export class PlannerStore {
     this.persist();
   };
 
+  /** Clone a plan (sections and all) into a new plan for the same term. */
+  duplicatePlan = (id: string): PlannerPlan | null => {
+    const source = this.plans.find((p) => p.id === id);
+    if (!source) return null;
+    const copy: PlannerPlan = {
+      id: crypto.randomUUID(),
+      label: this.uniqueLabel(`${source.label} copy`, source.termId),
+      termId: source.termId,
+      sections: source.sections.map((s) => ({ ...s })),
+    };
+    this.plans.push(copy);
+    this.activePlanIdByTerm[String(copy.termId)] = copy.id;
+    this.persist();
+    return copy;
+  };
+
+  /** Rename a plan; empty names are ignored, collisions get a numeric suffix. */
+  renamePlan = (id: string, label: string) => {
+    const plan = this.plans.find((p) => p.id === id);
+    if (!plan) return;
+    const trimmed = label.trim();
+    if (!trimmed) return;
+    plan.label = this.uniqueLabel(trimmed, plan.termId, plan.id);
+    this.persist();
+  };
+
   /** Add a decoded share payload as a new plan for its term and select it. */
   importShared = (termId: number, sections: PlannedSection[]): PlannerPlan => {
     const plan = this.newPlan(termId);
@@ -213,17 +239,31 @@ export class PlannerStore {
   }
 
   private newPlan(termId: number): PlannerPlan {
-    const used = new Set(
-      this.plans.filter((p) => p.termId === termId).map((p) => p.label),
-    );
-    let n = 1;
-    while (used.has(`Plan ${n}`)) n++;
     return {
       id: crypto.randomUUID(),
-      label: `Plan ${n}`,
+      label: this.uniqueLabel("Plan 1", termId),
       termId,
       sections: [],
     };
+  }
+
+  /** A label unique within the term. Falls back to "<base> (2)", "(3)", … on
+   * collision (and "Plan 1" → "Plan 1 (2)" gives the familiar Plan 2/3 feel). */
+  private uniqueLabel(base: string, termId: number, exceptId?: string): string {
+    const used = new Set(
+      this.plans
+        .filter((p) => p.termId === termId && p.id !== exceptId)
+        .map((p) => p.label),
+    );
+    if (base === "Plan 1") {
+      let n = 1;
+      while (used.has(`Plan ${n}`)) n++;
+      return `Plan ${n}`;
+    }
+    if (!used.has(base)) return base;
+    let n = 2;
+    while (used.has(`${base} (${n})`)) n++;
+    return `${base} (${n})`;
   }
 
   private persist() {

--- a/src/lib/stores/planner.store.test.ts
+++ b/src/lib/stores/planner.store.test.ts
@@ -190,4 +190,45 @@ describe("PlannerStore", () => {
     expect(sections.find((s) => s.type === "LEC")?.roomCode).toBe("NEW ROOM");
     expect(sections.find((s) => s.type === "LAB")?.stale).toBe(true);
   });
+
+  test("duplicatePlan clones sections into a new selected plan", () => {
+    const store = makeStore();
+    store.addOffering([row({}), row({ id: 2, type: "LAB" })]);
+    const source = store.activePlan!;
+    const copy = store.duplicatePlan(source.id);
+    expect(copy).not.toBeNull();
+    expect(copy!.id).not.toBe(source.id);
+    expect(copy!.label).toBe("Plan 1 copy");
+    expect(copy!.sections).toHaveLength(2);
+    // Deep copy — mutating the copy must not touch the source.
+    copy!.sections.pop();
+    expect(source.sections).toHaveLength(2);
+    expect(store.activePlan?.id).toBe(copy!.id);
+  });
+
+  test("duplicating twice gives distinct suffixed labels", () => {
+    const store = makeStore();
+    store.addOffering([row({})]);
+    const source = store.activePlan!;
+    store.duplicatePlan(source.id);
+    const second = store.duplicatePlan(source.id);
+    expect(second!.label).toBe("Plan 1 copy (2)");
+  });
+
+  test("renamePlan trims, ignores empty, and de-duplicates", () => {
+    const store = makeStore();
+    store.addOffering([row({})]);
+    const a = store.activePlan!;
+    const b = store.createPlan()!; // "Plan 2"
+    store.renamePlan(a.id, "  My schedule  ");
+    expect(store.plans.find((p) => p.id === a.id)?.label).toBe("My schedule");
+    // Empty rename is ignored.
+    store.renamePlan(b.id, "   ");
+    expect(store.plans.find((p) => p.id === b.id)?.label).toBe("Plan 2");
+    // Collision with an existing label gets a numeric suffix.
+    store.renamePlan(b.id, "My schedule");
+    expect(store.plans.find((p) => p.id === b.id)?.label).toBe(
+      "My schedule (2)",
+    );
+  });
 });


### PR DESCRIPTION
Ships six requested features.

## Planner
- **Duplicate plan** — clones sections into a new plan (deep copy), selects it. `duplicatePlan()`.
- **Rename plan** — inline edit (double-click a tab, or the **Rename** button); Enter saves, Esc cancels; labels de-dupe per term. `renamePlan()`.
- **Save as image** — timetable → PNG rendered on a canvas **from plan data** (no screenshot lib; reuses the grid's `parseScheduleTime`/`parseDays`/`getPlannerBlockColor`). Overlaps pack into side-by-side columns (`packColumns`, unit-tested).
- **Share / Add to Google Calendar / Save image always visible, greyed until scheduled** — buttons show whenever a plan exists and disable (with a hint tooltip) until at least one scheduled section, so the affordance is discoverable.
- **HK 12 / all sections** — new `fetchAllClasses()` paginates past the API's 100/page cap (safety cap 20 pages). Course search fetches every section when a code is typed (147-section HK 12 no longer truncates to 100), and the planner refresh + shared-plan import use it too so drag alternatives are complete.

## Auth — surface signup
- **"Sign up to contribute"** app-menu entry opens the login modal straight into the signup tab. `openLogin(mode)` + `loginInitialMode`. "Editor sign in" stays for staff.

## Student orgs
- **Info modal** (`StudentOrgsModal`) explaining org listings + tambayans, with **Browse organizations** and **Sign up** CTAs — opened from an ⓘ on every org listing.

## Verify (local)
- biome ci — clean (2 pre-existing infos)
- unit — 301 pass (incl 5 `plan-image` + 3 new store tests: duplicate/rename)
- component (vitest) — 91 pass
- pwa-legal — OK
- build — compiles fully (server+client); only the prerender step stops on `DATABASE_URL` env (present in CI)

Also reformats `map-chrome.css` (pre-existing biome drift from the staging→main merge #628 that was failing `verify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches planner persistence, multi-page class API usage, and auth entry points, but changes are mostly client-side UX with unit tests for plan-image packing and store duplicate/rename.
> 
> **Overview**
> Expands the **class planner** with plan **duplicate** and **rename** (inline tab edit or controls), **Save image** (canvas PNG from plan data with overlap column packing), and **Share / calendar / image** actions that stay visible but disabled until at least one scheduled section. **`fetchAllClasses`** paginates past the API’s 100-row cap so course search, planner refresh, drag alternatives, and shared-plan import see every section (e.g. large courses like HK 12).
> 
> Surfaces **contributor signup**: app menu **Sign up to contribute**, `openLogin('signup')` / `loginInitialMode`, and the login modal opening on the requested tab. Adds a **student organizations** info modal (`student-orgs`) with browse and sign-up CTAs, opened from an info control on org listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa4eeb55a991b5fec298c32ae29ed97d32ea3515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->