### PR TITLE
release: UI polish batch

### DIFF
--- a/e2e/browse/campus-browse-chips.spec.ts
+++ b/e2e/browse/campus-browse-chips.spec.ts
@@ -32,6 +32,28 @@ test.describe("campus browse chips", () => {
     );
   });
 
+  test("mobile top bar: term selector does not overlap browse chips", async ({
+    page,
+  }) => {
+    // Regression guard: on the mobile grid shell, the browse-chip row and the
+    // term-selector row must be explicitly placed. Auto-placement stuffed them
+    // side by side into the menu column, drawing the term selector on top of
+    // the chips.
+    await page.setViewportSize({ width: 390, height: 844 });
+    const chips = page.locator(".campus-browse-chips__container");
+    const term = page.locator(".campus-browse-chips__term");
+    await expect(chips).toBeVisible();
+    await expect(term).toBeVisible();
+
+    const chipsBox = await chips.boundingBox();
+    const termBox = await term.boundingBox();
+    if (!chipsBox || !termBox) throw new Error("missing bounding boxes");
+    // The term row must start at or below the bottom of the chips row.
+    expect(termBox.y).toBeGreaterThanOrEqual(chipsBox.y + chipsBox.height - 1);
+    // And both rows span the shell instead of hiding in the 2rem menu column.
+    expect(chipsBox.width).toBeGreaterThan(200);
+  });
+
   test("Classes opens class list without toggling building filter chip", async ({
     page,
   }) => {

--- a/e2e/smoke/app-menu.spec.ts
+++ b/e2e/smoke/app-menu.spec.ts
@@ -25,6 +25,25 @@ test.describe("app menu", () => {
     ).toBeVisible();
   });
 
+  test("What's new opens the full changelog in one click", async ({ page }) => {
+    await page.goto("/");
+    await waitForAppBoot(page);
+
+    await page.getByRole("button", { name: "App menu" }).click();
+    const panel = page.getByRole("dialog", { name: "App menu" });
+    await expect(panel).toBeVisible();
+
+    await panel.getByRole("button", { name: /what's new/i }).click();
+    const modal = page.getByRole("dialog", { name: "What's new" });
+    await expect(modal).toBeVisible();
+
+    // The changelog content itself must render in the modal — no second
+    // "Full changelog" click (#5). Expect several release headings.
+    const versions = modal.getByRole("heading", { level: 3 });
+    await expect(versions.first()).toHaveText(/^v\d+\.\d+\.\d+/);
+    expect(await versions.count()).toBeGreaterThan(1);
+  });
+
   test("offline popover opens without closing the App menu", async ({
     page,
   }) => {

--- a/e2e/smoke/planner-flow.spec.ts
+++ b/e2e/smoke/planner-flow.spec.ts
@@ -51,10 +51,11 @@ test.describe("planner interactions", () => {
   }) => {
     await suppressLandingModal(page);
     // Seed a plan with two overlapping sections. The schedule strings overlap on
-    // Monday 9:00-9:30, so the store derives exactly one conflict. Fake course
-    // codes return no rows from /api/classes, so refreshActivePlan leaves them
-    // intact. This exercises the badge render path deterministically, without
-    // depending on which real classes the e2e DB happens to hold.
+    // Monday 9:00-9:30, so the store derives exactly one conflict. Abort their
+    // refresh requests: a successful empty response correctly marks persisted
+    // sections stale, which would hide them from the current-offerings list.
+    // This keeps the fixture independent of e2e DB contents.
+    await page.route("**/api/classes?*", (route) => route.abort());
     await page.addInitScript(() => {
       const plan = {
         id: "e2e-conflict-plan",
@@ -96,8 +97,13 @@ test.describe("planner interactions", () => {
     await expect(planner).toBeVisible();
 
     // Both seeded offerings render, and the badge reports the conflict.
-    await expect(planner.getByText(/ZZZ 1\s*·\s*A/)).toBeVisible();
-    await expect(planner.getByText(/1 conflict\b/i)).toBeVisible();
+    await expect(
+      planner.locator(".planner-offering", { hasText: "ZZZ 1" }),
+    ).toBeVisible();
+    const conflictBadge = planner.locator(".planner-conflict-badge");
+    await expect(
+      conflictBadge.filter({ hasText: /^1 conflict$/ }),
+    ).toBeVisible();
 
     // Remove one side of the clash -> no more overlap -> "All clear".
     await planner
@@ -105,7 +111,11 @@ test.describe("planner interactions", () => {
       .getByRole("button", { name: "Remove" })
       .click();
 
-    await expect(planner.getByText(/all clear/i)).toBeVisible();
-    await expect(planner.getByText(/\d+ conflict/i)).toHaveCount(0);
+    await expect(
+      conflictBadge.filter({ hasText: /^All clear$/i }),
+    ).toBeVisible();
+    await expect(
+      conflictBadge.filter({ hasText: /\d+ conflict/i }),
+    ).toHaveCount(0);
   });
 });

--- a/src/components/svelte/AccountSettingsModal.svelte
+++ b/src/components/svelte/AccountSettingsModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { fade, fly } from "svelte/transition";
   import { X, User2 } from "@lucide/svelte";
   import { adminAuthStore, toastStore } from "@lib/store.svelte";
@@ -268,7 +269,7 @@
       {#if loadError}
         <EntityEditorMessage variant="error" message={loadError} />
       {:else if !profile}
-        <p class="settings-loading">Loading…</p>
+        <p class="settings-loading"><LoadingIndicator /></p>
       {:else}
         <section class="settings-section">
           <h3>Profile</h3>

--- a/src/components/svelte/ChangelogModal.component.test.ts
+++ b/src/components/svelte/ChangelogModal.component.test.ts
@@ -8,11 +8,14 @@ describe("ChangelogModal", () => {
     syncToastStore.needRefresh = false;
   });
 
-  test("without a pending update: shows Close and the full-changelog link, no reload", () => {
+  test("without a pending update: shows the full changelog inline and Close, no reload", () => {
     syncToastStore.needRefresh = false;
     render(ChangelogModal);
     expect(screen.getByRole("button", { name: /close/i })).toBeVisible();
-    expect(screen.getByRole("link", { name: /full changelog/i })).toBeVisible();
+    // The changelog itself renders in the modal — no second click needed (#5).
+    const versions = screen.getAllByRole("heading", { level: 3 });
+    expect(versions.length).toBeGreaterThan(1);
+    expect(versions[0]?.textContent).toMatch(/^v\d+\.\d+\.\d+/);
     expect(
       screen.queryByRole("button", { name: /reload to update/i }),
     ).toBeNull();

--- a/src/components/svelte/ChangelogModal.svelte
+++ b/src/components/svelte/ChangelogModal.svelte
@@ -1,21 +1,12 @@
 <script lang="ts">
-  import { RefreshCw, FileText } from "@lucide/svelte";
+  import { RefreshCw } from "@lucide/svelte";
   import { syncToastStore, modalStore } from "@lib/store.svelte";
-  import { APP_VERSION, APP_VERSION_LABEL } from "@constants/version";
-  import {
-    parseChangelogHighlights,
-    isChangelogCurrent,
-  } from "@lib/changelog-highlights";
+  import { APP_VERSION_LABEL } from "@constants/version";
+  import { parseChangelogEntries } from "@lib/changelog-highlights";
   import changelogRaw from "../../../CHANGELOG.md?raw";
 
-  const highlights = $derived(parseChangelogHighlights(changelogRaw));
+  const entries = $derived(parseChangelogEntries(changelogRaw));
   const hasUpdate = $derived(syncToastStore.needRefresh);
-  // Only show the parsed highlights when the changelog matches the installed
-  // version. A stale CHANGELOG (version bumped without regenerating it) would
-  // otherwise claim an older version than the one already running.
-  const showHighlights = $derived(
-    highlights !== null && isChangelogCurrent(highlights.version, APP_VERSION),
-  );
 
   let reloading = $state(false);
 
@@ -27,42 +18,44 @@
 </script>
 
 <div class="changelog-modal">
-  <p class="changelog-modal__version">
-    Room TBA {APP_VERSION_LABEL}
-  </p>
-
-  {#if hasUpdate}
-    <p class="changelog-modal__lead">
-      A new version is ready. Review what changed, then reload to update.
+  <header class="changelog-modal__header">
+    <p class="changelog-modal__version">
+      Room TBA {APP_VERSION_LABEL}
     </p>
-  {/if}
-
-  {#if showHighlights && highlights}
-    <ul class="changelog-modal__list">
-      {#each highlights.items as item (item)}
-        <li>{item}</li>
-      {/each}
-    </ul>
-    {#if highlights.totalCount > highlights.items.length}
-      <p class="changelog-modal__more">
-        + {highlights.totalCount - highlights.items.length} more in the full changelog
+    {#if hasUpdate}
+      <p class="changelog-modal__lead">
+        A new version is ready. Review what changed, then reload to update.
       </p>
     {/if}
-  {:else}
-    <p class="changelog-modal__lead">
-      See the full changelog for what's new.
-    </p>
-  {/if}
+  </header>
 
-  <a
-    class="changelog-modal__full-link"
-    href="/changelog"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    <FileText size={14} aria-hidden="true" />
-    Full changelog
-  </a>
+  <div class="changelog-modal__scroll">
+    {#if entries.length === 0}
+      <p class="changelog-modal__lead">
+        No changelog entries found. See <a href="/changelog">/changelog</a>.
+      </p>
+    {/if}
+    {#each entries as entry (entry.version)}
+      <section class="changelog-modal__entry">
+        <h3 class="changelog-modal__entry-version">
+          v{entry.version}
+          {#if entry.date}
+            <span class="changelog-modal__entry-date">{entry.date}</span>
+          {/if}
+        </h3>
+        {#each entry.sections as section}
+          {#if section.title}
+            <h4 class="changelog-modal__section-title">{section.title}</h4>
+          {/if}
+          <ul class="changelog-modal__list">
+            {#each section.items as item}
+              <li>{item}</li>
+            {/each}
+          </ul>
+        {/each}
+      </section>
+    {/each}
+  </div>
 
   <div class="changelog-modal__actions">
     {#if hasUpdate}
@@ -104,7 +97,15 @@
     flex-direction: column;
     gap: 0.625rem;
     padding: 0.25rem 0.25rem 0;
-    max-width: 26rem;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .changelog-modal__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding-right: 2.25rem;
   }
 
   .changelog-modal__version {
@@ -121,6 +122,53 @@
     line-height: 1.4;
   }
 
+  .changelog-modal__scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-right: 0.5rem;
+  }
+
+  .changelog-modal__entry {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    border-bottom: 1px solid hsl(0, 0%, 92%);
+    padding-bottom: 0.875rem;
+  }
+
+  .changelog-modal__entry:last-child {
+    border-bottom: none;
+  }
+
+  .changelog-modal__entry-version {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: hsl(5, 53%, 32%);
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .changelog-modal__entry-date {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: hsl(0, 0%, 50%);
+  }
+
+  .changelog-modal__section-title {
+    margin: 0.25rem 0 0;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 35%);
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+  }
+
   .changelog-modal__list {
     margin: 0;
     padding-left: 1.1rem;
@@ -133,36 +181,12 @@
     list-style: disc;
   }
 
-  .changelog-modal__more {
-    margin: 0;
-    font-size: 0.8125rem;
-    color: hsl(0, 0%, 45%);
-  }
-
-  .changelog-modal__full-link {
-    align-self: flex-start;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.25rem 0.625rem;
-    border: 1px solid hsl(5, 34%, 82%);
-    border-radius: 0.5rem;
-    color: hsl(5, 53%, 32%);
-    font-size: 0.8125rem;
-    font-weight: 600;
-    text-decoration: none;
-  }
-
-  .changelog-modal__full-link:hover,
-  .changelog-modal__full-link:focus-visible {
-    background: hsl(5, 20%, 96%);
-  }
-
   .changelog-modal__actions {
     display: flex;
     justify-content: flex-end;
     gap: 0.5rem;
-    margin-top: 0.25rem;
+    padding: 0.25rem 0 0.375rem;
+    border-top: 1px solid hsl(0, 0%, 92%);
   }
 
   .changelog-modal__btn {

--- a/src/components/svelte/EditorShelf.svelte
+++ b/src/components/svelte/EditorShelf.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CalendarPlus from "@lucide/svelte/icons/calendar-plus";
+  import ClipboardCheck from "@lucide/svelte/icons/clipboard-check";
   import LogOut from "@lucide/svelte/icons/log-out";
   import MapPinPlus from "@lucide/svelte/icons/map-pin-plus";
   import Pencil from "@lucide/svelte/icons/pencil";
@@ -11,11 +12,11 @@
     editorChromeStore,
     eventPlacementStore,
     mapEditStore,
+    modalStore,
     proposalsStore,
     toastStore,
   } from "@lib/store.svelte";
   import { beginEventPlacement } from "@lib/event-placement";
-  import ProposalReviewPanel from "@ui/ProposalReviewPanel.svelte";
 
   type Props = {
     onclose?: () => void;
@@ -74,6 +75,12 @@
     adminAuthStore.openManageUsers();
   }
 
+  function handleReviewQueue() {
+    editorChromeStore.closeShelf();
+    onclose?.();
+    modalStore.openModal("review");
+  }
+
   function addEventLabel() {
     if (eventPlacementStore.creating) return "Creating event…";
     if (eventPlacementStore.active) return "Choose event location";
@@ -127,7 +134,18 @@
     </div>
   {/if}
 
-  <ProposalReviewPanel />
+  {#if adminAuthStore.canReview}
+    <button
+      type="button"
+      class="editor-shelf-action"
+      onclick={handleReviewQueue}
+    >
+      <ClipboardCheck size={16} aria-hidden="true" />
+      Review suggested edits{proposalsStore.pendingCount > 0
+        ? ` (${proposalsStore.pendingCount})`
+        : ""}
+    </button>
+  {/if}
 
   <button
     type="button"

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -734,19 +734,18 @@
 
     .top-right-map-stack :global(.map-chrome-panel) {
       position: fixed;
-      top: var(--search-block-height);
-      right: 0;
-      left: 0;
+      /* Float below the search block with a gap, inset + rounded to match the
+         search chrome, instead of butting edge-to-edge against the top bar. */
+      top: calc(var(--search-block-height) + var(--map-ui-padding, 0.375rem));
+      right: var(--map-ui-padding, 0.375rem);
+      left: var(--map-ui-padding, 0.375rem);
       width: auto;
       max-width: none;
       max-height: calc(
-        100dvh - var(--search-block-height) - var(--status-bar-block-height)
+        100dvh - var(--search-block-height) - var(--map-ui-padding, 0.375rem) -
+          var(--status-bar-block-height)
       );
       margin: 0;
-      border-radius: 0;
-      border-top: none;
-      border-left: none;
-      border-right: none;
       pointer-events: auto;
     }
 
@@ -756,8 +755,8 @@
       max-height: min(
         42dvh,
         calc(
-          100dvh - var(--search-block-height) - var(--status-bar-block-height) -
-            0.5rem
+          100dvh - var(--search-block-height) - var(--map-ui-padding, 0.375rem) -
+            var(--status-bar-block-height) - 0.5rem
         )
       );
       padding: 0.5rem 0.625rem;

--- a/src/components/svelte/LoadingIndicator.svelte
+++ b/src/components/svelte/LoadingIndicator.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  // Shared loading state: a small spinner + label, sized by the parent's font.
+  let { label = "Loading…" }: { label?: string } = $props();
+</script>
+
+<span class="loading-indicator" role="status">
+  <span class="loading-indicator__spinner" aria-hidden="true"></span>
+  <span class="loading-indicator__label">{label}</span>
+</span>
+
+<style>
+  .loading-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+
+  .loading-indicator__spinner {
+    width: 0.875em;
+    height: 0.875em;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    border: 2px solid hsl(5, 30%, 85%);
+    border-top-color: hsl(5, 53%, 32%);
+    animation: loading-indicator-spin 0.8s linear infinite;
+  }
+
+  .loading-indicator__label {
+    min-width: 0;
+  }
+
+  @keyframes loading-indicator-spin {
+    to {
+      rotate: 360deg;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .loading-indicator__spinner {
+      animation: none;
+    }
+  }
+</style>

--- a/src/components/svelte/ManageUsersModal.svelte
+++ b/src/components/svelte/ManageUsersModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { fade, fly } from "svelte/transition";
   import { X, Users } from "@lucide/svelte";
   import { adminAuthStore, toastStore } from "@lib/store.svelte";
@@ -184,7 +185,7 @@
       {#if loadError}
         <EntityEditorMessage variant="error" message={loadError} />
       {:else if !users}
-        <p class="settings-loading">Loading…</p>
+        <p class="settings-loading"><LoadingIndicator /></p>
       {:else}
         {#if rowError}
           <EntityEditorMessage variant="error" message={rowError} />

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -2978,6 +2978,11 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
     padding: 0;
   }
+  .place-pin:hover,
+  .place-pin:focus-visible {
+    transform: scale(1.12);
+    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
+  }
   .place-pin--active {
     outline: 2px solid #0d7a5f;
     outline-offset: 1px;

--- a/src/components/svelte/ProposalReviewPanel.svelte
+++ b/src/components/svelte/ProposalReviewPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { SvelteSet } from "svelte/reactivity";
   import {
     adminAuthStore,
@@ -178,7 +179,9 @@
     </div>
 
     {#if proposalsStore.loading}
-      <p class="entity-review-empty" aria-live="polite">Loading proposals…</p>
+      <p class="entity-review-empty">
+        <LoadingIndicator label="Loading proposals…" />
+      </p>
     {:else if proposalsStore.proposals.length === 0}
       <p class="entity-review-empty">No pending suggestions.</p>
     {:else}
@@ -324,6 +327,11 @@
     font-size: 0.8rem;
     font-weight: 700;
     cursor: pointer;
+  }
+
+  .entity-review-batch-approve:hover:not(:disabled) {
+    border-color: hsl(140, 45%, 44%);
+    background: hsl(140, 45%, 44%);
   }
 
   .entity-review-batch-approve:disabled {

--- a/src/components/svelte/ScheduleImportPanel.svelte
+++ b/src/components/svelte/ScheduleImportPanel.svelte
@@ -270,6 +270,11 @@
     color: #fff;
   }
 
+  .schedule-import-panel__primary:hover:not(:disabled),
+  .schedule-import-panel__primary:focus-visible {
+    background: hsl(5, 53%, 38%);
+  }
+
   .schedule-import-panel__primary:disabled {
     opacity: 0.55;
     cursor: not-allowed;
@@ -279,6 +284,12 @@
     border: 1px solid var(--map-chrome-border, hsl(0, 0%, 58%));
     background: var(--map-chrome-surface, #fff);
     color: hsl(5, 53%, 22%);
+  }
+
+  .schedule-import-panel__secondary:hover,
+  .schedule-import-panel__secondary:focus-visible {
+    border-color: #c58f91;
+    background: #fdf3f3;
   }
 
   .schedule-import-panel__weekdays {
@@ -297,6 +308,14 @@
     font: inherit;
     font-size: 0.75rem;
     cursor: pointer;
+  }
+
+  .schedule-import-panel__weekday:hover:not(.schedule-import-panel__weekday--active),
+  .schedule-import-panel__weekday:focus-visible:not(
+      .schedule-import-panel__weekday--active
+    ) {
+    border-color: #c58f91;
+    background: #fdf3f3;
   }
 
   .schedule-import-panel__weekday--active {

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -910,4 +910,9 @@
   .bundled-rooms__add {
     font-weight: 600;
   }
+
+  .bundled-rooms__remove:hover,
+  .bundled-rooms__add:hover {
+    background-color: hsla(0, 0%, 0%, 0.08);
+  }
 </style>

--- a/src/components/svelte/TerrainControl.svelte
+++ b/src/components/svelte/TerrainControl.svelte
@@ -334,6 +334,10 @@
     padding: 0.25rem 0.5rem;
   }
 
+  .terrain-option:hover {
+    background-color: hsl(5, 53%, 98%);
+  }
+
   .terrain-option.active {
     border-color: hsl(5, 53%, 32%);
     background-color: hsl(5, 53%, 96%);

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import {
     adminAuthStore,
     mapEditStore,
@@ -750,7 +751,7 @@
       </section>
     {/if}
   {:else}
-    <p class="entity-loading-note">Loading building…</p>
+    <p class="entity-loading-note"><LoadingIndicator label="Loading building…" /></p>
   {/if}
 
   {#if buildingOrgs.length > 0}
@@ -774,7 +775,7 @@
     <ResultDisplay filteredRooms={buildingRooms} {classCounts} />
   {:else if building}
     <p class="entity-loading-note">
-      Loading rooms for {building.buildingName}…
+      <LoadingIndicator label="Loading rooms for {building.buildingName}…" />
     </p>
   {/if}
 </div>

--- a/src/components/svelte/controls/CampusBrowseList.svelte
+++ b/src/components/svelte/controls/CampusBrowseList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
   import EntityPanelFilter from "./EntityPanelFilter.svelte";
   import EntityPanelHeader from "./EntityPanelHeader.svelte";
@@ -218,7 +219,13 @@
         search
         oninput={onFilterInput}
       />
-      <p class="entity-panel-status" aria-live="polite">{statusLine}</p>
+      {#if !loaded}
+        <p class="entity-panel-status">
+          <LoadingIndicator label="Loading campus directory…" />
+        </p>
+      {:else}
+        <p class="entity-panel-status" aria-live="polite">{statusLine}</p>
+      {/if}
     {/snippet}
   </EntityPanelHeader>
 

--- a/src/components/svelte/controls/ClassQuery.svelte
+++ b/src/components/svelte/controls/ClassQuery.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { onMount } from "svelte";
   import EntityPagination from "./EntityPagination.svelte";
   import Classes from "@ui/room/Classes.svelte";
@@ -139,7 +140,7 @@
         </button>
       </div>
     {:else if classesLoading}
-      <p class="status">Loading classes…</p>
+      <p class="status"><LoadingIndicator label="Loading classes…" /></p>
     {:else if classesError}
       <div class="no-results">
         <p class="status">{classesError}</p>
@@ -194,7 +195,7 @@
       <h3 class="entity-section-heading">Final exams</h3>
       <p class="entity-panel-note">{FINALS_SCOPE_NOTE}</p>
       {#if finalsLoading}
-        <p class="status">Loading final exams…</p>
+        <p class="status"><LoadingIndicator label="Loading final exams…" /></p>
       {:else if finalExams.length > 0}
         <FinalExamsList exams={finalExams} showRoom />
       {:else}

--- a/src/components/svelte/controls/ClassesList.svelte
+++ b/src/components/svelte/controls/ClassesList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import Classes from "@ui/room/Classes.svelte";
   import EntityPanelFilter from "./EntityPanelFilter.svelte";
   import EntityPanelHeader from "./EntityPanelHeader.svelte";
@@ -97,7 +98,7 @@
 
   <div class="entity-panel-body">
     {#if loading}
-      <p class="entity-panel-note">Loading classes…</p>
+      <p class="entity-panel-note"><LoadingIndicator label="Loading classes…" /></p>
     {:else if loadError}
       <p class="entity-panel-note">{loadError}</p>
     {:else if classes.length === 0}

--- a/src/components/svelte/controls/CollegeResult.svelte
+++ b/src/components/svelte/controls/CollegeResult.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import {
     adminAuthStore,
     queryStore,
@@ -422,7 +423,7 @@
     />
   {:else if college}
     <p class="entity-loading-note">
-      Loading rooms for {college.collegeName}…
+      <LoadingIndicator label="Loading rooms for {college.collegeName}…" />
     </p>
   {/if}
 </div>

--- a/src/components/svelte/controls/DivisionResult.svelte
+++ b/src/components/svelte/controls/DivisionResult.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import {
     adminAuthStore,
     queryStore,
@@ -459,7 +460,7 @@
     />
   {:else if division}
     <p class="entity-loading-note">
-      Loading rooms for {division.divisionName}…
+      <LoadingIndicator label="Loading rooms for {division.divisionName}…" />
     </p>
   {/if}
 </div>

--- a/src/components/svelte/controls/EventResult.svelte
+++ b/src/components/svelte/controls/EventResult.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import ExternalLink from "@lucide/svelte/icons/external-link";
   import MapPin from "@lucide/svelte/icons/map-pin";
   import Route from "@lucide/svelte/icons/route";
@@ -1019,7 +1020,7 @@
       </section>
     {/if}
   {:else}
-    <p>Loading event...</p>
+    <p><LoadingIndicator label="Loading event…" /></p>
   {/if}
 </div>
 

--- a/src/components/svelte/controls/EventsList.svelte
+++ b/src/components/svelte/controls/EventsList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
   import MapPin from "@lucide/svelte/icons/map-pin";
   import EntityPanelHeader from "./EntityPanelHeader.svelte";
@@ -101,7 +102,9 @@
     >
       {#snippet trailing()}
         <h2 class="entity-header__title">Campus events</h2>
-        <p class="entity-panel-note">Loading campus events…</p>
+        <p class="entity-panel-note">
+          <LoadingIndicator label="Loading campus events…" />
+        </p>
       {/snippet}
     </EntityPanelHeader>
     <div class="events-tabs skeleton-tabs" aria-hidden="true">

--- a/src/components/svelte/controls/MainControls.svelte
+++ b/src/components/svelte/controls/MainControls.svelte
@@ -518,13 +518,14 @@
       flex-shrink: 0;
       align-self: stretch;
       width: auto;
-      min-height: 1.25rem;
-      padding: 0.25rem
+      height: auto;
+      min-height: 1rem;
+      padding: 0.1875rem
         max(
           var(--map-search-inline-pad, 0.625rem),
           env(safe-area-inset-right, 0px)
         )
-        0.3125rem
+        0.25rem
         max(
           var(--map-search-inline-pad, 0.625rem),
           env(safe-area-inset-left, 0px)

--- a/src/components/svelte/controls/OrgResult.svelte
+++ b/src/components/svelte/controls/OrgResult.svelte
@@ -407,6 +407,11 @@
     cursor: pointer;
   }
 
+  .building-badge:hover,
+  .building-badge:focus-visible {
+    background-color: hsl(5, 40%, 88%);
+  }
+
   .org-field {
     display: flex;
     flex-direction: column;

--- a/src/components/svelte/controls/PlaceResult.svelte
+++ b/src/components/svelte/controls/PlaceResult.svelte
@@ -259,12 +259,19 @@
     font-weight: 600;
     cursor: pointer;
   }
+  .place-edit-btn:hover:not(:disabled) {
+    background: #0b6851;
+  }
   .place-cancel-btn {
     padding: 0.375rem 0.75rem;
     border: 1px solid hsl(0, 0%, 80%);
     border-radius: 0.375rem;
     background: white;
     cursor: pointer;
+  }
+  .place-cancel-btn:hover:not(:disabled) {
+    border-color: #c58f91;
+    background: #fdf3f3;
   }
   .place-empty {
     padding: 1rem;

--- a/src/components/svelte/controls/entity-detail.css
+++ b/src/components/svelte/controls/entity-detail.css
@@ -470,6 +470,18 @@
   color: white;
 }
 
+.entity-merge-prompt__btn:hover:not(:disabled),
+.entity-merge-prompt__btn:focus-visible {
+  border-color: #c58f91;
+  background: #fdf3f3;
+}
+
+.entity-merge-prompt__btn--primary:hover:not(:disabled),
+.entity-merge-prompt__btn--primary:focus-visible {
+  border-color: hsl(5, 53%, 32%);
+  background: hsl(5, 53%, 38%);
+}
+
 .entity-merge-prompt__btn:disabled {
   opacity: 0.65;
   cursor: not-allowed;

--- a/src/components/svelte/editor/EntityHistoryPanel.svelte
+++ b/src/components/svelte/editor/EntityHistoryPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { buildFieldDiffs } from "@lib/proposals/diff";
   import { afterProposalPublished } from "@lib/proposals/apply-published-entity";
   import { syncOpenEntityQueryAfterPublish } from "@lib/proposals/sync-open-entity-query";
@@ -134,7 +135,9 @@
 
   {#if open}
     {#if loading}
-      <p class="entity-history-note" aria-live="polite">Loading history…</p>
+      <p class="entity-history-note">
+        <LoadingIndicator label="Loading history…" />
+      </p>
     {:else if error}
       <p class="entity-history-error" role="alert">{error}</p>
     {:else if entries.length === 0}
@@ -223,6 +226,14 @@
     color: hsl(5, 53%, 32%);
     cursor: pointer;
     text-decoration: underline;
+  }
+
+  .entity-history-toggle:hover {
+    background: hsl(0, 0%, 94%);
+  }
+
+  .entity-history-restore:hover {
+    background: #fdf3f3;
   }
 
   .entity-history-note,

--- a/src/components/svelte/editor/review-panel.css
+++ b/src/components/svelte/editor/review-panel.css
@@ -118,6 +118,21 @@
   color: hsl(0, 70%, 32%);
 }
 
+.entity-review-actions button:hover:not(:disabled) {
+  border-color: #c58f91;
+  background: #fdf3f3;
+}
+
+.entity-review-actions button.approve:hover:not(:disabled) {
+  border-color: hsl(160, 84%, 30%);
+  background: hsl(160, 60%, 96%);
+}
+
+.entity-review-actions button.reject:hover:not(:disabled) {
+  border-color: hsl(0, 70%, 78%);
+  background: hsl(0, 80%, 97%);
+}
+
 .entity-review-actions button:disabled {
   opacity: 0.65;
   color: hsl(0, 0%, 38%);

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -291,6 +291,13 @@ button.chrome-toggle-btn[aria-expanded="true"] {
     color 0.15s ease;
 }
 
+button.map-chrome-chip:hover:not(:disabled):not(
+  .map-chrome-chip--toggle-active
+):not(.map-chrome-chip--editor-active):not(.map-chrome-chip--filter-selected) {
+  border-color: #c58f91;
+  background-color: #fdf3f3;
+}
+
 button.map-chrome-chip:focus-visible {
   outline: 2px solid hsl(5, 53%, 32%);
   outline-offset: 1px;

--- a/src/components/svelte/modal/GithubContributorsSection.svelte
+++ b/src/components/svelte/modal/GithubContributorsSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import PeopleAvatarGrid from "./PeopleAvatarGrid.svelte";
   import type { GithubContributor } from "@lib/github-contributors";
   import { formatGithubContributions } from "@lib/github-contributors";
@@ -32,7 +33,9 @@
   <p class="section-note">{note}</p>
 
   {#if loading && !loaded}
-    <p class="status-line" aria-live="polite">Loading from GitHub...</p>
+    <p class="status-line">
+      <LoadingIndicator label="Loading from GitHub…" />
+    </p>
     <div class="people-grid-skeleton" aria-hidden="true">
       {#each Array(6) as _, index (index)}
         <div class="skeleton-card"></div>
@@ -108,5 +111,9 @@
     background: white;
     color: hsl(5, 53%, 28%);
     border: 1px solid hsl(5, 35%, 80%);
+  }
+
+  .secondary-btn:hover {
+    background-color: hsl(0, 0%, 92%);
   }
 </style>

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -75,7 +75,9 @@
         ? 'landing-modal-container'
         : modalStore.type === 'leaderboard'
           ? 'leaderboard-modal-container'
-          : ''}"
+          : modalStore.type === 'changelog' || modalStore.type === 'review'
+            ? 'modal-content--large'
+            : ''}"
       id="modal-content"
       role="dialog"
       aria-modal="true"
@@ -174,7 +176,7 @@
   }
   .review-modal-scroll {
     min-height: 0;
-    max-height: min(70vh, 40rem);
+    flex: 1 1 auto;
     overflow-y: auto;
     padding: 0.5rem 0.75rem 0.25rem;
   }
@@ -210,6 +212,12 @@
         outline-offset: 1px;
       }
     }
+  }
+  /* Task-focused dialogs (review queue, changelog) take most of the screen. */
+  .modal-content--large {
+    flex: 0 1 72rem;
+    width: 100%;
+    height: min(90dvh, 56rem);
   }
   .leaderboard-modal-container {
     flex: 0 1 32rem;

--- a/src/components/svelte/modal/ScheduleModal.svelte
+++ b/src/components/svelte/modal/ScheduleModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { currentRoom, roomClassesStore, termStore } from "@lib/store.svelte";
   import ScheduleRender from "@ui/room/ScheduleRender.svelte";
 
@@ -16,7 +17,9 @@
   </div>
   <div class="schedule-modal__body map-chrome-scroll">
     {#if roomClassesStore.loading}
-      <p class="schedule-modal__empty">Loading classes…</p>
+      <p class="schedule-modal__empty">
+        <LoadingIndicator label="Loading classes…" />
+      </p>
     {:else if room && classes.length > 0}
       <ScheduleRender roomCode={room.code} {classes} />
     {:else}

--- a/src/components/svelte/planner/PlannerCourseSearch.svelte
+++ b/src/components/svelte/planner/PlannerCourseSearch.svelte
@@ -427,4 +427,17 @@
       font-size: 0.875rem;
     }
   }
+
+  /* The planner stacks this panel above the week grid below 48rem. Let its
+     results take their natural height so the grid cannot paint over a course
+     header and capture its tap. The planner body owns vertical scrolling. */
+  @media (max-width: 48rem) {
+    .course-search {
+      min-height: auto;
+    }
+
+    .course-search__list {
+      overflow-y: visible;
+    }
+  }
 </style>

--- a/src/components/svelte/planner/PlannerGrid.svelte
+++ b/src/components/svelte/planner/PlannerGrid.svelte
@@ -166,6 +166,10 @@
     pointerPos = { x: e.clientX, y: e.clientY };
     // Stop the browser from scrolling the grid once a drag is underway.
     el.style.touchAction = "none";
+    // touch-action changes are ignored mid-gesture: once the finger moves the
+    // browser pans the grid and fires pointercancel, killing the drag. Cancel
+    // the pan directly with a non-passive touchmove preventer instead.
+    el.addEventListener("touchmove", preventTouchScroll, { passive: false });
     try {
       el.setPointerCapture(e.pointerId);
     } catch {
@@ -173,11 +177,16 @@
     }
   }
 
+  function preventTouchScroll(e: TouchEvent) {
+    e.preventDefault();
+  }
+
   function cleanup() {
     if (longPress) clearTimeout(longPress);
     longPress = null;
     if (drag && pending && pointerId !== null) {
       pending.el.style.touchAction = "";
+      pending.el.removeEventListener("touchmove", preventTouchScroll);
       try {
         pending.el.releasePointerCapture(pointerId);
       } catch {
@@ -532,6 +541,10 @@
     color: white;
     cursor: grab;
     overflow: hidden;
+    /* Long-press starts a drag; don't let iOS select text or show the callout. */
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
   }
 
   .planner-block__label:focus-visible {

--- a/src/components/svelte/room/FinalExamsList.svelte
+++ b/src/components/svelte/room/FinalExamsList.svelte
@@ -120,6 +120,10 @@
     text-underline-offset: 0.125rem;
   }
 
+  button.final-exam-row__room:hover {
+    color: #7b1113;
+  }
+
   .final-exam-row__room--tba {
     cursor: default;
     text-decoration: none;

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { onMount } from "svelte";
   import {
     adminAuthStore,
@@ -855,7 +856,9 @@
       <TermSelector />
       <p class="entity-schedule__scope">{ROOM_SCHEDULE_SCOPE_NOTE}</p>
       {#if roomClassesStore.loading}
-        <p class="entity-schedule__empty">Loading classes…</p>
+        <p class="entity-schedule__empty">
+          <LoadingIndicator label="Loading classes…" />
+        </p>
       {:else if roomClassesStore.classes.length > 0}
         <Classes
           classes={roomClassesStore.classes}
@@ -885,7 +888,9 @@
         {/if}
         <p class="entity-schedule__scope">{FINALS_SCOPE_NOTE}</p>
         {#if finalExamsLoading}
-          <p class="entity-schedule__empty">Loading final exams…</p>
+          <p class="entity-schedule__empty">
+            <LoadingIndicator label="Loading final exams…" />
+          </p>
         {:else}
           <FinalExamsList exams={finalExams} />
         {/if}
@@ -950,6 +955,16 @@
     border-color: hsl(5, 53%, 32%);
     background-color: hsl(5, 53%, 32%);
     color: white;
+  }
+
+  .merge-btn:hover:not(:disabled) {
+    border-color: #c58f91;
+    background: #fdf3f3;
+  }
+
+  .merge-btn-primary:hover:not(:disabled) {
+    border-color: hsl(5, 53%, 32%);
+    background-color: hsl(5, 53%, 38%);
   }
 
   .merge-btn:disabled {

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -621,13 +621,46 @@
     grid-row: 3;
   }
 
+  /* Browse chips + term selector stack as their own full-width rows under the
+     filter chips. Without explicit placement they auto-flow side by side into
+     the menu-button column and overlap (mobile top-bar regression). */
+  .search-root.mobile-shell .campus-browse-chips__container,
+  .search-root.mobile-shell .campus-browse-chips__term {
+    grid-column: 1 / -1;
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+
+  .search-root.mobile-shell .campus-browse-chips__container {
+    grid-row: 3;
+    padding: 0.4375rem 0 0;
+    border-top: 1px solid var(--map-chrome-divider, hsl(5 12% 88%));
+  }
+
+  .search-root.mobile-shell .campus-browse-chips__term {
+    grid-row: 4;
+    padding: 0.375rem 0 0.1875rem;
+  }
+
+  .search-root.mobile-shell.search-suggestions-open
+    .campus-browse-chips__container {
+    grid-row: 4;
+  }
+
+  .search-root.mobile-shell.search-suggestions-open
+    .campus-browse-chips__term {
+    grid-row: 5;
+  }
+
   .search-root.mobile-shell.search-suggestions-open.search-query-active
     .map-search-chrome__transit-routes,
   .search-root.mobile-shell.search-suggestions-open.search-query-active
     .map-search-chrome__events,
   .search-root.mobile-shell.search-suggestions-open.search-query-active
     .map-search-chrome__editor {
-    grid-row: 3;
+    grid-row: 6;
   }
 
   .search-root.mobile-shell.search-suggestions-open:not(.search-query-active)
@@ -636,7 +669,7 @@
     .map-search-chrome__events,
   .search-root.mobile-shell.search-suggestions-open:not(.search-query-active)
     .map-search-chrome__editor {
-    grid-row: 4;
+    grid-row: 6;
   }
 
   .search-root.mobile-shell:not(.search-suggestions-open)
@@ -646,7 +679,7 @@
   .search-root.mobile-shell:not(.search-suggestions-open)
     .map-search-chrome__editor {
     grid-column: 1 / -1;
-    grid-row: 3;
+    grid-row: 5;
     min-width: 0;
     width: 100%;
     max-width: 100%;

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { getAppData } from "@lib/context";
   import {
     getJSONFetch,
@@ -179,7 +180,9 @@
 
   {#if queryStore.inputValue !== ""}
     {#if roomLoading}
-      <p class="suggestions-status" aria-live="polite">Loading rooms…</p>
+      <p class="suggestions-status">
+        <LoadingIndicator label="Loading rooms…" />
+      </p>
     {:else}
       {#each roomResults as roomResult (roomResult.value)}
         <Suggestion {...roomResult} />

--- a/src/components/svelte/status-bar/ContributorProgressPanel.svelte
+++ b/src/components/svelte/status-bar/ContributorProgressPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { onMount } from "svelte";
   import { getAppData } from "@lib/context";
   import {
@@ -149,7 +150,9 @@
   {/if}
 
   {#if loading}
-    <p class="contributor-progress__status">Loading progress…</p>
+    <p class="contributor-progress__status">
+      <LoadingIndicator label="Loading progress…" />
+    </p>
   {:else if error}
     <p class="contributor-progress__status contributor-progress__status--error">
       {error}

--- a/src/components/svelte/status-bar/LeaderboardPanel.svelte
+++ b/src/components/svelte/status-bar/LeaderboardPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { onMount } from "svelte";
   import type { LeaderboardRow } from "@lib/services/contribution-service";
   
@@ -51,7 +52,9 @@
   </header>
 
   {#if loading}
-    <p class="leaderboard-status">Loading leaderboard…</p>
+    <p class="leaderboard-status">
+      <LoadingIndicator label="Loading leaderboard…" />
+    </p>
   {:else if error}
     <p class="leaderboard-status error">{error}</p>
   {:else if rows.length === 0}

--- a/src/components/svelte/status-bar/status-bar.css
+++ b/src/components/svelte/status-bar/status-bar.css
@@ -68,6 +68,10 @@ button.status-bar__pill {
   cursor: pointer;
 }
 
+button.status-bar__pill:hover {
+  background-color: hsla(0, 0%, 0%, 0.08);
+}
+
 button.status-bar__pill:focus-visible {
   outline: 2px solid currentColor;
   outline-offset: 1px;

--- a/src/lib/changelog-highlights.test.ts
+++ b/src/lib/changelog-highlights.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  parseChangelogEntries,
   parseChangelogHighlights,
   isChangelogCurrent,
 } from "./changelog-highlights";
@@ -49,5 +50,67 @@ describe("parseChangelogHighlights", () => {
     expect(
       parseChangelogHighlights("# [1.0.0](https://example.com)\n"),
     ).toBeNull();
+  });
+
+  test("accepts dash bullets (prettier rewrites * to -)", () => {
+    const md = `# [1.36.0](https://example.com) (2026-07-09)
+
+### Features
+
+- **account:** include saved planner plans in the data export ([#2](https://example.com/2))
+`;
+    const result = parseChangelogHighlights(md);
+    expect(result?.items).toEqual([
+      "account: include saved planner plans in the data export",
+    ]);
+  });
+});
+
+describe("parseChangelogEntries", () => {
+  test("parses every release with sections and dates", () => {
+    const md = `# [1.36.0](https://example.com) (2026-07-09)
+
+### Features
+
+- **account:** include saved planner plans ([abc](https://example.com))
+
+# [1.35.2](https://example.com) (2026-07-09)
+
+### Bug Fixes
+
+- **planner:** tile same-timeslot drag ghosts
+
+# [1.35.1](https://example.com)
+
+- sectionless bullet
+`;
+    const entries = parseChangelogEntries(md);
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toEqual({
+      version: "1.36.0",
+      date: "2026-07-09",
+      sections: [
+        { title: "Features", items: ["account: include saved planner plans"] },
+      ],
+    });
+    expect(entries[1]?.sections[0]?.title).toBe("Bug Fixes");
+    expect(entries[2]).toEqual({
+      version: "1.35.1",
+      date: null,
+      sections: [{ title: "", items: ["sectionless bullet"] }],
+    });
+  });
+
+  test("drops releases with no bullets and accepts h2 version headings", () => {
+    const md = `# [2.0.0](https://example.com) (2026-01-01)
+
+## [1.9.9](https://example.com) (2025-12-31)
+
+### Bug Fixes
+
+- real fix
+`;
+    const entries = parseChangelogEntries(md);
+    expect(entries.map((e) => e.version)).toEqual(["1.9.9"]);
   });
 });

--- a/src/lib/changelog-highlights.ts
+++ b/src/lib/changelog-highlights.ts
@@ -4,7 +4,9 @@ export type ChangelogHighlight = {
   totalCount: number;
 };
 
-const VERSION_HEADING = /^# \[([^\]]+)\]/;
+const VERSION_HEADING = /^#{1,2} \[([^\]]+)\]/;
+// Prettier rewrites "* item" bullets to "- item"; accept both.
+const BULLET = /^[*-] (.+)$/;
 
 /** Human-readable bullets for the update prompt (#212). */
 export function parseChangelogHighlights(
@@ -25,7 +27,7 @@ export function parseChangelogHighlights(
     }
     if (version === null) continue;
 
-    const bulletMatch = line.match(/^\* (.+)$/);
+    const bulletMatch = line.match(BULLET);
     if (bulletMatch?.[1]) {
       bullets.push(sanitizeBullet(bulletMatch[1]));
     }
@@ -38,6 +40,53 @@ export function parseChangelogHighlights(
     items: bullets.slice(0, maxItems),
     totalCount: bullets.length,
   };
+}
+
+export type ChangelogEntry = {
+  version: string;
+  date: string | null;
+  sections: { title: string; items: string[] }[];
+};
+
+/** Every release in the changelog, for the in-app full-changelog view. */
+export function parseChangelogEntries(markdown: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = [];
+  let entry: ChangelogEntry | null = null;
+  let section: ChangelogEntry["sections"][number] | null = null;
+
+  for (const line of markdown.split(/\r?\n/)) {
+    const versionMatch = line.match(VERSION_HEADING);
+    if (versionMatch?.[1]) {
+      entry = {
+        version: versionMatch[1],
+        date: line.match(/\((\d{4}-\d{2}-\d{2})\)\s*$/)?.[1] ?? null,
+        sections: [],
+      };
+      section = null;
+      entries.push(entry);
+      continue;
+    }
+    if (!entry) continue;
+
+    const sectionMatch = line.match(/^### (.+)$/);
+    if (sectionMatch?.[1]) {
+      section = { title: sectionMatch[1].trim(), items: [] };
+      entry.sections.push(section);
+      continue;
+    }
+
+    const bulletMatch = line.match(BULLET);
+    if (bulletMatch?.[1]) {
+      // Releases without "###" sections list bullets directly under the version.
+      if (!section) {
+        section = { title: "", items: [] };
+        entry.sections.push(section);
+      }
+      section.items.push(sanitizeBullet(bulletMatch[1]));
+    }
+  }
+
+  return entries.filter((e) => e.sections.some((s) => s.items.length > 0));
 }
 
 /** Compare dotted numeric versions ("1.31.1"); returns <0, 0, or >0. */


### PR DESCRIPTION
## Release summary

Promotes the reviewed UI polish batch from #634: mobile search and planner fixes, full in-app changelog, contributor review modal, and shared loading states.

## Verification

- `bun run lint` passed (two existing informational suggestions)
- `bun run test:components` passed: 94/94
- `bun run build` passed
- Planner E2E passed locally on desktop and mobile
- #634 blocking + advisory E2E passed
- Staging preview and smoke passed
- Staging E2E passed

Refs #634

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentational and test-hardening changes across Svelte/CSS with no auth, API, or data-model changes; planner drag behavior is the main behavioral touch area but scoped to the planner UI.
> 
> **Overview**
> **UI polish release** spanning mobile layout fixes, in-app changelog, editor review flow, shared loading UX, and broader interaction feedback.
> 
> The **What's new** changelog modal now renders the **full release history** inline (scrollable sections per version) via new `parseChangelogEntries`, replacing highlight snippets and the separate “Full changelog” link. Changelog parsing also accepts `-` bullets and `h2` version headings.
> 
> **Mobile search** explicitly grid-places browse chips and the term selector on full-width rows so they no longer overlap in the menu column; E2E asserts vertical stacking and width.
> 
> **Class planner** gets touch drag fixes (non-passive `touchmove`, `user-select: none`), mobile course-search list layout so headers stay tappable above the grid, and a stabler conflict-badge E2E (abort class refresh, tighter locators).
> 
> **Editors** open **Review suggested edits** in a large modal (`modal-content--large`) from the shelf instead of embedding `ProposalReviewPanel` inline.
> 
> New **`LoadingIndicator`** spinner replaces plain “Loading…” text across modals, entity panels, search, and status surfaces.
> 
> Wide **hover/focus** styling on map chrome, planner import, entity actions, and pins; mobile **map tools** panel is inset/rounded below the search block. New E2E for app-menu changelog and mobile browse chips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99ab67b7d85c4fef8f47c63b1855441944c2b02a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->