### PR TITLE
release: wiki midyear section names

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -473,7 +473,7 @@
     --bottom-fab-inset: 3.75rem;
     --pill-padding-x: 0.875rem;
     --map-chrome-radius: 1rem;
-    --map-chrome-toggle-size: 2rem;
+    --map-chrome-toggle-size: 2.75rem;
     --map-chrome-toggle-radius: 0.625rem;
     /* Map chrome contrast: warm off-white surfaces + stronger edges so controls
        float above light basemap tiles without dimming the map itself. */

--- a/src/components/svelte/LoadingIndicator.svelte
+++ b/src/components/svelte/LoadingIndicator.svelte
@@ -9,7 +9,7 @@
 {#if block}
   <span class="loading-block" role="status">
     <span class="loading-block__badge" aria-hidden="true">
-      <img src="/logo.png" alt="" width="28" height="28" />
+      <img src="/logo.png" alt="" width="28" height="28" decoding="async" />
     </span>
     <span class="loading-block__track" aria-hidden="true">
       <span class="loading-block__fill"></span>

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -2704,6 +2704,10 @@
                                     class="event-stack-thumb"
                                     src={image.src}
                                     alt=""
+                                    width="32"
+                                    height="32"
+                                    loading="lazy"
+                                    decoding="async"
                                   />
                                 {:else}
                                   <span

--- a/src/components/svelte/MapAttribution.svelte
+++ b/src/components/svelte/MapAttribution.svelte
@@ -63,6 +63,9 @@
       <img
         src="https://api.maptiler.com/resources/logo.svg"
         alt="MapTiler logo"
+        width="80"
+        height="20"
+        decoding="async"
       />
     </a>
   {/if}

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -812,7 +812,10 @@
           class="entity-image"
           src={building.imageUrl}
           alt={building.buildingName}
+          width="800"
+          height="450"
           loading="lazy"
+          decoding="async"
         />
       {/if}
       <section class="entity-directions" aria-label="Directions">

--- a/src/components/svelte/controls/DormResult.svelte
+++ b/src/components/svelte/controls/DormResult.svelte
@@ -713,7 +713,10 @@
         class="entity-image"
         src={dorm.imageUrl}
         alt={dorm.dormName}
+        width="800"
+        height="450"
         loading="lazy"
+        decoding="async"
       />
     {/if}
 

--- a/src/components/svelte/controls/EventResult.svelte
+++ b/src/components/svelte/controls/EventResult.svelte
@@ -644,7 +644,10 @@
           class="event-image"
           src={eventImage.src}
           alt={eventImage.alt}
+          width="800"
+          height="450"
           loading="lazy"
+          decoding="async"
         />
       {/if}
       <div class="entity-actions">

--- a/src/components/svelte/controls/EventsList.svelte
+++ b/src/components/svelte/controls/EventsList.svelte
@@ -187,7 +187,10 @@
                   class="events-list-card-image"
                   src={image.src}
                   alt=""
+                  width="64"
+                  height="64"
                   loading="lazy"
+                  decoding="async"
                 />
               {:else}
                 <span class="events-list-card-icon" aria-hidden="true">

--- a/src/components/svelte/controls/OrgResult.svelte
+++ b/src/components/svelte/controls/OrgResult.svelte
@@ -356,7 +356,10 @@
         class="entity-image"
         src={org.imageUrl}
         alt={org.name}
+        width="800"
+        height="450"
         loading="lazy"
+        decoding="async"
       />
     {/if}
 

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -53,8 +53,8 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  width: var(--map-chrome-toggle-size, 2rem);
-  height: var(--map-chrome-toggle-size, 2rem);
+  width: var(--map-chrome-toggle-size, 2.75rem);
+  height: var(--map-chrome-toggle-size, 2.75rem);
   border: 1px solid #d8b9ba;
   border-radius: var(--map-chrome-toggle-radius, 0.625rem);
   background: #fffafa;
@@ -453,12 +453,12 @@ button.map-chrome-chip:disabled {
 }
 
 .map-chrome-control-btn--compact {
-  width: 2.5rem;
-  height: 2.5rem;
-  min-width: 2.5rem;
-  min-height: 2.5rem;
-  max-width: 2.5rem;
-  max-height: 2.5rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  max-width: 2.75rem;
+  max-height: 2.75rem;
   border-width: 1px;
   box-shadow: var(
     --map-chrome-fab-shadow,
@@ -554,8 +554,10 @@ button.map-chrome-chip:disabled {
 
   .map-tools-panel .map-chrome-panel-close {
     flex-shrink: 0;
-    width: 2rem;
-    height: 2rem;
+    width: 2.75rem;
+    height: 2.75rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
     padding: 0;
   }
 
@@ -605,8 +607,10 @@ button.map-chrome-chip:disabled {
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   border: none;
   border-radius: 0.375rem;
   background: transparent;

--- a/src/components/svelte/map/EntityHoverPreview.svelte
+++ b/src/components/svelte/map/EntityHoverPreview.svelte
@@ -44,7 +44,10 @@
         class="entity-hover-preview__image"
         src={preview.imageUrl}
         alt=""
+        width="320"
+        height="180"
         loading="lazy"
+        decoding="async"
       />
     {/if}
     <div class="entity-hover-preview__body">

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -461,6 +461,7 @@
   .tab-btn {
     flex: 1;
     min-width: 0;
+    min-height: 2.75rem;
     border: none;
     background: transparent;
     color: hsl(0, 0%, 32%);
@@ -681,6 +682,7 @@
     justify-content: center;
     text-align: center;
     border-radius: 0.5rem;
+    min-height: 2.75rem;
     padding: 0.6875rem 1.75rem;
     font-size: 0.9375rem;
     font-weight: 700;
@@ -695,6 +697,11 @@
 
   .primary-btn:hover {
     background-color: hsl(5, 75%, 22%);
+  }
+
+  .primary-btn:focus-visible {
+    outline: 2px solid hsl(5, 75%, 22%);
+    outline-offset: 2px;
   }
 
   .install-btn {

--- a/src/components/svelte/modal/PeopleAvatarGrid.svelte
+++ b/src/components/svelte/modal/PeopleAvatarGrid.svelte
@@ -57,7 +57,10 @@
         <img
           src={imageFor(person)}
           alt={person.name}
+          width="44"
+          height="44"
           loading="lazy"
+          decoding="async"
           onerror={handleImageError}
         />
         <span class="person-name">{person.name}</span>
@@ -73,7 +76,10 @@
         <img
           src={imageFor(person)}
           alt={person.name}
+          width="44"
+          height="44"
           loading="lazy"
+          decoding="async"
           onerror={handleImageError}
         />
         <span class="person-name">{person.name}</span>

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -794,7 +794,10 @@
         class="entity-image"
         src={currentRoom.value.imageUrl}
         alt={currentRoom.value.code}
+        width="800"
+        height="450"
         loading="lazy"
+        decoding="async"
       />
     {/if}
 

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -306,7 +306,7 @@
 
   .search-root.mobile-shell .search-shell-main {
     display: grid;
-    grid-template-columns: var(--map-chrome-toggle-size, 2rem) minmax(0, 1fr);
+    grid-template-columns: var(--map-chrome-toggle-size, 2.75rem) minmax(0, 1fr);
     align-items: center;
     justify-items: stretch;
     column-gap: 0.375rem;
@@ -479,8 +479,10 @@
     flex: 0 0 auto;
     align-items: center;
     justify-content: center;
-    width: 2rem;
-    height: 2rem;
+    width: 2.75rem;
+    height: 2.75rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
     border: 1px solid var(--map-chrome-border, hsl(0, 0%, 58%));
     border-radius: 999px;
     background-color: var(--map-chrome-surface, rgba(255, 255, 255, 0.98));
@@ -510,7 +512,9 @@
   @media (max-width: 30rem) {
     .map-search-chrome__planner-btn {
       padding: 0;
-      width: 1.75rem;
+      width: 2.75rem;
+      min-width: 2.75rem;
+      min-height: 2.75rem;
       justify-content: center;
     }
 
@@ -584,10 +588,15 @@
 
   .clear-btn {
     all: unset;
+    box-sizing: border-box;
     display: flex;
     flex: 0 0 auto;
     align-items: center;
     justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
     cursor: pointer;
     color: hsl(0, 0%, 28%);
     border-radius: 999px;

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -125,7 +125,7 @@ import {
             > (from the app menu) to change your display name, email, or password;
             connect or disconnect a Google sign-in; download a copy of your account
             data; or delete your account. Deleting an account removes your email,
-            display name, and password — past proposals and edit history remain on
+            display name, and password; past proposals and edit history remain on
             record, attributed to a deleted user, so the audit trail for published
             changes stays intact.
           </li>

--- a/src/pages/wiki/section-times.astro
+++ b/src/pages/wiki/section-times.astro
@@ -813,8 +813,9 @@ const structuredData = jsonLd(
       </p>
       <ul class="break-list">
         <li>
-          <strong>Midyear</strong> — MTWThFS and 105-minute offsets, not the
-          TTh/WF ladder.
+          <strong>Midyear</strong> — MTWThFS and 105-minute offsets; A–H labels
+          no longer mean WF; compounds like <code>BCTU</code> /
+          <code>FGXY</code> stitch both letter ladders.
         </li>
         <li>
           <strong>Labs</strong> — letter echoes the lecture; lab time is

--- a/src/pages/wiki/section-times.astro
+++ b/src/pages/wiki/section-times.astro
@@ -194,6 +194,57 @@ const midyearQuartet = [
   "2:45–4:30",
 ] as const;
 
+
+/** Midyear (CRS 1253) section-name patterns — AMIS export + Room TBA census. */
+const midyearSectionPatterns = [
+  {
+    pattern: "A–H (single letter)",
+    example: "C, B, H, G",
+    meaning:
+      "Most common midyear LEC labels, but they almost always meet MTWThFS (or MTWThF), not WF. Do not read C as “WF 10:00.”",
+  },
+  {
+    pattern: "S–Z (single letter)",
+    example: "W, X, Z",
+    meaning:
+      "Rare in midyear LEC. When present, still usually on the dense daily grid — not the regular TTh ladder.",
+  },
+  {
+    pattern: "Two-letter pairs",
+    example: "AB, BC, FG, CU",
+    meaning:
+      "Same strings as regular-sem doubles, but schedules are midyear blocks (often MTWTh / MTWThFS).",
+  },
+  {
+    pattern: "Cross-ladder compounds",
+    example: "BCTU, FGXY, CDUV, GHYZ, ABST, DEVW",
+    meaning:
+      "Midyear-specific: stitches a WF-family pair with a TTh-family pair into one section name for a long daily lecture (e.g. B+C with T+U).",
+  },
+  {
+    pattern: "Letter + digits",
+    example: "B1, E2, G1",
+    meaning:
+      "Parallel midyear lecture groups under the same letter label; still dense daily meetings.",
+  },
+  {
+    pattern: "Labs",
+    example: "1L, 2L, AB1L, BC-1L, U-2L",
+    meaning:
+      "Bare nL is common in midyear CHEM/PHYS-style labs. Parent-letter labs still do not inherit the lecture’s MTWThFS clock.",
+  },
+] as const;
+
+/** Notable midyear compound section codes from the CRS 1253 AMIS export. */
+const midyearCompounds = [
+  { code: "ABST", bridge: "AB + ST", note: "Early WF pair + early TTh pair" },
+  { code: "BCTU", bridge: "BC + TU", note: "Common on CHEM midyear lectures" },
+  { code: "CDUV", bridge: "CD + UV", note: "Mid-morning bridge" },
+  { code: "DEVW", bridge: "DE + VW", note: "Late-morning / noon bridge" },
+  { code: "FGXY", bridge: "FG + XY", note: "Afternoon bridge (e.g. CHEM 32/40)" },
+  { code: "GHYZ", bridge: "GH + YZ", note: "Late-afternoon bridge" },
+] as const;
+
 const letterUseful = [
   {
     mode: "Regular paired LEC",
@@ -211,7 +262,7 @@ const letterUseful = [
     mode: "Midyear LEC",
     days: "Usually MTWThFS",
     block: "105 min",
-    useful: "No",
+    useful: "No — letters label groups; compounds like BCTU are midyear-only",
   },
   {
     mode: "Midyear LAB",
@@ -351,6 +402,7 @@ const structuredData = jsonLd(
         <li><a href="#special-courses">NSTP, HK, GI, residency, ROTC</a></li>
         <li><a href="#regular-sem">Regular semester day structure</a></li>
         <li><a href="#midyear">Midyear calendar</a></li>
+        <li><a href="#midyear-names">Midyear section names</a></li>
         <li><a href="#when-useful">When the letter is useful</a></li>
         <li><a href="#why-not-perfect">Why the code is not perfect</a></li>
         <li><a href="#method">How we checked</a></li>
@@ -776,6 +828,68 @@ const structuredData = jsonLd(
         Lengths cluster around 210 minutes, with occasional multi-hour
         marathons.
       </p>
+
+      <h3 id="midyear-names">Midyear section names</h3>
+      <p>
+        Midyear reuses the same alphabet soup as regular semesters, then bends
+        it. Single letters <strong>A–H</strong> still dominate lecture labels
+        (C, B, H, G are the busiest in the CRS 1253 AMIS export), but those
+        rows meet <strong>MTWThFS</strong> — so the regular “A–H = WF” rule is
+        false for midyear. S–Z singles are rare.
+      </p>
+      <p>
+        Departments also invent <strong>cross-ladder compounds</strong>: one
+        section string that concatenates a WF-family pair with a TTh-family
+        pair so the name covers a long daily block.
+      </p>
+      <div class="table-wrap">
+        <table class="dense">
+          <thead>
+            <tr>
+              <th scope="col">Pattern</th>
+              <th scope="col">Examples</th>
+              <th scope="col">Meaning in midyear</th>
+            </tr>
+          </thead>
+          <tbody>
+            {midyearSectionPatterns.map((row) => (
+              <tr>
+                <td>{row.pattern}</td>
+                <td><code>{row.example}</code></td>
+                <td>{row.meaning}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 id="midyear-compounds">Cross-ladder compounds (CRS 1253)</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Section</th>
+              <th scope="col">Letter bridge</th>
+              <th scope="col">Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            {midyearCompounds.map((row) => (
+              <tr>
+                <td><code>{row.code}</code></td>
+                <td><code>{row.bridge}</code></td>
+                <td>{row.note}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p class="figure-note">
+        Observed on midyear AMIS lecture rows (e.g. CHEM 32 <code>BCTU</code> /
+        <code>FGXY</code> on MTWThFS). Treat these as midyear labels, not as
+        “take both a BC and a TU regular-sem section.”
+      </p>
+
     </section>
 
     <section aria-labelledby="when-useful">

--- a/src/test/setup-components.ts
+++ b/src/test/setup-components.ts
@@ -3,7 +3,7 @@ import { cleanup } from "@testing-library/svelte";
 import { afterEach } from "vitest";
 import "@ui/map-chrome/map-chrome.css";
 
-document.documentElement.style.setProperty("--map-chrome-toggle-size", "2rem");
+document.documentElement.style.setProperty("--map-chrome-toggle-size", "2.75rem");
 
 if (!Element.prototype.animate) {
   Element.prototype.animate = () =>

--- a/src/test/setup-components.ts
+++ b/src/test/setup-components.ts
@@ -3,7 +3,10 @@ import { cleanup } from "@testing-library/svelte";
 import { afterEach } from "vitest";
 import "@ui/map-chrome/map-chrome.css";
 
-document.documentElement.style.setProperty("--map-chrome-toggle-size", "2.75rem");
+document.documentElement.style.setProperty(
+  "--map-chrome-toggle-size",
+  "2.75rem",
+);
 
 if (!Element.prototype.animate) {
   Element.prototype.animate = () =>


### PR DESCRIPTION
## Summary
- Document midyear section naming: A–H on MTWThFS (not WF), rare S–Z, labs, and cross-ladder compounds (BCTU, FGXY, CDUV, …).

## Test plan
- [ ] `/wiki/section-times#midyear-names` on prod

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static wiki content and presentational CSS/HTML attributes; no auth, data, or API behavior changes.
> 
> **Overview**
> **Midyear section naming** on `/wiki/section-times` gets a dedicated **Midyear section names** section: pattern tables (A–H on MTWThFS, compounds, labs), CRS 1253 compound examples (`BCTU`, `FGXY`, etc.), nav TOC link, and updated “when useful” / “why not perfect” copy so midyear is not read as regular-sem WF/TTh rules.
> 
> **Map and modal UX** bumps interactive chrome from **2rem → 2.75rem** via `--map-chrome-toggle-size` in `Entry.svelte`, `map-chrome.css`, `Search.svelte`, and component tests—toggle buttons, panel closes, compact FABs, search clear/editor/planner chips, and landing modal tab/primary buttons (plus **focus-visible** on primary). **Images** across map, entity results, hover preview, loading badge, and people grid gain explicit **`width`/`height`**, **`decoding="async"`**, and **`loading="lazy"`** where missing.
> 
> Trivial copy fix on **privacy** (em dash → semicolon).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 005d4f011c5a281d710b95f58de74f0dcc6f2f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->