### PR TITLE
fix(ui): polish sidebar, legend, landing stats, and splash

### DIFF
--- a/e2e/helpers/map-tools.ts
+++ b/e2e/helpers/map-tools.ts
@@ -1,14 +1,16 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
+/** Ensure the app sidebar rail is open (mobile hides it behind the App menu
+ * button) and return its locator for scoping browse-entry clicks. */
 export async function openAppSidebar(page: Page): Promise<Locator> {
   const sidebar = page.locator("#app-sidebar");
-  const menuButton = page.getByRole("button", { name: /app menu/i });
-
-  if (await sidebar.evaluate((el) => el.classList.contains("retracted"))) {
-    await menuButton.click();
+  const retracted = await sidebar
+    .evaluate((el) => el.classList.contains("retracted"))
+    .catch(() => true);
+  if (retracted) {
+    await page.getByRole("button", { name: /app menu/i }).click();
+    await expect(sidebar).not.toHaveClass(/retracted/, { timeout: 10_000 });
   }
-
-  await expect(sidebar).not.toHaveClass(/retracted/);
   return sidebar;
 }
 
@@ -31,20 +33,4 @@ export async function expandMapToolsSection(page: Page, section: string) {
   await page
     .getByRole("button", { name: new RegExp(`^${section}$`, "i") })
     .click();
-}
-
-/** Ensure the app sidebar rail is open (mobile hides it behind the App menu
- * button) and return its locator for scoping browse-entry clicks. */
-export async function openAppSidebar(page: Page) {
-  const sidebar = page.locator("#app-sidebar");
-  // Mobile keeps the rail mounted but retracted (translated off-canvas), so
-  // check the class rather than visibility.
-  const retracted = await sidebar
-    .evaluate((el) => el.classList.contains("retracted"))
-    .catch(() => true);
-  if (retracted) {
-    await page.getByRole("button", { name: /app menu/i }).click();
-    await expect(sidebar).not.toHaveClass(/retracted/, { timeout: 10_000 });
-  }
-  return sidebar;
 }

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -600,13 +600,26 @@
   .bottom-chrome__actions {
     display: flex;
     flex: 0 0 auto;
-    /* Bottom-align so the open legend panel grows upward without dragging the
-       add/locate buttons to the middle of the screen. */
+    /* Bottom-align controls so an open legend panel grows upward without
+       floating +/locate over the panel body. */
     align-items: flex-end;
-    gap: 0.125rem;
-    min-height: 2.75rem;
-    padding: 0.125rem;
+    gap: 0.375rem;
+    padding: 0;
     pointer-events: auto;
+  }
+
+  .bottom-chrome__actions :global(.map-legend--open) {
+    position: relative;
+    z-index: 2;
+  }
+
+  .bottom-chrome__actions :global(.map-control-stack.embedded) {
+    position: relative;
+    z-index: 1;
+  }
+
+  .bottom-chrome__actions :global(.map-chrome-control-btn--compact) {
+    flex-shrink: 0;
   }
 
   .bottom-band::before {

--- a/src/components/svelte/GithubStarLink.svelte
+++ b/src/components/svelte/GithubStarLink.svelte
@@ -25,6 +25,10 @@
       ? `Star Room TBA on GitHub (${stars.toLocaleString()} stars)`
       : "Star Room TBA on GitHub",
   );
+
+  const displayCount = $derived(
+    stars !== null ? stars.toLocaleString() : failed ? "—" : "…",
+  );
 </script>
 
 <a
@@ -34,47 +38,70 @@
   rel="noopener noreferrer"
   aria-label={label}
 >
-  <Star size={14} aria-hidden="true" class="github-star-link__icon" />
-  <span>Star on GitHub</span>
-  {#if stars !== null}
-    <span class="github-star-link__count" aria-hidden="true">
-      · {stars.toLocaleString()}
-    </span>
-  {:else if !failed}
-    <span class="github-star-link__count github-star-link__count--loading" aria-hidden="true">
-      · …
-    </span>
-  {/if}
+  <Star size={16} aria-hidden="true" class="github-star-link__icon" />
+  <span class="github-star-link__copy">
+    <span class="github-star-link__count" aria-hidden="true">{displayCount}</span>
+    <span class="github-star-link__label">GitHub stars</span>
+  </span>
 </a>
 
 <style>
   .github-star-link {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.5rem;
     margin: 0;
-    font-size: 0.75rem;
-    color: hsl(0, 0%, 42%);
+    padding: 0.5rem 0.875rem;
+    border-radius: 999px;
+    background: hsl(5, 32%, 95%);
+    border: 1px solid hsl(5, 28%, 78%);
+    color: hsl(5, 58%, 22%);
     text-decoration: none;
+    box-shadow: 0 1px 2px hsla(5, 40%, 20%, 0.06);
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
   }
 
   .github-star-link:hover {
-    color: hsl(5, 53%, 32%);
-    text-decoration: underline;
-    text-underline-offset: 2px;
+    background: hsl(5, 38%, 92%);
+    border-color: hsl(5, 45%, 62%);
+    box-shadow: 0 2px 6px hsla(5, 40%, 20%, 0.1);
+  }
+
+  .github-star-link:focus-visible {
+    outline: 2px solid hsl(5, 65%, 32%);
+    outline-offset: 2px;
   }
 
   .github-star-link :global(.github-star-link__icon) {
-    color: hsl(45, 90%, 42%);
     flex-shrink: 0;
+    color: hsl(42, 92%, 38%);
+    fill: hsl(42, 92%, 38%);
+  }
+
+  .github-star-link__copy {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.0625rem;
+    min-width: 0;
   }
 
   .github-star-link__count {
-    color: hsl(0, 0%, 50%);
+    font-size: 1rem;
+    font-weight: 800;
+    line-height: 1.1;
     font-variant-numeric: tabular-nums;
+    color: hsl(5, 70%, 20%);
   }
 
-  .github-star-link__count--loading {
-    opacity: 0.6;
+  .github-star-link__label {
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1.2;
+    color: hsl(5, 45%, 30%);
+    white-space: nowrap;
   }
 </style>

--- a/src/components/svelte/LocationButton.svelte
+++ b/src/components/svelte/LocationButton.svelte
@@ -3,6 +3,7 @@
   import Locate from "@lucide/svelte/icons/locate";
   import LocateFixed from "@lucide/svelte/icons/locate-fixed";
   import Plus from "@lucide/svelte/icons/plus";
+  import "./map-chrome/map-chrome.css";
   import {
     adminAuthStore,
     editorChromeStore,
@@ -50,26 +51,28 @@
 <div class="map-control-stack" class:embedded>
   {#if showSuggestAddition}
     <button
-      class="map-control-btn"
+      class="map-chrome-control-btn"
+      class:map-chrome-control-btn--compact={embedded}
       onclick={() => editorChromeStore.openAdditionModal()}
       title="Add something to the map"
       aria-label="Add something to the map"
       aria-haspopup="dialog"
     >
-      <Plus aria-hidden="true" />
+      <Plus size={embedded ? 18 : 24} aria-hidden="true" />
     </button>
   {/if}
 
   <button
-    class="map-control-btn"
+    class="map-chrome-control-btn"
+    class:map-chrome-control-btn--compact={embedded}
     onclick={handleLocationClick}
     title="My Location"
     aria-label="My Location"
   >
     {#if centered}
-      <LocateFixed aria-hidden="true" />
+      <LocateFixed size={embedded ? 18 : 24} aria-hidden="true" />
     {:else}
-      <Locate aria-hidden="true" />
+      <Locate size={embedded ? 18 : 24} aria-hidden="true" />
     {/if}
   </button>
 </div>
@@ -88,55 +91,4 @@
     align-items: center;
     gap: 0.375rem;
   }
-
-  .map-control-btn {
-    position: relative;
-    background-color: var(--map-chrome-surface, rgba(255, 255, 255, 0.98));
-    backdrop-filter: blur(10px);
-    border: 1.5px solid var(--map-chrome-border-accent, hsl(5, 40%, 42%));
-    border-radius: 50%;
-    width: 3rem;
-    height: 3rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    box-shadow: var(
-      --map-chrome-shadow,
-      0 0 0 1px hsla(0, 0%, 0%, 0.18),
-      0 2px 6px hsla(0, 0%, 0%, 0.18),
-      0 8px 20px hsla(0, 0%, 0%, 0.14)
-    );
-    color: hsl(5, 53%, 32%);
-    transition:
-      background-color 0.2s,
-      border-color 0.2s;
-  }
-
-  .embedded .map-control-btn {
-    width: 2.5rem;
-    height: 2.5rem;
-    border-width: 1px;
-    box-shadow: var(
-      --map-chrome-fab-shadow,
-      inset 0 0 0 1px hsla(0, 0%, 100%, 0.72),
-      0 1px 4px hsla(0, 0%, 0%, 0.16)
-    );
-  }
-
-  .embedded .map-control-btn :global(svg) {
-    width: 1.125rem;
-    height: 1.125rem;
-  }
-
-  .map-control-btn:hover {
-    background-color: hsl(0, 0%, 99%);
-    border-color: hsl(5, 53%, 32%);
-  }
-
-  .map-control-btn:focus-visible {
-    outline: 2px solid hsl(5, 53%, 32%);
-    outline-offset: 2px;
-  }
-
 </style>

--- a/src/components/svelte/MapLegend.svelte
+++ b/src/components/svelte/MapLegend.svelte
@@ -4,6 +4,7 @@
   import Layers from "@lucide/svelte/icons/layers";
   import X from "@lucide/svelte/icons/x";
   import IconButton from "@ui/IconButton.svelte";
+  import "./map-chrome/map-chrome.css";
   import { getAppData } from "@lib/context";
   import {
     floatingControlPanelStore,
@@ -123,7 +124,7 @@
   }
 </script>
 
-<div class="map-legend" class:embedded>
+<div class="map-legend" class:embedded class:map-legend--open={open}>
   {#if showPanel}
     <div
       id="map-icon-legend"
@@ -248,8 +249,9 @@
 
   {#if !embedded}
     <button
-      class="legend-btn"
-      class:legend-btn--chip={trigger === "chip"}
+      class={trigger === "chip"
+        ? "map-chrome-control-btn map-chrome-control-btn--compact"
+        : "legend-btn"}
       class:active={open}
       type="button"
       onclick={togglePanel}
@@ -259,8 +261,7 @@
       aria-controls="map-icon-legend"
     >
       {#if trigger === "chip"}
-        <Layers size={16} aria-hidden="true" />
-        <span>Legend</span>
+        <Layers size={18} aria-hidden="true" />
       {:else}
         <Info />
       {/if}
@@ -333,45 +334,52 @@
     pointer-events: auto;
   }
 
+  .map-legend--open .legend-panel {
+    position: relative;
+    z-index: 1;
+  }
+
   .legend-btn {
     display: flex;
     width: 3rem;
     height: 3rem;
     align-items: center;
     justify-content: center;
-    border: 1px solid #ececec;
+    border: 1.5px solid var(--map-chrome-border-accent, hsl(5, 40%, 42%));
     border-radius: 50%;
-    background-color: white;
+    background-color: var(--map-chrome-surface, rgba(255, 255, 255, 0.98));
+    backdrop-filter: blur(10px);
     color: hsl(5, 53%, 32%);
     cursor: pointer;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: var(
+      --map-chrome-shadow,
+      0 0 0 1px hsla(0, 0%, 0%, 0.18),
+      0 2px 6px hsla(0, 0%, 0%, 0.18),
+      0 8px 20px hsla(0, 0%, 0%, 0.14)
+    );
     transition:
       background-color 0.2s,
-      transform 0.2s;
+      border-color 0.2s;
   }
 
   .legend-btn:hover {
-    background-color: hsl(5, 53%, 98%);
-    transform: scale(1.05);
+    background-color: hsl(0, 0%, 99%);
+    border-color: hsl(5, 53%, 32%);
+  }
+
+  .legend-btn:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 2px;
   }
 
   .legend-btn.active {
-    border-color: hsl(5, 53%, 75%);
+    border-color: hsl(5, 53%, 32%);
     background-color: hsl(5, 53%, 32%);
     color: white;
-  }
-
-  .legend-btn--chip {
-    width: auto;
-    /* Match the 3rem circular add/locate buttons beside it. */
-    min-height: 3rem;
-    height: auto;
-    gap: 0.375rem;
-    border-radius: 999px;
-    padding: 0.375rem 0.875rem;
-    font: inherit;
-    font-size: 0.75rem;
-    font-weight: 700;
+    box-shadow:
+      inset 0 0 0 1px hsla(0, 0%, 100%, 0.2),
+      0 2px 6px hsla(0, 0%, 0%, 0.18),
+      0 6px 14px hsla(0, 0%, 0%, 0.12);
   }
 
   .legend-panel {

--- a/src/components/svelte/OfflineMaps.svelte
+++ b/src/components/svelte/OfflineMaps.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import DownloadCloud from "@lucide/svelte/icons/download-cloud";
+  import Download from "@lucide/svelte/icons/download";
   import { mapToolsStore, offlineStore } from "@lib/store.svelte";
   import { registerEphemeralOverlayDismisser } from "@lib/overlay-stack";
   import { rafThrottle } from "@lib/layout-css-vars";
@@ -198,7 +199,8 @@
             class="offline-btn"
             onclick={() => offlineStore.downloadCampus()}
           >
-            Download campus map
+            <Download size={14} aria-hidden="true" />
+            <span>Download campus map</span>
           </button>
         {/if}
       </section>
@@ -257,7 +259,8 @@
             class="offline-btn"
             onclick={() => offlineStore.downloadCampusDirectory()}
           >
-            Download campus directory
+            <Download size={14} aria-hidden="true" />
+            <span>Download campus directory</span>
           </button>
         {/if}
       </section>
@@ -306,7 +309,8 @@
             class="offline-btn"
             onclick={() => offlineStore.downloadClassSchedules()}
           >
-            Download class schedules
+            <Download size={14} aria-hidden="true" />
+            <span>Download class schedules</span>
           </button>
         {/if}
       </section>
@@ -357,6 +361,8 @@
 
   .offline-maps--inline {
     width: 100%;
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .sr-only {
@@ -385,9 +391,17 @@
     width: 100%;
     box-sizing: border-box;
     max-height: none;
+    flex: 0 0 auto;
     padding: 0;
+    border: none;
     background: transparent;
     box-shadow: none;
+    backdrop-filter: none;
+  }
+
+  .offline-popover--inline .offline-category:first-of-type {
+    border-top: none;
+    padding-top: 0;
   }
 
   .offline-category {
@@ -425,16 +439,30 @@
   }
 
   .offline-btn {
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: flex-start;
+    gap: 0.375rem;
+    width: auto;
+    max-width: 100%;
     margin-top: 0.125rem;
     border: none;
     border-radius: 0.5rem;
-    padding: 0.375rem 0.625rem;
+    padding: 0.4375rem 0.75rem;
     background-color: hsl(5, 53%, 32%);
     color: white;
     font: inherit;
     font-size: 0.8125rem;
     font-weight: 600;
+    line-height: 1.2;
     cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .offline-btn :global(svg) {
+    flex-shrink: 0;
   }
   .offline-btn:hover {
     background-color: hsl(5, 53%, 40%);

--- a/src/components/svelte/VisitorCounter.svelte
+++ b/src/components/svelte/VisitorCounter.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import Users from "@lucide/svelte/icons/users";
   import { fetchVisitorCount } from "@lib/visitor-count";
 
-  let { digits = 6, label = "You are visitor #" }: {
+  let { digits = 6, label = "Visitor #" }: {
     digits?: number;
     label?: string;
   } = $props();
@@ -38,38 +39,71 @@
 </script>
 
 <p class="visitor-counter" role="status" aria-live="polite" aria-label={announce}>
-  <span class="visitor-counter__label">{label}</span>
-  {#each display.split("") as char, i (i)}
-    <span class="visitor-counter__digit" aria-hidden="true">{char}</span>
-  {/each}
+  <Users size={16} aria-hidden="true" class="visitor-counter__icon" />
+  <span class="visitor-counter__copy">
+    <span class="visitor-counter__label">{label}</span>
+    <span class="visitor-counter__digits" aria-hidden="true">
+      {#each display.split("") as char, i (i)}
+        <span class="visitor-counter__digit">{char}</span>
+      {/each}
+    </span>
+  </span>
 </p>
 
 <style>
   .visitor-counter {
     display: inline-flex;
     align-items: center;
-    gap: 0.125rem;
+    gap: 0.5rem;
     margin: 0;
-    font-size: 0.75rem;
-    color: hsl(0, 0%, 45%);
+    padding: 0.5rem 0.875rem;
+    border-radius: 999px;
+    background: hsl(5, 32%, 95%);
+    border: 1px solid hsl(5, 28%, 78%);
+    color: hsl(5, 58%, 22%);
+    box-shadow: 0 1px 2px hsla(5, 40%, 20%, 0.06);
+  }
+
+  .visitor-counter :global(.visitor-counter__icon) {
+    flex-shrink: 0;
+    color: hsl(5, 65%, 32%);
+  }
+
+  .visitor-counter__copy {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.375rem;
+    min-width: 0;
   }
 
   .visitor-counter__label {
-    margin-right: 0.25rem;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+
+  .visitor-counter__digits {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.125rem;
   }
 
   .visitor-counter__digit {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 1rem;
-    padding: 0.125rem 0;
-    border-radius: 0.25rem;
-    background: hsl(5, 25%, 18%);
-    color: hsl(45, 90%, 70%);
+    min-width: 1.0625rem;
+    padding: 0.1875rem 0.25rem;
+    border-radius: 0.3125rem;
+    background: white;
+    border: 1px solid hsl(5, 24%, 72%);
+    color: hsl(5, 70%, 22%);
     font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: 0.875rem;
+    font-weight: 800;
     line-height: 1;
+    box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, 0.9);
   }
 </style>

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -421,6 +421,79 @@ button.map-chrome-chip:disabled {
     0 6px 14px hsla(0, 0%, 0%, 0.12);
 }
 
+/* Bottom-chrome + / locate / legend — one size, no pill drift. */
+.map-chrome-control-btn {
+  position: relative;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: 1.5px solid var(--map-chrome-border-accent, hsl(5, 40%, 42%));
+  border-radius: 50%;
+  width: 3rem;
+  height: 3rem;
+  background-color: var(--map-chrome-surface, rgba(255, 255, 255, 0.98));
+  backdrop-filter: blur(10px);
+  color: hsl(5, 53%, 32%);
+  cursor: pointer;
+  line-height: 0;
+  font: inherit;
+  box-shadow: var(
+    --map-chrome-shadow,
+    0 0 0 1px hsla(0, 0%, 0%, 0.18),
+    0 2px 6px hsla(0, 0%, 0%, 0.18),
+    0 8px 20px hsla(0, 0%, 0%, 0.14)
+  );
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+}
+
+.map-chrome-control-btn--compact {
+  width: 2.5rem;
+  height: 2.5rem;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  max-width: 2.5rem;
+  max-height: 2.5rem;
+  border-width: 1px;
+  box-shadow: var(
+    --map-chrome-fab-shadow,
+    inset 0 0 0 1px hsla(0, 0%, 100%, 0.72),
+    0 1px 4px hsla(0, 0%, 0%, 0.16)
+  );
+}
+
+.map-chrome-control-btn--compact svg {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex-shrink: 0;
+}
+
+.map-chrome-control-btn:hover {
+  background-color: hsl(0, 0%, 99%);
+  border-color: hsl(5, 53%, 32%);
+}
+
+.map-chrome-control-btn:focus-visible {
+  outline: 2px solid hsl(5, 53%, 32%);
+  outline-offset: 2px;
+}
+
+.map-chrome-control-btn.active,
+.map-chrome-control-btn[aria-expanded="true"] {
+  border-color: hsl(5, 53%, 32%);
+  background-color: hsl(5, 53%, 32%);
+  color: white;
+  box-shadow:
+    inset 0 0 0 1px hsla(0, 0%, 100%, 0.2),
+    0 2px 6px hsla(0, 0%, 0%, 0.18),
+    0 6px 14px hsla(0, 0%, 0%, 0.12);
+}
+
 .map-chrome-panel,
 .map-chrome-popover {
   display: flex;

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -439,8 +439,8 @@ button.map-chrome-chip:disabled {
   backdrop-filter: blur(10px);
   color: hsl(5, 53%, 32%);
   cursor: pointer;
-  line-height: 0;
   font: inherit;
+  line-height: 0;
   box-shadow: var(
     --map-chrome-shadow,
     0 0 0 1px hsla(0, 0%, 0%, 0.18),

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -544,9 +544,11 @@
   .footer-meta {
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
+    align-items: stretch;
     justify-content: center;
-    gap: 0.5rem 0.875rem;
+    gap: 0.625rem;
+    width: 100%;
+    padding: 0.125rem 0 0.25rem;
   }
 
   .legal-hint {
@@ -560,8 +562,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem 1rem;
+    gap: 0.625rem;
+    padding: 0.875rem 1rem 1rem;
     border-top: 1px solid hsl(0, 0%, 92%);
     background: white;
     width: 100%;

--- a/src/components/svelte/navigation/Sidebar.svelte
+++ b/src/components/svelte/navigation/Sidebar.svelte
@@ -14,7 +14,6 @@
   import Globe from "@lucide/svelte/icons/globe";
   import Wrench from "@lucide/svelte/icons/wrench";
   import HeartHandshake from "@lucide/svelte/icons/heart-handshake";
-  import X from "@lucide/svelte/icons/x";
   import Sparkles from "@lucide/svelte/icons/sparkles";
   import University from "@lucide/svelte/icons/university";
   import UserPlus from "@lucide/svelte/icons/user-plus";
@@ -34,6 +33,7 @@
   import CloudDownload from "@lucide/svelte/icons/cloud-download";
   import Keyboard from "@lucide/svelte/icons/keyboard";
   import Cookie from "@lucide/svelte/icons/cookie";
+  import { MediaQuery } from "svelte/reactivity";
   import { slide } from "svelte/transition";
   import CircleQuestionMark from "@lucide/svelte/icons/circle-question-mark";
   import Tag from "@lucide/svelte/icons/tag";
@@ -114,6 +114,24 @@
   // Labels show when the rail is expanded (desktop toggle) or when the
   // mobile drawer is open — a drawer has the room, so always label it.
   const labeled = $derived(sidebarStore.expanded || sidebarStore.railOpen);
+
+  const isMobileRail = new MediaQuery("max-width: 48rem");
+
+  function handleRailToggle() {
+    if (isMobileRail.current) {
+      sidebarStore.closeRail();
+      return;
+    }
+    sidebarStore.toggleExpanded();
+  }
+
+  const railToggleLabel = $derived(
+    isMobileRail.current
+      ? "Close menu"
+      : sidebarStore.expanded
+        ? "Collapse menu"
+        : "Expand menu",
+  );
 </script>
 
 <aside
@@ -121,18 +139,6 @@
   class:retracted={!sidebarStore.railOpen}
   class:sidebar--expanded={sidebarStore.expanded}
 >
-  <div class="rail-close">
-    <NavLink
-      active={false}
-      hard={false}
-      tooltip="Close menu"
-      expanded={labeled}
-      aria-label="Close menu"
-      onclick={() => sidebarStore.closeRail()}
-    >
-      <X size={20} />
-    </NavLink>
-  </div>
   <div class="top">
     <button
       type="button"
@@ -284,10 +290,11 @@
       active={false}
       hard={false}
       expanded={labeled}
-      tooltip={sidebarStore.expanded ? "Collapse menu" : "Expand menu"}
-      onclick={() => sidebarStore.toggleExpanded()}
+      tooltip={railToggleLabel}
+      aria-label={railToggleLabel}
+      onclick={handleRailToggle}
     >
-      {#if sidebarStore.expanded}
+      {#if isMobileRail.current || sidebarStore.expanded}
         <ChevronLeft size={20} />
       {:else}
         <ChevronRight size={20} />
@@ -651,11 +658,6 @@
     width: 100%;
   }
 
-  /* Rail close affordance is a mobile-overlay concern only. */
-  div.rail-close {
-    display: none;
-  }
-
   @media (max-width: 48rem) {
     /* Overlay drawer: leaves no reserved flex column behind, so the search
        chrome and map data pill hug the viewport edge when it is closed. */
@@ -675,12 +677,6 @@
     aside.retracted {
       transform: translateX(calc(-100% - 0.5rem));
       pointer-events: none;
-    }
-
-    div.rail-close {
-      display: flex;
-      justify-content: center;
-      margin-bottom: 0.25rem;
     }
 
     /* Tighter rhythm so the full rail fits small screens. */

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -162,13 +162,30 @@ const shareTitle = ogTitle ?? title;
     <Analytics />
     <script is:inline define:vars={{ splashLines: LOADING_SPLASH_MESSAGES }}>
       (() => {
-        // Deterministic witty splash line: rotates by wall-clock minute.
         const splashEl = document.querySelector(".app-loading-shell__splash");
-        if (splashEl) {
-          splashEl.textContent =
-            splashLines[new Date().getMinutes() % splashLines.length];
+        let splashIndex = 0;
+        let splashTimer = null;
+
+        function showSplashLine() {
+          if (!splashEl) return;
+          splashEl.textContent = splashLines[splashIndex % splashLines.length];
+          splashIndex += 1;
         }
+
+        function stopSplashRotation() {
+          if (splashTimer !== null) {
+            clearInterval(splashTimer);
+            splashTimer = null;
+          }
+        }
+
+        if (splashEl) {
+          showSplashLine();
+          splashTimer = setInterval(showSplashLine, 3_500);
+        }
+
         function dismissLoadingShell() {
+          stopSplashRotation();
           document.getElementById("app-loading-shell")?.remove();
         }
         document.addEventListener(

--- a/src/lib/loading-splash-messages.ts
+++ b/src/lib/loading-splash-messages.ts
@@ -1,5 +1,4 @@
-/** Whimsical one-liners shown below the loading phase label (not error state).
- * One is picked deterministically by minute (Layout.astro inline script). */
+/** Whimsical one-liners shown below the loading phase label (not error state). */
 export const LOADING_SPLASH_MESSAGES = [
   "Finding where you need to be",
   "Asking the guard where AnSci is",


### PR DESCRIPTION
## Summary
- Shared `map-chrome-control-btn` styles for legend, locate, and zoom controls
- Mobile sidebar: single chevron closes drawer; desktop keeps expand/collapse
- Legend panel z-index fix so it stacks above map chrome buttons
- Landing modal: more prominent visitor count and GitHub star chips
- Splash witty lines rotate every 3.5s instead of once per minute
- Offline maps: compact icon download buttons, cleaner modal layout

## Test plan
- [ ] Mobile: open sidebar → chevron closes drawer (no duplicate close controls)
- [ ] Desktop: sidebar expand/collapse still works
- [ ] Legend chip matches locate/+ button styling; panel opens above map controls
- [ ] Landing modal shows visitor + star counts clearly
- [ ] Splash line changes every ~3.5s on slow load
- [ ] Offline maps download buttons render with icons

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and navigation UX only; no auth, data, or API behavior changes.
> 
> **Overview**
> **Map bottom chrome** unifies legend, add, and locate behind shared `map-chrome-control-btn` styles (including compact embedded sizing). Legend chip is icon-only; z-index in `Entry` keeps an open legend panel above the +/locate stack.
> 
> **Mobile sidebar** drops the extra top close control—the rail chevron closes the drawer on small screens and still expand/collapses on desktop (`MediaQuery` + `handleRailToggle`).
> 
> **Landing footer** restyles visitor count and GitHub stars as matching pill chips (prominent numbers, icons). **Offline maps** adds download icons on primary buttons and tidies inline modal layout.
> 
> **Loading shell** cycles witty splash lines every **3.5s** (with cleanup on dismiss) instead of one line per clock minute. E2E `openAppSidebar` is deduped with a stricter retracted-state wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5573527fb47e53c8985c5e409386e030d08e0fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->