### PR TITLE
fix(ci): mkdir node_modules before frozen install (flaky ENOENT)

### DIFF
--- a/.github/workflows/bundle-advisory.yml
+++ b/.github/workflows/bundle-advisory.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
-      - run: bun install --frozen-lockfile
+      - run: mkdir -p node_modules && bun install --frozen-lockfile
       - run: bun run build
       - run: bun run check:bundle
       - name: Bundle budget notice

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           bun-version: 1.3.12
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: mkdir -p node_modules && bun install --frozen-lockfile
 
       - name: Biome check (format + lint)
         run: bunx biome ci .
@@ -74,7 +74,7 @@ jobs:
           bun-version: 1.3.12
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: mkdir -p node_modules && bun install --frozen-lockfile
 
       - name: Schema tables present
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
           bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: mkdir -p node_modules && bun install --frozen-lockfile
 
       # Astro SSG queries Postgres at build time — skip `bun run build` in CI.
       # Source-level JS/TS analysis still covers app logic, API routes, and libs.

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -31,7 +31,7 @@ jobs:
           bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: mkdir -p node_modules && bun install --frozen-lockfile
 
       - name: Install Playwright browsers
         run: bunx playwright install chromium --with-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: mkdir -p node_modules && bun install --frozen-lockfile
 
       - name: Release
         env:

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
-      - run: bun install --frozen-lockfile
+      - run: mkdir -p node_modules && bun install --frozen-lockfile
       - run: bunx playwright install chromium --with-deps
       - run: bun run e2e:staging


### PR DESCRIPTION
Follow-up to #632. Even on the pinned bun 1.3.12, `bun install --frozen-lockfile` **intermittently** fails on a fresh runner:
```
ENOENT: could not open the "node_modules" directory
```
Same ci.yml + same bun passed on #632 but failed twice on #631 — an environmental race, not code. Pre-creating `node_modules` makes bun's `open()` succeed, so frozen install is deterministic. Applied to every frozen-install job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow install steps; no application, auth, or data-path changes.
> 
> **Overview**
> Makes **`bun install --frozen-lockfile`** reliable on fresh GitHub runners by running **`mkdir -p node_modules`** first, avoiding intermittent **`ENOENT: could not open the "node_modules" directory`** even with Bun pinned at 1.3.12.
> 
> The same install step is updated in **CI** (`verify` and `migrations`), **CodeQL**, **E2E (reusable)**, **bundle advisory**, **release**, and **staging smoke**—every workflow that uses a frozen install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b235890662ffd357eb63bf87516984629e5fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->