### PR TITLE
fix(editor): improve suggest form contrast

### DIFF
--- a/e2e/admin/map-edit.spec.ts
+++ b/e2e/admin/map-edit.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { E2E_FIXTURES } from "../../scripts/e2e-reset-db";
 import { waitForAppBoot } from "../helpers/app";
 import { loginAsAdmin, logout } from "../helpers/auth";
@@ -12,8 +12,11 @@ import { openBuilding, openDorm } from "../helpers/search";
 test.describe("map edit", () => {
   test.slow();
   test.describe.configure({ retries: 1 });
+  let pageErrors: string[];
 
   test.beforeEach(async ({ page }) => {
+    pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
     await page.goto("/");
     await waitForAppBoot(page);
     await loginAsAdmin(page);
@@ -21,6 +24,7 @@ test.describe("map edit", () => {
 
   test.afterEach(async ({ page }) => {
     await logout(page);
+    expect(pageErrors).toEqual([]);
   });
 
   test("building pin drag saves coordinates", async ({ page }) => {

--- a/src/components/svelte/SubmitterNameField.svelte
+++ b/src/components/svelte/SubmitterNameField.svelte
@@ -95,9 +95,10 @@
 
   .submitter-name-hint {
     margin: 0.125rem 0 0;
-    font-size: 0.6875rem;
+    font-size: 0.8125rem;
+    line-height: 1.4;
     font-weight: 500;
-    color: hsl(0, 0%, 48%);
+    color: hsl(0, 0%, 34%);
   }
 
   .submitter-name-hint.at-limit {

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -814,8 +814,9 @@
   .editor-advanced summary {
     cursor: pointer;
     padding: 0.45rem 0.55rem;
-    font-size: 0.75rem;
+    font-size: 0.8125rem;
     font-weight: 700;
+    line-height: 1.3;
     color: hsl(5, 53%, 32%);
     list-style: none;
   }

--- a/src/components/svelte/editor/entity-editor.css
+++ b/src/components/svelte/editor/entity-editor.css
@@ -151,8 +151,9 @@
   color: #7b1113;
   cursor: pointer;
   font: inherit;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   font-weight: 700;
+  line-height: 1.2;
   padding: 0.3125rem 0.5rem;
 }
 
@@ -162,8 +163,10 @@
 }
 
 .field-save-btn:disabled {
+  border-color: #d9c7c8;
+  background: #f8f1f1;
+  color: #704b4d;
   cursor: not-allowed;
-  opacity: 0.55;
 }
 
 .editor-note {
@@ -295,7 +298,7 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 0.375rem;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
 }
 
 .entity-editor-pin-label {
@@ -316,8 +319,8 @@
 
 .entity-editor-muted {
   margin: 0;
-  color: #71717a;
-  font-size: 0.75rem;
+  color: #52525b;
+  font-size: 0.8125rem;
   line-height: 1.45;
 }
 
@@ -349,10 +352,10 @@
 
 .contributor-form .field-hint {
   margin: 0;
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   font-weight: 500;
   line-height: 1.45;
-  color: hsl(0, 0%, 46%);
+  color: hsl(0, 0%, 34%);
 }
 
 .contributor-form .editor-field input,
@@ -379,7 +382,7 @@
 .contributor-form .editor-field textarea::placeholder,
 .contributor-form .editor-control-row input::placeholder,
 .contributor-form .editor-control-row textarea::placeholder {
-  color: hsl(0, 0%, 54%);
+  color: hsl(0, 0%, 38%);
 }
 
 .contributor-form .editor-field input:focus,
@@ -425,7 +428,8 @@
 }
 
 .contributor-form .submitter-name-hint {
-  color: hsl(0, 0%, 46%);
+  font-size: 0.8125rem;
+  color: hsl(0, 0%, 34%);
   line-height: 1.4;
 }
 


### PR DESCRIPTION
## Summary

Improves contributor/editor suggest-form readability by increasing helper/action text size, darkening muted and placeholder copy, and making disabled inline Submit buttons readable without opacity-only styling. Tightens the existing editor pin-move Playwright spec so building and dorm drag saves also fail on page errors.

Refs #426
Refs #238

## Verification

- [x] Focused Biome checks
- [x] `bun run check:readme`
- [ ] Browser screenshots from the PR preview or local environment still needed

## Known gaps

- E2E requires the local database environment.