### PR TITLE
data(gates): campus gate coordinates volunteer spreadsheet (#249)

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_correction.yml
+++ b/.github/ISSUE_TEMPLATE/data_correction.yml
@@ -9,6 +9,8 @@ body:
       **No pull request required.** A developer or maintainer will implement the fix. Thank you for keeping campus data accurate.
 
       Prefer the [in-app suggest flow](https://room-tba.uplbtools.me) if you have contributor access.
+
+      Collecting **campus gate coordinates** for a batch? Use the [gate coordinates spreadsheet workflow](https://github.com/uplbtools/room-tba/blob/staging/CONTRIBUTING.md#campus-gate-coordinates) instead.
   - type: dropdown
     id: entity_type
     attributes:
@@ -16,6 +18,7 @@ body:
       options:
         - Room schedule
         - Building location / pin
+        - Campus gate / entry point
         - Directions text
         - Missing room or building
         - Event

--- a/.github/ISSUE_TEMPLATE/gate_coordinates_batch.yml
+++ b/.github/ISSUE_TEMPLATE/gate_coordinates_batch.yml
@@ -1,0 +1,48 @@
+name: Gate coordinates (batch)
+description: Submit verified campus gate / entry-point coordinates from the volunteer spreadsheet
+title: "[DATA] Gate coordinates batch: "
+labels:
+  - data
+body:
+  - type: markdown
+    value: |
+      **No pull request required.** Use this after filling [data/campus-gate-coordinates-template.csv](https://github.com/uplbtools/room-tba/blob/staging/data/campus-gate-coordinates-template.csv).
+
+      Workflow: [CONTRIBUTING.md § Campus gate coordinates](https://github.com/uplbtools/room-tba/blob/staging/CONTRIBUTING.md#campus-gate-coordinates). Parent feature: [#157](https://github.com/uplbtools/room-tba/issues/157).
+  - type: input
+    id: batch_label
+    attributes:
+      label: Batch label
+      description: e.g. "Batch 1 — Raymundo + main gate" or your org name
+      placeholder: Batch 1
+    validations:
+      required: true
+  - type: textarea
+    id: gates_summary
+    attributes:
+      label: Gates included
+      description: List gate names in this batch (one per line)
+      placeholder: |
+        Raymundo Gate
+        Main Gate (Oblation)
+    validations:
+      required: true
+  - type: textarea
+    id: spreadsheet
+    attributes:
+      label: Spreadsheet link or attachment
+      description: Google Sheets view link, or note that the filled CSV is attached to this issue
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: How coordinates were verified
+      description: On-site GPS, OpenStreetMap pin, walked perimeter, photo of gate sign, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes (optional)
+      description: Uncertain gates, duplicate names, vehicle vs pedestrian access, OSM links

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thanks for helping UPLB students find rooms. You do **not** need to clone this r
 | Path | Who | What to do | Open a PR? |
 | ------------------------------------------------------------------------------------------------------------ | ----------------- | --------------------------------------- | ---------- |
 | [Report wrong data](#report-wrong-data) | Anyone on campus | File a data issue or use in-app suggest | No |
+| [Campus gate coordinates](#campus-gate-coordinates) | Data volunteers | Fill gate spreadsheet, file batch issue | No |
 | [Campus QA](#campus-qa) | Testers | Verify the app on your phone | No |
 | [Developers](#developers-no-ai-required) | Coders | Branch, code, PR to `staging` | Yes |
 | [Good first issues](https://github.com/uplbtools/room-tba/issues?q=is%3Aopen+label%3A%22good+first+issue%22) | New devs | Smaller coding tasks | Yes |
@@ -32,6 +33,26 @@ Include:
 - How you verified (walked there, SAIS, org page, photo)
 
 **You do not need to open a pull request.** Someone else will ship the fix and reply on the issue.
+
+---
+
+## Campus gate coordinates
+
+Use this when you can verify where campus gates and entry points are on the map. This feeds [#157](https://github.com/uplbtools/room-tba/issues/157) (gates as searchable entities).
+
+1. Download [`data/campus-gate-coordinates-template.csv`](data/campus-gate-coordinates-template.csv) from this repo (or copy into Google Sheets via **File → Import**).
+2. Fill one row per gate. Starter rows list common gates from building directions and jeepney routes; **leave `lat`/`lon` blank until you verify on site** (do not copy coordinates from other apps without checking).
+3. For each gate you verify:
+   - Stand at the gate sign or main vehicle/pedestrian entry.
+   - Record `lat` and `lon` (phone GPS or OpenStreetMap pin at the entry).
+   - Set `gate_type` (`vehicle`, `pedestrian`, or `both`), `verified` to `yes`, and `verification_method` (e.g. "walked there 2026-07-16, GPS at sign").
+   - Optional: `directions` (one sentence for walkers), `osm_link`, `notes`.
+4. When a batch is ready, open a [Gate coordinates (batch)](https://github.com/uplbtools/room-tba/issues/new?template=gate_coordinates_batch.yml) issue. Attach the filled CSV or link your Google Sheet.
+5. A maintainer imports verified rows when the `entry_points` schema ships ([#157](https://github.com/uplbtools/room-tba/issues/157)).
+
+**You do not need to open a pull request.**
+
+Column reference: `name`, `short_name`, `slug`, `gate_type`, `lat`, `lon`, `is_primary`, `directions`, `osm_link`, `verified`, `verification_method`, `notes`.
 
 ---
 

--- a/data/campus-gate-coordinates-template.csv
+++ b/data/campus-gate-coordinates-template.csv
@@ -1,0 +1,6 @@
+name,short_name,slug,gate_type,lat,lon,is_primary,directions,osm_link,verified,verification_method,notes
+Raymundo Gate,Raymundo,raymundo-gate,both,,,false,,,no,,"STARTER — verify on site; referenced in jeepney routes and building directions"
+Main Gate (Oblation),Main Gate,main-gate-oblation,both,,,true,,,no,,"STARTER — verify on site; common origin in building directions"
+CEAT / Pili Drive,CEAT,pili-drive-ceat,vehicle,,,false,,,no,,"STARTER — verify on site; vehicle entrance near CEAT"
+CFNR Gate (Forestry),CFNR,cfnr-gate,vehicle,,,false,,,no,,"STARTER — verify on site; College of Forestry and Natural Resources"
+,,,,,,,,,,,"ADD ROWS BELOW — gate_type: vehicle|pedestrian|both; is_primary: true|false; verified: yes|no; lat/lon only after on-site GPS or map pin check"

--- a/docs/volunteer-triage.md
+++ b/docs/volunteer-triage.md
@@ -52,3 +52,4 @@ gh pr list --state open --base staging
 
 - [Issue hygiene](issue-hygiene.md)
 - [Volunteer triage](volunteer-triage.md)
+- [Campus gate coordinates](../CONTRIBUTING.md#campus-gate-coordinates) — [`data/campus-gate-coordinates-template.csv`](../data/campus-gate-coordinates-template.csv) + [batch issue template](https://github.com/uplbtools/room-tba/issues/new?template=gate_coordinates_batch.yml) ([#249](https://github.com/uplbtools/room-tba/issues/249) / [#157](https://github.com/uplbtools/room-tba/issues/157))

--- a/src/lib/campus-gate-coordinates-template.test.ts
+++ b/src/lib/campus-gate-coordinates-template.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  assertCampusGateCoordinatesHeaders,
+  CAMPUS_GATE_COORDINATES_HEADERS,
+  parseCampusGateCoordinatesCsv,
+  parseCsvRow,
+  validateCampusGateCoordinatesCsv,
+  validateCampusGateRow,
+} from "./campus-gate-coordinates-template";
+
+const TEMPLATE_PATH = join(
+  import.meta.dir,
+  "../../data/campus-gate-coordinates-template.csv",
+);
+const CONTRIBUTING_PATH = join(import.meta.dir, "../../CONTRIBUTING.md");
+const VOLUNTEER_TRIAGE_PATH = join(
+  import.meta.dir,
+  "../../docs/volunteer-triage.md",
+);
+const ISSUE_TEMPLATE_PATH = join(
+  import.meta.dir,
+  "../../.github/ISSUE_TEMPLATE/gate_coordinates_batch.yml",
+);
+
+describe("campus-gate-coordinates-template", () => {
+  it("parses quoted CSV fields", () => {
+    expect(parseCsvRow('a,"b,c",d')).toEqual(["a", "b,c", "d"]);
+  });
+
+  it("repo template has expected headers and starter rows", () => {
+    const text = readFileSync(TEMPLATE_PATH, "utf8");
+    const parsed = parseCampusGateCoordinatesCsv(text);
+    assertCampusGateCoordinatesHeaders(parsed.headers);
+    expect(parsed.skippedInstructionRows).toBe(1);
+    expect(parsed.rows.length).toBeGreaterThanOrEqual(4);
+    expect(parsed.rows.map((row) => row.name)).toContain("Raymundo Gate");
+    expect(parsed.rows.every((row) => !row.lat && !row.lon)).toBe(true);
+  });
+
+  it("allows draft rows without coordinates", () => {
+    const errors = validateCampusGateRow({
+      name: "Test Gate",
+      short_name: "",
+      slug: "test-gate",
+      gate_type: "both",
+      lat: "",
+      lon: "",
+      is_primary: "false",
+      directions: "",
+      osm_link: "",
+      verified: "no",
+      verification_method: "",
+      notes: "",
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("requires coordinates and verification for submission rows", () => {
+    const errors = validateCampusGateRow(
+      {
+        name: "Raymundo Gate",
+        short_name: "Raymundo",
+        slug: "raymundo-gate",
+        gate_type: "both",
+        lat: "14.16774",
+        lon: "121.24161",
+        is_primary: "false",
+        directions: "Along Raymundo Road",
+        osm_link: "",
+        verified: "yes",
+        verification_method: "On-site GPS at gate sign",
+        notes: "",
+      },
+      { requireCoordinates: true },
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects out-of-campus coordinates", () => {
+    const errors = validateCampusGateRow(
+      {
+        name: "Far Gate",
+        short_name: "",
+        slug: "",
+        gate_type: "both",
+        lat: "14.5",
+        lon: "121.0",
+        is_primary: "false",
+        directions: "",
+        osm_link: "",
+        verified: "yes",
+        verification_method: "walked",
+        notes: "",
+      },
+      { requireCoordinates: true },
+    );
+    expect(errors.some((e) => e.includes("lat"))).toBe(true);
+    expect(errors.some((e) => e.includes("lon"))).toBe(true);
+  });
+
+  it("validateCampusGateCoordinatesCsv flags invalid gate_type", () => {
+    const csv = [
+      CAMPUS_GATE_COORDINATES_HEADERS.join(","),
+      "Bad Gate,,,service,,,false,,,no,,",
+    ].join("\n");
+    const invalid = validateCampusGateCoordinatesCsv(csv);
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0]?.errors).toContain(
+      "gate_type must be vehicle, pedestrian, or both",
+    );
+  });
+});
+
+describe("volunteer gate coordinates onboarding", () => {
+  it("CONTRIBUTING documents the spreadsheet workflow", () => {
+    const doc = readFileSync(CONTRIBUTING_PATH, "utf8");
+    expect(doc).toContain("Campus gate coordinates");
+    expect(doc).toContain("campus-gate-coordinates-template.csv");
+    expect(doc).toContain("gate_coordinates_batch.yml");
+  });
+
+  it("volunteer triage links to gate coordinates workflow", () => {
+    const doc = readFileSync(VOLUNTEER_TRIAGE_PATH, "utf8");
+    expect(doc).toContain("Campus gate coordinates");
+    expect(doc).toContain("campus-gate-coordinates-template.csv");
+  });
+
+  it("batch issue template covers submission fields", () => {
+    const template = readFileSync(ISSUE_TEMPLATE_PATH, "utf8");
+    expect(template).toContain("Gate coordinates (batch)");
+    expect(template).toContain("spreadsheet");
+    expect(template).toContain("verification");
+  });
+});

--- a/src/lib/campus-gate-coordinates-template.ts
+++ b/src/lib/campus-gate-coordinates-template.ts
@@ -1,0 +1,232 @@
+/** Volunteer CSV for campus gate / entry-point coordinates (#249, parent #157). */
+
+export const CAMPUS_GATE_COORDINATES_HEADERS = [
+  "name",
+  "short_name",
+  "slug",
+  "gate_type",
+  "lat",
+  "lon",
+  "is_primary",
+  "directions",
+  "osm_link",
+  "verified",
+  "verification_method",
+  "notes",
+] as const;
+
+export type CampusGateCoordinatesHeader =
+  (typeof CAMPUS_GATE_COORDINATES_HEADERS)[number];
+
+export type GateType = "vehicle" | "pedestrian" | "both";
+
+export type CampusGateCoordinatesRow = Record<
+  CampusGateCoordinatesHeader,
+  string
+>;
+
+export type CampusGateCoordinatesParseResult = {
+  headers: string[];
+  rows: CampusGateCoordinatesRow[];
+  skippedInstructionRows: number;
+};
+
+export type CampusGateRowValidation = {
+  rowIndex: number;
+  name: string;
+  errors: string[];
+};
+
+/** Rough UPLB campus bounds for volunteer coordinate sanity checks. */
+export const UPLB_CAMPUS_LAT_RANGE = { min: 14.15, max: 14.19 } as const;
+export const UPLB_CAMPUS_LON_RANGE = { min: 121.23, max: 121.26 } as const;
+
+const GATE_TYPES = new Set<GateType>(["vehicle", "pedestrian", "both"]);
+const VERIFIED_VALUES = new Set(["yes", "no", "true", "false", ""]);
+const PRIMARY_VALUES = new Set(["true", "false", "yes", "no", ""]);
+
+function isInstructionRow(row: CampusGateCoordinatesRow): boolean {
+  const name = row.name.trim();
+  const hasOtherData = CAMPUS_GATE_COORDINATES_HEADERS.some((key) => {
+    if (key === "name" || key === "notes") return false;
+    return row[key].trim().length > 0;
+  });
+  return name.length === 0 && !hasOtherData && row.notes.trim().length > 0;
+}
+
+/** Minimal RFC-style CSV row parser (quoted fields, commas). */
+export function parseCsvRow(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (char === ",") {
+      fields.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  fields.push(current);
+  return fields;
+}
+
+export function rowFromFields(fields: string[]): CampusGateCoordinatesRow {
+  const row = {} as CampusGateCoordinatesRow;
+  for (let i = 0; i < CAMPUS_GATE_COORDINATES_HEADERS.length; i++) {
+    row[CAMPUS_GATE_COORDINATES_HEADERS[i]] = (fields[i] ?? "").trim();
+  }
+  return row;
+}
+
+export function parseCampusGateCoordinatesCsv(
+  text: string,
+): CampusGateCoordinatesParseResult {
+  const lines = text
+    .replace(/^\uFEFF/, "")
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    throw new Error("CSV is empty");
+  }
+
+  const headers = parseCsvRow(lines[0]).map((h) => h.trim());
+  const rows: CampusGateCoordinatesRow[] = [];
+  let skippedInstructionRows = 0;
+
+  for (const line of lines.slice(1)) {
+    const row = rowFromFields(parseCsvRow(line));
+    if (isInstructionRow(row)) {
+      skippedInstructionRows++;
+      continue;
+    }
+    rows.push(row);
+  }
+
+  return { headers, rows, skippedInstructionRows };
+}
+
+export function assertCampusGateCoordinatesHeaders(headers: string[]): void {
+  const expected = [...CAMPUS_GATE_COORDINATES_HEADERS];
+  if (
+    headers.length !== expected.length ||
+    !expected.every((header, index) => headers[index] === header)
+  ) {
+    throw new Error(
+      `Unexpected headers. Expected: ${expected.join(", ")}; got: ${headers.join(", ")}`,
+    );
+  }
+}
+
+function parseOptionalNumber(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const num = Number(trimmed);
+  return Number.isFinite(num) ? num : null;
+}
+
+export function validateCampusGateRow(
+  row: CampusGateCoordinatesRow,
+  options: { requireCoordinates?: boolean } = {},
+): string[] {
+  const errors: string[] = [];
+  const requireCoordinates = options.requireCoordinates ?? false;
+
+  if (!row.name.trim()) {
+    errors.push("name is required");
+  }
+
+  const gateType = row.gate_type.trim().toLowerCase();
+  if (gateType && !GATE_TYPES.has(gateType as GateType)) {
+    errors.push("gate_type must be vehicle, pedestrian, or both");
+  }
+
+  const primary = row.is_primary.trim().toLowerCase();
+  if (primary && !PRIMARY_VALUES.has(primary)) {
+    errors.push("is_primary must be true or false");
+  }
+
+  const verified = row.verified.trim().toLowerCase();
+  if (verified && !VERIFIED_VALUES.has(verified)) {
+    errors.push("verified must be yes or no");
+  }
+
+  const lat = parseOptionalNumber(row.lat);
+  const lon = parseOptionalNumber(row.lon);
+
+  if (requireCoordinates) {
+    if (lat === null || lon === null) {
+      errors.push("lat and lon are required for submission");
+    }
+  }
+
+  if (lat !== null) {
+    if (lat < UPLB_CAMPUS_LAT_RANGE.min || lat > UPLB_CAMPUS_LAT_RANGE.max) {
+      errors.push(
+        `lat ${lat} is outside UPLB campus range (${UPLB_CAMPUS_LAT_RANGE.min}–${UPLB_CAMPUS_LAT_RANGE.max})`,
+      );
+    }
+  }
+
+  if (lon !== null) {
+    if (lon < UPLB_CAMPUS_LON_RANGE.min || lon > UPLB_CAMPUS_LON_RANGE.max) {
+      errors.push(
+        `lon ${lon} is outside UPLB campus range (${UPLB_CAMPUS_LON_RANGE.min}–${UPLB_CAMPUS_LON_RANGE.max})`,
+      );
+    }
+  }
+
+  if ((lat === null) !== (lon === null)) {
+    errors.push("lat and lon must both be filled or both left empty");
+  }
+
+  if (requireCoordinates && verified !== "yes" && verified !== "true") {
+    errors.push("verified must be yes before submission");
+  }
+
+  if (requireCoordinates && !row.verification_method.trim()) {
+    errors.push("verification_method is required for submission");
+  }
+
+  return errors;
+}
+
+export function validateCampusGateCoordinatesCsv(
+  text: string,
+  options: { requireCoordinates?: boolean } = {},
+): CampusGateRowValidation[] {
+  const parsed = parseCampusGateCoordinatesCsv(text);
+  assertCampusGateCoordinatesHeaders(parsed.headers);
+
+  return parsed.rows
+    .map((row, index) => {
+      const errors = validateCampusGateRow(row, options);
+      return {
+        rowIndex: index + 2,
+        name: row.name,
+        errors,
+      };
+    })
+    .filter((result) => result.errors.length > 0);
+}


### PR DESCRIPTION
## Who are you?

- [ ] **Campus / data / QA only:** no code in this PR? Comment on the issue and skip the rest.
- [x] **Developer:** code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.

## Summary

Closes #249. Adds a contributor-facing CSV template, batch GitHub issue form, CONTRIBUTING workflow, and CSV validation helpers so campus volunteers can collect verified gate/entry-point coordinates for parent epic #157 without inventing coordinates in the repo.

**Linked issues:** Closes #249

## Implementation plan

1. Confirmed no merged/open PR implements campus gate/entry-point coordinate spreadsheets (distinct from #311 contributor hub, closed #698/#700 pin-audit attempts, and generic “entry point” code paths).
2. Add `data/campus-gate-coordinates-template.csv` with headers aligned to proposed `entry_points` fields in #157; starter rows name common gates with empty `lat`/`lon`.
3. Add `src/lib/campus-gate-coordinates-template.ts` for CSV parse/validation (UPLB bounds, gate_type enum, submission checks).
4. Add `.github/ISSUE_TEMPLATE/gate_coordinates_batch.yml` for completed batch filings.
5. Document Google Sheets import + on-site verification steps in CONTRIBUTING.md; cross-link from `docs/volunteer-triage.md` and `data_correction.yml`.
6. Regression tests in `src/lib/campus-gate-coordinates-template.test.ts` guard template headers, validation, and doc/template wiring.

## Developer checklist

- [x] `bun run test` (363 pass, 0 fail)
- [x] `bun run lint` (Biome format on touched files)
- [ ] If a feature/page was removed, its automated test was removed or repurposed and `bun run generate:test-inventory` was run.
- [x] Linked issue commented with this PR URL
- [ ] **Heavy CI:** PR marked ready for review (or `run/e2e` label) before merge: integration + E2E are gated ([testing.md § Heavy CI gating](docs/testing.md#heavy-ci-gating-prs))

## QA Summary (code changes)

Automated:

- [x] Biome format passed: `bunx biome format --write` on touched files
- [x] Unit tests passed: `bun run test` (363 pass, 0 fail); focused test (9 pass, 0 fail)
- [ ] E2E + integration passed: not required (docs/templates/CSV + unit lib only)
- [ ] Full lint passed (local): not run (no app runtime changes)
- [ ] Build passed (local): not run (no runtime/schema changes)

If auth, routing, or schema changed:

- [x] Admin redirects verified — N/A
- [x] Migration applied on Supabase — N/A

If map chrome, editor, or side panel changed:

- [x] Verified at 320px and/or 768px — N/A
- [x] Editor/login/drag-save flows — N/A

Known gaps:

- PR `verify` currently fails on pre-existing Biome errors in `scripts/import-amis-classes.ts` / `src/lib/amis/normalize-class.ts` from the `staging` base; the same failure is present on base PR #697. All files touched here pass `bunx biome ci`.
- Blocking E2E CI also fails before browser tests because the `staging` workflow invokes missing `integration/preload.ts`; unrelated to this docs/template change.
- Template only; no gate rows seeded into DB (blocked on #157 schema + verified volunteer submissions).
- No hosted Google Sheet URL (volunteers import repo CSV into their own Sheet; same pattern as #682 events template).
- Manual check on GitHub after merge: issue picker shows **Gate coordinates (batch)** template.

Follow-up:

- [#157](https://github.com/uplbtools/room-tba/issues/157) schema/import when verified batches arrive.

## Issues updated (maintainers / detailed specs)

- [x] Linked issue(s) commented with this PR
- [ ] Acceptance criteria / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
- [ ] `Last verified against staging:` date set on linked issues (after merge)

## Test plan

```sh
bun run test
# 363 pass, 0 fail

bun test src/lib/campus-gate-coordinates-template.test.ts
# 9 pass, 0 fail

bunx biome format --write \
  data/campus-gate-coordinates-template.csv \
  CONTRIBUTING.md \
  docs/volunteer-triage.md \
  .github/ISSUE_TEMPLATE/gate_coordinates_batch.yml \
  .github/ISSUE_TEMPLATE/data_correction.yml \
  src/lib/campus-gate-coordinates-template.ts \
  src/lib/campus-gate-coordinates-template.test.ts
```

Made with [Cursor](https://cursor.com)