### PR TITLE
feat(contributor): WYSIWYG draft pin preview for suggest addition

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Integration tests
         if: inputs.suite == 'blocking'
-        run: PREVIEW_BASE_URL=http://127.0.0.1:4321 bun test ./integration --preload integration/preload.ts --concurrency 1
+        run: PREVIEW_BASE_URL=http://127.0.0.1:4321 bun test ./integration --preload ./integration/preload.ts --concurrency 1
 
       - name: Restart preview after integration
         if: inputs.suite == 'blocking'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format": "biome format --write .",
     "test": "bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts'",
     "test:components": "vitest run",
-    "test:integration": "bun test ./integration --preload integration/preload.ts --concurrency 1",
+    "test:integration": "bun test ./integration --preload ./integration/preload.ts --concurrency 1",
     "test:integration:live": "bash scripts/run-integration-preview.sh",
     "test:all": "bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts' && bun run test:components && bun run test:integration",
     "e2e": "playwright test",

--- a/scripts/import-amis-classes.ts
+++ b/scripts/import-amis-classes.ts
@@ -53,7 +53,10 @@ import {
   resolveImportRows,
   summarizeImportChanges,
 } from "@lib/amis/import-classes";
-import { extractClassRows, normalizeAmisClass } from "@lib/amis/normalize-class";
+import {
+  extractClassRows,
+  normalizeAmisClass,
+} from "@lib/amis/normalize-class";
 import {
   amisExportContainsInstructorPii,
   sanitizeAmisRows,
@@ -160,7 +163,10 @@ async function refreshSyncKey(
     .where(eq(updateTable.tableName, tableName));
 }
 
-function inferTermIdFromPayload(payload: unknown, rows: AmisClassRow[]): number {
+function inferTermIdFromPayload(
+  payload: unknown,
+  rows: AmisClassRow[],
+): number {
   const envelope = payload as { term_id?: number; termId?: number };
   if (Number.isFinite(envelope.term_id)) return Number(envelope.term_id);
   if (Number.isFinite(envelope.termId)) return Number(envelope.termId);

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -48,6 +48,7 @@
   import Briefcase from "@lucide/svelte/icons/briefcase";
   import Store from "@lucide/svelte/icons/store";
   import EventMapPin from "./map/EventMapPin.svelte";
+  import ContributorDraftPinMarker from "./map/ContributorDraftPinMarker.svelte";
   import EventPlacementImageField from "./map-chrome/EventPlacementImageField.svelte";
   import MapEntityPin from "./map/MapEntityPin.svelte";
   import { MediaQuery } from "svelte/reactivity";
@@ -1824,6 +1825,19 @@
 
   $effect(() => {
     const map = mapStore.mapInstance;
+    const pin = additionProposalStore.draftPin;
+    if (!map || !pin) return;
+
+    map.easeTo({
+      center: [pin.lon, pin.lat],
+      zoom: Math.max(map.getZoom(), 17),
+      duration: 650,
+      padding: calculatePadding(untrack(() => md.current)),
+    });
+  });
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
     if (!map || !eventPlacementStore.active) return;
 
     const canvas = map.getCanvas();
@@ -2530,7 +2544,13 @@
               lat: additionProposalStore.draftPin.lat,
             }}
           >
-            <div class="addition-draft-pin" aria-hidden="true"></div>
+            {#if additionProposalStore.draftPinPreview}
+              <ContributorDraftPinMarker
+                preview={additionProposalStore.draftPinPreview}
+              />
+            {:else}
+              <div class="addition-draft-pin" aria-hidden="true"></div>
+            {/if}
           </Marker>
         {/if}
         {#if loaded}
@@ -3046,7 +3066,10 @@
         role="status"
         aria-live="polite"
       >
-        <p class="edit-dock-status">Tap the map to set the pin location</p>
+        <p class="edit-dock-status">
+          Tap the map to set the pin location. The preview shows how it will
+          look after approval.
+        </p>
         <button
           class="edit-dock-action cancel"
           type="button"
@@ -3064,7 +3087,10 @@
       >
         <div class="event-placement-copy">
           <strong>Choose a map pin location</strong>
-          <span>Click or tap the map where this entry should appear.</span>
+          <span>
+            Click or tap the map where this entry should appear. The preview
+            pin shows how it will look after approval.
+          </span>
         </div>
         <button
           class="event-placement-cancel"

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -1828,12 +1828,21 @@
     const pin = additionProposalStore.draftPin;
     if (!map || !pin) return;
 
-    map.easeTo({
-      center: [pin.lon, pin.lat],
-      zoom: Math.max(map.getZoom(), 17),
-      duration: 650,
-      padding: calculatePadding(untrack(() => md.current)),
+    // Defer the camera move out of the reactive flush: easeTo fires zoom/move
+    // handlers synchronously, and their state writes inside this flush can
+    // chain into effect_update_depth_exceeded, which kills the whole Svelte
+    // scheduler (app looks frozen, hover still works). Same guard as the
+    // jeepney stop-focus flyTo effect below.
+    const padding = calculatePadding(untrack(() => md.current));
+    const frame = requestAnimationFrame(() => {
+      map.easeTo({
+        center: [pin.lon, pin.lat],
+        zoom: Math.max(map.getZoom(), 17),
+        duration: 650,
+        padding,
+      });
     });
+    return () => cancelAnimationFrame(frame);
   });
 
   $effect(() => {

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -41,6 +41,10 @@
     orgCategoryLabel,
   } from "@constants/org-categories";
   import { onMount } from "svelte";
+  import {
+    buildDraftPinPreview,
+    draftPinRowLabel,
+  } from "@lib/editor/draft-pin-preview";
 
   type AdditionOption = {
     value: ProposalCreateType;
@@ -148,6 +152,10 @@
   );
 
   const draftPin = $derived(additionProposalStore.draftPin);
+  const draftPinPreview = $derived(additionProposalStore.draftPinPreview);
+  const draftPinRowText = $derived(
+    draftPinRowLabel(draftPinPreview, Boolean(draftPin)),
+  );
 
   function resetFields(clearPin = true) {
     buildingName = "";
@@ -313,6 +321,28 @@
     bundledRooms;
     additionProposalStore.draftPin;
     scheduleSuggestAdditionDraftSave(snapshotAdditionDraft);
+  });
+
+  $effect(() => {
+    if (!draftReady) return;
+    if (!needsPin) {
+      additionProposalStore.setDraftPinPreview(null);
+      return;
+    }
+    additionProposalStore.setDraftPinPreview(
+      buildDraftPinPreview({
+        kind,
+        buildingName,
+        dormName,
+        placeName,
+        placeCategory,
+        organizationName,
+        organizationCategory,
+        eventTitle,
+        eventStartsAt,
+        eventImageUrl,
+      }),
+    );
   });
 
   function dismissHost() {
@@ -1034,9 +1064,7 @@
 
   {#if needsPin}
     <EntityEditorPinRow
-      label={draftPin
-        ? `Pin set · ${draftPin.lat.toFixed(5)}, ${draftPin.lon.toFixed(5)}`
-        : "Drop a pin on the map"}
+      label={draftPinRowText}
       pickLabel={draftPin ? "Move pin" : "Pick on map"}
       disabled={submitting}
       onclick={pickOnMap}

--- a/src/components/svelte/map/ContributorDraftPinMarker.component.test.ts
+++ b/src/components/svelte/map/ContributorDraftPinMarker.component.test.ts
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+import ContributorDraftPinMarker from "./ContributorDraftPinMarker.svelte";
+import { mountAtWidth } from "@test/layout-assertions";
+
+describe("ContributorDraftPinMarker", () => {
+  test("renders building preview with label at 320px", () => {
+    mountAtWidth(320);
+    render(ContributorDraftPinMarker, {
+      props: {
+        preview: { kind: "building", label: "Baker Hall" },
+      },
+    });
+
+    expect(screen.getByText("Baker Hall")).toBeTruthy();
+    const pin = document.querySelector(
+      ".contributor-draft-pin .map-entity-pin",
+    );
+    expect(pin).toBeTruthy();
+    expect(pin?.classList.contains("building")).toBe(true);
+    expect(pin?.classList.contains("active")).toBe(true);
+  });
+});

--- a/src/components/svelte/map/ContributorDraftPinMarker.svelte
+++ b/src/components/svelte/map/ContributorDraftPinMarker.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import Briefcase from "@lucide/svelte/icons/briefcase";
+  import House from "@lucide/svelte/icons/house";
+  import Landmark from "@lucide/svelte/icons/landmark";
+  import Store from "@lucide/svelte/icons/store";
+  import University from "@lucide/svelte/icons/university";
+  import Users from "@lucide/svelte/icons/users";
+  import {
+    draftPinMapProps,
+    type DraftPinPreview,
+  } from "@lib/editor/draft-pin-preview";
+  import EventMapPin from "./EventMapPin.svelte";
+  import MapEntityPin from "./MapEntityPin.svelte";
+
+  type Props = {
+    preview: DraftPinPreview;
+  };
+
+  let { preview }: Props = $props();
+
+  const mapProps = $derived(draftPinMapProps(preview));
+</script>
+
+<div class="contributor-draft-pin">
+  {#if mapProps.component === "event"}
+    <EventMapPin
+      active
+      ariaLabel={mapProps.label}
+      dateLabel={mapProps.dateLabel ?? "TBD"}
+      imageSrc={mapProps.imageSrc}
+      labelTitle={mapProps.label}
+      labelVisible
+      onclick={() => {}}
+      status="upcoming"
+      title={mapProps.label}
+      useCentralHoverPreview={false}
+    />
+  {:else}
+    <MapEntityPin
+      active
+      label={mapProps.label}
+      labelVisible
+      tone={mapProps.tone}
+      useCentralHoverPreview={false}
+    >
+      {#if mapProps.icon === "university"}
+        <University size="20" />
+      {:else if mapProps.icon === "house"}
+        <House size="18" />
+      {:else if mapProps.icon === "landmark"}
+        <Landmark size="16" />
+      {:else if mapProps.icon === "store"}
+        <Store size="16" />
+      {:else if mapProps.icon === "users"}
+        <Users size="16" />
+      {:else}
+        <Briefcase size="16" />
+      {/if}
+    </MapEntityPin>
+  {/if}
+</div>
+
+<style>
+  .contributor-draft-pin {
+    position: relative;
+    z-index: 90;
+  }
+
+  .contributor-draft-pin :global(.map-entity-pin) {
+    border-width: 3px;
+    transform: scale(1.18);
+    box-shadow:
+      0 0 0 2px rgba(255, 255, 255, 0.95),
+      0 4px 12px rgba(0, 0, 0, 0.35);
+  }
+
+  .contributor-draft-pin :global(.map-entity-pin.building) {
+    box-shadow:
+      0 0 0 2px rgba(255, 255, 255, 0.95),
+      0 0 0 4px hsl(5 53% 40% / 0.55),
+      0 4px 12px rgba(0, 0, 0, 0.35);
+  }
+
+  .contributor-draft-pin :global(.map-entity-pin.dorm) {
+    box-shadow:
+      0 0 0 2px rgba(255, 255, 255, 0.95),
+      0 0 0 4px hsl(170 50% 45% / 0.55),
+      0 4px 12px rgba(0, 0, 0, 0.35);
+  }
+
+  .contributor-draft-pin :global(.map-entity-pin.organization) {
+    box-shadow:
+      0 0 0 2px rgba(255, 255, 255, 0.95),
+      0 0 0 4px hsl(265 45% 58% / 0.55),
+      0 4px 12px rgba(0, 0, 0, 0.35);
+  }
+
+  .contributor-draft-pin :global(.map-entity-pin.office) {
+    box-shadow:
+      0 0 0 2px rgba(255, 255, 255, 0.95),
+      0 0 0 4px hsl(208 52% 52% / 0.55),
+      0 4px 12px rgba(0, 0, 0, 0.35);
+  }
+
+  .contributor-draft-pin :global(.map-entity-pin.landmark) {
+    box-shadow:
+      0 0 0 2px rgba(255, 255, 255, 0.95),
+      0 0 0 4px hsl(34 62% 52% / 0.55),
+      0 4px 12px rgba(0, 0, 0, 0.35);
+  }
+
+  .contributor-draft-pin :global(.map-entity-pin.establishment) {
+    box-shadow:
+      0 0 0 2px rgba(255, 255, 255, 0.95),
+      0 0 0 4px hsl(334 54% 53% / 0.55),
+      0 4px 12px rgba(0, 0, 0, 0.35);
+  }
+
+  .contributor-draft-pin :global(.map-entity-pin.active::before) {
+    outline-width: 0.2rem;
+    outline-offset: 0.2rem;
+  }
+
+  .contributor-draft-pin :global(.event-map-pin) {
+    border-width: 3px;
+    transform: scale(1.18);
+    box-shadow:
+      0 0 0 2px rgba(255, 255, 255, 0.95),
+      0 0 0 4px rgba(123, 17, 19, 0.45),
+      0 4px 12px rgba(0, 0, 0, 0.35);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .contributor-draft-pin :global(.map-entity-pin),
+    .contributor-draft-pin :global(.event-map-pin) {
+      transform: none;
+    }
+  }
+</style>

--- a/src/lib/amis/normalize-class.ts
+++ b/src/lib/amis/normalize-class.ts
@@ -220,7 +220,8 @@ export function normalizeAmisClass(
   row: AmisClassRow,
   termId: number,
 ): NormalizedAmisClass | null {
-  const courseCode = asString(row["course_code"]) ?? asString(row["courseCode"]);
+  const courseCode =
+    asString(row["course_code"]) ?? asString(row["courseCode"]);
   const section = asString(row["section"]);
   if (!courseCode || !section) return null;
 

--- a/src/lib/editor/draft-pin-preview.test.ts
+++ b/src/lib/editor/draft-pin-preview.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildDraftPinPreview,
+  draftPinMapProps,
+  draftPinRowLabel,
+} from "./draft-pin-preview";
+
+describe("buildDraftPinPreview", () => {
+  test("returns null when the pin kind has no name yet", () => {
+    expect(
+      buildDraftPinPreview({
+        kind: "create_building",
+        buildingName: "  ",
+        dormName: "",
+        placeName: "",
+        placeCategory: "landmark",
+        organizationName: "",
+        organizationCategory: "student-org",
+        eventTitle: "",
+        eventStartsAt: "",
+        eventImageUrl: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("maps building and dorm kinds", () => {
+    expect(
+      buildDraftPinPreview({
+        kind: "create_building",
+        buildingName: " Baker Hall ",
+        dormName: "",
+        placeName: "",
+        placeCategory: "landmark",
+        organizationName: "",
+        organizationCategory: "student-org",
+        eventTitle: "",
+        eventStartsAt: "",
+        eventImageUrl: null,
+      }),
+    ).toEqual({ kind: "building", label: "Baker Hall" });
+
+    expect(
+      buildDraftPinPreview({
+        kind: "create_dorm",
+        buildingName: "",
+        dormName: "Sampaguita",
+        placeName: "",
+        placeCategory: "landmark",
+        organizationName: "",
+        organizationCategory: "student-org",
+        eventTitle: "",
+        eventStartsAt: "",
+        eventImageUrl: null,
+      }),
+    ).toEqual({ kind: "dorm", label: "Sampaguita" });
+  });
+
+  test("maps place and organization categories to preview metadata", () => {
+    expect(
+      draftPinMapProps({
+        kind: "place",
+        label: "Oblation",
+        placeCategory: "tourist-spot",
+      }).tone,
+    ).toBe("landmark");
+
+    expect(
+      draftPinMapProps({
+        kind: "place",
+        label: "Cafe",
+        placeCategory: "food",
+      }),
+    ).toMatchObject({ tone: "establishment", icon: "store" });
+
+    expect(
+      draftPinMapProps({
+        kind: "organization",
+        label: "CSS",
+        orgCategory: "student-org",
+      }),
+    ).toMatchObject({ tone: "organization", icon: "users" });
+
+    expect(
+      draftPinMapProps({
+        kind: "organization",
+        label: "Registrar",
+        orgCategory: "office",
+      }),
+    ).toMatchObject({ tone: "office", icon: "briefcase" });
+  });
+
+  test("formats event preview date label", () => {
+    const props = draftPinMapProps({
+      kind: "event",
+      label: "Lantern Parade",
+      eventStartsAt: "2026-12-18T18:00",
+      eventImageUrl: null,
+    });
+    expect(props.component).toBe("event");
+    expect(props.dateLabel).toMatch(/Dec/);
+  });
+});
+
+describe("draftPinRowLabel", () => {
+  test("uses entity name when coords exist", () => {
+    expect(
+      draftPinRowLabel({ kind: "building", label: "Baker Hall" }, true),
+    ).toBe("Pin set · Baker Hall");
+    expect(draftPinRowLabel(null, false)).toBe("Drop a pin on the map");
+    expect(draftPinRowLabel(null, true)).toBe("Pin set on map");
+  });
+});

--- a/src/lib/editor/draft-pin-preview.ts
+++ b/src/lib/editor/draft-pin-preview.ts
@@ -1,0 +1,169 @@
+import {
+  isLandmarkPlaceCategory,
+  type PlaceCategory,
+} from "@constants/place-categories";
+import {
+  isStudentOrganization,
+  type OrgCategory,
+} from "@constants/org-categories";
+import { formatCampusDateShort } from "@lib/event-time";
+import type { ProposalCreateType } from "@lib/proposals/client";
+
+export type DraftPinEntityKind =
+  | "building"
+  | "dorm"
+  | "place"
+  | "organization"
+  | "event";
+
+export type DraftPinPreview = {
+  kind: DraftPinEntityKind;
+  label: string;
+  placeCategory?: PlaceCategory;
+  orgCategory?: OrgCategory;
+  eventStartsAt?: string;
+  eventImageUrl?: string | null;
+};
+
+export type EntityPinTone =
+  | "building"
+  | "dorm"
+  | "organization"
+  | "office"
+  | "landmark"
+  | "establishment";
+
+export type DraftPinIconKind =
+  | "university"
+  | "house"
+  | "landmark"
+  | "store"
+  | "users"
+  | "briefcase"
+  | "event";
+
+export type DraftPinMapProps = {
+  component: "entity" | "event";
+  tone?: EntityPinTone;
+  icon: DraftPinIconKind;
+  label: string;
+  dateLabel?: string;
+  imageSrc?: string | null;
+};
+
+export type SuggestAdditionPreviewInput = {
+  kind: ProposalCreateType;
+  buildingName: string;
+  dormName: string;
+  placeName: string;
+  placeCategory: PlaceCategory;
+  organizationName: string;
+  organizationCategory: OrgCategory;
+  eventTitle: string;
+  eventStartsAt: string;
+  eventImageUrl: string | null;
+};
+
+export function buildDraftPinPreview(
+  input: SuggestAdditionPreviewInput,
+): DraftPinPreview | null {
+  switch (input.kind) {
+    case "create_building": {
+      const label = input.buildingName.trim();
+      return label ? { kind: "building", label } : null;
+    }
+    case "create_dorm": {
+      const label = input.dormName.trim();
+      return label ? { kind: "dorm", label } : null;
+    }
+    case "create_place": {
+      const label = input.placeName.trim();
+      return label
+        ? { kind: "place", label, placeCategory: input.placeCategory }
+        : null;
+    }
+    case "create_organization": {
+      const label = input.organizationName.trim();
+      return label
+        ? {
+            kind: "organization",
+            label,
+            orgCategory: input.organizationCategory,
+          }
+        : null;
+    }
+    case "create_event": {
+      const label = input.eventTitle.trim();
+      return label
+        ? {
+            kind: "event",
+            label,
+            eventStartsAt: input.eventStartsAt,
+            eventImageUrl: input.eventImageUrl,
+          }
+        : null;
+    }
+    default:
+      return null;
+  }
+}
+
+export function draftPinMapProps(preview: DraftPinPreview): DraftPinMapProps {
+  switch (preview.kind) {
+    case "building":
+      return {
+        component: "entity",
+        tone: "building",
+        icon: "university",
+        label: preview.label,
+      };
+    case "dorm":
+      return {
+        component: "entity",
+        tone: "dorm",
+        icon: "house",
+        label: preview.label,
+      };
+    case "place": {
+      const landmark = isLandmarkPlaceCategory(preview.placeCategory);
+      return {
+        component: "entity",
+        tone: landmark ? "landmark" : "establishment",
+        icon: landmark ? "landmark" : "store",
+        label: preview.label,
+      };
+    }
+    case "organization": {
+      const student = isStudentOrganization(preview.orgCategory);
+      return {
+        component: "entity",
+        tone: student ? "organization" : "office",
+        icon: student ? "users" : "briefcase",
+        label: preview.label,
+      };
+    }
+    case "event":
+      return {
+        component: "event",
+        icon: "event",
+        label: preview.label,
+        dateLabel: formatDraftEventDateLabel(preview.eventStartsAt),
+        imageSrc: preview.eventImageUrl,
+      };
+  }
+}
+
+function formatDraftEventDateLabel(startsAt: string | undefined): string {
+  if (!startsAt?.trim()) return "TBD";
+  const formatted = formatCampusDateShort(startsAt);
+  return formatted || "TBD";
+}
+
+export function draftPinRowLabel(
+  preview: DraftPinPreview | null,
+  hasCoords: boolean,
+): string {
+  if (!hasCoords) return "Drop a pin on the map";
+  if (!preview?.label) return "Pin set on map";
+  return `Pin set · ${preview.label}`;
+}

--- a/src/lib/stores/editor-stores.store.test.ts
+++ b/src/lib/stores/editor-stores.store.test.ts
@@ -74,6 +74,21 @@ describe("AdditionProposalStore", () => {
     await expect(pending).resolves.toEqual({ lat: 14.1, lon: 121.2 });
     expect(store.pinPickActive).toBe(false);
   });
+
+  test("setDraftPinPreview stores preview metadata independently of coords", () => {
+    const store = new AdditionProposalStore();
+    store.setDraftPinPreview({ kind: "building", label: "Baker Hall" });
+    expect(store.draftPinPreview).toEqual({
+      kind: "building",
+      label: "Baker Hall",
+    });
+    store.clearDraftPin();
+    expect(store.draftPin).toBeNull();
+    expect(store.draftPinPreview).toEqual({
+      kind: "building",
+      label: "Baker Hall",
+    });
+  });
 });
 
 describe("EventPlacementStore", () => {

--- a/src/lib/stores/editor-stores.svelte.ts
+++ b/src/lib/stores/editor-stores.svelte.ts
@@ -1,4 +1,5 @@
 import { clearProposeEventDraft } from "../contributor-drafts.js";
+import type { DraftPinPreview } from "../editor/draft-pin-preview.js";
 import { deactivateMapModesExcept } from "./map-modes.js";
 import type { EventPlacementDraft, MapProposalTarget } from "./store-types.js";
 
@@ -71,6 +72,7 @@ export class MapProposalStore {
 export class AdditionProposalStore {
   pinPickActive = $state(false);
   draftPin: { lat: number; lon: number } | null = $state(null);
+  draftPinPreview: DraftPinPreview | null = $state(null);
   private pinResolver: ((coords: { lat: number; lon: number }) => void) | null =
     null;
   private pinReject: ((reason?: unknown) => void) | null = null;
@@ -108,6 +110,10 @@ export class AdditionProposalStore {
 
   setDraftPin(pin: { lat: number; lon: number } | null) {
     this.draftPin = pin;
+  }
+
+  setDraftPinPreview(preview: DraftPinPreview | null) {
+    this.draftPinPreview = preview;
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace the generic contributor draft teardrop with a WYSIWYG map marker that uses the same tone rules as live pins (building, dorm, place, org, event).
- Draft pins get extra static contrast (scale, thicker border, white halo, tone ring) so they stand out without animation.
- Suggest Addition pin row shows `Pin set · {entity name}` instead of raw coordinates; the map eases to the placed preview.

## Test plan

- [x] `bunx vitest run src/lib/editor/draft-pin-preview.test.ts src/lib/stores/editor-stores.store.test.ts`
- [x] `bun run test:components -- src/components/svelte/map/ContributorDraftPinMarker.component.test.ts`
- [ ] Manual: Suggest addition → building → enter name → Pick on map → preview pin shows label + maroon tone at 320px and desktop
- [ ] Manual: Switch entity kind after pin set → preview updates from form fields


Made with [Cursor](https://cursor.com)