### PR TITLE
fix(directory): clarify organization map pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Install the [Biome VS Code extension](https://marketplace.visualstudio.com/items
 | `bunx drizzle-kit studio` | Browse/edit Postgres visually |
 | `bun run seed:aliases` | Seed building aliases from `public/room_info.json` |
 | `bun run import:osa-orgs` | Add the current public OSA organization directory (`DATABASE_URL`; safe to rerun) |
-| `bun run import:uplb-trail` | Add missing UPLB TRAIL offices and units (`DATABASE_URL`; safe to rerun) |
+| `bun run import:campus-offices` | Add missing campus offices and units (`DATABASE_URL`; safe to rerun) |
 | `bun run import:amis-classes` | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`) |
 | `bun run import:final-exams` | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`) |
 

--- a/e2e/browse/campus-browse-chips.spec.ts
+++ b/e2e/browse/campus-browse-chips.spec.ts
@@ -50,44 +50,52 @@ test.describe("campus browse chips", () => {
     await expect(
       page.getByRole("heading", { name: "Offices & Academic Units" }),
     ).toBeVisible({ timeout: 10_000 });
-    await page.locator("button.entity-list-row").first().click();
-    await expect(
-      page.locator(".entity-detail h2"),
-    ).toBeVisible({ timeout: 10_000 });
+    const office = page.locator("button.entity-list-row").first();
+    const officeName = await office
+      .locator(".entity-list-row__label")
+      .textContent();
+    if (!officeName) throw new Error("missing office name");
+    await office.click();
+    await expect(page.locator(".entity-detail h2")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const pin = page.locator(`.map-entity-pin[aria-label="${officeName}"]`);
+    await expect(pin).toHaveClass(/active/);
+    await expect(pin.locator("svg")).toHaveClass(/landmark/);
+
+    await page.getByRole("button", { name: "Collapse details panel" }).click();
+    await expect(page.locator("#side-panel-details")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+    await pin.click();
+    await expect(page.locator("#side-panel-details")).toHaveAttribute(
+      "aria-hidden",
+      "false",
+    );
   });
 
-  test("mobile top bar: term selector does not overlap browse chips", async ({
+  test("mobile top bar keeps browse and term controls in one scroll row", async ({
     page,
   }) => {
-    // Regression guard: on the mobile grid shell, the browse-chip row and the
-    // term-selector row must be explicitly placed. Auto-placement stuffed them
-    // side by side into the menu column, drawing the term selector on top of
-    // the chips.
     await page.setViewportSize({ width: 390, height: 844 });
-    const chips = page.locator(".campus-browse-chips__container");
-    const directoryChips = page.locator(".campus-directory-chips");
-    const term = page.locator(".campus-browse-chips__term");
+    const controls = page.locator(".map-search-chrome__chips");
+    const chips = page.locator(".campus-browse-chips");
+    const term = page.locator(".term-filter-chip");
+    await expect(controls).toBeVisible();
     await expect(chips).toBeVisible();
-    await expect(directoryChips).toBeVisible();
     await expect(term).toBeVisible();
 
+    const controlsBox = await controls.boundingBox();
     const chipsBox = await chips.boundingBox();
     const termBox = await term.boundingBox();
-    if (!chipsBox || !termBox) throw new Error("missing bounding boxes");
-    // The term row must start at or below the bottom of the chips row.
-    expect(termBox.y).toBeGreaterThanOrEqual(chipsBox.y + chipsBox.height - 1);
-    // And both rows span the shell instead of hiding in the 2rem menu column.
-    expect(chipsBox.width).toBeGreaterThan(200);
-
-    const orgsBox = await page
-      .getByRole("button", { name: "Browse student organizations" })
-      .boundingBox();
-    const officesBox = await page
-      .getByRole("button", { name: "Browse offices and academic units" })
-      .boundingBox();
-    if (!orgsBox || !officesBox) throw new Error("missing directory chips");
-    expect(Math.abs(orgsBox.y - officesBox.y)).toBeLessThanOrEqual(1);
-    expect(officesBox.x + officesBox.width).toBeLessThanOrEqual(390);
+    if (!controlsBox || !chipsBox || !termBox) {
+      throw new Error("missing compact controls");
+    }
+    expect(Math.abs(chipsBox.y - termBox.y)).toBeLessThanOrEqual(1);
+    expect(chipsBox.y).toBeGreaterThanOrEqual(controlsBox.y);
+    expect(controlsBox.height).toBeLessThan(56);
   });
 
   test("Classes opens class list without toggling building filter chip", async ({

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "seed:events": "bun src/seed-events.ts",
     "seed:aliases": "bun run scripts/seed-aliases.ts",
     "import:osa-orgs": "bun run scripts/import-osa-organizations.ts",
-    "import:uplb-trail": "bun run scripts/import-uplb-trail-directory.ts",
+    "import:campus-offices": "bun run scripts/import-campus-office-directory.ts",
     "import:amis-classes": "bun run scripts/import-amis-classes.ts",
     "import:final-exams": "bun run scripts/import-final-exams.ts",
     "release": "semantic-release",

--- a/scripts/import-campus-office-directory.ts
+++ b/scripts/import-campus-office-directory.ts
@@ -1,8 +1,8 @@
 /**
- * Add missing UPLB offices and units from UPLB TRAIL's public website directory.
+ * Add missing UPLB offices and units from the public campus website directory.
  *
  * Usage:
- *   DATABASE_URL=... bun run scripts/import-uplb-trail-directory.ts [--dry-run]
+ *   DATABASE_URL=... bun run scripts/import-campus-office-directory.ts [--dry-run]
  */
 
 import { config } from "dotenv";
@@ -18,34 +18,37 @@ import {
 } from "@drizzle/schema";
 import { normalizeAlias } from "@lib/site";
 import {
-  trailDirectoryEntries,
-  type TrailWebsite,
-} from "@lib/uplb-trail-directory";
+  campusOfficeDirectoryEntries,
+  type CampusWebsite,
+} from "@lib/campus-office-directory";
 
-const TRAIL_WEBSITES_API =
+const CAMPUS_WEBSITES_API =
   "https://iaepijmnqstgxtivmlsh.supabase.co/rest/v1/websites?select=name,url,description,category&order=name";
-const TRAIL_PUBLIC_KEY = "sb_publishable_JL-xKlm48a57Lkoi7JK1MQ_6lBlLxGL";
+const CAMPUS_DIRECTORY_PUBLIC_KEY =
+  "sb_publishable_JL-xKlm48a57Lkoi7JK1MQ_6lBlLxGL";
 
 config({ path: ".env" });
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) throw new Error("DATABASE_URL is required");
 
-const response = await fetch(TRAIL_WEBSITES_API, {
-  headers: { apikey: TRAIL_PUBLIC_KEY },
+const response = await fetch(CAMPUS_WEBSITES_API, {
+  headers: { apikey: CAMPUS_DIRECTORY_PUBLIC_KEY },
 });
 if (!response.ok) {
   throw new Error(
-    `UPLB TRAIL request failed: ${response.status} ${response.statusText}`,
+    `Campus directory request failed: ${response.status} ${response.statusText}`,
   );
 }
 
-const sources = (await response.json()) as TrailWebsite[];
+const sources = (await response.json()) as CampusWebsite[];
 if (sources.length < 150) {
-  throw new Error(`UPLB TRAIL returned only ${sources.length} website records`);
+  throw new Error(
+    `Campus directory returned only ${sources.length} website records`,
+  );
 }
 
-const entries = trailDirectoryEntries(sources);
+const entries = campusOfficeDirectoryEntries(sources);
 const nameKeys = (name: string) => {
   const keys = [normalizeAlias(name)];
   const bare = name.replace(/\s*\([^)]*\)\s*$/, "");
@@ -113,7 +116,7 @@ try {
 
   if (process.argv.includes("--dry-run")) {
     console.log(
-      `UPLB TRAIL: ${sources.length} links, ${entries.length} eligible units, ${additions.length} to add, ${linkUpdates.length} links to enrich, ${covered} covered elsewhere.`,
+      `Campus offices: ${sources.length} links, ${entries.length} eligible units, ${additions.length} to add, ${linkUpdates.length} links to enrich, ${covered} covered elsewhere.`,
     );
   } else {
     await db.transaction(async (tx) => {
@@ -150,7 +153,7 @@ try {
       }
     });
     console.log(
-      `Added ${additions.length} UPLB TRAIL units and enriched ${linkUpdates.length} existing links.`,
+      `Added ${additions.length} campus units and enriched ${linkUpdates.length} existing links.`,
     );
   }
 } finally {

--- a/scripts/seed-uplb-directory.ts
+++ b/scripts/seed-uplb-directory.ts
@@ -1,7 +1,7 @@
 /**
  * Seed UPLB organizations/offices/spots from data/uplb-directory.json into the
  * `organizations` and `places` tables. Entries were researched from
- * uplb-trail.vercel.app, uplb.edu.ph, and OpenStreetMap (source URL per row).
+ * public university directories and OpenStreetMap (source URL per row).
  *
  * Idempotent: rows whose normalized name already exists in the target table
  * (or as a dorm/college/building for org-like entries) are skipped.

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -34,6 +34,7 @@
   import Undo2 from "@lucide/svelte/icons/undo-2";
   import Redo2 from "@lucide/svelte/icons/redo-2";
   import University from "@lucide/svelte/icons/university";
+  import Landmark from "@lucide/svelte/icons/landmark";
   import EventMapPin from "./map/EventMapPin.svelte";
   import EventPlacementImageField from "./map-chrome/EventPlacementImageField.svelte";
   import MapEntityPin from "./map/MapEntityPin.svelte";
@@ -42,7 +43,14 @@
   import type { StyleSpecification } from "maplibre-gl";
   import * as mapGl from "maplibre-gl";
   import type { FeatureCollection, LineString } from "geojson";
-  import type { BuildingData, DormData, EventData, PlaceData } from "@lib/types";
+  import type {
+    BuildingData,
+    DormData,
+    EventData,
+    OrgData,
+    PlaceData,
+  } from "@lib/types";
+  import { isStudentOrganization } from "@constants/org-categories";
   import MapPin from "@lucide/svelte/icons/map-pin";
   import {
     JEEPNEY_ROUTES,
@@ -140,25 +148,25 @@
   // Organizations pin at their own coordinate, else fall back to the coords of
   // the building they sit in. Orgs without any resolvable location are dropped
   // from the map (they still appear in the directory list).
+  function organizationPosition(org: OrgData) {
+    let lat = org.lat;
+    let lon = org.lon;
+    if ((lat === null || lon === null) && org.buildingId !== null) {
+      const host = buildings.find((building) => building.id === org.buildingId);
+      if (host) {
+        lat = host.lat;
+        lon = host.lon;
+      }
+    }
+    return lat !== null && lon !== null ? { lat, lon } : null;
+  }
+
   const filteredOrganizations = $derived.by(() => {
     if (!loaded || !mapViewStore.showOrgs) return [];
-    return organizations
-      .map((org) => {
-        let lat = org.lat;
-        let lon = org.lon;
-        if ((lat === null || lon === null) && org.buildingId !== null) {
-          const host = buildings.find((b) => b.id === org.buildingId);
-          if (host) {
-            lat = host.lat;
-            lon = host.lon;
-          }
-        }
-        return { org, lat, lon };
-      })
-      .filter(
-        (entry): entry is { org: (typeof organizations)[number]; lat: number; lon: number } =>
-          entry.lat !== null && entry.lon !== null,
-      );
+    return organizations.flatMap((org) => {
+      const position = organizationPosition(org);
+      return position ? [{ org, ...position }] : [];
+    });
   });
   const filteredPlaces = $derived.by(() => {
     if (!loaded || !mapViewStore.showPlaces) return [];
@@ -721,6 +729,20 @@
         if (!loaded) return;
         const currentEvent = findSelectedEvent(events);
         if (currentEvent) focusMapOnEvent(map, currentEvent);
+      } else if (category === "organization") {
+        if (!loaded) return;
+        mapViewStore.showOrgs = true;
+        const currentOrg = organizations.find((org) => org.name === value);
+        const position = currentOrg ? organizationPosition(currentOrg) : null;
+        if (position) {
+          map.flyTo({
+            center: [position.lon, position.lat],
+            zoom: 18,
+            pitch: 60,
+            padding: calculatePadding(md.current),
+            duration: 1500,
+          });
+        }
       }
     });
   }
@@ -1930,13 +1952,20 @@
   function handleOrgMarkerClick(name: string) {
     if (eventPlacementStore.active) return;
     if (isMapEditEnabled() && selectedEditKey !== null) return;
-    if (name === queryStore.inputValue) return;
+    if (
+      queryStore.category === "organization" &&
+      name === queryStore.inputValue
+    ) {
+      sidePanelStore.expand();
+      return;
+    }
     queryStore.updateQuery({
       category: "organization",
       type: "result",
       value: name,
     });
     queryStore.inputValue = name;
+    sidePanelStore.expand();
   }
 
   function handleEventMarkerClick(event: EventData) {
@@ -2764,12 +2793,18 @@
             <Marker lngLat={[lon, lat]}>
               <MapEntityPin
                 label={org.name}
-                tone="organization"
+                tone={isStudentOrganization(org.category)
+                  ? "organization"
+                  : "office"}
                 active={activeOrgName === org.name}
                 labelVisible={zoomLevel >= 17 || activeOrgName === org.name}
                 onclick={() => handleOrgMarkerClick(org.name)}
               >
-                <Users size="16" />
+                {#if isStudentOrganization(org.category)}
+                  <Users size="16" />
+                {:else}
+                  <Landmark size="16" />
+                {/if}
               </MapEntityPin>
             </Marker>
           {/each}

--- a/src/components/svelte/controls/CampusBrowseList.svelte
+++ b/src/components/svelte/controls/CampusBrowseList.svelte
@@ -5,7 +5,10 @@
   import EntityPanelHeader from "./EntityPanelHeader.svelte";
   import { getAppData } from "@lib/context";
   import type { CampusBrowseTab } from "@lib/browse-campus";
-  import { orgCategoryLabel } from "@constants/org-categories";
+  import {
+    isStudentOrganization,
+    orgCategoryLabel,
+  } from "@constants/org-categories";
   import { queryStore } from "@lib/store.svelte";
 
   const appData = getAppData();
@@ -116,9 +119,9 @@
     if (activeTab !== "organizations" && activeTab !== "offices") return [];
     const needle = filterText.trim().toLowerCase();
     const rows = organizations.filter((row) => {
-      const isStudentOrg =
-        row.category === "student-org" || row.category === "college-org";
-      return activeTab === "organizations" ? isStudentOrg : !isStudentOrg;
+      return activeTab === "organizations"
+        ? isStudentOrganization(row.category)
+        : !isStudentOrganization(row.category);
     }).sort((a, b) =>
       a.name.localeCompare(b.name),
     );

--- a/src/components/svelte/controls/OrgResult.svelte
+++ b/src/components/svelte/controls/OrgResult.svelte
@@ -16,7 +16,11 @@
   import EntityLastUpdated from "../EntityLastUpdated.svelte";
   import EntityEditorToggle from "@ui/editor/EntityEditorToggle.svelte";
   import type { OrgData } from "@lib/types";
-  import { orgCategoryLabel, ORG_CATEGORIES } from "@constants/org-categories";
+  import {
+    isStudentOrganization,
+    orgCategoryLabel,
+    ORG_CATEGORIES,
+  } from "@constants/org-categories";
   import { persistEntityChange } from "@lib/proposals/client";
   import { handlePersistEntityResult } from "@lib/editor/handle-persist-result";
 
@@ -29,9 +33,7 @@
   );
 
   const categoryLabel = $derived(org ? orgCategoryLabel(org.category) : null);
-  const isStudentOrganization = $derived(
-    org?.category === "student-org" || org?.category === "college-org",
-  );
+  const isStudentOrg = $derived(isStudentOrganization(org?.category));
 
   // Resolve the host building (for the "located in" link and coord fallback).
   const hostBuilding = $derived(
@@ -175,7 +177,7 @@
     <header class="entity-header">
       <div class="entity-header__title-row">
         <h2 class="entity-header__title">{org.name}</h2>
-        {#if isStudentOrganization}
+        {#if isStudentOrg}
           <button
             type="button"
             class="org-info-btn"
@@ -191,7 +193,7 @@
       <div class="entity-meta-row">
         {#if categoryLabel}
           <span class="entity-meta-chip org-badge">
-            {#if isStudentOrganization}
+            {#if isStudentOrg}
               <Users size={12} />
             {:else}
               <Building2 size={12} />

--- a/src/components/svelte/map/MapEntityPin.svelte
+++ b/src/components/svelte/map/MapEntityPin.svelte
@@ -2,7 +2,12 @@
   import Move from "@lucide/svelte/icons/move";
   import type { Snippet } from "svelte";
 
-  type EntityPinTone = "building" | "dorm" | "privateDorm" | "organization";
+  type EntityPinTone =
+    | "building"
+    | "dorm"
+    | "privateDorm"
+    | "organization"
+    | "office";
   type EntityPinSaveState = "idle" | "saving" | "saved" | "failed";
 
   type Props = {
@@ -15,6 +20,7 @@
     hovered?: boolean;
     label: string;
     labelVisible?: boolean;
+    onclick?: (event: MouseEvent | KeyboardEvent) => void;
     /** Hide inline pin label while the shared EntityHoverPreview is shown for this pin. */
     previewSuppressed?: boolean;
     onpointerenter?: (event: PointerEvent) => void;
@@ -35,6 +41,7 @@
     hovered = false,
     label,
     labelVisible = false,
+    onclick,
     previewSuppressed = false,
     onpointerenter,
     onpointerleave,
@@ -59,6 +66,12 @@
     editable && (hovered || editing || active || saveState !== "idle"),
   );
   const showExpandedPin = $derived(editable && showDragAffordance);
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (!onclick || (event.key !== "Enter" && event.key !== " ")) return;
+    event.preventDefault();
+    onclick(event);
+  }
 </script>
 
 <div
@@ -68,6 +81,7 @@
   class:dorm={tone === "dorm"}
   class:private={tone === "privateDorm"}
   class:organization={tone === "organization"}
+  class:office={tone === "office"}
   class:central-hover-preview={useCentralHoverPreview}
   class:editable={showExpandedPin}
   class:editing
@@ -79,6 +93,10 @@
   class:saved={saveState === "saved"}
   class:failed={saveState === "failed"}
   aria-label={label}
+  role={onclick ? "button" : undefined}
+  tabindex={onclick ? 0 : undefined}
+  {onclick}
+  onkeydown={handleKeydown}
   {onpointerenter}
   {onpointerleave}
 >
@@ -134,6 +152,10 @@
     background-color: hsl(265, 45%, 48%);
   }
 
+  .map-entity-pin.office {
+    background-color: hsl(208, 52%, 42%);
+  }
+
   .map-entity-pin.active {
     z-index: 85;
   }
@@ -162,12 +184,25 @@
     outline-color: hsl(265, 45%, 58%);
   }
 
+  .map-entity-pin.office.active::before {
+    outline-color: hsl(208, 52%, 52%);
+  }
+
   .map-entity-pin:hover.organization {
     background-color: hsl(265, 45%, 58%);
   }
 
+  .map-entity-pin:hover.office {
+    background-color: hsl(208, 52%, 52%);
+  }
+
   .map-entity-pin.active.organization .pin-label {
     background-color: hsl(265, 45%, 48%);
+    color: white;
+  }
+
+  .map-entity-pin.active.office .pin-label {
+    background-color: hsl(208, 52%, 42%);
     color: white;
   }
 

--- a/src/components/svelte/modal/StudentOrgsModal.svelte
+++ b/src/components/svelte/modal/StudentOrgsModal.svelte
@@ -9,10 +9,7 @@
     sidePanelStore,
   } from "@lib/store.svelte";
   import { openCampusBrowse } from "@lib/browse-campus";
-  import {
-    UPLB_OSA_ORGANIZATIONS_URL,
-    UPLB_TRAIL_URL,
-  } from "@constants/community-links";
+  import { UPLB_OSA_ORGANIZATIONS_URL } from "@constants/community-links";
 
   function browseOrganizations() {
     openCampusBrowse(queryStore, sidePanelStore, "organizations");
@@ -73,14 +70,6 @@
       rel="noopener noreferrer"
     >
       Official OSA directory
-    </a>
-    <a
-      class="orgs-modal__btn"
-      href={UPLB_TRAIL_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      UPLB Trail links
     </a>
     {#if !adminAuthStore.isLoggedIn}
       <button type="button" class="orgs-modal__btn" onclick={signUp}>

--- a/src/components/svelte/search/CampusBrowseChips.svelte
+++ b/src/components/svelte/search/CampusBrowseChips.svelte
@@ -22,6 +22,8 @@
     { id: "buildings", label: "Buildings", icon: University },
     { id: "colleges", label: "Colleges", icon: GraduationCap },
     { id: "divisions", label: "Divisions", icon: Landmark },
+    { id: "organizations", label: "Student orgs", icon: Users },
+    { id: "offices", label: "Offices & units", icon: Landmark },
     { id: "classes", label: "Classes", icon: BookText },
     // Planner is pinned as a standalone always-visible chip in Search.svelte.
   ];
@@ -58,7 +60,11 @@
       aria-pressed={activeTab === tab.id}
       aria-label={tab.id === "classes"
         ? "Browse all classes"
-        : `Browse ${tab.label.toLowerCase()}`}
+        : tab.id === "organizations"
+          ? "Browse student organizations"
+          : tab.id === "offices"
+            ? "Browse offices and academic units"
+            : `Browse ${tab.label.toLowerCase()}`}
       onclick={(event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -73,59 +79,12 @@
   {/each}
 </div>
 
-<div class="campus-directory-chips" role="toolbar" aria-label="Browse campus directory">
-  <button
-    type="button"
-    class="map-chrome-chip campus-browse-chip"
-    class:map-chrome-chip--toggle-active={activeTab === "organizations"}
-    aria-pressed={activeTab === "organizations"}
-    aria-label="Browse student organizations"
-    onclick={(event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      handleBrowse("organizations");
-    }}
-  >
-    <span class="map-chrome-chip__icon" aria-hidden="true">
-      <Users size={14} />
-    </span>
-    <span>Student orgs</span>
-  </button>
-  <button
-    type="button"
-    class="map-chrome-chip campus-browse-chip"
-    class:map-chrome-chip--toggle-active={activeTab === "offices"}
-    aria-pressed={activeTab === "offices"}
-    aria-label="Browse offices and academic units"
-    onclick={(event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      handleBrowse("offices");
-    }}
-  >
-    <span class="map-chrome-chip__icon" aria-hidden="true">
-      <Landmark size={14} />
-    </span>
-    <span>Offices &amp; units</span>
-  </button>
-</div>
-
 <style>
   .campus-browse-chips {
     display: inline-flex;
     flex: 0 0 auto;
     align-items: center;
     gap: 0.375rem;
-    min-width: 0;
-  }
-
-  .campus-directory-chips {
-    display: flex;
-    flex: 0 0 auto;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.375rem;
-    margin-top: 0.375rem;
     min-width: 0;
   }
 </style>

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -381,15 +381,6 @@
         </div>
       </div>
 
-      {#if chrome.showSearchSuggestions}
-        <div class="campus-browse-chips__container">
-          <CampusBrowseChips />
-        </div>
-        <div class="campus-browse-chips__term">
-          <TermSelector />
-        </div>
-      {/if}
-
       {#if showSearchDropdown}
         <!-- svelte-ignore a11y_interactive_supports_focus -->
         <div
@@ -417,6 +408,8 @@
           {/if}
 
           {#if chrome.showSearchSuggestions}
+            <CampusBrowseChips />
+            <TermSelector />
             {#if showIdleEventsChrome}
               <button
                 type="button"
@@ -490,12 +483,6 @@
 </div>
 
 <style>
-    .campus-browse-chips__container {
-        padding: .5rem .75rem;
-    }
-  .campus-browse-chips__term {
-    padding: 0 0.75rem 0.5rem;
-  }
   .sr-only {
     position: absolute;
     width: 1px;
@@ -621,46 +608,13 @@
     grid-row: 3;
   }
 
-  /* Browse chips + term selector stack as their own full-width rows under the
-     filter chips. Without explicit placement they auto-flow side by side into
-     the menu-button column and overlap (mobile top-bar regression). */
-  .search-root.mobile-shell .campus-browse-chips__container,
-  .search-root.mobile-shell .campus-browse-chips__term {
-    grid-column: 1 / -1;
-    min-width: 0;
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-  }
-
-  .search-root.mobile-shell .campus-browse-chips__container {
+  .search-root.mobile-shell.search-suggestions-open.search-query-active
+    .map-search-chrome__transit-routes,
+  .search-root.mobile-shell.search-suggestions-open.search-query-active
+    .map-search-chrome__events,
+  .search-root.mobile-shell.search-suggestions-open.search-query-active
+    .map-search-chrome__editor {
     grid-row: 3;
-    padding: 0.4375rem 0 0;
-    border-top: 1px solid var(--map-chrome-divider, hsl(5 12% 88%));
-  }
-
-  .search-root.mobile-shell .campus-browse-chips__term {
-    grid-row: 4;
-    padding: 0.375rem 0 0.1875rem;
-  }
-
-  .search-root.mobile-shell.search-suggestions-open
-    .campus-browse-chips__container {
-    grid-row: 4;
-  }
-
-  .search-root.mobile-shell.search-suggestions-open
-    .campus-browse-chips__term {
-    grid-row: 5;
-  }
-
-  .search-root.mobile-shell.search-suggestions-open.search-query-active
-    .map-search-chrome__transit-routes,
-  .search-root.mobile-shell.search-suggestions-open.search-query-active
-    .map-search-chrome__events,
-  .search-root.mobile-shell.search-suggestions-open.search-query-active
-    .map-search-chrome__editor {
-    grid-row: 6;
   }
 
   .search-root.mobile-shell.search-suggestions-open:not(.search-query-active)
@@ -669,7 +623,7 @@
     .map-search-chrome__events,
   .search-root.mobile-shell.search-suggestions-open:not(.search-query-active)
     .map-search-chrome__editor {
-    grid-row: 6;
+    grid-row: 4;
   }
 
   .search-root.mobile-shell:not(.search-suggestions-open)
@@ -679,7 +633,7 @@
   .search-root.mobile-shell:not(.search-suggestions-open)
     .map-search-chrome__editor {
     grid-column: 1 / -1;
-    grid-row: 5;
+    grid-row: 3;
     min-width: 0;
     width: 100%;
     max-width: 100%;

--- a/src/constants/community-links.ts
+++ b/src/constants/community-links.ts
@@ -6,7 +6,6 @@ const ROOM_TBA_SITE_URL = "https://room-tba.uplbtools.me";
 export const UPLB_TOOLS_URL = "https://uplbtools.me";
 export const DISCORD_URL = "https://discord.uplbtools.me";
 export const UPLB_OSA_ORGANIZATIONS_URL = "https://uplbosa.org/orgs";
-export const UPLB_TRAIL_URL = "https://uplb-trail.vercel.app/";
 
 /** Facebook Messenger group chat invites (targets for redirect workers). */
 export const MESSENGER_CONTRIBUTE_TARGET = "https://m.me/j/Aba1V0prvQyLrafZ/";

--- a/src/constants/org-categories.test.ts
+++ b/src/constants/org-categories.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   ORG_CATEGORIES,
+  isStudentOrganization,
   normalizeOrgCategory,
   orgCategoryLabel,
 } from "./org-categories.js";
@@ -21,5 +22,10 @@ describe("normalizeOrgCategory", () => {
       expect(normalizeOrgCategory(c)).toBe(c);
       expect(orgCategoryLabel(c)).toBeTruthy();
     }
+  });
+  test("only student-facing categories use the organization marker", () => {
+    expect(isStudentOrganization("student-org")).toBe(true);
+    expect(isStudentOrganization("college-org")).toBe(true);
+    expect(isStudentOrganization("office")).toBe(false);
   });
 });

--- a/src/constants/org-categories.ts
+++ b/src/constants/org-categories.ts
@@ -35,3 +35,8 @@ export function orgCategoryLabel(value: unknown): string | null {
   const c = normalizeOrgCategory(value);
   return c ? ORG_CATEGORY_LABELS[c] : null;
 }
+
+export function isStudentOrganization(value: unknown): boolean {
+  const category = normalizeOrgCategory(value);
+  return category === "student-org" || category === "college-org";
+}

--- a/src/lib/campus-office-directory.test.ts
+++ b/src/lib/campus-office-directory.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { trailDirectoryEntries } from "./uplb-trail-directory.ts";
+import { campusOfficeDirectoryEntries } from "./campus-office-directory.ts";
 
-describe("trailDirectoryEntries", () => {
+describe("campusOfficeDirectoryEntries", () => {
   test("keeps a canonical office entry and prefers its official site", () => {
-    const entries = trailDirectoryEntries([
+    const entries = campusOfficeDirectoryEntries([
       {
         name: "OSA FB Page",
         url: "https://www.facebook.com/uplbosa.ovcsa/",

--- a/src/lib/campus-office-directory.ts
+++ b/src/lib/campus-office-directory.ts
@@ -1,11 +1,11 @@
-export type TrailWebsite = {
+export type CampusWebsite = {
   name: string;
   url: string;
   description: string;
   category: string;
 };
 
-export type TrailDirectoryEntry = {
+export type CampusOfficeDirectoryEntry = {
   name: string;
   description: string;
   category: "academic" | "office" | "service" | "unit";
@@ -15,7 +15,7 @@ export type TrailDirectoryEntry = {
 
 const EXCLUDED_CATEGORIES = new Set(["Colleges & Schools", "Main Portals"]);
 
-function titleFromSource(source: TrailWebsite) {
+function titleFromSource(source: CampusWebsite) {
   const description = source.description.trim();
   const title = description
     .replace(/^The official (?:page|website) of\s+/i, "")
@@ -32,7 +32,7 @@ function titleFromSource(source: TrailWebsite) {
   return title.split(".")[0].trim() || source.name;
 }
 
-function shortName(source: TrailWebsite) {
+function shortName(source: CampusWebsite) {
   return source.name.replace(/\s+(?:FB Page|OCS Website|Website)$/i, "").trim();
 }
 
@@ -40,7 +40,7 @@ function normalized(value: string) {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
 }
 
-function directoryName(source: TrailWebsite) {
+function directoryName(source: CampusWebsite) {
   const title = titleFromSource(source);
   const short = shortName(source);
   return normalized(title).includes(normalized(short))
@@ -49,9 +49,9 @@ function directoryName(source: TrailWebsite) {
 }
 
 function directoryCategory(
-  source: TrailWebsite,
+  source: CampusWebsite,
   name: string,
-): TrailDirectoryEntry["category"] {
+): CampusOfficeDirectoryEntry["category"] {
   if (source.category === "Major Offices & Services") return "service";
   if (/^Units Under (?:OC|OV)/.test(source.category)) return "office";
   if (
@@ -77,13 +77,13 @@ function isFacebook(url: string) {
 }
 
 /**
- * Converts TRAIL's public websites directory to map-searchable UPLB units.
+ * Converts the public campus websites directory to map-searchable UPLB units.
  * Colleges and broad portals remain in their existing dedicated app surfaces.
  */
-export function trailDirectoryEntries(
-  sources: TrailWebsite[],
-): TrailDirectoryEntry[] {
-  const groups = new Map<string, TrailWebsite[]>();
+export function campusOfficeDirectoryEntries(
+  sources: CampusWebsite[],
+): CampusOfficeDirectoryEntry[] {
+  const groups = new Map<string, CampusWebsite[]>();
   for (const source of sources) {
     if (EXCLUDED_CATEGORIES.has(source.category)) continue;
     const key = normalized(titleFromSource(source));


### PR DESCRIPTION
## Summary
- compact directory controls into one horizontal row
- distinguish student organization and office map pins
- focus selected entries on the map and reopen details from map pins
- remove the named source from active code and documentation

## Verification
- `bun test src/constants/org-categories.test.ts src/lib/campus-office-directory.test.ts`
- `bun run test:components`
- `bun run build`
- focused Playwright desktop + mobile suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core map pin rendering, query-driven camera behavior, and mobile search layout—user-visible regressions are possible, but changes stay in UI and import scripts with no auth or schema changes.
> 
> **Overview**
> **Student orgs and campus offices** are now visually distinct on the map: purple **Users** pins for `student-org` / `college-org`, blue **Landmark** pins for everything else, driven by a shared `isStudentOrganization()` helper used in browse lists and detail UI.
> 
> **Map ↔ directory interaction** improves selection: choosing an organization flies the map to its resolved position (with org layers shown), org pins are proper keyboard-accessible controls, and clicking an already-selected pin re-expands the details panel after collapse.
> 
> **Search chrome** folds student-org and office browse chips into the main `CampusBrowseChips` row beside the term filter (dropping the second “directory” chip row and the mobile grid hacks that stacked chips above the term selector). Playwright coverage now asserts office pin styling and pin-to-panel reopening.
> 
> **Data tooling / branding**: the UPLB TRAIL–named import (`import:uplb-trail`, `uplb-trail-directory`) is renamed to **`import:campus-offices`** / `campus-office-directory` with neutral copy; the **UPLB Trail** link is removed from the student-orgs modal and `community-links`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2a81099f82ecb3dd18221b2f4dc1f22f6b94c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->