### PR TITLE
refactor: tech-debt cleanup from code review

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@astrojs/check": "^0.9.9",
         "@astrojs/node": "^11.0.2",
         "@astrojs/svelte": "^9.0.1",
-        "@astrojs/vercel": "^11.0.2",
+        "@astrojs/vercel": "^11.0.3",
         "@aws-sdk/client-s3": "^3.1081.0",
         "@datadog/browser-rum": "^7.5.0",
         "@electric-sql/pglite": "^0.5.4",
@@ -117,7 +117,7 @@
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.2", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ=="],
 
-    "@astrojs/vercel": ["@astrojs/vercel@11.0.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@vercel/analytics": "^1.6.1", "@vercel/functions": "^3.4.3", "@vercel/nft": "^1.3.2", "@vercel/routing-utils": "^5.3.3", "esbuild": "^0.28.0", "tinyglobby": "^0.2.15" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-Y9P+hfmKwZKeS7bTxsvTsJRdAobmzm6NFTd6dTzb+Muv3Jr0t87bR+2wdP1jaKM3h7QW65mSYXaL9hxvpoAAXg=="],
+    "@astrojs/vercel": ["@astrojs/vercel@11.0.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@vercel/analytics": "^1.6.1", "@vercel/functions": "^3.4.3", "@vercel/nft": "^1.3.2", "@vercel/routing-utils": "^5.3.3", "esbuild": "^0.28.0", "tinyglobby": "^0.2.15" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-UMhcZ/lWB0/B2l1L8BJh6QxysjZt8SLS9e40xRfBdVhfi3Y6SIDw+99rY/+OGW/yem/S7sBRkvqvto8neevO2A=="],
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
 

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -189,8 +189,8 @@ export const finalExamsTable = pgTable(
     courseTitle: text("course_title"),
     roomId: integer("room_id"),
     examDate: date("exam_date", { mode: "string" }).notNull(),
-    startsAt: time("starts_at", { mode: "string" }).notNull(),
-    endsAt: time("ends_at", { mode: "string" }).notNull(),
+    startsAt: time("starts_at").notNull(),
+    endsAt: time("ends_at").notNull(),
     source: varchar({ length: 64 }).notNull(),
     version: integer().default(1).notNull(),
     updatedAt: timestamp("updated_at", { mode: "string" })

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@astrojs/check": "^0.9.9",
     "@astrojs/node": "^11.0.2",
     "@astrojs/svelte": "^9.0.1",
-    "@astrojs/vercel": "^11.0.2",
+    "@astrojs/vercel": "^11.0.3",
     "@aws-sdk/client-s3": "^3.1081.0",
     "@datadog/browser-rum": "^7.5.0",
     "@electric-sql/pglite": "^0.5.4",

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -118,6 +118,7 @@
     isPlaceHoverPreview,
     organizationPreviewFromRow,
     placePreviewFromRow,
+    type EntityHoverPreview,
   } from "@lib/entity-hover-preview.svelte";
   import { patchEventLocations, patchPosition } from "@lib/map-edit/patch-api";
   import { formatMinutes } from "@lib/schedule-import/day-stops";
@@ -947,23 +948,37 @@
     );
   }
 
+  function handlePinPointerEnter(
+    preview: EntityHoverPreview,
+    pointer: PointerEvent,
+    editKey?: string,
+  ) {
+    if (editKey !== undefined) handleEditablePinEnter(editKey);
+    if (!shouldShowEntityHoverPreview()) return;
+    if (editKey !== undefined && canDragPin(editKey)) return;
+    entityHoverPreviewStore.show(preview, {
+      x: pointer.clientX,
+      y: pointer.clientY,
+    });
+  }
+
+  function handlePinPointerLeave(editKey?: string) {
+    if (editKey !== undefined) handleEditablePinLeave(editKey);
+    if (!shouldShowEntityHoverPreview()) return;
+    if (editKey !== undefined && canDragPin(editKey)) return;
+    entityHoverPreviewStore.scheduleHide();
+  }
+
   function handleBuildingPinPointerEnter(
     building: BuildingData,
     editKey: string,
     event: PointerEvent,
   ) {
-    handleEditablePinEnter(editKey);
-    if (!shouldShowEntityHoverPreview() || canDragPin(editKey)) return;
-    entityHoverPreviewStore.show(buildingPreviewFromRow(building), {
-      x: event.clientX,
-      y: event.clientY,
-    });
+    handlePinPointerEnter(buildingPreviewFromRow(building), event, editKey);
   }
 
   function handleBuildingPinPointerLeave(editKey: string) {
-    handleEditablePinLeave(editKey);
-    if (!shouldShowEntityHoverPreview() || canDragPin(editKey)) return;
-    entityHoverPreviewStore.scheduleHide();
+    handlePinPointerLeave(editKey);
   }
 
   function handleDormPinPointerEnter(
@@ -971,55 +986,34 @@
     editKey: string,
     event: PointerEvent,
   ) {
-    handleEditablePinEnter(editKey);
-    if (!shouldShowEntityHoverPreview() || canDragPin(editKey)) return;
-    entityHoverPreviewStore.show(dormPreviewFromRow(dorm), {
-      x: event.clientX,
-      y: event.clientY,
-    });
+    handlePinPointerEnter(dormPreviewFromRow(dorm), event, editKey);
   }
 
   function handleDormPinPointerLeave(editKey: string) {
-    handleEditablePinLeave(editKey);
-    if (!shouldShowEntityHoverPreview() || canDragPin(editKey)) return;
-    entityHoverPreviewStore.scheduleHide();
+    handlePinPointerLeave(editKey);
   }
 
   function handleEventPinPointerEnter(event: EventData, pointer: PointerEvent) {
-    if (!shouldShowEntityHoverPreview()) return;
-    entityHoverPreviewStore.show(eventPreviewFromRow(event), {
-      x: pointer.clientX,
-      y: pointer.clientY,
-    });
+    handlePinPointerEnter(eventPreviewFromRow(event), pointer);
   }
 
   function handleEventPinPointerLeave() {
-    if (!shouldShowEntityHoverPreview()) return;
-    entityHoverPreviewStore.scheduleHide();
+    handlePinPointerLeave();
   }
 
   function handleOrganizationPinPointerEnter(
     organization: OrgData,
     pointer: PointerEvent,
   ) {
-    if (!shouldShowEntityHoverPreview()) return;
-    entityHoverPreviewStore.show(organizationPreviewFromRow(organization), {
-      x: pointer.clientX,
-      y: pointer.clientY,
-    });
+    handlePinPointerEnter(organizationPreviewFromRow(organization), pointer);
   }
 
   function handlePlacePinPointerEnter(place: PlaceData, pointer: PointerEvent) {
-    if (!shouldShowEntityHoverPreview()) return;
-    entityHoverPreviewStore.show(placePreviewFromRow(place), {
-      x: pointer.clientX,
-      y: pointer.clientY,
-    });
+    handlePinPointerEnter(placePreviewFromRow(place), pointer);
   }
 
   function handleDetailPinPointerLeave() {
-    if (!shouldShowEntityHoverPreview()) return;
-    entityHoverPreviewStore.scheduleHide();
+    handlePinPointerLeave();
   }
 
   function beginMarkerDrag(key: string) {

--- a/src/lib/admin/entity-merge-route.ts
+++ b/src/lib/admin/entity-merge-route.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import { json } from "@lib/api/json";
 import {
   EditConflictError,
   DuplicateNameError,
@@ -23,13 +24,6 @@ type EntityMergeBody = {
   preferredRoomCode?: string;
   preferredName?: string;
 };
-
-function json(data: unknown, status = 200) {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
 
 export function createEntityMergeRoute<TEntity>(options: {
   entityLabel: string;

--- a/src/lib/admin/entity-patch-route.ts
+++ b/src/lib/admin/entity-patch-route.ts
@@ -1,0 +1,102 @@
+import type { APIRoute } from "astro";
+import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
+import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
+import { json, errorResponse, parseIdParam } from "@lib/api/json";
+import {
+  EditConflictError,
+  DuplicateNameError,
+  DuplicateSlugError,
+} from "@lib/services/admin-service";
+
+type ApplyResult<TInput> =
+  | { ok: true; input: TInput; version?: number }
+  | { ok: false; response: Response };
+
+/**
+ * Factory for admin PATCH routes — mirrors `createEntityMergeRoute` but for
+ * single-entity updates. Faktors out the identical auth → parse-id → parse-body
+ * → version → error-catch shell so each route only provides its validation +
+ * update logic.
+ */
+export function createEntityPatchRoute<TEntity, TInput>(options: {
+  entityLabel: string;
+  responseKey: string;
+  /**
+   * Validate the parsed body and build the input for the update function.
+   * Return `{ ok: true, input, version }` to proceed or
+   * `{ ok: false, response }` to short-circuit with an error.
+   */
+  validateAndBuild: (body: unknown) => ApplyResult<TInput>;
+  /** The service-layer update function. */
+  update: (
+    id: number,
+    input: TInput,
+    expectedVersion: number,
+    editedBy: string,
+  ) => Promise<TEntity | null>;
+}): APIRoute {
+  return async ({ cookies, params, request }) => {
+    const auth = await editorSessionOrUnauthorized(cookies, {
+      requirePublish: true,
+    });
+    if (auth instanceof Response) return auth;
+
+    const id = parseIdParam(params.id);
+    if (id === null) {
+      return errorResponse(`Invalid ${options.entityLabel} ID`, 400);
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return errorResponse("Invalid JSON body", 400);
+    }
+
+    const result = options.validateAndBuild(body);
+    if (!result.ok) return result.response;
+
+    const parsedVersion = parseRequiredEditorVersion(result.version);
+    if (!parsedVersion.ok) return parsedVersion.response;
+
+    try {
+      const entity = await options.update(
+        id,
+        result.input,
+        parsedVersion.version,
+        auth.editedBy,
+      );
+      return json({ success: true, [options.responseKey]: entity });
+    } catch (err) {
+      if (err instanceof EditConflictError) {
+        return json(
+          {
+            error: `This ${options.entityLabel} was changed by another editor.`,
+            latest: err.latest,
+          },
+          409,
+        );
+      }
+
+      if (err instanceof DuplicateNameError) {
+        return json(
+          {
+            error: err.message,
+            code: "duplicate_name",
+            entityType: err.entityType,
+            mergeCandidate: err.candidate,
+            attemptedName: err.attemptedName,
+          },
+          409,
+        );
+      }
+
+      if (err instanceof DuplicateSlugError) {
+        return json({ error: err.message }, 409);
+      }
+
+      console.error(`Failed to update ${options.entityLabel}:`, err);
+      return errorResponse(`Failed to save ${options.entityLabel}`, 500);
+    }
+  };
+}

--- a/src/lib/api/json.ts
+++ b/src/lib/api/json.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared API response helpers.
+ *
+ * Every API route should use these instead of reinventing
+ * `new Response(JSON.stringify(...), { status, headers })`.
+ */
+
+/** Standard JSON response. */
+export function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Standard error response — `{ error: message }` with the given status. */
+export function errorResponse(error: string, status: number): Response {
+  return json({ error }, status);
+}
+
+/**
+ * Parse and validate a numeric `:id` path parameter.
+ * Returns the positive integer, or `null` if invalid.
+ */
+export function parseIdParam(value: string | undefined): number | null {
+  const id = parseInt(value ?? "", 10);
+  return Number.isNaN(id) || id < 1 ? null : id;
+}

--- a/src/lib/services/admin-service.ts
+++ b/src/lib/services/admin-service.ts
@@ -126,6 +126,58 @@ export async function recordEditorHistory({
   });
 }
 
+/**
+ * Generic entity update helper — factors out the shared update skeleton:
+ * fetch before → execute update → conflict check → record history →
+ * refresh sync key → return updated (or re-fetch).
+ *
+ * The caller provides entity-specific parts (building updates, dup checks,
+ * the Drizzle update query) via callbacks.
+ */
+async function performEntityUpdate<
+  TEntity extends { id: number; version: number },
+>(options: {
+  id: number;
+  expectedVersion?: number;
+  editedBy: string;
+  entityType: string;
+  getById: (id: number) => Promise<TEntity | null>;
+  executeUpdate: () => Promise<TEntity[]>;
+  history?: EditorHistoryOverride;
+  syncKeyType: string;
+  syncKeyPaths: (updated: TEntity | null, before: TEntity | null) => string[];
+}): Promise<TEntity | null> {
+  const before = await options.getById(options.id);
+
+  const rows = await options.executeUpdate();
+  const updated = rows[0];
+
+  if (!updated && options.expectedVersion !== undefined) {
+    throw new EditConflictError(await options.getById(options.id));
+  }
+
+  if (before && updated) {
+    await recordEditorHistory({
+      entityType: options.entityType,
+      entityId: options.id,
+      action: options.history?.action ?? "update",
+      before,
+      after: updated,
+      versionBefore: before.version,
+      versionAfter: updated.version,
+      editedBy: options.editedBy,
+      summary: options.history?.summary ?? null,
+    });
+  }
+
+  await refreshSyncKey(
+    options.syncKeyType,
+    options.syncKeyPaths(updated ?? null, before),
+  );
+
+  return updated ?? (await options.getById(options.id));
+}
+
 // ── Rooms ──
 
 export type RoomWithRelations = RoomData;
@@ -467,38 +519,6 @@ function serializeRoomPosition(position: RoomPosition | null) {
   };
 }
 
-export async function upsertRoomPosition(
-  roomId: number,
-  input: RoomPositionUpdateInput,
-): Promise<void> {
-  const existing = await getRoomPosition(roomId);
-  const updatedAt = new Date().toISOString();
-  if (existing) {
-    await db
-      .update(roomPositionsTable)
-      .set({
-        floor: input.floor,
-        posX: input.posX,
-        posY: input.posY,
-        updatedAt,
-      })
-      .where(eq(roomPositionsTable.id, existing.id));
-  } else {
-    await db.insert(roomPositionsTable).values({
-      floor: input.floor,
-      posX: input.posX,
-      posY: input.posY,
-      updatedAt,
-      roomId,
-    });
-  }
-  const room = await getRoomById(roomId);
-  await refreshSyncKey(
-    "rooms",
-    room ? [roomIsrPath(room), "/room/"] : ["/room/"],
-  );
-}
-
 export async function updateRoomPosition(
   roomId: number,
   input: RoomPositionUpdateInput,
@@ -604,10 +624,6 @@ export async function getBuildingById(
     .where(eq(buildingsTable.id, id))
     .limit(1);
   return rows[0] ?? null;
-}
-
-export async function getAllBuildingsAdmin(): Promise<BuildingAdmin[]> {
-  return db.select().from(buildingsTable).orderBy(buildingsTable.buildingName);
 }
 
 export type BuildingUpdateInput = {
@@ -749,10 +765,6 @@ export async function getCollegeById(id: number): Promise<CollegeAdmin | null> {
   return rows[0] ?? null;
 }
 
-export async function getAllCollegesAdmin(): Promise<CollegeAdmin[]> {
-  return db.select().from(collegesTable).orderBy(collegesTable.collegeName);
-}
-
 export async function updateCollege(
   id: number,
   collegeName: string,
@@ -765,47 +777,37 @@ export async function updateCollege(
     throw new DuplicateNameError("college", candidate, collegeName);
   }
 
-  const before = await getCollegeById(id);
-  const where =
-    expectedVersion === undefined
-      ? eq(collegesTable.id, id)
-      : and(
-          eq(collegesTable.id, id),
-          eq(collegesTable.version, expectedVersion),
-        );
-  const [updated] = await db
-    .update(collegesTable)
-    .set({
-      collegeName,
-      version: sql`"version" + 1`,
-      updatedAt: sql`now()`,
-    })
-    .where(where)
-    .returning();
-
-  if (!updated && expectedVersion !== undefined) {
-    throw new EditConflictError(await getCollegeById(id));
-  }
-
-  if (before && updated) {
-    await recordEditorHistory({
-      entityType: "college",
-      entityId: id,
-      action: history?.action ?? "update",
-      before,
-      after: updated,
-      versionBefore: before.version,
-      versionAfter: updated.version,
-      editedBy,
-      summary: history?.summary ?? null,
-    });
-  }
-
-  await refreshSyncKey("colleges", [
-    collegeIsrPath(updated ?? before),
-    "/college/",
-  ]);
-  return updated ?? (await getCollegeById(id));
+  return performEntityUpdate({
+    id,
+    expectedVersion,
+    editedBy,
+    entityType: "college",
+    getById: getCollegeById,
+    executeUpdate: async () => {
+      const where =
+        expectedVersion === undefined
+          ? eq(collegesTable.id, id)
+          : and(
+              eq(collegesTable.id, id),
+              eq(collegesTable.version, expectedVersion),
+            );
+      return db
+        .update(collegesTable)
+        .set({
+          collegeName,
+          version: sql`"version" + 1`,
+          updatedAt: sql`now()`,
+        })
+        .where(where)
+        .returning();
+    },
+    history,
+    syncKeyType: "colleges",
+    syncKeyPaths: (updated, before) => [
+      collegeIsrPath(updated ?? before),
+      "/college/",
+    ],
+  });
 }
 
 export async function createCollege(
@@ -848,10 +850,6 @@ export async function getDivisionById(
   return rows[0] ?? null;
 }
 
-export async function getAllDivisionsAdmin(): Promise<DivisionAdmin[]> {
-  return db.select().from(divisionsTable).orderBy(divisionsTable.divisionName);
-}
-
 export type DivisionUpdateInput = {
   divisionName?: string;
   collegeId?: number | null;
@@ -883,47 +881,37 @@ export async function updateDivision(
     }
   }
 
-  const before = await getDivisionById(id);
-  const where =
-    expectedVersion === undefined
-      ? eq(divisionsTable.id, id)
-      : and(
-          eq(divisionsTable.id, id),
-          eq(divisionsTable.version, expectedVersion),
-        );
-  const [updated] = await db
-    .update(divisionsTable)
-    .set({
-      ...updates,
-      version: sql`"version" + 1`,
-      updatedAt: sql`now()`,
-    })
-    .where(where)
-    .returning();
-
-  if (!updated && expectedVersion !== undefined) {
-    throw new EditConflictError(await getDivisionById(id));
-  }
-
-  if (before && updated) {
-    await recordEditorHistory({
-      entityType: "division",
-      entityId: id,
-      action: history?.action ?? "update",
-      before,
-      after: updated,
-      versionBefore: before.version,
-      versionAfter: updated.version,
-      editedBy,
-      summary: history?.summary ?? null,
-    });
-  }
-
-  await refreshSyncKey("divisions", [
-    divisionIsrPath(updated ?? before),
-    "/division/",
-  ]);
-  return updated ?? (await getDivisionById(id));
+  return performEntityUpdate({
+    id,
+    expectedVersion,
+    editedBy,
+    entityType: "division",
+    getById: getDivisionById,
+    executeUpdate: async () => {
+      const where =
+        expectedVersion === undefined
+          ? eq(divisionsTable.id, id)
+          : and(
+              eq(divisionsTable.id, id),
+              eq(divisionsTable.version, expectedVersion),
+            );
+      return db
+        .update(divisionsTable)
+        .set({
+          ...updates,
+          version: sql`"version" + 1`,
+          updatedAt: sql`now()`,
+        })
+        .where(where)
+        .returning();
+    },
+    history,
+    syncKeyType: "divisions",
+    syncKeyPaths: (updated, before) => [
+      divisionIsrPath(updated ?? before),
+      "/division/",
+    ],
+  });
 }
 
 export type DivisionCreateInput = {
@@ -977,10 +965,6 @@ export async function getDormById(id: number): Promise<DormAdmin | null> {
     .where(eq(dormsTable.id, id))
     .limit(1);
   return rows[0] ?? null;
-}
-
-export async function getAllDormsAdmin(): Promise<DormAdmin[]> {
-  return db.select().from(dormsTable).orderBy(dormsTable.dormName);
 }
 
 export type DormUpdateInput = Partial<{
@@ -1200,10 +1184,6 @@ export async function getOrganizationById(
     .where(eq(organizationsTable.id, id))
     .limit(1);
   return rows[0] ?? null;
-}
-
-export async function getAllOrganizationsAdmin(): Promise<OrgAdmin[]> {
-  return db.select().from(organizationsTable).orderBy(organizationsTable.name);
 }
 
 export type OrgUpdateInput = Partial<{
@@ -1462,6 +1442,19 @@ export async function updateEvent(
 ): Promise<EventData | null> {
   const before = await getEventById(id, { includeInactive: true });
   if (!before) return null;
+
+  // Check slug uniqueness if slug is changing (mirrors createEvent guard)
+  if (input.slug !== undefined && input.slug !== before.slug) {
+    const slug = input.slug;
+    if (slug) {
+      const [existing] = await db
+        .select({ id: eventsTable.id })
+        .from(eventsTable)
+        .where(and(eq(eventsTable.slug, slug), ne(eventsTable.id, id)))
+        .limit(1);
+      if (existing) throw new DuplicateSlugError(slug);
+    }
+  }
 
   const updates = getEventUpdates(input);
   const shouldReplaceChildren =

--- a/src/lib/services/admin-user-service.ts
+++ b/src/lib/services/admin-user-service.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import bcrypt from "bcrypt";
 import { and, desc, eq, ne, sql } from "drizzle-orm";
 import { ADMIN_PASSWORD } from "astro:env/server";
@@ -244,7 +244,14 @@ export async function ensureBootstrapAdminUser(): Promise<void> {
 export async function authenticateLegacyAdminPassword(
   password: string,
 ): Promise<SessionUser | null> {
-  if (!ADMIN_PASSWORD || password !== ADMIN_PASSWORD) return null;
+  if (!ADMIN_PASSWORD) return null;
+  const passwordBuf = Buffer.from(password);
+  const expectedBuf = Buffer.from(ADMIN_PASSWORD);
+  if (
+    passwordBuf.length !== expectedBuf.length ||
+    !timingSafeEqual(passwordBuf, expectedBuf)
+  )
+    return null;
   await ensureBootstrapAdminUser();
   return authenticateAdminUser("admin", password);
 }

--- a/src/pages/api/admin/buildings/[id].ts
+++ b/src/pages/api/admin/buildings/[id].ts
@@ -3,6 +3,7 @@ import { R2_PUBLIC_URL } from "astro:env/server";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
 import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
 import { parseImageUrl } from "@lib/r2-upload-core";
+import { json, errorResponse } from "@lib/api/json";
 import {
   EditConflictError,
   updateBuilding,
@@ -30,43 +31,28 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
 
   const id = parseInt(params.id ?? "", 10);
   if (Number.isNaN(id)) {
-    return new Response(JSON.stringify({ error: "Invalid building ID" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse("Invalid building ID", 400);
   }
 
   let body: BuildingPatchBody;
   try {
     body = await request.json();
   } catch {
-    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse("Invalid JSON body", 400);
   }
 
   if (
     body.buildingName !== undefined &&
     body.buildingName.trim().length === 0
   ) {
-    return new Response(
-      JSON.stringify({ error: "Building name cannot be empty" }),
-      {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return errorResponse("Building name cannot be empty", 400);
   }
 
   if (
     body.buildingType &&
     !["admin", "non-admin"].includes(body.buildingType)
   ) {
-    return new Response(JSON.stringify({ error: "Invalid building type" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse("Invalid building type", 400);
   }
 
   const parsedImageUrl = parseImageUrl(
@@ -75,10 +61,7 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
     "Building image",
   );
   if (!parsedImageUrl.ok) {
-    return new Response(JSON.stringify({ error: parsedImageUrl.error }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse(parsedImageUrl.error, 400);
   }
 
   const parsedVersion = parseRequiredEditorVersion(body.version);
@@ -105,44 +88,32 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
       auth.editedBy,
     );
 
-    return new Response(JSON.stringify({ success: true, building }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    return json({ success: true, building });
   } catch (err) {
     if (err instanceof EditConflictError) {
-      return new Response(
-        JSON.stringify({
+      return json(
+        {
           error: "This building was changed by another editor.",
           latest: err.latest,
-        }),
-        {
-          status: 409,
-          headers: { "Content-Type": "application/json" },
         },
+        409,
       );
     }
 
     if (err instanceof DuplicateNameError) {
-      return new Response(
-        JSON.stringify({
+      return json(
+        {
           error: err.message,
           code: "duplicate_name",
           entityType: err.entityType,
           mergeCandidate: err.candidate,
           attemptedName: err.attemptedName,
-        }),
-        {
-          status: 409,
-          headers: { "Content-Type": "application/json" },
         },
+        409,
       );
     }
 
     console.error("Failed to update building:", err);
-    return new Response(JSON.stringify({ error: "Failed to save building" }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse("Failed to save building", 500);
   }
 };

--- a/src/pages/api/admin/colleges/[id].ts
+++ b/src/pages/api/admin/colleges/[id].ts
@@ -1,11 +1,7 @@
 import type { APIRoute } from "astro";
-import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
-import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
-import {
-  EditConflictError,
-  updateCollege,
-  DuplicateNameError,
-} from "@lib/services/admin-service";
+import { createEntityPatchRoute } from "@lib/admin/entity-patch-route";
+import { errorResponse } from "@lib/api/json";
+import { updateCollege, type CollegeAdmin } from "@lib/services/admin-service";
 
 export const prerender = false;
 
@@ -14,87 +10,18 @@ type CollegePatchBody = {
   version?: number;
 };
 
-export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = await editorSessionOrUnauthorized(cookies, {
-    requirePublish: true,
-  });
-  if (auth instanceof Response) return auth;
-
-  const id = parseInt(params.id ?? "", 10);
-  if (Number.isNaN(id)) {
-    return new Response(JSON.stringify({ error: "Invalid college ID" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
-
-  let body: CollegePatchBody;
-  try {
-    body = await request.json();
-  } catch {
-    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
-
-  if (!body.collegeName || body.collegeName.trim().length === 0) {
-    return new Response(JSON.stringify({ error: "College name is required" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
-
-  const parsedVersion = parseRequiredEditorVersion(body.version);
-  if (!parsedVersion.ok) return parsedVersion.response;
-  const expectedVersion = parsedVersion.version;
-
-  try {
-    const college = await updateCollege(
-      id,
-      body.collegeName.trim(),
-      expectedVersion,
-      auth.editedBy,
-    );
-
-    return new Response(JSON.stringify({ success: true, college }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
-  } catch (err) {
-    if (err instanceof EditConflictError) {
-      return new Response(
-        JSON.stringify({
-          error: "This college was changed by another editor.",
-          latest: err.latest,
-        }),
-        {
-          status: 409,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+export const PATCH: APIRoute = createEntityPatchRoute<CollegeAdmin, string>({
+  entityLabel: "college",
+  responseKey: "college",
+  validateAndBuild: (body) => {
+    const b = body as CollegePatchBody;
+    if (!b.collegeName || b.collegeName.trim().length === 0) {
+      return {
+        ok: false,
+        response: errorResponse("College name is required", 400),
+      };
     }
-
-    if (err instanceof DuplicateNameError) {
-      return new Response(
-        JSON.stringify({
-          error: err.message,
-          code: "duplicate_name",
-          entityType: err.entityType,
-          mergeCandidate: err.candidate,
-          attemptedName: err.attemptedName,
-        }),
-        {
-          status: 409,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    }
-
-    console.error("Failed to update college:", err);
-    return new Response(JSON.stringify({ error: "Failed to save college" }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
-};
+    return { ok: true, input: b.collegeName.trim(), version: b.version };
+  },
+  update: updateCollege,
+});

--- a/src/pages/api/admin/divisions/[id].ts
+++ b/src/pages/api/admin/divisions/[id].ts
@@ -1,10 +1,9 @@
 import type { APIRoute } from "astro";
-import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
-import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
+import { createEntityPatchRoute } from "@lib/admin/entity-patch-route";
+import { errorResponse } from "@lib/api/json";
 import {
-  EditConflictError,
   updateDivision,
-  DuplicateNameError,
+  type DivisionAdmin,
   type DivisionUpdateInput,
 } from "@lib/services/admin-service";
 
@@ -16,95 +15,41 @@ type DivisionPatchBody = {
   version?: number;
 };
 
-function json(data: unknown, status = 200) {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
 function invalidCollegeId(value: unknown) {
   return value !== undefined && value !== null && !Number.isInteger(value);
 }
 
-export const PATCH: APIRoute = async ({ cookies, params, request }) => {
-  const auth = await editorSessionOrUnauthorized(cookies, {
-    requirePublish: true,
-  });
-  if (auth instanceof Response) return auth;
-
-  const id = parseInt(params.id ?? "", 10);
-  if (Number.isNaN(id)) {
-    return json({ error: "Invalid division ID" }, 400);
-  }
-
-  let body: DivisionPatchBody;
-  try {
-    body = await request.json();
-  } catch {
-    return json({ error: "Invalid JSON body" }, 400);
-  }
-
-  if (
-    body.divisionName !== undefined &&
-    body.divisionName.trim().length === 0
-  ) {
-    return json({ error: "Division name is required" }, 400);
-  }
-  if (invalidCollegeId(body.collegeId)) {
-    return json({ error: "College must be a valid selection" }, 400);
-  }
-
-  const parsedVersion = parseRequiredEditorVersion(body.version);
-  if (!parsedVersion.ok) return parsedVersion.response;
-  const expectedVersion = parsedVersion.version;
-
-  const updates: DivisionUpdateInput = {};
-  if (body.divisionName !== undefined) {
-    updates.divisionName = body.divisionName.trim();
-  }
-  if (body.collegeId !== undefined) {
-    updates.collegeId = body.collegeId;
-  }
-
-  if (Object.keys(updates).length === 0) {
-    return json({ error: "No division fields to update" }, 400);
-  }
-
-  try {
-    const division = await updateDivision(
-      id,
-      updates,
-      expectedVersion,
-      auth.editedBy,
-    );
-
-    return json({ success: true, division });
-  } catch (err) {
-    if (err instanceof EditConflictError) {
-      return json(
-        {
-          error: "This division was changed by another editor.",
-          latest: err.latest,
-        },
-        409,
-      );
+export const PATCH: APIRoute = createEntityPatchRoute<
+  DivisionAdmin,
+  DivisionUpdateInput
+>({
+  entityLabel: "division",
+  responseKey: "division",
+  validateAndBuild: (body) => {
+    const b = body as DivisionPatchBody;
+    if (b.divisionName !== undefined && b.divisionName.trim().length === 0) {
+      return {
+        ok: false,
+        response: errorResponse("Division name is required", 400),
+      };
     }
-
-    if (err instanceof DuplicateNameError) {
-      return json(
-        {
-          error: err.message,
-          code: "duplicate_name",
-          entityType: err.entityType,
-          mergeCandidate: err.candidate,
-          attemptedName: err.attemptedName,
-        },
-        409,
-      );
+    if (invalidCollegeId(b.collegeId)) {
+      return {
+        ok: false,
+        response: errorResponse("College must be a valid selection", 400),
+      };
     }
-
-    console.error("Failed to update division:", err);
-    return json({ error: "Failed to save division" }, 500);
-  }
-};
+    const input: DivisionUpdateInput = {};
+    if (b.divisionName !== undefined)
+      input.divisionName = b.divisionName.trim();
+    if (b.collegeId !== undefined) input.collegeId = b.collegeId;
+    if (Object.keys(input).length === 0) {
+      return {
+        ok: false,
+        response: errorResponse("No division fields to update", 400),
+      };
+    }
+    return { ok: true, input, version: b.version };
+  },
+  update: updateDivision,
+});

--- a/src/pages/api/admin/dorms/[id].ts
+++ b/src/pages/api/admin/dorms/[id].ts
@@ -3,6 +3,7 @@ import { R2_PUBLIC_URL } from "astro:env/server";
 import { editorSessionOrUnauthorized } from "@lib/admin/require-editor";
 import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
 import { parseImageUrl } from "@lib/r2-upload-core";
+import { json, errorResponse } from "@lib/api/json";
 import {
   EditConflictError,
   updateDorm,
@@ -39,27 +40,18 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
 
   const id = parseInt(params.id ?? "", 10);
   if (Number.isNaN(id)) {
-    return new Response(JSON.stringify({ error: "Invalid dorm ID" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse("Invalid dorm ID", 400);
   }
 
   let body: DormPatchBody;
   try {
     body = await request.json();
   } catch {
-    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse("Invalid JSON body", 400);
   }
 
   if (body.dormName !== undefined && body.dormName.trim().length === 0) {
-    return new Response(JSON.stringify({ error: "Dorm name is required" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse("Dorm name is required", 400);
   }
 
   const parsedImageUrl = parseImageUrl(
@@ -68,10 +60,7 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
     "Dorm image",
   );
   if (!parsedImageUrl.ok) {
-    return new Response(JSON.stringify({ error: parsedImageUrl.error }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse(parsedImageUrl.error, 400);
   }
 
   const parsedVersion = parseRequiredEditorVersion(body.version);
@@ -117,44 +106,32 @@ export const PATCH: APIRoute = async ({ cookies, params, request }) => {
 
     const dorm = await updateDorm(id, updates, expectedVersion, auth.editedBy);
 
-    return new Response(JSON.stringify({ success: true, dorm }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    return json({ success: true, dorm });
   } catch (err) {
     if (err instanceof EditConflictError) {
-      return new Response(
-        JSON.stringify({
+      return json(
+        {
           error: "This dorm was changed by another editor.",
           latest: err.latest,
-        }),
-        {
-          status: 409,
-          headers: { "Content-Type": "application/json" },
         },
+        409,
       );
     }
 
     if (err instanceof DuplicateNameError) {
-      return new Response(
-        JSON.stringify({
+      return json(
+        {
           error: err.message,
           code: "duplicate_name",
           entityType: err.entityType,
           mergeCandidate: err.candidate,
           attemptedName: err.attemptedName,
-        }),
-        {
-          status: 409,
-          headers: { "Content-Type": "application/json" },
         },
+        409,
       );
     }
 
     console.error("Failed to update dorm:", err);
-    return new Response(JSON.stringify({ error: "Failed to save dorm" }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return errorResponse("Failed to save dorm", 500);
   }
 };

--- a/src/pages/api/admin/events/[id].ts
+++ b/src/pages/api/admin/events/[id].ts
@@ -5,6 +5,7 @@ import { parseRequiredEditorVersion } from "@lib/admin/expected-version";
 import { parseEventImageUrl } from "@lib/r2-upload";
 import {
   deactivateEvent,
+  DuplicateSlugError,
   EditConflictError,
   updateEvent,
   type EventWriteInput,
@@ -96,6 +97,10 @@ function parseEventId(value: string | undefined) {
 }
 
 function handleEventError(err: unknown) {
+  if (err instanceof DuplicateSlugError) {
+    return json({ error: err.message }, 409);
+  }
+
   if (err instanceof EditConflictError) {
     return json(
       {

--- a/src/pages/api/cron/proposal-digest.ts
+++ b/src/pages/api/cron/proposal-digest.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { timingSafeEqual } from "node:crypto";
 import { CRON_SECRET } from "astro:env/server";
 import { sendProposalDigest } from "@lib/services/digest-service";
 
@@ -9,7 +10,14 @@ export const GET: APIRoute = async ({ request }) => {
   if (!CRON_SECRET) {
     return json({ error: "Cron is not configured on this server." }, 503);
   }
-  if (request.headers.get("authorization") !== `Bearer ${CRON_SECRET}`) {
+  const authHeader = request.headers.get("authorization") ?? "";
+  const expected = `Bearer ${CRON_SECRET}`;
+  const authBuf = Buffer.from(authHeader);
+  const expectedBuf = Buffer.from(expected);
+  if (
+    authBuf.length !== expectedBuf.length ||
+    !timingSafeEqual(authBuf, expectedBuf)
+  ) {
     return json({ error: "Unauthorized" }, 401);
   }
 

--- a/src/pages/api/proposals/index.ts
+++ b/src/pages/api/proposals/index.ts
@@ -81,12 +81,8 @@ export const POST: APIRoute = async ({ cookies, request }) => {
     if (err instanceof ProposalValidationError) {
       return json({ error: err.message }, 400);
     }
-    const message =
-      err instanceof Error && err.message.trim()
-        ? err.message
-        : "Failed to submit proposal";
     console.error("Failed to submit proposal:", err);
-    return json({ error: message }, 500);
+    return json({ error: "Failed to submit proposal" }, 500);
   }
 };
 


### PR DESCRIPTION
## Summary

Code review identified accumulated structural debt from vibe-coding. This PR addresses the quick wins, medium-effort refactors, and conservative larger investments.

## Changes

### Quick wins
- **Fix drizzle/schema.ts time() type error** — removed invalid `{ mode: "string" }` config (Drizzle 0.45 `time()` already returns string; `TimeConfig` only has `precision` and `withTimezone`)
- **Delete 6 dead exports** in admin-service.ts (`upsertRoomPosition`, `getAllBuildingsAdmin`, `getAllCollegesAdmin`, `getAllDivisionsAdmin`, `getAllDormsAdmin`, `getAllOrganizationsAdmin` — all verified zero importers)
- **Add DuplicateSlugError guard to updateEvent** — mirrors createEvent slug uniqueness check; prevents ungraceful 500 on rename to existing slug
- **Fix 2 non-constant-time comparisons** — admin-user-service.ts legacy password and cron/proposal-digest.ts bearer secret now use `timingSafeEqual`
- **Return generic error on proposal submit failure** — no longer leaks `err.message` (potential DB schema details) to client
- **Update @astrojs/vercel** to 11.0.3

### Shared helpers (MED1)
- **Add `src/lib/api/json.ts`** with `json()`, `errorResponse()`, `parseIdParam()` — replaces ad-hoc per-route implementations
- Updated buildings, dorms, entity-merge-route to use shared helpers (removed verbose `new Response(JSON.stringify(...))` patterns)

### Route consolidation (MED2)
- **Add `src/lib/admin/entity-patch-route.ts`** (`createEntityPatchRoute` factory) — mirrors existing `createEntityMergeRoute` but for PATCH operations
- Converted divisions + colleges PATCH routes to use the helper (removed duplicated auth+validate+error-catch boilerplate)

### Service-layer refactor (BIG1)
- **Add `performEntityUpdate()` generic helper** in admin-service.ts — factors out the shared update skeleton (fetch before → execute update → conflict check → record history → refresh sync key)
- Refactored `updateCollege` + `updateDivision` to use it (~15 lines saved each)

### Map.svelte pin handler unification (BIG2)
- Extracted `handlePinPointerEnter(preview, pointer, editKey?)` and `handlePinPointerLeave(editKey?)` generic handlers
- Converted 8 entity-specific handlers to thin wrappers (~20 lines saved)

## Verification
- ✅ Lint: 0 errors (2 pre-existing CSS warnings, 51 infos)
- ✅ Tests: 354 pass / 0 fail / 765 expect() calls across 82 files
- ⏭️ Build: skipped locally (requires DATABASE_URL)

## Follow-up items (not in this PR)
- Extract 5 inline store classes from `stores/index.svelte.ts` (972 lines → composition root only)
- Convert remaining PATCH routes (rooms, buildings, dorms, events) to use `createEntityPatchRoute`
- Convert remaining `updateX` functions to use `performEntityUpdate`
- Full Map.svelte decomposition into per-domain child components
- path-to-regexp vuln is transitive via `@vercel/routing-utils` — needs upstream fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication timing, admin update/history/sync paths, and event slug rules—mostly refactors with small behavior changes; proposal errors are intentionally less verbose for clients.
> 
> **Overview**
> This PR reduces duplicated admin/API and map code while tightening a few security and data-validation edges.
> 
> **Admin API & services:** Adds shared `@lib/api/json` helpers and a `createEntityPatchRoute` factory (college/division PATCH routes now use it; merge routes drop local `json`). Introduces `performEntityUpdate` and refactors college/division updates through it. Removes unused admin list/upsert exports. Building/dorm PATCH routes adopt the JSON helpers but stay hand-written for now.
> 
> **Events & proposals:** `updateEvent` now rejects slug collisions with `DuplicateSlugError` (handled on the events API). Proposal submit failures return a generic 500 message instead of raw `err.message`.
> 
> **Security:** Legacy admin password and cron bearer checks use `timingSafeEqual`.
> 
> **Schema & deps:** Final-exam `startsAt`/`endsAt` drop invalid Drizzle `time({ mode: "string" })`; `@astrojs/vercel` bumps to 11.0.3.
> 
> **Map:** Pin hover preview logic is centralized in `handlePinPointerEnter` / `handlePinPointerLeave` with thin per-entity wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19a1837a9941ec9670f409c29268107042714737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->