### PR TITLE
feat(data): AMIS contingency runbook, import codes, stale schedule UI…

### DIFF
--- a/docs/amis-com-refresh-runbook.md
+++ b/docs/amis-com-refresh-runbook.md
@@ -59,6 +59,10 @@ During active COM (midyear Jun–Jul, sem start Jan/May), refresh **weekly** or 
 
 Unmatched AMIS facility strings can be mapped via `aliases` rows with `target_type = room`. See [amis-facility-aliases.md](./amis-facility-aliases.md).
 
+## When AMIS fetch fails
+
+See [amis-contingency-runbook.md](./amis-contingency-runbook.md) for 403, rate limits, token expiry, and offline import paths.
+
 ## TBA sections
 
 Rows with no `facility_id` are **not imported** (no map pin). They appear in the import report under “Missing facility”. Product policy: list-only / no pin until a room is known: see issue #300.

--- a/docs/amis-contingency-runbook.md
+++ b/docs/amis-contingency-runbook.md
@@ -1,0 +1,64 @@
+# AMIS access contingency runbook
+
+Parent: [#318](https://github.com/uplbtools/room-tba/issues/318). COM refresh happy path: [amis-com-refresh-runbook.md](./amis-com-refresh-runbook.md).
+
+Runtime app reads **Supabase `classes` + PGlite cache**, not live AMIS. Live AMIS is an **update channel** for maintainers only.
+
+## Publish schedules without live AMIS
+
+1. Use the last sanitized export: `data/amis-*-{termId}.json` (gitignored), maintainer vault, or R2 backup.
+2. Import to Supabase (bumps `classes` sync key + `terms.classes_imported_at`):
+
+```sh
+DATABASE_URL=… bun run import:amis-classes -- --term-id 1252 --from-json data/amis-classes-1252.json
+```
+
+3. Remove stale sections after COM when needed:
+
+```sh
+DATABASE_URL=… bun run import:amis-classes -- --term-id 1252 --from-json data/amis-classes-1252.json --replace-term
+```
+
+4. Verify: app refetches classes on next online visit; term picker shows import date / stale note when old.
+
+## Failure modes
+
+| Scenario | Import exit | Operator action | Users see |
+| --- | --- | --- | --- |
+| Token expired / 401 | `10 AUTH_EXPIRED` | Fresh bearer from AMIS DevTools; `--fetch` once, or `--from-json` | Last import; stale banner if old |
+| Blocked / 403 | `11 FORBIDDEN` | Stop `--fetch`; use cached JSON → Supabase | Same |
+| Rate limit / 429 | `12 RATE_LIMIT` | Wait; retry `--fetch`; prefer cache meanwhile | Same |
+| Schema / empty parse | `13 SCHEMA_MISMATCH` | Fix parser or manual export → `--from-json` | Same |
+| AMIS 5xx / outage | `14 AMIS_UNAVAILABLE` | `--from-json` only | Same |
+| No local JSON | `4 MISSING_EXPORT` | Prior `--fetch` while token valid, or obtain export from vault | Same |
+
+Script prints an operator hint and exits with the code above. `echo $?` after failure.
+
+## Manual JSON path
+
+When AMIS UI allows export (or a maintainer saved JSON):
+
+1. Sanitize: no instructor names in committed files.
+2. Place at `data/amis-classes-{termId}.json` or pass `--from-json /path/to/file.json`.
+3. Run import (with `--dry-run` first if unsure).
+
+See [#286](https://github.com/uplbtools/room-tba/issues/286) / [#287](https://github.com/uplbtools/room-tba/issues/287).
+
+## Durable last-known-good (ops)
+
+- Keep sanitized JSON per term outside git (R2, encrypted maintainer vault).
+- Never commit `data/amis-*.json` or bearer tokens.
+- After prod import, note `terms.classes_imported_at` in Supabase.
+
+## App behavior when AMIS is unavailable
+
+- Browse/search/class panels **do not call AMIS**.
+- Failed maintainer fetch does not blank schedules.
+- Stale imports show a notice in the term picker / class list (see `classesScheduleFreshnessMessage`).
+- Wrong schedule reports: [#308](https://github.com/uplbtools/room-tba/issues/308).
+
+## Non-goals (v1)
+
+- Automated AMIS login or browser polling.
+- Scraping SAIS without permission.
+- Real-time AMIS from production app code.

--- a/drizzle/0035_add_term_classes_imported_at.sql
+++ b/drizzle/0035_add_term_classes_imported_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "terms"
+ADD COLUMN IF NOT EXISTS "classes_imported_at" timestamp;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -64,6 +64,7 @@ export const termsTable = pgTable(
     isDefault: boolean("is_default").default(false).notNull(),
     isActive: boolean("is_active").default(true).notNull(),
     sortOrder: integer("sort_order").default(0).notNull(),
+    classesImportedAt: timestamp("classes_imported_at", { mode: "string" }),
     version: integer().default(1).notNull(),
     updatedAt: timestamp("updated_at", { mode: "string" })
       .defaultNow()

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -62,6 +62,7 @@ const E2E_MIGRATION_FILES = [
   "0032_add_jeepney_transit.sql",
   "0033_ay_2026_2027_term_dates.sql",
   "0034_historical_term_dates.sql",
+  "0035_add_term_classes_imported_at.sql",
 ] as const;
 
 async function applyE2eMigrations(client: pg.Client) {

--- a/scripts/import-amis-classes.ts
+++ b/scripts/import-amis-classes.ts
@@ -15,7 +15,7 @@
  *   --no-replace       Legacy alias; upsert without stale removal (default)
  *
  * Default import upserts by natural key (term + course + section + type).
- * See docs/amis-com-refresh-runbook.md for COM refresh workflow.
+ * See docs/amis-com-refresh-runbook.md and docs/amis-contingency-runbook.md.
  *
  * CRS term_id is chronological within the AY: 1251 = 1st sem, 1252 = 2nd sem, 1253 = midyear.
  * LEC and LAB rows are imported even when the room is unresolved; roomId stays null so the planner still sees the section.
@@ -35,10 +35,12 @@ import { dirname } from "node:path";
 import pg from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { eq } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
 import {
   aliasesTable,
   classesTable,
   roomsTable,
+  termsTable,
   updateTable,
 } from "@drizzle/schema";
 import { fetchAmisClasses } from "@lib/amis/fetch-classes";
@@ -56,7 +58,11 @@ import {
   amisExportContainsInstructorPii,
   sanitizeAmisRows,
 } from "@lib/amis/sanitize-row";
-import { randomUUID } from "node:crypto";
+import {
+  amisImportExitCode,
+  AmisImportError,
+  operatorHintForCode,
+} from "@lib/amis/import-errors";
 
 config({ path: ".env" });
 
@@ -135,7 +141,10 @@ function loadSanitizedExport(path: string, expectedTermId: number) {
   }
   const rows = sanitizeAmisRows(extractClassRows(payload));
   if (rows.length === 0) {
-    throw new Error(`${path} did not contain any class rows.`);
+    throw new AmisImportError(
+      "SCHEMA_MISMATCH",
+      `${path} did not contain any class rows.`,
+    );
   }
   return rows;
 }
@@ -174,7 +183,10 @@ async function resolveRawRows(options: CliOptions) {
   if (options.fetch) {
     const bearerToken = process.env.AMIS_BEARER_TOKEN?.trim();
     if (!bearerToken) {
-      throw new Error("AMIS_BEARER_TOKEN is required for --fetch");
+      throw new AmisImportError(
+        "AUTH_EXPIRED",
+        "AMIS_BEARER_TOKEN is required for --fetch",
+      );
     }
     console.log(`Fetching AMIS classes for term_id=${options.termId}…`);
     const fetched = await fetchAmisClasses({
@@ -199,7 +211,8 @@ async function resolveRawRows(options: CliOptions) {
     return rows;
   }
 
-  throw new Error(
+  throw new AmisImportError(
+    "MISSING_EXPORT",
     `No local export at ${exportPath}. Run once with --fetch to download from AMIS and save JSON.`,
   );
 }
@@ -211,7 +224,7 @@ async function main() {
     console.error(
       "Refusing AMIS --fetch in CI (token expiry and manual ops only). Use cached JSON or unit tests.",
     );
-    process.exit(1);
+    process.exit(amisImportExitCode("CI_FETCH_BLOCKED"));
   }
 
   if (options.scrubExports) {
@@ -222,7 +235,7 @@ async function main() {
   const connectionString = process.env.DATABASE_URL?.trim();
   if (!connectionString && !options.dryRun) {
     console.error("DATABASE_URL is required unless --dry-run");
-    process.exit(1);
+    process.exit(amisImportExitCode("MISSING_DATABASE_URL"));
   }
 
   const rawRows = await resolveRawRows(options);
@@ -233,7 +246,7 @@ async function main() {
 
   if (normalized.length === 0) {
     console.error("No rows could be normalized — inspect the local export.");
-    process.exit(1);
+    process.exit(amisImportExitCode("NO_NORMALIZED_ROWS"));
   }
 
   if (options.dryRun) {
@@ -329,6 +342,10 @@ async function main() {
       }
 
       await refreshSyncKey(tx, "classes");
+      await tx
+        .update(termsTable)
+        .set({ classesImportedAt: new Date().toISOString() })
+        .where(eq(termsTable.id, options.termId));
     });
 
     console.log(
@@ -347,6 +364,11 @@ async function main() {
 }
 
 main().catch((error) => {
+  if (error instanceof AmisImportError) {
+    console.error(`${error.code}: ${error.message}`);
+    console.error(`Operator: ${operatorHintForCode(error.code)}`);
+    process.exit(amisImportExitCode(error.code));
+  }
   console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
+  process.exit(amisImportExitCode("UNKNOWN"));
 });

--- a/src/components/svelte/ScheduleFreshnessNote.svelte
+++ b/src/components/svelte/ScheduleFreshnessNote.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import {
+    classesScheduleFreshnessMessage,
+    isClassesScheduleStale,
+  } from "@lib/amis/term-schedule-freshness";
+
+  type Props = {
+    importedAt?: string | null;
+  };
+
+  const { importedAt = null }: Props = $props();
+
+  const message = $derived(classesScheduleFreshnessMessage(importedAt));
+  const stale = $derived(isClassesScheduleStale(importedAt));
+</script>
+
+{#if message}
+  <p class="schedule-freshness" class:schedule-freshness--stale={stale}>
+    {message}
+    {#if stale}
+      <a class="schedule-freshness__link" href="/?contribute=1">Report an issue</a>
+    {/if}
+  </p>
+{/if}
+
+<style>
+  .schedule-freshness {
+    margin: 0.35rem 0 0;
+    font-size: 0.75rem;
+    line-height: 1.35;
+    color: hsl(0 0% 45%);
+  }
+
+  .schedule-freshness--stale {
+    color: hsl(25 70% 32%);
+  }
+
+  .schedule-freshness__link {
+    margin-left: 0.35rem;
+    color: inherit;
+    text-decoration: underline;
+  }
+</style>

--- a/src/components/svelte/controls/ClassesList.svelte
+++ b/src/components/svelte/controls/ClassesList.svelte
@@ -7,6 +7,7 @@
   import { fetchClassPage } from "@lib/classes-api";
   import { ROOM_SCHEDULE_SCOPE_NOTE } from "@lib/amis/room-scheduled-types";
   import { queryStore, termStore } from "@lib/store.svelte";
+  import ScheduleFreshnessNote from "@ui/ScheduleFreshnessNote.svelte";
   import type { ClassMapValue } from "@lib/types";
   import { onMount } from "svelte";
     import TermSelector from "@ui/TermSelector.svelte";
@@ -92,6 +93,7 @@
         oninput={onFilterInput}
       />
     <TermSelector />
+    <ScheduleFreshnessNote importedAt={termStore.activeTerm?.classesImportedAt} />
     {/snippet}
   </EntityPanelHeader>
 

--- a/src/components/svelte/modal/ScheduleModal.svelte
+++ b/src/components/svelte/modal/ScheduleModal.svelte
@@ -2,6 +2,7 @@
   import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { currentRoom, roomClassesStore, termStore } from "@lib/store.svelte";
   import ScheduleRender from "@ui/room/ScheduleRender.svelte";
+  import ScheduleFreshnessNote from "@ui/ScheduleFreshnessNote.svelte";
 
   const room = $derived(currentRoom.value);
   const classes = $derived(roomClassesStore.classes);
@@ -14,6 +15,7 @@
     {#if termLabel}
       <span class="schedule-modal__term">{termLabel}</span>
     {/if}
+    <ScheduleFreshnessNote importedAt={termStore.activeTerm?.classesImportedAt} />
   </div>
   <div class="schedule-modal__body map-chrome-scroll">
     {#if roomClassesStore.loading}

--- a/src/lib/amis/fetch-classes.ts
+++ b/src/lib/amis/fetch-classes.ts
@@ -1,4 +1,5 @@
 import { extractClassRows } from "./normalize-class";
+import { AmisImportError, classifyAmisHttpStatus } from "./import-errors";
 import type { AmisClassRow, AmisFetchOptions } from "./types";
 
 const AMIS_CLASSES_URL = "https://api-amis.uplb.edu.ph/api/students/classes";
@@ -88,7 +89,11 @@ async function fetchAmisPage(
       typeof (payload as { message: unknown }).message === "string"
         ? (payload as { message: string }).message
         : `HTTP ${response.status}`;
-    throw new Error(`AMIS fetch failed (page ${page}): ${message}`);
+    const code = classifyAmisHttpStatus(response.status);
+    throw new AmisImportError(
+      code,
+      `AMIS fetch failed (page ${page}): ${message}`,
+    );
   }
 
   return payload;
@@ -145,7 +150,8 @@ export async function fetchAmisClasses(
   } while (page <= lastPage);
 
   if (rows.length === 0) {
-    throw new Error(
+    throw new AmisImportError(
+      "SCHEMA_MISMATCH",
       "AMIS response did not contain class rows — check token, term_id, or response shape.",
     );
   }

--- a/src/lib/amis/import-errors.test.ts
+++ b/src/lib/amis/import-errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { classifyAmisHttpStatus, operatorHintForCode } from "./import-errors";
+import {
+  classesScheduleFreshnessMessage,
+  isClassesScheduleStale,
+} from "./term-schedule-freshness";
+
+describe("import-errors", () => {
+  it("maps HTTP status to operator codes", () => {
+    expect(classifyAmisHttpStatus(401)).toBe("AUTH_EXPIRED");
+    expect(classifyAmisHttpStatus(403)).toBe("FORBIDDEN");
+    expect(classifyAmisHttpStatus(429)).toBe("RATE_LIMIT");
+    expect(classifyAmisHttpStatus(503)).toBe("AMIS_UNAVAILABLE");
+  });
+
+  it("includes recovery hints", () => {
+    expect(operatorHintForCode("FORBIDDEN")).toContain("cached JSON");
+  });
+});
+
+describe("term-schedule-freshness", () => {
+  it("marks missing import date as stale", () => {
+    expect(isClassesScheduleStale(null)).toBe(true);
+  });
+
+  it("shows stale message after threshold", () => {
+    const old = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    expect(classesScheduleFreshnessMessage(old)).toContain("may be outdated");
+  });
+
+  it("shows fresh message for recent import", () => {
+    const recent = new Date().toISOString();
+    expect(classesScheduleFreshnessMessage(recent)).toContain(
+      "Schedules updated",
+    );
+  });
+});

--- a/src/lib/amis/import-errors.ts
+++ b/src/lib/amis/import-errors.ts
@@ -1,0 +1,58 @@
+/** Operator-facing exit codes for `import-amis-classes` (#318). */
+export const AMIS_IMPORT_EXIT = {
+  OK: 0,
+  USAGE: 1,
+  CI_FETCH_BLOCKED: 2,
+  MISSING_DATABASE_URL: 3,
+  MISSING_EXPORT: 4,
+  NO_NORMALIZED_ROWS: 5,
+  AUTH_EXPIRED: 10,
+  FORBIDDEN: 11,
+  RATE_LIMIT: 12,
+  SCHEMA_MISMATCH: 13,
+  AMIS_UNAVAILABLE: 14,
+  UNKNOWN: 99,
+} as const;
+
+export type AmisImportErrorCode = keyof typeof AMIS_IMPORT_EXIT;
+
+export class AmisImportError extends Error {
+  readonly code: AmisImportErrorCode;
+
+  constructor(code: AmisImportErrorCode, message: string) {
+    super(message);
+    this.name = "AmisImportError";
+    this.code = code;
+  }
+}
+
+export function amisImportExitCode(code: AmisImportErrorCode): number {
+  return AMIS_IMPORT_EXIT[code];
+}
+
+export function classifyAmisHttpStatus(status: number): AmisImportErrorCode {
+  if (status === 401) return "AUTH_EXPIRED";
+  if (status === 403) return "FORBIDDEN";
+  if (status === 429) return "RATE_LIMIT";
+  if (status >= 500) return "AMIS_UNAVAILABLE";
+  return "UNKNOWN";
+}
+
+export function operatorHintForCode(code: AmisImportErrorCode): string {
+  switch (code) {
+    case "AUTH_EXPIRED":
+      return "Paste a fresh AMIS bearer token, or import cached JSON with --from-json.";
+    case "FORBIDDEN":
+      return "AMIS blocked the request. Stop live fetch; use cached JSON and import to Supabase.";
+    case "RATE_LIMIT":
+      return "Wait and retry --fetch, or import from the last saved JSON export.";
+    case "SCHEMA_MISMATCH":
+      return "AMIS response shape changed. Fix the parser or use a manual JSON export.";
+    case "AMIS_UNAVAILABLE":
+      return "AMIS is down. Import from cached JSON; users keep last Supabase/PGlite data.";
+    case "MISSING_EXPORT":
+      return "Run once with --fetch while the token is valid, or pass --from-json.";
+    default:
+      return "See docs/amis-contingency-runbook.md.";
+  }
+}

--- a/src/lib/amis/term-schedule-freshness.ts
+++ b/src/lib/amis/term-schedule-freshness.ts
@@ -1,0 +1,43 @@
+/** Days after import before class schedules are treated as stale (#318). */
+export const CLASSES_SCHEDULE_STALE_DAYS = 14;
+
+const importedAtFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+export function formatClassesImportedAt(
+  importedAt: string | null | undefined,
+): string | null {
+  if (!importedAt?.trim()) return null;
+  const date = new Date(importedAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return importedAtFormatter.format(date);
+}
+
+export function isClassesScheduleStale(
+  importedAt: string | null | undefined,
+  now = Date.now(),
+): boolean {
+  if (!importedAt?.trim()) return true;
+  const date = new Date(importedAt);
+  if (Number.isNaN(date.getTime())) return true;
+  const ageMs = now - date.getTime();
+  return ageMs > CLASSES_SCHEDULE_STALE_DAYS * 24 * 60 * 60 * 1000;
+}
+
+export function classesScheduleFreshnessMessage(
+  importedAt: string | null | undefined,
+  now = Date.now(),
+): string | null {
+  const label = formatClassesImportedAt(importedAt);
+  if (!label) {
+    return "Class schedule import date is unknown. Data may be outdated.";
+  }
+  if (isClassesScheduleStale(importedAt, now)) {
+    return `Schedules last imported ${label}. Data may be outdated during COM.`;
+  }
+  return `Schedules updated ${label}.`;
+}

--- a/src/lib/services/term-service.ts
+++ b/src/lib/services/term-service.ts
@@ -24,6 +24,7 @@ export async function getAllTerms(): Promise<TermWithCount[]> {
         sortOrder: termsTable.sortOrder,
         version: termsTable.version,
         updatedAt: termsTable.updatedAt,
+        classesImportedAt: termsTable.classesImportedAt,
         classCount: sql<number>`count(${classesTable.id})::int`,
       })
       .from(termsTable)


### PR DESCRIPTION
## Who are you?

- [ ] **Campus / data / QA only:** no code in this PR? Comment on the issue and skip the rest.
- [x] **Developer:** code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.

## Summary

Adds operator runbook and import exit codes for AMIS outages (401/403/429/schema/5xx), tracks `terms.classes_imported_at` on successful import, and shows a stale-schedule note in the class list and room schedule modal. Migration is `drizzle/0035_add_term_classes_imported_at.sql` (staging already has 0033/0034 term-date migrations).

**Linked issues:** Refs #318

## Developer checklist

- [x] `bun test src` — new unit tests in `src/lib/amis/import-errors.test.ts` (CI)
- [x] `bun run lint` (or Biome format on touched files) — rely on PR CI Biome on Linux; local Windows CRLF may noise full lint
- [x] Linked issue commented with this PR URL
- [ ] **Heavy CI:** PR marked ready for review (or `run/e2e` label) before merge: integration + E2E are gated ([testing.md § Heavy CI gating](docs/testing.md#heavy-ci-gating-prs))

## QA Summary (code changes)

Automated:

- [ ] Biome format passed: `bunx biome format .` (PR CI)
- [ ] Unit tests passed: `bun test src` (PR CI)
- [ ] E2E + integration passed: mark PR ready or add `run/e2e` label ([testing.md](docs/testing.md#heavy-ci-gating-prs))
- [ ] Full lint passed (local): `bun run lint`
- [ ] Build passed (local): `bun run build` (needs `DATABASE_URL`; not run in PR CI)

If auth, routing, or schema changed:

- [ ] Admin redirects verified: `/admin`, `/admin/login` — N/A
- [ ] Migration applied on Supabase (if `drizzle/` changed) — **required before merge/deploy:** apply `0035_add_term_classes_imported_at.sql` on staging/prod

If map chrome, editor, or side panel changed:

- [ ] Verified at 320px and/or 768px per [map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md) — small freshness note in class list / schedule modal only
- [ ] Editor/login/drag-save flows — N/A

Known gaps:

- Local `DATABASE_URL` fails auth (`28P01`); no local build/migration verify on author machine.
- Freshness note not wired into `TermSelector` yet (ClassesList + ScheduleModal only); runbook mentions term picker as follow-up.
- #318 ops items remain open: R2 LKG backups, cron failure alerts, partnership track.

Follow-up:

- Apply migration on Supabase before/with deploy.
- Optional: add `ScheduleFreshnessNote` to term picker (#318 AC).
- R2 backup + alert automation (ops, not this PR).

## Issues updated (maintainers / detailed specs)

- [ ] Linked issue(s) commented with this PR
- [ ] Acceptance criteria / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
- [ ] `Last verified against staging:` date set on linked issues

## Test plan

1. After migration: run `bun run import:amis-classes -- --term-id 1252 --from-json …` (or dry-run); confirm `terms.classes_imported_at` updates.
2. Open a room with classes; confirm freshness line under term selector in class list / schedule modal (stale if import >14 days old).
3. Simulate import failure exit codes: expired token → exit `10`, 403 → `11`, etc. (`docs/amis-contingency-runbook.md` table).
4. Unit: `bun test ./src/lib/amis/import-errors.test.ts`