### PR TITLE
docs(contributing): campus QA screenshot how-to (#226)

### DIFF
--- a/.github/ISSUE_TEMPLATE/campus_qa.yml
+++ b/.github/ISSUE_TEMPLATE/campus_qa.yml
@@ -48,4 +48,4 @@ body:
     id: screenshots
     attributes:
       label: Screenshots (optional)
-      description: Drag images into the comment after filing, or paste links here
+      description: Leave blank when filing if needed. After submit, edit the issue or reply and drag images into the comment. See CONTRIBUTING.md § Campus QA → Screenshots for phone and desktop capture steps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,24 @@ Use this when you can test the live or staging app on a real device.
 1. [New campus QA issue](https://github.com/uplbtools/room-tba/issues/new?template=campus_qa.yml)
 2. Label `qa` is applied automatically.
 
+The template asks for device, URL, steps, expected vs actual behavior, and optional screenshots.
+
 Helpful checks: search a room you know, open schedules for the current term, try offline mode after loading once, check layout at narrow phone width.
+
+### Screenshots (recommended)
+
+Screenshots help developers reproduce layout bugs. You do not need to clone the repo.
+
+**After you submit the issue**, edit the comment or add a reply with images:
+
+| Device | Capture | Attach on GitHub |
+| --- | --- | --- |
+| Windows / Linux | `Win + Shift + S` or your desktop screenshot tool | Paste into the comment (`Ctrl + V`) or drag a file into the box |
+| macOS | `Cmd + Shift + 4` (region) or `Cmd + Shift + 5` (menu) | Drag the `.png` into the comment or paste from clipboard |
+| Android | Usually Power + Volume Down (varies by phone) | Open the issue in Chrome → **Attach files**, or drag from Gallery |
+| iPhone / iPad | Side button + Volume Up | In Safari, tap the comment field → photo picker, or paste from Photos |
+
+Include the URL bar when the bug depends on staging vs production. Crop to the broken control if the full screen is noisy. One screenshot per step is enough; a short screen recording is fine for animation glitches.
 
 **No PR required.** Describe what you saw. A developer will fix it from your report.
 

--- a/docs/volunteer-triage.md
+++ b/docs/volunteer-triage.md
@@ -50,5 +50,5 @@ gh pr list --state open --base staging
 
 ## Resources
 
+- [CONTRIBUTING.md § Campus QA](../CONTRIBUTING.md#campus-qa) (issue template + screenshot how-to)
 - [Issue hygiene](issue-hygiene.md)
-- [Volunteer triage](volunteer-triage.md)

--- a/src/lib/volunteer-qa-onboarding.test.ts
+++ b/src/lib/volunteer-qa-onboarding.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+describe("volunteer QA onboarding docs (#226)", () => {
+  test("campus_qa.yml template includes required reporter fields", () => {
+    const template = readFileSync(
+      join(repoRoot, ".github/ISSUE_TEMPLATE/campus_qa.yml"),
+      "utf8",
+    );
+
+    for (const field of [
+      "device",
+      "url",
+      "steps",
+      "expected",
+      "actual",
+      "screenshots",
+    ]) {
+      expect(template).toContain(`id: ${field}`);
+    }
+    expect(template).toContain("labels:");
+    expect(template).toContain("- qa");
+  });
+
+  test("CONTRIBUTING.md documents campus QA screenshot capture", () => {
+    const contributing = readFileSync(
+      join(repoRoot, "CONTRIBUTING.md"),
+      "utf8",
+    );
+
+    expect(contributing).toContain("campus_qa.yml");
+    expect(contributing).toContain("### Screenshots");
+    expect(contributing).toMatch(/Android|iPhone/i);
+    expect(contributing).toMatch(/Attach|drag/i);
+  });
+});


### PR DESCRIPTION
## Who are you?

- [ ] **Campus / data / QA only:** no code in this PR? Comment on the issue and skip the rest.
- [x] **Developer:** code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.

## Summary

Closes #226. The campus QA GitHub issue template shipped in #311, but contributors had no screenshot capture or attach steps in published docs. This adds a screenshot how-to to CONTRIBUTING.md, points the template at that section, links from volunteer triage, and adds a regression test.

**Linked issues:** Closes #226

## Implementation plan

1. Confirm `.github/ISSUE_TEMPLATE/campus_qa.yml` already covers device, URL, steps, expected, actual, and screenshots fields (from #311).
2. Expand CONTRIBUTING.md § Campus QA with platform-specific capture and GitHub attach steps.
3. Update the template screenshots field description to reference CONTRIBUTING.
4. Cross-link from `docs/volunteer-triage.md` Resources.
5. Add `src/lib/volunteer-qa-onboarding.test.ts` to guard template fields and doc content.

## Developer checklist

- [x] `bun test src`
- [x] `bun run lint` (or Biome format on touched files)
- [ ] If a feature/page was removed, its automated test was removed or repurposed and `bun run generate:test-inventory` was run.
- [x] Linked issue commented with this PR URL
- [ ] **Heavy CI:** PR marked ready for review (or `run/e2e` label) before merge: integration + E2E are gated ([testing.md § Heavy CI gating](docs/testing.md#heavy-ci-gating-prs))

## QA Summary (code changes)

Automated:

- [x] Biome format passed: `bunx biome format` on touched files
- [x] Unit tests passed: `bun test src/lib/volunteer-qa-onboarding.test.ts` (2 pass)
- [ ] E2E + integration passed: mark PR ready or add `run/e2e` label ([testing.md](docs/testing.md#heavy-ci-gating-prs))
- [ ] Full lint passed (local): `bun run lint`
- [ ] Build passed (local): `bun run build` (needs `DATABASE_URL`; not run in PR CI)

Known gaps:

- Docs-only change; no build or E2E run required.
- Manual check on GitHub: new Campus QA issue shows updated screenshots field description.

## Test plan

```sh
bun test src/lib/volunteer-qa-onboarding.test.ts
# 2 pass, 0 fail
bunx biome format --write CONTRIBUTING.md docs/volunteer-triage.md .github/ISSUE_TEMPLATE/campus_qa.yml src/lib/volunteer-qa-onboarding.test.ts
```

Made with [Cursor](https://cursor.com)