### PR TITLE
fix(ci): pin bun to 1.3.12 (1.3.14 broke --frozen-lockfile)

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: "1.3.12" # pin: avoid bun 1.3.14 frozen-lockfile regression
       - name: Install pg_dump
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Run backup

--- a/.github/workflows/bundle-advisory.yml
+++ b/.github/workflows/bundle-advisory.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: bun run check:bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          # Pin: bun 1.3.14 regressed `--frozen-lockfile` (ENOENT: could not
+          # open the "node_modules" directory on a fresh checkout), breaking
+          # every job. Unpin once upstream ships a fix.
+          bun-version: 1.3.12
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -62,6 +67,11 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          # Pin: bun 1.3.14 regressed `--frozen-lockfile` (ENOENT: could not
+          # open the "node_modules" directory on a fresh checkout), breaking
+          # every job. Unpin once upstream ships a fix.
+          bun-version: 1.3.12
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/discord-test-inventory.yml
+++ b/.github/workflows/discord-test-inventory.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: "1.3.12" # pin: avoid bun 1.3.14 frozen-lockfile regression
       - name: Post test inventory to Discord
         env:
           GATEWAY_URL: ${{ secrets.NOTIFICATION_GATEWAY_URL }}

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
       - run: bun install --frozen-lockfile
       - run: bunx playwright install chromium --with-deps
       - run: bun run e2e:staging


### PR DESCRIPTION
**CI is red on every PR** (verify, bundle, e2e, …) — not from code.

bun **1.3.14** regressed `bun install --frozen-lockfile` on a fresh checkout:
```
ENOENT: could not open the "node_modules" directory
```
The `setup-bun@v2` steps were unpinned (→ `latest` = 1.3.14) or pinned to 1.3.14, so jobs started failing the moment CI rolled to it (#629 passed ~25 min earlier on 1.3.12).

Pins every `setup-bun` across all workflows to **1.3.12** (last known-green). YAML validated. Unpin when upstream fixes `--frozen-lockfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only tooling pin with no application or runtime behavior changes; slightly delays picking up future Bun fixes until the pin is lifted.
> 
> **Overview**
> **Restores CI** by pinning Bun to **1.3.12** on every `oven-sh/setup-bun@v2` step across GitHub Actions workflows (CI verify/migrations, E2E reusable, bundle advisory, CodeQL, release, staging smoke, DB backup, Discord test inventory).
> 
> Bun **1.3.14** causes `bun install --frozen-lockfile` to fail on a clean checkout with `ENOENT` on `node_modules`, so unpinned or 1.3.14-pinned jobs were failing at install. Comments note the regression and that the pin can be removed once upstream fixes `--frozen-lockfile`.
> 
> `bundle-advisory.yml` also adds an explicit `with: bun-version` block where setup previously had no version pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a04ae05f9d4753b4ae88e1e61b9fdb7d00acff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->