### PR TITLE
feat(buildings): CR facilities list (saan may bidet?)

### DIFF
--- a/drizzle/0035_add_building_cr_facilities.sql
+++ b/drizzle/0035_add_building_cr_facilities.sql
@@ -1,0 +1,3 @@
+-- Comfort-room facilities per building ("saan may bidet?"): array of slugs
+-- from src/constants/cr-facilities.ts. NULL/empty = not yet surveyed.
+ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "cr_facilities" text[];

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -257,6 +257,7 @@ export const buildingsTable = pgTable("buildings", {
   lat: doublePrecision().notNull(),
   directions: text().notNull(),
   imageUrl: text("image_url"),
+  crFacilities: text("cr_facilities").array(),
   version: integer().default(1).notNull(),
   updatedAt: timestamp("updated_at", { mode: "string" }).defaultNow().notNull(),
 });

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -62,6 +62,7 @@ const E2E_MIGRATION_FILES = [
   "0032_add_jeepney_transit.sql",
   "0033_ay_2026_2027_term_dates.sql",
   "0034_historical_term_dates.sql",
+  "0035_add_building_cr_facilities.sql",
 ] as const;
 
 async function applyE2eMigrations(client: pg.Client) {

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -48,12 +48,18 @@
     readEntityContributorDraft,
     scheduleEntityContributorDraftSave,
   } from "@lib/contributor-drafts";
+  import {
+    CR_FACILITIES,
+    crFacilityLabel,
+    sanitizeCrFacilities,
+  } from "@constants/cr-facilities";
 
   type BuildingEditableField =
     | "buildingName"
     | "directions"
     | "buildingType"
-    | "imageUrl";
+    | "imageUrl"
+    | "crFacilities";
 
   const appData = getAppData();
   const appActions = getAppActions();
@@ -123,6 +129,7 @@
   let directionsDraft = $state("");
   let typeDraft = $state<BuildingData["buildingType"]>("non-admin");
   let imageDraft = $state<string | null>(null);
+  let crFacilitiesDraft = $state<string[]>([]);
   let savingField = $state<BuildingEditableField | null>(null);
   let savedField = $state<BuildingEditableField | null>(null);
   let fieldError = $state<string | null>(null);
@@ -143,6 +150,7 @@
     directions: "Building directions",
     buildingType: "Building type",
     imageUrl: "Building photo",
+    crFacilities: "CR facilities",
   };
 
   // Room list must reload when the selected building changes (search result,
@@ -235,6 +243,7 @@
     directionsDraft = current.directions ?? "";
     typeDraft = current.buildingType;
     imageDraft = current.imageUrl ?? null;
+    crFacilitiesDraft = sanitizeCrFacilities(current.crFacilities);
     savedField = null;
     fieldError = null;
     mergePrompt = null;
@@ -312,6 +321,7 @@
       directions?: string;
       buildingType?: BuildingData["buildingType"];
       imageUrl?: string | null;
+      crFacilities?: string[];
     } = { version: current.version };
 
     if (field === "buildingName") {
@@ -327,6 +337,8 @@
       body.buildingType = typeDraft;
     } else if (field === "imageUrl") {
       body.imageUrl = imageDraft || null;
+    } else if (field === "crFacilities") {
+      body.crFacilities = sanitizeCrFacilities(crFacilitiesDraft);
     }
 
     savingField = field;
@@ -442,13 +454,29 @@
     }
   }
 
+  const crFacilitiesChanged = $derived.by(() => {
+    const current = building;
+    if (!current) return false;
+    return (
+      sanitizeCrFacilities(crFacilitiesDraft).join("|") !==
+      sanitizeCrFacilities(current.crFacilities).join("|")
+    );
+  });
+
+  function toggleCrFacility(slug: string) {
+    crFacilitiesDraft = crFacilitiesDraft.includes(slug)
+      ? crFacilitiesDraft.filter((item) => item !== slug)
+      : [...crFacilitiesDraft, slug];
+  }
+
   const allFieldsUnchanged = $derived.by(() => {
     const current = building;
     if (!current) return true;
     return (
       nameDraft.trim() === current.buildingName &&
       directionsDraft.trim() === (current.directions ?? "") &&
-      typeDraft === current.buildingType
+      typeDraft === current.buildingType &&
+      !crFacilitiesChanged
     );
   });
 
@@ -470,6 +498,9 @@
     }
     if (typeDraft !== current.buildingType) {
       patch.buildingType = typeDraft;
+    }
+    if (crFacilitiesChanged) {
+      patch.crFacilities = sanitizeCrFacilities(crFacilitiesDraft);
     }
 
     savingField = "buildingName" as BuildingEditableField;
@@ -699,6 +730,38 @@
                 {/snippet}
               </EntityEditorField>
 
+              <EntityEditorField
+                label="CR facilities"
+                inputId="building-cr-facilities-editor"
+                {canPublish}
+                disabled={savingField !== null}
+                fieldSaving={savingField === "crFacilities"}
+                stacked
+                unchanged={!crFacilitiesChanged}
+                onsave={() => saveField("crFacilities")}
+              >
+                {#snippet control()}
+                  <div
+                    id="building-cr-facilities-editor"
+                    class="cr-facilities-editor"
+                    role="group"
+                    aria-label="CR facilities"
+                  >
+                    {#each CR_FACILITIES as facility (facility.slug)}
+                      <label class="cr-facilities-editor__option">
+                        <input
+                          type="checkbox"
+                          checked={crFacilitiesDraft.includes(facility.slug)}
+                          disabled={savingField !== null}
+                          onchange={() => toggleCrFacility(facility.slug)}
+                        />
+                        {facility.label}
+                      </label>
+                    {/each}
+                  </div>
+                {/snippet}
+              </EntityEditorField>
+
               {#if adminAuthStore.isLoggedIn}
                 <div class="editor-image-row">
                   <ImageUpload
@@ -756,6 +819,18 @@
           entityId={building.id}
         />
       </section>
+      {#if sanitizeCrFacilities(building.crFacilities).length > 0}
+        <section class="building-cr" aria-label="CR facilities">
+          <h3 class="entity-section-heading">CR facilities</h3>
+          <div class="entity-tag-list">
+            {#each sanitizeCrFacilities(building.crFacilities) as slug (slug)}
+              <span class="entity-tag-chip building-cr__chip"
+                >{crFacilityLabel(slug)}</span
+              >
+            {/each}
+          </div>
+        </section>
+      {/if}
     {/if}
   {:else}
     <p class="entity-loading-note"><LoadingIndicator label="Loading building…" /></p>
@@ -792,6 +867,23 @@
 
   .building-orgs {
     padding: 0.5rem 0.25rem 0;
+  }
+
+  .building-cr {
+    padding: 0.5rem 0.25rem 0;
+  }
+
+  .cr-facilities-editor {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem 0.75rem;
+  }
+
+  .cr-facilities-editor__option {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
   }
 
   .building-orgs__chip {

--- a/src/constants/cr-facilities.test.ts
+++ b/src/constants/cr-facilities.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { crFacilityLabel, sanitizeCrFacilities } from "./cr-facilities";
+
+describe("sanitizeCrFacilities", () => {
+  it("keeps known slugs in canonical order, drops junk and dupes", () => {
+    expect(
+      sanitizeCrFacilities(["pwd-accessible", "bidet", "bidet", "jacuzzi", 3]),
+    ).toEqual(["bidet", "pwd-accessible"]);
+  });
+
+  it("returns [] for non-arrays", () => {
+    expect(sanitizeCrFacilities(null)).toEqual([]);
+    expect(sanitizeCrFacilities("bidet")).toEqual([]);
+  });
+});
+
+describe("crFacilityLabel", () => {
+  it("labels known slugs and echoes unknown ones", () => {
+    expect(crFacilityLabel("bidet")).toBe("Bidet");
+    expect(crFacilityLabel("mystery")).toBe("mystery");
+  });
+});

--- a/src/constants/cr-facilities.ts
+++ b/src/constants/cr-facilities.ts
@@ -1,0 +1,31 @@
+/**
+ * Comfort-room facilities a building can list ("saan may bidet?").
+ * Stored on buildings.cr_facilities as an array of slugs; unknown slugs are
+ * dropped at the API boundary so the set can only grow via this list.
+ */
+export const CR_FACILITIES = [
+  { slug: "bidet", label: "Bidet" },
+  { slug: "tissue", label: "Tissue paper" },
+  { slug: "soap", label: "Soap" },
+  { slug: "hand-dryer", label: "Hand dryer" },
+  { slug: "hot-water", label: "Hot water" },
+  { slug: "pwd-accessible", label: "PWD-accessible" },
+  { slug: "all-gender", label: "All-gender CR" },
+] as const;
+
+export type CrFacilitySlug = (typeof CR_FACILITIES)[number]["slug"];
+
+const LABELS = new Map<string, string>(
+  CR_FACILITIES.map((f) => [f.slug, f.label]),
+);
+
+export function crFacilityLabel(slug: string): string {
+  return LABELS.get(slug) ?? slug;
+}
+
+/** Keep only known slugs, deduped, in canonical (display) order. */
+export function sanitizeCrFacilities(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const given = new Set(value.filter((item) => typeof item === "string"));
+  return CR_FACILITIES.filter((f) => given.has(f.slug)).map((f) => f.slug);
+}

--- a/src/lib/local/data/pgliteDB.ts
+++ b/src/lib/local/data/pgliteDB.ts
@@ -273,6 +273,9 @@ export async function initPGLiteDB(db: PGlite) {
     ALTER TABLE buildings
     ADD COLUMN IF NOT EXISTS "updated_at" text NOT NULL DEFAULT CURRENT_TIMESTAMP;
 
+    ALTER TABLE buildings
+    ADD COLUMN IF NOT EXISTS "cr_facilities" text[];
+
     ALTER TABLE dorms
     ADD COLUMN IF NOT EXISTS "version" integer NOT NULL DEFAULT 1;
 

--- a/src/lib/local/data/sync.ts
+++ b/src/lib/local/data/sync.ts
@@ -111,8 +111,8 @@ export async function syncBuildings(
     try {
       await localDB.query(
         `
-        INSERT INTO buildings (id, building_name, lon, lat, directions, type, rooms_fetched, image_url, version, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, false, $7, $8, $9)
+        INSERT INTO buildings (id, building_name, lon, lat, directions, type, rooms_fetched, image_url, cr_facilities, version, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, false, $7, $8, $9, $10)
         ON CONFLICT (id) DO UPDATE SET
         id = EXCLUDED.id,
         building_name = EXCLUDED.building_name,
@@ -122,6 +122,7 @@ export async function syncBuildings(
         type = EXCLUDED.type,
         rooms_fetched = EXCLUDED.rooms_fetched,
         image_url = EXCLUDED.image_url,
+        cr_facilities = EXCLUDED.cr_facilities,
         version = EXCLUDED.version,
         updated_at = EXCLUDED.updated_at;
         `,
@@ -133,6 +134,7 @@ export async function syncBuildings(
           b.directions,
           b.buildingType,
           b.imageUrl ?? null,
+          b.crFacilities ?? null,
           b.version,
           b.updatedAt,
         ],

--- a/src/lib/local/data/utils.ts
+++ b/src/lib/local/data/utils.ts
@@ -77,7 +77,7 @@ export async function getLocalBuildings(): Promise<BuildingData[] | undefined> {
     const localDB = getDB();
     await localDB.waitReady;
     const data = (await localDB.query(`
-        SELECT building_name AS "buildingName", lon, lat, id, directions, type AS "buildingType", image_url AS "imageUrl", version, updated_at AS "updatedAt" FROM buildings
+        SELECT building_name AS "buildingName", lon, lat, id, directions, type AS "buildingType", image_url AS "imageUrl", cr_facilities AS "crFacilities", version, updated_at AS "updatedAt" FROM buildings
       `)) as Results<BuildingData>;
     return data.rows;
   } catch (e) {

--- a/src/lib/proposals/diff.ts
+++ b/src/lib/proposals/diff.ts
@@ -23,6 +23,7 @@ export const FIELD_LABELS: Record<string, string> = {
   endsAt: "Ends",
   sourceUrl: "Source URL",
   imageUrl: "Image",
+  crFacilities: "CR facilities",
   recurrence: "Recurrence",
   rooms: "Bundled rooms",
   locations: "Locations",

--- a/src/lib/services/admin-service.ts
+++ b/src/lib/services/admin-service.ts
@@ -17,6 +17,7 @@ import {
   updateTable,
 } from "@drizzle/schema";
 import { normalizeEntityName } from "@lib/entity-names";
+import { sanitizeCrFacilities } from "@constants/cr-facilities";
 import { normalizePlaceCategory } from "@constants/place-categories";
 import { normalizeRoomCategory } from "@constants/room-categories";
 import { db } from "@lib/db";
@@ -616,6 +617,7 @@ export type BuildingUpdateInput = {
   buildingType?: "admin" | "non-admin";
   directions?: string;
   imageUrl?: string | null;
+  crFacilities?: string[] | null;
 };
 
 export async function updateBuilding(
@@ -634,6 +636,8 @@ export async function updateBuilding(
     updates.buildingType = input.buildingType;
   if (input.directions !== undefined) updates.directions = input.directions;
   if (input.imageUrl !== undefined) updates.imageUrl = input.imageUrl;
+  if (input.crFacilities !== undefined)
+    updates.crFacilities = sanitizeCrFacilities(input.crFacilities);
 
   if (Object.keys(updates).length > 0) {
     if (input.buildingName !== undefined) {

--- a/src/pages/api/admin/buildings/[id].ts
+++ b/src/pages/api/admin/buildings/[id].ts
@@ -18,6 +18,7 @@ type BuildingPatchBody = {
   buildingType?: "admin" | "non-admin";
   directions?: string;
   imageUrl?: string | null;
+  crFacilities?: string[] | null;
   version?: number;
 };
 
@@ -94,6 +95,8 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
       updates.buildingType = body.buildingType;
     if (body.directions !== undefined) updates.directions = body.directions;
     if (parsedImageUrl.provided) updates.imageUrl = parsedImageUrl.imageUrl;
+    if (body.crFacilities !== undefined)
+      updates.crFacilities = body.crFacilities;
 
     const building = await updateBuilding(
       id,


### PR DESCRIPTION
## What

Buildings can now list their comfort-room facilities — answering the eternal question, *saan may bidet?*

- **Slug set**: `src/constants/cr-facilities.ts` — bidet, tissue paper, soap, hand dryer, hot water, PWD-accessible, all-gender CR. `sanitizeCrFacilities()` drops unknown slugs and dedupes at every write path.
- **Schema**: `buildings.cr_facilities text[]` (migration 0035, **already applied to prod** — idempotent). Mirrored in the local pglite schema and buildings sync.
- **Editing**: checkbox group under the building panel's *More fields*, wired through the existing publish/proposal flow (admins publish, contributors suggest; proposal review shows a "CR facilities" diff).
- **Display**: chips section on the building panel when the list is non-empty; hidden otherwise.

Starts empty everywhere — data comes from contributors/editors building by building.

## Skipped (follow-ups if wanted)

- Search hook ("bidet" as a query filter for buildings)
- Per-floor granularity — one list per building for now

## Verified

Unit (337) incl. new sanitize tests, component (110), biome, `bun run build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive nullable column and building metadata editing; no auth or payment changes, with slug allowlisting at the service layer.
> 
> **Overview**
> Adds **per-building comfort-room facilities** so editors can record what’s available (e.g. bidet) and visitors see it on the building panel.
> 
> **Data & API:** New optional `buildings.cr_facilities` `text[]` (migration 0035, Drizzle, PGlite, building sync/read paths). Canonical slugs live in `src/constants/cr-facilities.ts` with `sanitizeCrFacilities()` on writes (`updateBuilding` and the building PATCH route). Proposal diffs label the field **CR facilities**.
> 
> **UI:** `BuildingResult` gets a checkbox group under *More fields* and tag chips when the list is non-empty, wired through the existing publish/proposal/save-all flows with client-side sanitization matching the server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f50f0f9e8165d6e3dd13eac967bf397ef1d97d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->