### PR TITLE
fix(proposals): harden public submit abuse controls (#223)

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Integration tests
         if: inputs.suite == 'blocking'
-        run: PREVIEW_BASE_URL=http://127.0.0.1:4321 bun test ./integration --preload integration/preload.ts --concurrency 1
+        run: PREVIEW_BASE_URL=http://127.0.0.1:4321 bun test ./integration --preload ./integration/preload.ts --concurrency 1
 
       - name: Restart preview after integration
         if: inputs.suite == 'blocking'

--- a/docs/contributor-proposal-qa.md
+++ b/docs/contributor-proposal-qa.md
@@ -29,6 +29,8 @@ This is the repeatable QA record for [#255](https://github.com/uplbtools/room-tb
 
 `POST /api/proposals` and `POST /api/proposals/:id/withdraw` are rate-limited in [`src/lib/api/proposal-rate-limit.ts`](../src/lib/api/proposal-rate-limit.ts). Limits use an in-memory bucket **per serverless instance** (effective cap scales with cold-start fan-out; shared KV is deferred).
 
+The IP key comes from `x-forwarded-for` ([`src/lib/api/rate-limit.ts`](../src/lib/api/rate-limit.ts)), which is client-writable in general but is stripped/overwritten by Vercel's standard routing (not the paid Trusted Proxy tier) before it reaches the app. This limiter assumes that platform behavior; if a CDN/WAF is ever added in front without stripping client-supplied `x-forwarded-for`, or Trusted Proxy is enabled, this becomes spoofable and should move to `x-vercel-forwarded-for`.
+
 | Actor | Short window (10 min) | Daily window (24 h) |
 | --- | --- | --- |
 | Anonymous (by IP) | 8 submits | 40 submits |

--- a/docs/contributor-proposal-qa.md
+++ b/docs/contributor-proposal-qa.md
@@ -25,6 +25,22 @@ This is the repeatable QA record for [#255](https://github.com/uplbtools/room-tb
 - Attempt withdrawal as another signed-in user; verify it is rejected with `403`.
 - Cause an approval conflict by changing the live entity after submission; verify approval returns `409`, leaves the proposal open, and clears any review claim.
 
+## Proposal rate limits ([#223](https://github.com/uplbtools/room-tba/issues/223))
+
+`POST /api/proposals` and `POST /api/proposals/:id/withdraw` are rate-limited in [`src/lib/api/proposal-rate-limit.ts`](../src/lib/api/proposal-rate-limit.ts). Limits use an in-memory bucket **per serverless instance** (effective cap scales with cold-start fan-out; shared KV is deferred).
+
+| Actor | Short window (10 min) | Daily window (24 h) |
+| --- | --- | --- |
+| Anonymous (by IP) | 8 submits | 40 submits |
+| Signed-in (IP + user id) | 24 submits each | 40 per IP, 120 per user |
+| Withdraw (IP + user when signed in) | 12 per 10 min | — |
+
+- **429** response: JSON `{ "error": "Too many requests…" }` plus `Retry-After` (seconds).
+- **Honeypot:** non-empty `_hp` body field returns **201** `{ "success": true }` without creating a row or sending Discord.
+- **CI / E2E:** set `ASTRO_E2E_SKIP_LOGIN_RATE_LIMIT=1` to skip proposal limits (same flag as login rate-limit tests).
+
+Manual check: from one browser session, submit nine anonymous suggestions within ten minutes; the ninth should fail with the rate-limit message.
+
 ## Scope and edge-case disposition
 
 | Scenario | Expected behavior today | Coverage | Disposition / follow-up |
@@ -39,7 +55,7 @@ This is the repeatable QA record for [#255](https://github.com/uplbtools/room-tb
 | C: duplicate create | Duplicate validation occurs during approval and returns `409`. | Manual | Shipped. |
 | D: anonymous pin move | Anonymous suggestions require a display name and local stored reference. | Manual | Shipped within same browser. |
 | E: contributor deletion | Deactivate/delete proposals are not a contributor v1 feature. | Manual | Won't fix v1. |
-| F: spam / abuse | Submission rate limiting exists; broader abuse controls remain separately tracked. | Manual | [#223](https://github.com/uplbtools/room-tba/issues/223). |
+| F: spam / abuse | Short + daily IP limits, dual-key for signed-in users, honeypot no-op, withdraw cap. In-memory per serverless instance. | Integration + manual | Shipped ([#223](https://github.com/uplbtools/room-tba/issues/223)). Turnstile / shared KV deferred. |
 | G: review notification failure | Notifications are fire-and-forget; record the configured staging result. | Manual | Ops/configuration follow-up if failed. |
 | H: wrong approval | Editors publish a corrective change; no contributor undo control exists. | Manual | [#202](https://github.com/uplbtools/room-tba/issues/202). |
 | I: request changes without note | The server rejects it. | Component/manual | Shipped. |

--- a/integration/helpers/http.ts
+++ b/integration/helpers/http.ts
@@ -43,6 +43,7 @@ export async function patchBuilding(
 export async function submitProposal(
   body: Record<string, unknown>,
   cookie?: string,
+  extraHeaders?: Record<string, string>,
 ) {
   return fetch(
     `${PREVIEW_BASE}/api/proposals`,
@@ -51,6 +52,7 @@ export async function submitProposal(
       headers: {
         "Content-Type": "application/json",
         ...(cookie ? { Cookie: cookie } : {}),
+        ...extraHeaders,
       },
       body: JSON.stringify(body),
     }),

--- a/integration/http/proposals-rate-limit.integration.test.ts
+++ b/integration/http/proposals-rate-limit.integration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, beforeAll } from "bun:test";
+import { PREVIEW_BASE, requirePreview, skipWithoutE2eDb } from "../helpers/env";
+import { submitProposal } from "../helpers/http";
+
+const describeIntegration = skipWithoutE2eDb() ? describe.skip : describe;
+
+const ISOLATED_IP = "203.0.113.88";
+
+describeIntegration("proposal submit rate limit", () => {
+  beforeAll(async () => {
+    await requirePreview(PREVIEW_BASE);
+  });
+
+  test("returns 429 after repeated anonymous submissions from one IP", async () => {
+    let lastStatus = 400;
+    for (let i = 0; i < 10; i += 1) {
+      const res = await submitProposal(
+        {
+          entityType: "room",
+          entityId: 1,
+          baseVersion: 1,
+          patch: {},
+          // Invalid name: consumes rate limit but does not write edit_proposals.
+          submitterName: "x",
+          _hp: "",
+        },
+        undefined,
+        { "X-Forwarded-For": ISOLATED_IP },
+      );
+      lastStatus = res.status;
+      if (lastStatus === 429) break;
+      expect(lastStatus).toBe(400);
+    }
+    expect(lastStatus).toBe(429);
+    const blocked = await submitProposal(
+      {
+        entityType: "room",
+        entityId: 1,
+        baseVersion: 1,
+        patch: {},
+        submitterName: "x",
+        _hp: "",
+      },
+      undefined,
+      { "X-Forwarded-For": ISOLATED_IP },
+    );
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("Retry-After")).toBeTruthy();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format": "biome format --write .",
     "test": "bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts'",
     "test:components": "vitest run",
-    "test:integration": "bun test ./integration --preload integration/preload.ts --concurrency 1",
+    "test:integration": "bun test ./integration --preload ./integration/preload.ts --concurrency 1",
     "test:integration:live": "bash scripts/run-integration-preview.sh",
     "test:all": "bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts' && bun run test:components && bun run test:integration",
     "e2e": "playwright test",

--- a/scripts/import-amis-classes.ts
+++ b/scripts/import-amis-classes.ts
@@ -53,7 +53,10 @@ import {
   resolveImportRows,
   summarizeImportChanges,
 } from "@lib/amis/import-classes";
-import { extractClassRows, normalizeAmisClass } from "@lib/amis/normalize-class";
+import {
+  extractClassRows,
+  normalizeAmisClass,
+} from "@lib/amis/normalize-class";
 import {
   amisExportContainsInstructorPii,
   sanitizeAmisRows,
@@ -160,7 +163,10 @@ async function refreshSyncKey(
     .where(eq(updateTable.tableName, tableName));
 }
 
-function inferTermIdFromPayload(payload: unknown, rows: AmisClassRow[]): number {
+function inferTermIdFromPayload(
+  payload: unknown,
+  rows: AmisClassRow[],
+): number {
   const envelope = payload as { term_id?: number; termId?: number };
   if (Number.isFinite(envelope.term_id)) return Number(envelope.term_id);
   if (Number.isFinite(envelope.termId)) return Number(envelope.termId);

--- a/src/lib/amis/normalize-class.ts
+++ b/src/lib/amis/normalize-class.ts
@@ -220,7 +220,8 @@ export function normalizeAmisClass(
   row: AmisClassRow,
   termId: number,
 ): NormalizedAmisClass | null {
-  const courseCode = asString(row["course_code"]) ?? asString(row["courseCode"]);
+  const courseCode =
+    asString(row["course_code"]) ?? asString(row["courseCode"]);
   const section = asString(row["section"]);
   if (!courseCode || !section) return null;
 

--- a/src/lib/api/proposal-rate-limit.test.ts
+++ b/src/lib/api/proposal-rate-limit.test.ts
@@ -52,6 +52,18 @@ describe("enforceProposalSubmitLimits", () => {
     expect(blocked?.allowed).toBe(false);
   });
 
+  test("authenticated traffic on a shared IP does not block a fresh anonymous request", () => {
+    resetRateLimitsForTests();
+    const now = 3_500_000;
+    const ip = "198.51.100.60";
+    for (let i = 0; i < 20; i += 1) {
+      const result = enforceProposalSubmitLimits({ id: i + 1 }, ip, now);
+      expect(result).toBeNull();
+    }
+    const anonResult = enforceProposalSubmitLimits(null, ip, now);
+    expect(anonResult).toBeNull();
+  });
+
   test("daily window blocks after short window resets", () => {
     resetRateLimitsForTests();
     const ip = "198.51.100.50";

--- a/src/lib/api/proposal-rate-limit.test.ts
+++ b/src/lib/api/proposal-rate-limit.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+  enforceProposalSubmitLimits,
+  enforceProposalWithdrawLimits,
+  isProposalHoneypotTripped,
+  PROPOSAL_HONEYPOT_FIELD,
+} from "./proposal-rate-limit";
+import { resetRateLimitsForTests } from "./rate-limit";
+
+describe("isProposalHoneypotTripped", () => {
+  test("empty honeypot is allowed", () => {
+    expect(isProposalHoneypotTripped({ [PROPOSAL_HONEYPOT_FIELD]: "" })).toBe(
+      false,
+    );
+    expect(isProposalHoneypotTripped({})).toBe(false);
+  });
+
+  test("non-empty honeypot trips", () => {
+    expect(
+      isProposalHoneypotTripped({ [PROPOSAL_HONEYPOT_FIELD]: "spam" }),
+    ).toBe(true);
+  });
+});
+
+describe("enforceProposalSubmitLimits", () => {
+  test("allows anonymous requests under the IP short cap", () => {
+    resetRateLimitsForTests();
+    const now = 1_000_000;
+    for (let i = 0; i < 8; i += 1) {
+      expect(enforceProposalSubmitLimits(null, "198.51.100.1", now)).toBeNull();
+    }
+  });
+
+  test("blocks anonymous requests over the IP short cap", () => {
+    resetRateLimitsForTests();
+    const now = 2_000_000;
+    for (let i = 0; i < 8; i += 1) {
+      enforceProposalSubmitLimits(null, "198.51.100.2", now);
+    }
+    const blocked = enforceProposalSubmitLimits(null, "198.51.100.2", now);
+    expect(blocked?.allowed).toBe(false);
+  });
+
+  test("blocks signed-in user when user bucket is full even on a fresh IP", () => {
+    resetRateLimitsForTests();
+    const now = 3_000_000;
+    const session = { id: 42 };
+    for (let i = 0; i < 24; i += 1) {
+      enforceProposalSubmitLimits(session, `198.51.100.${i}`, now);
+    }
+    const blocked = enforceProposalSubmitLimits(session, "198.51.100.99", now);
+    expect(blocked?.allowed).toBe(false);
+  });
+
+  test("daily window blocks after short window resets", () => {
+    resetRateLimitsForTests();
+    const ip = "198.51.100.50";
+    let now = 4_000_000;
+    for (let i = 0; i < 40; i += 1) {
+      const denied = enforceProposalSubmitLimits(null, ip, now);
+      expect(denied).toBeNull();
+      now += SHORT_WINDOW_MS + 1;
+    }
+    const blocked = enforceProposalSubmitLimits(null, ip, now);
+    expect(blocked?.allowed).toBe(false);
+  });
+});
+
+const SHORT_WINDOW_MS = 10 * 60 * 1000;
+
+describe("enforceProposalWithdrawLimits", () => {
+  test("blocks after withdraw cap", () => {
+    resetRateLimitsForTests();
+    const now = 5_000_000;
+    for (let i = 0; i < 12; i += 1) {
+      expect(
+        enforceProposalWithdrawLimits({ id: 7 }, "203.0.113.1", now),
+      ).toBeNull();
+    }
+    const blocked = enforceProposalWithdrawLimits(
+      { id: 7 },
+      "203.0.113.1",
+      now,
+    );
+    expect(blocked?.allowed).toBe(false);
+  });
+});

--- a/src/lib/api/proposal-rate-limit.ts
+++ b/src/lib/api/proposal-rate-limit.ts
@@ -1,0 +1,116 @@
+import { checkRateLimit } from "./rate-limit";
+
+const SHORT_WINDOW_MS = 10 * 60 * 1000;
+const DAILY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const ANON_IP_SHORT_MAX = 8;
+const AUTH_IP_SHORT_MAX = 24;
+const AUTH_USER_SHORT_MAX = 24;
+const ANON_IP_DAILY_MAX = 40;
+const AUTH_USER_DAILY_MAX = 120;
+const WITHDRAW_SHORT_MAX = 12;
+
+export const PROPOSAL_HONEYPOT_FIELD = "_hp";
+
+export type ProposalRateLimitSession = { id: number } | null | undefined;
+
+export function shouldSkipProposalRateLimits(): boolean {
+  return process.env.ASTRO_E2E_SKIP_LOGIN_RATE_LIMIT === "1";
+}
+
+/** Bots that fill hidden fields get a silent no-op success (no DB write, no notify). */
+export function isProposalHoneypotTripped(
+  body: Record<string, unknown>,
+): boolean {
+  const value = body[PROPOSAL_HONEYPOT_FIELD];
+  return typeof value === "string" && value.trim() !== "";
+}
+
+export function enforceProposalSubmitLimits(
+  session: ProposalRateLimitSession,
+  ip: string,
+  now = Date.now(),
+): { allowed: false; resetAt: number } | null {
+  if (shouldSkipProposalRateLimits()) return null;
+
+  const signedIn = Boolean(session && session.id > 0);
+  const ipShortMax = signedIn ? AUTH_IP_SHORT_MAX : ANON_IP_SHORT_MAX;
+
+  const ipShort = checkRateLimit(
+    `proposals:ip:${ip}`,
+    ipShortMax,
+    SHORT_WINDOW_MS,
+    now,
+  );
+  if (!ipShort.allowed) {
+    return { allowed: false, resetAt: ipShort.resetAt };
+  }
+
+  if (signedIn && session) {
+    const userShort = checkRateLimit(
+      `proposals:user:${session.id}`,
+      AUTH_USER_SHORT_MAX,
+      SHORT_WINDOW_MS,
+      now,
+    );
+    if (!userShort.allowed) {
+      return { allowed: false, resetAt: userShort.resetAt };
+    }
+  }
+
+  const ipDaily = checkRateLimit(
+    `proposals:daily:ip:${ip}`,
+    ANON_IP_DAILY_MAX,
+    DAILY_WINDOW_MS,
+    now,
+  );
+  if (!ipDaily.allowed) {
+    return { allowed: false, resetAt: ipDaily.resetAt };
+  }
+
+  if (signedIn && session) {
+    const userDaily = checkRateLimit(
+      `proposals:daily:user:${session.id}`,
+      AUTH_USER_DAILY_MAX,
+      DAILY_WINDOW_MS,
+      now,
+    );
+    if (!userDaily.allowed) {
+      return { allowed: false, resetAt: userDaily.resetAt };
+    }
+  }
+
+  return null;
+}
+
+export function enforceProposalWithdrawLimits(
+  session: ProposalRateLimitSession,
+  ip: string,
+  now = Date.now(),
+): { allowed: false; resetAt: number } | null {
+  if (shouldSkipProposalRateLimits()) return null;
+
+  const ipRate = checkRateLimit(
+    `proposals-withdraw:ip:${ip}`,
+    WITHDRAW_SHORT_MAX,
+    SHORT_WINDOW_MS,
+    now,
+  );
+  if (!ipRate.allowed) {
+    return { allowed: false, resetAt: ipRate.resetAt };
+  }
+
+  if (session && session.id > 0) {
+    const userRate = checkRateLimit(
+      `proposals-withdraw:user:${session.id}`,
+      WITHDRAW_SHORT_MAX,
+      SHORT_WINDOW_MS,
+      now,
+    );
+    if (!userRate.allowed) {
+      return { allowed: false, resetAt: userRate.resetAt };
+    }
+  }
+
+  return null;
+}

--- a/src/lib/api/proposal-rate-limit.ts
+++ b/src/lib/api/proposal-rate-limit.ts
@@ -36,8 +36,12 @@ export function enforceProposalSubmitLimits(
   const signedIn = Boolean(session && session.id > 0);
   const ipShortMax = signedIn ? AUTH_IP_SHORT_MAX : ANON_IP_SHORT_MAX;
 
+  // Keyed separately per auth state: a shared "proposals:ip:${ip}" bucket
+  // would let authenticated traffic (capped at 24) push the counter past the
+  // anonymous cap (8), blocking a brand-new anonymous request from the same
+  // IP/NAT even though it's the first one that IP has ever sent.
   const ipShort = checkRateLimit(
-    `proposals:ip:${ip}`,
+    `proposals:ip:${signedIn ? "auth" : "anon"}:${ip}`,
     ipShortMax,
     SHORT_WINDOW_MS,
     now,

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -537,7 +537,7 @@ export async function submitEntityProposal(input: {
     method: "POST",
     credentials: "same-origin",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ ...input, proposalId }),
+    body: JSON.stringify({ ...input, proposalId, _hp: "" }),
   });
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {

--- a/src/pages/api/proposals/[id]/withdraw.ts
+++ b/src/pages/api/proposals/[id]/withdraw.ts
@@ -1,5 +1,7 @@
 import type { APIRoute } from "astro";
 import { getEditorSession } from "@lib/admin/require-editor";
+import { clientIp, rateLimitResponse } from "@lib/api/rate-limit";
+import { enforceProposalWithdrawLimits } from "@lib/api/proposal-rate-limit";
 import { validateSubmitterName } from "@constants/proposals";
 import {
   ProposalActionError,
@@ -12,12 +14,18 @@ export const prerender = false;
 type WithdrawBody = { submitterName?: string };
 
 export const POST: APIRoute = async ({ cookies, params, request }) => {
+  const session = getEditorSession(cookies);
+  const ip = clientIp(request);
+  const denied = enforceProposalWithdrawLimits(session, ip);
+  if (denied) {
+    return rateLimitResponse(denied.resetAt);
+  }
+
   const id = Number(params.id);
   if (!Number.isInteger(id)) {
     return json({ error: "Invalid proposal ID" }, 400);
   }
 
-  const session = getEditorSession(cookies);
   const body = await request.json().catch(() => ({}) as WithdrawBody);
   const submitterName =
     session?.displayName ||

--- a/src/pages/api/proposals/index.ts
+++ b/src/pages/api/proposals/index.ts
@@ -1,10 +1,10 @@
 import type { APIRoute } from "astro";
 import { getEditorSession } from "@lib/admin/require-editor";
+import { clientIp, rateLimitResponse } from "@lib/api/rate-limit";
 import {
-  checkRateLimit,
-  clientIp,
-  rateLimitResponse,
-} from "@lib/api/rate-limit";
+  enforceProposalSubmitLimits,
+  isProposalHoneypotTripped,
+} from "@lib/api/proposal-rate-limit";
 import { validateSubmitterName } from "@constants/proposals";
 import {
   ProposalValidationError,
@@ -17,9 +17,6 @@ import {
 
 export const prerender = false;
 
-const ANON_LIMIT = { max: 8, windowMs: 10 * 60 * 1000 };
-const AUTH_LIMIT = { max: 24, windowMs: 10 * 60 * 1000 };
-
 type ProposalBody = {
   entityType?: string;
   entityId?: number;
@@ -27,19 +24,15 @@ type ProposalBody = {
   patch?: Record<string, unknown>;
   submitterName?: string;
   proposalId?: number;
+  _hp?: string;
 };
 
 export const POST: APIRoute = async ({ cookies, request }) => {
   const session = getEditorSession(cookies);
   const ip = clientIp(request);
-  const limit = session ? AUTH_LIMIT : ANON_LIMIT;
-  const rate = checkRateLimit(
-    `proposals:${session?.id ?? ip}`,
-    limit.max,
-    limit.windowMs,
-  );
-  if (!rate.allowed) {
-    return rateLimitResponse(rate.resetAt);
+  const denied = enforceProposalSubmitLimits(session, ip);
+  if (denied) {
+    return rateLimitResponse(denied.resetAt);
   }
 
   let body: ProposalBody;
@@ -47,6 +40,10 @@ export const POST: APIRoute = async ({ cookies, request }) => {
     body = await request.json();
   } catch {
     return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (isProposalHoneypotTripped(body as Record<string, unknown>)) {
+    return json({ success: true }, 201);
   }
 
   const submitterName =


### PR DESCRIPTION
## Summary

Closes the remaining #223 acceptance criteria on top of the existing in-memory limiter on `POST /api/proposals`.

- Adds [`src/lib/api/proposal-rate-limit.ts`](src/lib/api/proposal-rate-limit.ts): short (10 min) + daily (24 h) buckets, dual IP/user keys for signed-in submits, withdraw cap (12/10 min), honeypot no-op
- Wires submit + withdraw routes; client sends `_hp: ""`
- Documents limits in [`docs/contributor-proposal-qa.md`](docs/contributor-proposal-qa.md)
- Unit + HTTP integration tests for 429 / `Retry-After`

## Review notes (known limits)

- **Per-instance buckets** — same as existing `@lib/api/rate-limit`; effective cap scales with serverless cold starts. Shared KV deferred.
- **Shared NAT** — signed-in users on one campus IP share the 24/10 min IP bucket (each user also has their own user bucket).
- **Failed validation counts** — 400 responses still consume quota (intentional anti-abuse; integration test uses invalid submitter name to avoid writing rows).
- **Honeypot** — only non-empty string `_hp` triggers silent 201; Turnstile deferred.

## Test plan

- [x] `bun test src/lib/api/proposal-rate-limit.test.ts`
- [ ] CI integration job: `integration/http/proposals-rate-limit.integration.test.ts` (isolated `X-Forwarded-For`)
- [ ] Manual: 9 anonymous submits in 10 min on staging → 429 with retry message


Made with [Cursor](https://cursor.com)