### PR TITLE
fix(wiki): restore section-times CSS on custom domain

### DIFF
--- a/src/layouts/WikiLayout.astro
+++ b/src/layouts/WikiLayout.astro
@@ -42,11 +42,22 @@ const { title, description, canonicalPath, structuredData = [] } = Astro.props;
 </Layout>
 
 <style is:global>
+  /* Light canvas so missing page CSS (CF 404 cache on hashed assets) stays readable. */
+  html {
+    color-scheme: only light;
+    background: #fff;
+  }
+
+  body {
+    background: #fff;
+  }
+
   .wiki-page {
     width: min(62rem, calc(100% - 2rem));
     margin: 0 auto;
     padding: 2rem 0 4rem;
     color: hsl(0, 0%, 15%);
+    background: #fff;
   }
 
   .wiki-brand {

--- a/src/pages/wiki/section-times.astro
+++ b/src/pages/wiki/section-times.astro
@@ -1115,6 +1115,7 @@ const structuredData = jsonLd(
 <style>
   .wiki-article {
     max-width: 52rem;
+    background: #fff; /* new asset hash; busts CF immutable 404 on old /_astro/*.css */
   }
 
   .article-hero {


### PR DESCRIPTION
## Summary
- Cloudflare on `room-tba.uplbtools.me` cached an **immutable 404** for `/_astro/section-times.W3fpjx1x.css` (deploy race). Vercel deploy URLs still served the file; the custom domain did not.
- Bump stylesheet content so Astro emits a new hashed CSS URL; set explicit light wiki canvas so a missing sheet is still readable.

## Test plan
- [ ] `https://room-tba.uplbtools.me/wiki/section-times` — tables/letter chips styled, white background
- [ ] Linked `/_astro/section-times.*.css` returns 200 `text/css` on the custom domain (no query string)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only wiki CSS and cache-busting; no application logic, auth, or data changes.
> 
> **Overview**
> Fixes **section-times** styling on the custom domain after Cloudflare cached an **immutable 404** for an old `/_astro/section-times.*.css` hash (deploy race). Vercel still served the file; the custom domain did not.
> 
> A minimal **`background: #fff`** on `.wiki-article` in `section-times.astro` changes the scoped stylesheet so Astro ships a **new hashed CSS URL**, bypassing the stale 404.
> 
> **WikiLayout** adds global **light canvas** styles (`html`/`body`/`.wiki-page` white backgrounds, `color-scheme: only light`) so wiki pages stay readable if a hashed asset is missing again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c060d84378fab1edcb050331d15db3688a96f1b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->