### PR TITLE
docs(contributing): pin audit spreadsheet and batch issue template (#228)

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_correction.yml
+++ b/.github/ISSUE_TEMPLATE/data_correction.yml
@@ -9,6 +9,8 @@ body:
       **No pull request required.** A developer or maintainer will implement the fix. Thank you for keeping campus data accurate.
 
       Prefer the [in-app suggest flow](https://room-tba.uplbtools.me) if you have contributor access.
+
+      Auditing many building pins? Use the [pin audit batch template](https://github.com/uplbtools/room-tba/issues/new?template=pin_audit_batch.yml) and [spreadsheet](https://github.com/uplbtools/room-tba/blob/staging/data/building-pin-audit-template.csv) instead.
   - type: dropdown
     id: entity_type
     attributes:

--- a/.github/ISSUE_TEMPLATE/pin_audit_batch.yml
+++ b/.github/ISSUE_TEMPLATE/pin_audit_batch.yml
@@ -1,0 +1,47 @@
+name: Building pin audit (batch)
+description: Submit a completed spreadsheet batch verifying building map pins
+title: "[DATA] Pin audit batch: "
+labels:
+  - data
+body:
+  - type: markdown
+    value: |
+      **No pull request required.** Fill the [pin audit spreadsheet template](https://github.com/uplbtools/room-tba/blob/staging/data/building-pin-audit-template.csv) first. Step-by-step: [CONTRIBUTING.md § Batch building pin audit](https://github.com/uplbtools/room-tba/blob/staging/CONTRIBUTING.md#batch-building-pin-audit-volunteers).
+
+      One-off wrong pins can use the **Data correction** template instead.
+  - type: input
+    id: batch_name
+    attributes:
+      label: Batch name or building list
+      description: e.g. Batch 1 — 50 CAS buildings, or paste the building names you audited
+      placeholder: Batch 1 — PhySci cluster
+    validations:
+      required: true
+  - type: input
+    id: rows_completed
+    attributes:
+      label: Number of buildings audited
+      placeholder: "50"
+    validations:
+      required: true
+  - type: input
+    id: spreadsheet_link
+    attributes:
+      label: Google Sheet or CSV link
+      description: Share link (Anyone with the link can view) or attach a CSV export after filing
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: How many pins are OK vs need a fix? Any buildings you could not find?
+    validations:
+      required: true
+  - type: textarea
+    id: verified
+    attributes:
+      label: How did you verify?
+      description: On-campus walk, Google Maps satellite, org map, photo, etc.
+    validations:
+      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,17 @@ Include:
 
 **You do not need to open a pull request.** Someone else will ship the fix and reply on the issue.
 
+### Batch building pin audit (volunteers)
+
+Use this when you are checking many building pins at once (campus map audits, e.g. [#232](https://github.com/uplbtools/room-tba/issues/232)).
+
+1. **Get the spreadsheet template:** download [`data/building-pin-audit-template.csv`](data/building-pin-audit-template.csv) from this repo, or open the [raw file on GitHub](https://github.com/uplbtools/room-tba/blob/staging/data/building-pin-audit-template.csv) and save it.
+2. **Copy into Google Sheets:** [sheets.new](https://sheets.new) → **File → Import → Upload** (or **Import → URL** with the raw GitHub link above). One row per building.
+3. **Fill a row for each building:** search the building on [room-tba.uplbtools.me](https://room-tba.uplbtools.me), compare the map pin to where you stand or satellite view, set `pin_status` to `ok`, `wrong`, `missing`, or `not_found`. If the pin is wrong, put the correct coordinates in `verified_lat` / `verified_lon`. Spell `building_name` exactly as the app search shows it.
+4. **Submit the batch:** [New pin audit batch issue](https://github.com/uplbtools/room-tba/issues/new?template=pin_audit_batch.yml) with a view-only Google Sheet link or attach a CSV export after you file.
+
+**No PR required.** A developer imports verified fixes from your sheet.
+
 ---
 
 ## Campus QA

--- a/data/building-pin-audit-template.csv
+++ b/data/building-pin-audit-template.csv
@@ -1,0 +1,4 @@
+building_name,pin_status,app_lat,app_lon,verified_lat,verified_lon,verified_how,notes
+AMPED Building,ok,14.161854,121.248875,,,walked_on_campus,EXAMPLE — pin matches main entrance; leave verified_lat/lon blank when ok
+AFBED Building,wrong,14.161508,121.248976,14.161420,121.249010,satellite,EXAMPLE — pin sits on parking; verified_* is where the pin should move
+,,,,,,,,"ADD ROWS BELOW — pin_status: ok|wrong|missing|not_found; building_name must match the app search spelling exactly"

--- a/docs/volunteer-triage.md
+++ b/docs/volunteer-triage.md
@@ -50,5 +50,6 @@ gh pr list --state open --base staging
 
 ## Resources
 
+- [CONTRIBUTING.md § Batch building pin audit](../CONTRIBUTING.md#batch-building-pin-audit-volunteers) (spreadsheet template + issue form)
 - [Issue hygiene](issue-hygiene.md)
 - [Volunteer triage](volunteer-triage.md)

--- a/src/lib/volunteer-data-onboarding.test.ts
+++ b/src/lib/volunteer-data-onboarding.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+const PIN_AUDIT_CSV_HEADERS = [
+  "building_name",
+  "pin_status",
+  "app_lat",
+  "app_lon",
+  "verified_lat",
+  "verified_lon",
+  "verified_how",
+  "notes",
+];
+
+describe("volunteer DATA onboarding (#228)", () => {
+  test("pin_audit_batch.yml template includes required reporter fields", () => {
+    const template = readFileSync(
+      join(repoRoot, ".github/ISSUE_TEMPLATE/pin_audit_batch.yml"),
+      "utf8",
+    );
+
+    for (const field of [
+      "batch_name",
+      "rows_completed",
+      "spreadsheet_link",
+      "summary",
+      "verified",
+    ]) {
+      expect(template).toContain(`id: ${field}`);
+    }
+    expect(template).toContain("labels:");
+    expect(template).toContain("- data");
+    expect(template).toContain("building-pin-audit-template.csv");
+  });
+
+  test("building-pin-audit-template.csv has expected columns and examples", () => {
+    const csv = readFileSync(
+      join(repoRoot, "data/building-pin-audit-template.csv"),
+      "utf8",
+    );
+    const [headerLine, ...rows] = csv.trimEnd().split("\n");
+    const headers = headerLine.split(",");
+
+    expect(headers).toEqual(PIN_AUDIT_CSV_HEADERS);
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    expect(csv).toContain("AMPED Building");
+    expect(csv).toMatch(/pin_status.*ok\|wrong/i);
+  });
+
+  test("CONTRIBUTING.md documents batch pin audit spreadsheet workflow", () => {
+    const contributing = readFileSync(
+      join(repoRoot, "CONTRIBUTING.md"),
+      "utf8",
+    );
+
+    expect(contributing).toContain("pin_audit_batch.yml");
+    expect(contributing).toContain("building-pin-audit-template.csv");
+    expect(contributing).toMatch(/Google Sheets|Google Sheet/i);
+    expect(contributing).toMatch(/Batch building pin audit/i);
+  });
+});


### PR DESCRIPTION
## Who are you?

- [ ] **Campus / data / QA only:** no code in this PR? Comment on the issue and skip the rest.
- [x] **Developer:** code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.

## Summary

Closes #228. Volunteers running building pin audits had the generic data correction template (#311) but no batch spreadsheet or dedicated GitHub form. This adds a CSV template volunteers can import into Google Sheets, a `pin_audit_batch` issue template, CONTRIBUTING workflow docs, cross-links from volunteer triage and data correction, and regression tests.

**Linked issues:** Closes #228

## Implementation plan

1. Confirm no prior PR shipped pin-audit-specific template or spreadsheet (distinct from #311 `data_correction.yml` and #682 events CSV for #235).
2. Add `data/building-pin-audit-template.csv` with columns aligned to building pin verification (`building_name`, `pin_status`, coordinates, verification method).
3. Add `.github/ISSUE_TEMPLATE/pin_audit_batch.yml` for completed batch submissions.
4. Document Google Sheets import + batch filing steps in CONTRIBUTING.md; link from `docs/volunteer-triage.md` and `data_correction.yml`.
5. Add `src/lib/volunteer-data-onboarding.test.ts` to guard template fields, CSV headers, and doc content.

## Developer checklist

- [x] `bun test src`
- [x] `bun run lint` (Biome format on touched files)
- [ ] If a feature/page was removed, its automated test was removed or repurposed and `bun run generate:test-inventory` was run.
- [x] Linked issue commented with this PR URL
- [ ] **Heavy CI:** PR marked ready for review (or `run/e2e` label) before merge: integration + E2E are gated ([testing.md § Heavy CI gating](docs/testing.md#heavy-ci-gating-prs))

## QA Summary (code changes)

Automated:

- [x] Biome format passed: `bunx biome format --write` on touched files
- [x] Unit tests passed: `bun test src/lib/volunteer-data-onboarding.test.ts` (3 pass, 0 fail)
- [ ] E2E + integration passed: not required (docs/templates/CSV only)
- [ ] Full lint passed (local): not run (no app code)
- [ ] Build passed (local): not run (no runtime changes)

If auth, routing, or schema changed:

- [x] Admin redirects verified — N/A
- [x] Migration applied on Supabase — N/A

If map chrome, editor, or side panel changed:

- [x] Verified at 320px and/or 768px — N/A
- [x] Editor/login/drag-save flows — N/A

Known gaps:

- No hosted Google Sheet URL (volunteers import repo CSV into their own Sheet; same pattern as #682 events template).
- Manual check on GitHub after merge: issue picker shows **Building pin audit (batch)** template.

Follow-up:

- [#232](https://github.com/uplbtools/room-tba/issues/232) batch work can reference the new template when volunteers start auditing.

## Issues updated (maintainers / detailed specs)

- [x] Linked issue(s) commented with this PR
- [ ] Acceptance criteria / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
- [ ] `Last verified against staging:` date set on linked issues (after merge)

## Test plan

```sh
bun test src/lib/volunteer-data-onboarding.test.ts
# 3 pass, 0 fail

bunx biome format --write \
  CONTRIBUTING.md \
  docs/volunteer-triage.md \
  .github/ISSUE_TEMPLATE/pin_audit_batch.yml \
  .github/ISSUE_TEMPLATE/data_correction.yml \
  data/building-pin-audit-template.csv \
  src/lib/volunteer-data-onboarding.test.ts
```

Made with [Cursor](https://cursor.com)