### PR TITLE
427 side panel empty states more whimsical campus forward visuals

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Integration tests
         if: inputs.suite == 'blocking'
-        run: PREVIEW_BASE_URL=http://127.0.0.1:4321 bun test ./integration --preload integration/preload.ts --concurrency 1
+        run: PREVIEW_BASE_URL=http://127.0.0.1:4321 bun test ./integration --preload ./integration/preload.ts --concurrency 1
 
       - name: Restart preview after integration
         if: inputs.suite == 'blocking'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format": "biome format --write .",
     "test": "bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts'",
     "test:components": "vitest run",
-    "test:integration": "bun test ./integration --preload integration/preload.ts --concurrency 1",
+    "test:integration": "bun test ./integration --preload ./integration/preload.ts --concurrency 1",
     "test:integration:live": "bash scripts/run-integration-preview.sh",
     "test:all": "bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts' && bun run test:components && bun run test:integration",
     "e2e": "playwright test",

--- a/src/components/svelte/controls/CampusBrowseList.svelte
+++ b/src/components/svelte/controls/CampusBrowseList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
+  import EntityEmptyState from "./EntityEmptyState.svelte";
   import EntityPanelFilter from "./EntityPanelFilter.svelte";
   import EntityPanelHeader from "./EntityPanelHeader.svelte";
   import { getAppData } from "@lib/context";
@@ -436,56 +437,54 @@
         {/each}
       </ul>
     {:else if loaded}
-      <div class="campus-browse-empty" role="status">
-        <svg
-          class="campus-browse-empty__art"
-          viewBox="0 0 180 128"
-          fill="none"
-          aria-hidden="true"
-        >
-          <!-- Folded campus map with a dotted route and a location pin. -->
-          <rect
-            x="28"
-            y="34"
-            width="124"
-            height="70"
-            rx="10"
-            fill="currentColor"
-            opacity=".1"
-          />
-          <rect
-            x="28"
-            y="34"
-            width="124"
-            height="70"
-            rx="10"
-            stroke="currentColor"
-            stroke-width="3"
-          />
-          <path
-            d="M69 36v66M111 36v66"
-            stroke="currentColor"
-            stroke-width="2"
-            opacity=".25"
-          />
-          <path
-            d="M42 90c12-8 20-24 34-20s22 18 44-2"
-            stroke="currentColor"
-            stroke-width="3.5"
-            stroke-linecap="round"
-            stroke-dasharray="1 8"
-          />
-          <circle cx="42" cy="90" r="4" fill="currentColor" />
-          <path
-            d="M124 22c-8.8 0-16 7-16 15.6 0 10.8 16 26.4 16 26.4s16-15.6 16-26.4C140 29 132.8 22 124 22Z"
-            fill="currentColor"
-            opacity=".85"
-          />
-          <circle cx="124" cy="38" r="5.5" fill="white" />
-        </svg>
-        <h3>{emptyState.title}</h3>
-        <p>{emptyState.description}</p>
-      </div>
+      <EntityEmptyState
+        title={emptyState.title}
+        description={emptyState.description}
+      >
+        {#snippet icon()}
+          <svg viewBox="0 0 180 128" fill="none" aria-hidden="true">
+            <!-- Folded campus map with a dotted route and a location pin. -->
+            <rect
+              x="28"
+              y="34"
+              width="124"
+              height="70"
+              rx="10"
+              fill="currentColor"
+              opacity=".1"
+            />
+            <rect
+              x="28"
+              y="34"
+              width="124"
+              height="70"
+              rx="10"
+              stroke="currentColor"
+              stroke-width="3"
+            />
+            <path
+              d="M69 36v66M111 36v66"
+              stroke="currentColor"
+              stroke-width="2"
+              opacity=".25"
+            />
+            <path
+              d="M42 90c12-8 20-24 34-20s22 18 44-2"
+              stroke="currentColor"
+              stroke-width="3.5"
+              stroke-linecap="round"
+              stroke-dasharray="1 8"
+            />
+            <circle cx="42" cy="90" r="4" fill="currentColor" />
+            <path
+              d="M124 22c-8.8 0-16 7-16 15.6 0 10.8 16 26.4 16 26.4s16-15.6 16-26.4C140 29 132.8 22 124 22Z"
+              fill="currentColor"
+              opacity=".85"
+            />
+            <circle cx="124" cy="38" r="5.5" fill="white" />
+          </svg>
+        {/snippet}
+      </EntityEmptyState>
     {/if}
   </div>
 </div>
@@ -524,37 +523,6 @@
     height: 0.625rem;
     border-radius: 999px;
     box-shadow: 0 0 0 1px hsla(0, 0%, 100%, 0.85);
-  }
-
-  .campus-browse-empty {
-    display: grid;
-    place-items: center;
-    align-content: center;
-    min-height: 100%;
-    padding: 1.5rem 1rem 2rem;
-    color: #8d393b;
-    text-align: center;
-  }
-
-  .campus-browse-empty__art {
-    width: min(10.5rem, 55vw);
-    margin-bottom: 0.875rem;
-  }
-
-  .campus-browse-empty h3 {
-    margin: 0;
-    color: #3f3f46;
-    font-size: 0.9375rem;
-    line-height: 1.3;
-  }
-
-  .campus-browse-empty p {
-    max-width: 19rem;
-    margin: 0.375rem 0 0;
-    color: #71717a;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    line-height: 1.45;
   }
 
 

--- a/src/components/svelte/controls/ClassesList.svelte
+++ b/src/components/svelte/controls/ClassesList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import Classes from "@ui/room/Classes.svelte";
+  import EntityEmptyState from "./EntityEmptyState.svelte";
   import EntityPanelFilter from "./EntityPanelFilter.svelte";
   import EntityPanelHeader from "./EntityPanelHeader.svelte";
   import EntityPagination from "./EntityPagination.svelte";
@@ -103,11 +104,57 @@
     {:else if loadError}
       <p class="entity-panel-note">{loadError}</p>
     {:else if classes.length === 0}
-      <p class="entity-panel-note">
-        No classes listed{termStore.activeTerm?.label
-          ? ` for ${termStore.activeTerm.label}`
-          : ""}{coursePrefix ? ` matching “${coursePrefix}”` : ""}.
-      </p>
+      <EntityEmptyState
+        title="No classes on the board"
+        description={coursePrefix
+          ? `Nothing matches “${coursePrefix}”${
+              termStore.activeTerm?.label
+                ? ` in ${termStore.activeTerm.label}`
+                : ""
+            }. Try a shorter code or another term.`
+          : `No classes listed${
+              termStore.activeTerm?.label
+                ? ` for ${termStore.activeTerm.label}`
+                : ""
+            } yet. Switch terms or check back after the next import.`}
+      >
+        {#snippet icon()}
+          <svg viewBox="0 0 180 128" fill="none" aria-hidden="true">
+            <!-- Open schedule booklet. -->
+            <rect
+              x="34"
+              y="28"
+              width="112"
+              height="76"
+              rx="10"
+              fill="currentColor"
+              opacity=".1"
+            />
+            <path
+              d="M90 30v72"
+              stroke="currentColor"
+              stroke-width="3"
+              opacity=".35"
+            />
+            <rect
+              x="34"
+              y="28"
+              width="112"
+              height="76"
+              rx="10"
+              stroke="currentColor"
+              stroke-width="3"
+            />
+            <path
+              d="M50 48h28M50 64h28M50 80h20M102 48h28M102 64h28M102 80h20"
+              stroke="currentColor"
+              stroke-width="3"
+              stroke-linecap="round"
+              opacity=".55"
+            />
+          </svg>
+        {/snippet}
+      </EntityEmptyState>
     {:else}
       <Classes {classes} />
     {/if}

--- a/src/components/svelte/controls/EntityEmptyState.component.test.ts
+++ b/src/components/svelte/controls/EntityEmptyState.component.test.ts
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+import EntityEmptyStateHost from "@test/components/EntityEmptyStateHost.svelte";
+import {
+  expectNoHorizontalOverflow,
+  mountAtWidth,
+} from "@test/layout-assertions";
+
+describe("EntityEmptyState", () => {
+  test("renders title and body without overflowing at 320px", () => {
+    mountAtWidth(320);
+    const { container } = render(EntityEmptyStateHost);
+
+    expect(
+      screen.getByRole("heading", { name: "Empty floors for now" }),
+    ).toBeVisible();
+    expect(screen.getByText("No rooms found for this building.")).toBeVisible();
+    expect(screen.getByRole("status")).toBeVisible();
+    expect(
+      container.querySelector(
+        ".entity-empty-state__art svg[aria-hidden='true']",
+      ),
+    ).toBeTruthy();
+    expectNoHorizontalOverflow(container);
+  });
+});

--- a/src/components/svelte/controls/EntityEmptyState.svelte
+++ b/src/components/svelte/controls/EntityEmptyState.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    title: string;
+    description?: string;
+    /** Decorative illustration; mark SVG/icons aria-hidden inside the snippet. */
+    icon?: Snippet;
+    /** Optional next-step control (button/link). */
+    action?: Snippet;
+  };
+
+  let { title, description, icon, action }: Props = $props();
+</script>
+
+<div class="entity-empty-state" role="status">
+  {#if icon}
+    <div class="entity-empty-state__art">
+      {@render icon()}
+    </div>
+  {/if}
+  <h3 class="entity-empty-state__title">{title}</h3>
+  {#if description}
+    <p class="entity-empty-state__body">{description}</p>
+  {/if}
+  {#if action}
+    <div class="entity-empty-state__action">
+      {@render action()}
+    </div>
+  {/if}
+</div>
+
+<style>
+  @import "./entity-detail.css";
+</style>

--- a/src/components/svelte/controls/ResultDisplay.svelte
+++ b/src/components/svelte/controls/ResultDisplay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import EntityEmptyState from "./EntityEmptyState.svelte";
   import EntityPagination from "./EntityPagination.svelte";
   import { queryStore } from "@lib/store.svelte";
   import type { RoomData } from "@lib/types";
@@ -77,12 +78,56 @@
   }
 </script>
 
+{#snippet roomsEmptyIcon()}
+  <svg viewBox="0 0 180 128" fill="none" aria-hidden="true">
+    <!-- Doorway with a quiet hallway hint. -->
+    <rect
+      x="52"
+      y="22"
+      width="76"
+      height="90"
+      rx="8"
+      fill="currentColor"
+      opacity=".1"
+    />
+    <rect
+      x="52"
+      y="22"
+      width="76"
+      height="90"
+      rx="8"
+      stroke="currentColor"
+      stroke-width="3"
+    />
+    <path
+      d="M70 112V38h40v74"
+      stroke="currentColor"
+      stroke-width="3"
+      stroke-linejoin="round"
+      fill="currentColor"
+      fill-opacity=".06"
+    />
+    <circle cx="102" cy="74" r="3.5" fill="currentColor" opacity=".85" />
+    <path
+      d="M40 112h100"
+      stroke="currentColor"
+      stroke-width="3"
+      stroke-linecap="round"
+      opacity=".35"
+    />
+  </svg>
+{/snippet}
+
 <section class="entity-list-section rooms-section">
   <h3 class="entity-section-heading">{sectionTitle}</h3>
   <TermSelector />
   {#if groupByBuilding && buildingGroups}
     {#if buildingGroups.length === 0}
-      <p class="entity-empty-state">{emptyMessage}</p>
+      <EntityEmptyState
+        title="Empty floors for now"
+        description={emptyMessage}
+        icon={roomsEmptyIcon}
+      />
     {:else}
       <div class="building-groups">
         {#each buildingGroups as group (group.key)}
@@ -125,7 +170,11 @@
       {/each}
 
       {#if filteredRooms.length === 0}
-        <p class="entity-empty-state">{emptyMessage}</p>
+        <EntityEmptyState
+          title="Empty floors for now"
+          description={emptyMessage}
+          icon={roomsEmptyIcon}
+        />
       {/if}
     </div>
   {/if}

--- a/src/components/svelte/controls/entity-detail.css
+++ b/src/components/svelte/controls/entity-detail.css
@@ -561,13 +561,56 @@
   color: #71717a;
 }
 
+/* Shared empty panel: icon + title + body (+ optional action). Calm, static. */
 .entity-empty-state {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
   margin: 0;
-  font-size: 0.8125rem;
-  line-height: 1.45;
-  color: #71717a;
+  padding: 1.25rem 0.75rem 1.5rem;
+  color: hsl(5, 40%, 38%);
   text-align: center;
-  padding: 0.75rem 0;
+}
+
+.entity-empty-state__art {
+  display: grid;
+  place-items: center;
+  width: min(10.5rem, 70%);
+  max-width: 100%;
+  margin: 0 0 0.75rem;
+  color: inherit;
+}
+
+.entity-empty-state__art :global(svg) {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 10.5rem;
+}
+
+.entity-empty-state__title {
+  margin: 0;
+  max-width: 19rem;
+  color: #3f3f46;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.entity-empty-state__body {
+  max-width: 19rem;
+  margin: 0.375rem 0 0;
+  color: #52525b;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.entity-empty-state__action {
+  margin-top: 0.75rem;
 }
 
 /* Browse / class / event list panel chrome. */

--- a/src/test/components/EntityEmptyStateHost.svelte
+++ b/src/test/components/EntityEmptyStateHost.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import EntityEmptyState from "@ui/controls/EntityEmptyState.svelte";
+</script>
+
+<div class="host">
+  <EntityEmptyState
+    title="Empty floors for now"
+    description="No rooms found for this building."
+  >
+    {#snippet icon()}
+      <svg viewBox="0 0 180 128" fill="none" aria-hidden="true">
+        <rect
+          x="52"
+          y="22"
+          width="76"
+          height="90"
+          rx="8"
+          stroke="currentColor"
+          stroke-width="3"
+        />
+      </svg>
+    {/snippet}
+  </EntityEmptyState>
+</div>
+
+<style>
+  .host {
+    width: 100%;
+    max-width: 320px;
+    box-sizing: border-box;
+    padding: 0.5rem;
+  }
+</style>


### PR DESCRIPTION
## Who are you?

- [ ] **Campus / data / QA only:** no code in this PR? Comment on the issue and skip the rest.
- [x] **Developer:** code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.

## Summary

Adds a shared `EntityEmptyState` (icon, title, body, optional action) so side-panel empties are calm and campus-forward instead of plain gray text. Wires it for building rooms and the classes browser, and moves the campus-browse empty onto the same component.

**Linked issues:** Closes #427

## Developer checklist

- [ ] `bun test src`
- [x] `bun run lint` (or Biome format on touched files)
- [ ] If a feature/page was removed, its automated test was removed or repurposed and `bun run generate:test-inventory` was run.
- [ ] Linked issue commented with this PR URL
- [ ] **Heavy CI:** PR marked ready for review (or `run/e2e` label) before merge: integration + E2E are gated ([testing.md § Heavy CI gating](docs/testing.md#heavy-ci-gating-prs))

## QA Summary (code changes)

Automated:

- [ ] Biome format passed: `bunx biome format.` (PR CI)
- [ ] Unit tests passed: `bun test src` (PR CI)
- [ ] E2E + integration passed: mark PR ready or add `run/e2e` label ([testing.md](docs/testing.md#heavy-ci-gating-prs))
- [x] Full lint passed (local): Biome check/write on touched files
- [ ] Build passed (local): `bun run build` (needs `DATABASE_URL`; not run in PR CI)

If auth, routing, or schema changed:

- [ ] Admin redirects verified: `/admin`, `/admin/login`
- [ ] Migration applied on Supabase (if `drizzle/` changed)

If map chrome, editor, or side panel changed:

- [x] Verified at 320px and/or 768px per [map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md) — component test mounts empty state at 320px
- [ ] Editor/login/drag-save flows (see [editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md))

Known gaps:

- Local `bun run build` / live browser against real entity data not run: no working staging `DATABASE_URL` on this machine (Supabase auth `28P01`). Visual check should use the Vercel preview.
- Events list, proposal queue, and other stretch empties from #427 left for follow-up; AC minimum (rooms + one list) covered.
- Full `bun test src` / `bun run lint` not re-run as a whole-repo pass after the last edit; targeted component test + Biome on touched files did run.

Follow-up:

- Apply `EntityEmptyState` to Events list and proposal queue empties when convenient.

## Issues updated (maintainers / detailed specs)

- [ ] Linked issue(s) commented with this PR
- [ ] Acceptance criteria / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
- [ ] `Last verified against staging:` date set on linked issues

## Test plan

1. `bun run test:components -- src/components/svelte/controls/EntityEmptyState.component.test.ts`
2. On the Vercel preview (no local DB needed):
   - Open a building with no rooms → "Empty floors for now" + illustration
   - Browse Classes with a filter that matches nothing → "No classes on the board"; loading/error still use the old note/spinner paths
   - Campus browse filter miss → shared empty layout, no overflow at ~320px width