### PR TITLE
refactor(config): consolidate UPLB values into src/campus.config.ts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,13 +8,14 @@ import {
   MESSENGER_CONTRIBUTE_TARGET,
   MESSENGER_MAINTAIN_TARGET,
 } from "./src/constants/community-links.ts";
+import { campusCommunity, campusSite } from "./src/campus.config.ts";
 
 /** Local E2E + integration preview — Vercel adapter does not support `astro preview`. */
 const e2eNodeAdapter = process.env.ASTRO_E2E_NODE === "1";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://room-tba.uplbtools.me",
+  site: campusSite.url,
 
   integrations: [
     svelte(),
@@ -128,7 +129,7 @@ export default defineConfig({
 
   redirects: {
     "/contribute": "/?contribute=1",
-    "/discord": "https://discord.uplbtools.me",
+    "/discord": campusCommunity.discordUrl,
     "/messenger": MESSENGER_CONTRIBUTE_TARGET,
     "/messenger/contribute": MESSENGER_CONTRIBUTE_TARGET,
     "/messenger/maintain": MESSENGER_MAINTAIN_TARGET,

--- a/src/campus.config.ts
+++ b/src/campus.config.ts
@@ -1,0 +1,54 @@
+/**
+ * Single source of truth for campus-specific config.
+ *
+ * A fork changes this file (and the data — see /wiki/fork-for-your-campus).
+ * Run `bun run fork:check` after editing to catch stray UPLB strings elsewhere.
+ *
+ * Values are plain literals so astro.config.mjs can import this module at
+ * config-eval time (no process.env reads at module top level).
+ */
+
+export const campusSite = {
+  url: "https://room-tba.uplbtools.me",
+  name: "Room TBA",
+  title: "Room TBA | Find Rooms, Buildings, Colleges, and Divisions at UPLB",
+  description:
+    "Room TBA helps UPLB students find rooms, buildings, colleges, and divisions across the Los Banos campus.",
+} as const;
+
+export const campusMap: {
+  maxBounds: [[number, number], [number, number]];
+  defaultCamera: {
+    center: [number, number];
+    zoom: number;
+    pitch: number;
+    bearing: number;
+  };
+} = {
+  /** [lng, lat] — west/south corner, then east/north corner. */
+  maxBounds: [
+    // West/south: Mt. Makiling foothills, BSP Jamboree site, National Arts Center corridor.
+    [121.168, 14.095],
+    [121.335, 14.215],
+  ],
+  /** Default camera: center [lng, lat], zoom, pitch (0 = top-down, 60 = tilted 3D), bearing. */
+  defaultCamera: {
+    center: [121.24125948460573, 14.16323736946326],
+    zoom: 15.81,
+    pitch: 60,
+    bearing: -154.48,
+  },
+};
+
+export const campusCommunity = {
+  orgUrl: "https://uplbtools.me",
+  githubUrl: "https://github.com/uplbtools/room-tba",
+  discordUrl: "https://discord.uplbtools.me",
+  osaOrganizationsUrl: "https://uplbosa.org/orgs",
+  /** Messenger group chat invites (targets for redirect workers). */
+  messengerContributeTarget: "https://m.me/j/Aba1V0prvQyLrafZ/",
+  messengerMaintainTarget: "https://m.me/j/AbZtqMU8UUTiwQfn/",
+  /** Short links on a community subdomain (Cloudflare Worker). Delete if unused. */
+  messengerShortContributeUrl: "https://messenger.uplbtools.me/contribute",
+  messengerShortMaintainUrl: "https://messenger.uplbtools.me/maintain",
+} as const;

--- a/src/constants/community-links.ts
+++ b/src/constants/community-links.ts
@@ -1,22 +1,29 @@
-/** External UPLB Tools community and org links (also wired as short redirects in astro.config). */
+/** External community and org links (also wired as short redirects in astro.config).
+ *
+ * Campus-specific values live in src/campus.config.ts — a fork edits that one
+ * file. This module re-exports them under the names the rest of the app imports
+ * and derives the app-stable redirect URLs from the site URL. */
+import { campusCommunity, campusSite } from "../campus.config";
 
-/** Canonical production origin — literal so astro.config can import this module. */
-const ROOM_TBA_SITE_URL = "https://room-tba.uplbtools.me";
+/** Canonical production origin. */
+const ROOM_TBA_SITE_URL = campusSite.url;
 
-export const UPLB_TOOLS_URL = "https://uplbtools.me";
-export const GITHUB_ROOM_TBA_URL = "https://github.com/uplbtools/room-tba";
-export const DISCORD_URL = "https://discord.uplbtools.me";
-export const UPLB_OSA_ORGANIZATIONS_URL = "https://uplbosa.org/orgs";
+export const UPLB_TOOLS_URL = campusCommunity.orgUrl;
+export const GITHUB_ROOM_TBA_URL = campusCommunity.githubUrl;
+export const DISCORD_URL = campusCommunity.discordUrl;
+export const UPLB_OSA_ORGANIZATIONS_URL = campusCommunity.osaOrganizationsUrl;
 
 /** Facebook Messenger group chat invites (targets for redirect workers). */
-export const MESSENGER_CONTRIBUTE_TARGET = "https://m.me/j/Aba1V0prvQyLrafZ/";
-export const MESSENGER_MAINTAIN_TARGET = "https://m.me/j/AbZtqMU8UUTiwQfn/";
+export const MESSENGER_CONTRIBUTE_TARGET =
+  campusCommunity.messengerContributeTarget;
+export const MESSENGER_MAINTAIN_TARGET =
+  campusCommunity.messengerMaintainTarget;
 
-/** Short links on messenger.uplbtools.me (Cloudflare Worker). */
+/** Short links on a community subdomain (Cloudflare Worker). */
 export const MESSENGER_SHORT_CONTRIBUTE_URL =
-  "https://messenger.uplbtools.me/contribute";
+  campusCommunity.messengerShortContributeUrl;
 export const MESSENGER_SHORT_MAINTAIN_URL =
-  "https://messenger.uplbtools.me/maintain";
+  campusCommunity.messengerShortMaintainUrl;
 
 /** App-stable redirect URLs on room-tba (avoids messenger subdomain DNS cache misses). */
 export const MESSENGER_CONTRIBUTE_URL = `${ROOM_TBA_SITE_URL}/messenger/contribute`;

--- a/src/constants/map-terrain.ts
+++ b/src/constants/map-terrain.ts
@@ -1,4 +1,5 @@
 import { MAPTILER_KEY_PLACEHOLDER, withMaptilerKey } from "@lib/maptiler-key";
+import { campusMap } from "../campus.config";
 
 export const TERRAIN_SOURCE_ID = "makiling-terrain-dem";
 export const TERRAIN_HILLSHADE_LAYER_ID = "makiling-terrain-hillshade";
@@ -13,11 +14,8 @@ export function getTerrainTileJsonUrl(): string {
 export const TERRAIN_EXAGGERATION_OPTIONS = [1, 1.5, 2] as const;
 export const DEFAULT_TERRAIN_EXAGGERATION = 1.5;
 
-export const CAMPUS_MAX_BOUNDS: [[number, number], [number, number]] = [
-  // West/south: Mt. Makiling foothills, BSP Jamboree site, National Arts Center corridor.
-  [121.168, 14.095],
-  [121.335, 14.215],
-];
+export const CAMPUS_MAX_BOUNDS: [[number, number], [number, number]] =
+  campusMap.maxBounds;
 
 /** Flat object form for bounds checks (offline tiles, geolocation, admin APIs). */
 export const CAMPUS_BOUNDS = {
@@ -27,12 +25,7 @@ export const CAMPUS_BOUNDS = {
   maxLat: CAMPUS_MAX_BOUNDS[1][1],
 } as const;
 
-export const CAMPUS_DEFAULT_CAMERA = {
-  center: [121.24125948460573, 14.16323736946326] as [number, number],
-  zoom: 15.81,
-  pitch: 60,
-  bearing: -154.48,
-};
+export const CAMPUS_DEFAULT_CAMERA = campusMap.defaultCamera;
 
 export const MAKILING_TERRAIN_MAX_BOUNDS: [[number, number], [number, number]] =
   [

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,9 +1,9 @@
-export const SITE_URL = "https://room-tba.uplbtools.me";
-export const SITE_NAME = "Room TBA";
-export const DEFAULT_TITLE =
-  "Room TBA | Find Rooms, Buildings, Colleges, and Divisions at UPLB";
-export const DEFAULT_DESCRIPTION =
-  "Room TBA helps UPLB students find rooms, buildings, colleges, and divisions across the Los Banos campus.";
+import { campusSite } from "../campus.config";
+
+export const SITE_URL = campusSite.url;
+export const SITE_NAME = campusSite.name;
+export const DEFAULT_TITLE = campusSite.title;
+export const DEFAULT_DESCRIPTION = campusSite.description;
 export const DEFAULT_OG_IMAGE = "/og.png";
 export const OG_IMAGE_WIDTH = 1200;
 export const OG_IMAGE_HEIGHT = 630;


### PR DESCRIPTION
## Who are you?

- [x] **Developer:** code PR to `staging`.

## Summary

A fork now edits **one file** (`src/campus.config.ts`) instead of six. The existing modules keep their public exports and re-source the values from campus.config.ts. No importer changes — `site.ts`, `map-terrain.ts`, `community-links.ts` become thin re-exports.

**Linked issues:** none. Pairs with the fork guide (#706) and fork:check scanner (#707).

## Why

The fork guide (#706) lists 6+ files a fork must change by hand (`site.ts`, `map-terrain.ts`, `community-links.ts`, `status-bar-links.ts`, `astro.config.mjs`, `public/room_info.json`). The failure mode is forgetting one. This PR consolidates the code-side values into a single config module. A fork edits `src/campus.config.ts` and runs `bun run fork:check` (#707) to catch anything missed.

## What moved

| File | Values moved to campus.config.ts |
| --- | --- |
| `src/lib/site.ts` | `SITE_URL`, `SITE_NAME`, `DEFAULT_TITLE`, `DEFAULT_DESCRIPTION` |
| `src/constants/map-terrain.ts` | `CAMPUS_MAX_BOUNDS`, `CAMPUS_DEFAULT_CAMERA` |
| `src/constants/community-links.ts` | All UPLB community URLs, messenger targets, short links |
| `astro.config.mjs` | `site:` URL, `/discord` redirect target |

`status-bar-links.ts` imports from `community-links.ts`, so it is covered transitively. `public/room_info.json` is a data file, not code — left as-is (the fork guide covers it).

## Type preservation

- `campusSite` / `campusCommunity`: `as const` → string literal types preserved (matches existing `export const X = "literal"` inference).
- `campusMap`: explicit tuple type annotations → mutable `[[number, number], [number, number]]` preserved (no `readonly` propagation).
- Every existing export keeps its exact type. `astro check` stays at **667 errors** (down from 668; no new errors).

## Developer checklist

- [x] `bun run lint` — Biome check on all 4 changed `.ts` files passes clean.
- [x] `bunx astro check` — 667 errors (baseline was 668; no new errors). All 4 changed files clean individually.
- [x] `astro.config.mjs` transpiles (`bun build` parse check).
- [x] UPLB literals verified consolidated: zero in `site.ts`/`map-terrain.ts`/`community-links.ts`; all in `campus.config.ts`. One residual in `astro.config.mjs:223` is a doc-string email example (`digest@uplbtools.me` in an envField description), not a config value.
- [ ] `bun run build` — not run (needs `DATABASE_URL`; change is pure value-sourcing, same values + types, astro check validates types).

No schema, routing, auth, or map chrome logic changes. The `/discord` redirect now sources from `campusCommunity.discordUrl` (same value, just not hardcoded).

## QA Summary

Verified:
- Biome clean on `src/campus.config.ts`, `src/lib/site.ts`, `src/constants/map-terrain.ts`, `src/constants/community-links.ts`.
- `astro check`: 667 errors total (no regressions); all 4 changed files individually clean.
- `astro.config.mjs` parses.
- UPLB string grep: 0 code literals in refactored files; all in `campus.config.ts`.

Known gaps:
- No full `bun run build` (env blocked this session). Risk is low: values are identical, types preserved, import graph validated by astro check. The `astro.config.mjs` config-eval path (imports `campusSite`/`campusCommunity` from `./src/campus.config.ts`) works the same as the existing `community-links.ts` import — plain literals, no `process.env` at module top level.

## Test plan

```sh
bunx biome check src/campus.config.ts src/lib/site.ts src/constants/map-terrain.ts src/constants/community-links.ts
bunx astro check   # 667 errors, no new ones
bun dev            # confirm site name, map center, community links render as before
```

## Follow-up

Once this lands, update the fork guide (#706) to point at `src/campus.config.ts` as the single file to edit (currently lists 6 files).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure value relocation with preserved export surfaces and identical literals; no auth, data, or routing logic changes beyond sourcing the same URLs from one module.
> 
> **Overview**
> Introduces **`src/campus.config.ts`** as the single place for campus-specific literals (site URL/name/SEO copy, map bounds and default camera, community and messenger URLs). Forks are expected to edit this file instead of hunting strings across the repo.
> 
> **`site.ts`**, **`map-terrain.ts`**, and **`community-links.ts`** keep their existing export names but now read from `campus.config.ts`, so downstream imports stay unchanged. **`astro.config.mjs`** uses `campusSite.url` for `site` and `campusCommunity.discordUrl` for the `/discord` redirect instead of inline UPLB URLs.
> 
> Runtime behavior and values are unchanged; this is structural consolidation ahead of fork tooling/docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ab522c9cb710b3e75bed650aec013858d0358e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->