### PR TITLE
feat(scripts): fork:check — scan for UPLB strings a fork must replace

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "generate:test-inventory": "bun run scripts/generate-test-inventory.ts",
     "post:test-inventory-discord": "bun run scripts/post-test-inventory-discord.ts",
     "check:readme": "bun run scripts/check-readme-drift.ts",
+    "fork:check": "bun run scripts/fork-check.ts",
     "install:agent-tooling": "bash scripts/install-agent-tooling.sh",
     "install:agent-plugins": "bash scripts/install-agent-plugins.sh",
     "install:shopped-skills": "bash scripts/install-shopped-skills.sh",

--- a/scripts/fork-check.ts
+++ b/scripts/fork-check.ts
@@ -1,0 +1,118 @@
+/**
+ * Scan tracked files for UPLB-specific strings a fork must replace.
+ *
+ * On upstream (uplbtools/room-tba) this reports many hits — that is expected,
+ * this is the UPLB app. Run it on YOUR fork after you think you have replaced
+ * everything. A clean run means you caught it all; remaining hits are things
+ * you forgot.
+ *
+ * Usage:
+ *   bun run fork:check            # report hits, exit 1 if any
+ *   bun run fork:check --silent   # exit code only (for your fork's CI)
+ *
+ * Wire it into your fork's CI after the upstream files are replaced.
+ */
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+type Marker = { pattern: RegExp; hint: string };
+
+const markers: Marker[] = [
+  { pattern: /\buplb\b/gi, hint: "UPLB name — rebrand to your campus." },
+  { pattern: /uplbtools/gi, hint: "UPLB Tools org/domain — your org/domain." },
+  {
+    pattern: /room-tba\.uplbtools\.me/gi,
+    hint: "Production URL — set to your domain (also astro.config.mjs `site:`).",
+  },
+  {
+    pattern: /(discord|messenger)\.uplbtools\.me/gi,
+    hint: "UPLB community subdomains — your community links, or delete.",
+  },
+  {
+    pattern: /m\.me\/j\/[A-Za-z0-9_-]+/gi,
+    hint: "UPLB Messenger group invite — your community link, or delete.",
+  },
+  { pattern: /\bMakiling\b/g, hint: "Mt. Makiling terrain — your terrain source, or disable 3D." },
+  {
+    pattern: /\bAMIS\b/g,
+    hint: "UPLB course system. You do not have AMIS — write your own class importer.",
+  },
+  { pattern: /\bSAIS\b/g, hint: "UPLB student system reference — repoint to your registrar." },
+  { pattern: /\bPSLH\b/g, hint: "UPLB building code (Physical Sciences Lecture Hall)." },
+  { pattern: /\bPhySci\b/g, hint: "UPLB building alias (Physical Sciences)." },
+  { pattern: /\bOble\b|\bOblation\b/g, hint: "UPLB landmark — your campus landmark, or remove copy." },
+  { pattern: /Los Ba[ñn]os/g, hint: "UPLB campus locale — your campus location." },
+  { pattern: /r\/peyups/gi, hint: "UPLB subreddit source credit — remove or replace." },
+  {
+    pattern: /121\.24125948460573|14\.16323736946326/g,
+    hint: "UPLB default map center — set to your campus center in map-terrain.ts.",
+  },
+];
+
+// Files that mention UPLB by design (this scanner, the fork guide that tells
+// you to replace UPLB strings). Everything else is a real "you forgot this".
+const allowList = [/scripts\/fork-check\.ts$/, /src\/pages\/wiki\/fork-for-your-campus\.astro$/];
+
+type Hit = { file: string; line: number; text: string; hint: string };
+
+function isBinary(buf: Buffer): boolean {
+  return buf.includes(0, 0, Math.min(buf.length, 8000));
+}
+
+function scan(): Hit[] {
+  const files = execSync("git ls-files", { encoding: "utf8" }).trim().split("\n");
+  const hits: Hit[] = [];
+  for (const file of files) {
+    if (allowList.some((re) => re.test(file))) continue;
+    let buf: Buffer;
+    try {
+      buf = readFileSync(file);
+    } catch {
+      continue;
+    }
+    if (isBinary(buf)) continue;
+    const text = buf.toString("utf8");
+    const lines = text.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      for (const { pattern, hint } of markers) {
+        pattern.lastIndex = 0;
+        if (pattern.test(line)) {
+          hits.push({ file, line: i + 1, text: line.trim().slice(0, 160), hint });
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+const silent = process.argv.includes("--silent");
+const hits = scan();
+
+if (hits.length === 0) {
+  if (!silent) console.log("fork:check passed — no UPLB-specific strings found.");
+  process.exit(0);
+}
+
+if (!silent) {
+  const byFile = new Map<string, Hit[]>();
+  for (const h of hits) {
+    const arr = byFile.get(h.file) ?? [];
+    arr.push(h);
+    byFile.set(h.file, arr);
+  }
+  console.error(`fork:check found ${hits.length} UPLB-specific hit(s) across ${byFile.size} file(s).\n`);
+  for (const [file, fileHits] of byFile) {
+    console.error(`  ${file}  (${fileHits.length})`);
+    for (const h of fileHits.slice(0, 5)) {
+      console.error(`    :${h.line}  ${h.hint}`);
+    }
+    if (fileHits.length > 5) {
+      console.error(`    … and ${fileHits.length - 5} more in this file.`);
+    }
+  }
+  console.error(
+    "\nReplace or delete these before deploying your fork. See /wiki/fork-for-your-campus.",
+  );
+}
+process.exit(1);


### PR DESCRIPTION
## Who are you?

- [x] **Developer:** code PR to `staging`.

## Summary

Adds `bun run fork:check` — a scanner that greps tracked files for hardcoded UPLB-specific strings a fork must replace (uplb, uplbtools.me, AMIS, Makiling, PSLH, the default map center coords, Messenger invites, etc.). Reports file:line hits with hints. A fork author runs it after they think they have replaced everything; a clean run means they caught it all.

**Linked issues:** none. Pairs with the fork guide in #706.

## Why

The fork guide (#706) lists 6+ files a fork must change by hand. The failure mode is "I changed the logo and site name but left UPLB data baked into a constants file I forgot." This script catches that. On upstream it reports ~2000 hits across ~160 files — expected, this is the UPLB app. On a finished fork it should report zero.

## Developer checklist

- [x] `bun run lint` — Biome check on `scripts/fork-check.ts` passes clean (no diagnostics).
- [x] `bunx astro check` — no new errors from this change.
- [x] Script runs: `bun run fork:check` reports hits grouped by file, exit 1 on hits, exit 0 clean; `--silent` exits code-only.
- [x] Allowlist verified: the scanner does not flag itself or the fork guide wiki page.
- Not wired into upstream CI — upstream is supposed to contain UPLB strings. A fork wires it into their own CI.

## QA Summary

Verified locally:
- `bun run fork:check` → 1966 hits across 164 files (upstream baseline).
- `bun run fork:check --silent` → exit 1 (correct).
- Self-flag check: `scripts/fork-check.ts` not in output (allowlist works).
- Fork guide not flagged (allowlist works).

No schema, routing, auth, or map chrome changes. No tests added (script is a standalone tool; behavior verified by running it).

Known gaps:
- Marker list is v1 (high-signal: uplb, uplbtools.me, AMIS, SAIS, Makiling, PSLH, PhySci, Oblation, Los Baños, r/peyups, map center coords, messenger invites). Can be extended; kept tight to avoid false positives (skipped `OSA`/`OUR` as too generic).

## Test plan

```sh
bun run fork:check            # see hits grouped by file
bun run fork:check --silent   # exit code only
```
On upstream both report hits (exit 1). On a fork that has replaced everything, exit 0.

## Follow-up

Update the fork guide (#706) to mention `bun run fork:check` as the "catch what you missed" step. Will patch #706 once this lands (or in this PR if preferred).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Standalone script and package.json script only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`bun run fork:check`**, a dev tool for campus forks to verify they removed upstream UPLB branding and data before deploy.
> 
> The new **`scripts/fork-check.ts`** walks **git-tracked** text files and matches a curated list of markers (e.g. `uplb`, `uplbtools`, production/community URLs, AMIS/SAIS, Makiling, building codes, default map coordinates). Hits are grouped by file with **actionable hints**; the process **exits 1** when any remain and **0** when clean. **`--silent`** is for fork CI (exit code only). The scanner and **`fork-for-your-campus`** wiki page are **allowlisted** so upstream is not expected to pass. Upstream CI is intentionally **not** wired to this check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1d7a995dd08c280ea94bc3dacbd7dadfb6e906c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->