### PR TITLE
vm-preserve: smoke/combined-fork-prs (emergency backup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ The short version of what you replace:
 
 The hard part is class schedules. Room TBA pulls from AMIS, which is UPLB's system. You do not have AMIS — you need an importer for whatever your registrar gives you, pointed at the `classes` table, rerun each term. The existing import scripts are a template for the shape, not the source.
 
+After you think you've replaced everything, run `bun run fork:check` — it scans for hardcoded UPLB strings you missed and reports file:line hits. Wire it into your fork's CI so a stray UPLB string does not sneak back in on a merge from upstream.
+
 ---
 
 ## License

--- a/README.md
+++ b/README.md
@@ -236,9 +236,32 @@ Org: [uplbtools](https://github.com/uplbtools) · Campus tool, not an official U
 
 ---
 
+## Fork this for your campus
+
+MIT lets you fork this and run it for a different school. This is not a "swap the logo and ship" fork — a lot of the app is UPLB data and UPLB-specific glue. You keep the engine (map UI, search, offline cache, editor, planner, the Drizzle schema) and replace the UPLB parts.
+
+Full guide with every file path and the painful parts: **[Fork this for your campus](https://room-tba.uplbtools.me/wiki/fork-for-your-campus)** in the wiki.
+
+The short version of what you replace:
+
+| File | What to change |
+| --- | --- |
+| `src/lib/site.ts` | Site name, URL, title, description |
+| `src/constants/map-terrain.ts` | Campus bounds, default camera (center lng/lat, zoom), terrain source |
+| `src/constants/community-links.ts`, `status-bar-links.ts` | UPLB community links → your own |
+| `astro.config.mjs` | `site:` → your domain |
+| `public/room_info.json` | UPLB building seed → your buildings |
+| `src/constants/jeepney-routes.ts` + geometries | Delete if no campus transit overlay |
+| `scripts/import-amis-classes.ts` and friends | UPLB data sources (AMIS, OUR finals, OSA). Write your own importer for your registrar's export. |
+| Supabase DB contents | Every row is UPLB. Schema stays; data goes. |
+
+The hard part is class schedules. Room TBA pulls from AMIS, which is UPLB's system. You do not have AMIS — you need an importer for whatever your registrar gives you, pointed at the `classes` table, rerun each term. The existing import scripts are a template for the shape, not the source.
+
+---
+
 ## License
 
-[MIT](LICENSE). Use it, fork it, teach with it. If you deploy a fork for another campus, change the data, not just the logo.
+[MIT](LICENSE). Use it, fork it, teach with it. If you deploy a fork for another campus, change the data, not just the logo. See the [fork guide](#fork-this-for-your-campus) above.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -246,10 +246,8 @@ The short version of what you replace:
 
 | File | What to change |
 | --- | --- |
-| `src/lib/site.ts` | Site name, URL, title, description |
-| `src/constants/map-terrain.ts` | Campus bounds, default camera (center lng/lat, zoom), terrain source |
-| `src/constants/community-links.ts`, `status-bar-links.ts` | UPLB community links → your own |
-| `astro.config.mjs` | `site:` → your domain |
+| `src/campus.config.ts` | **The single config file.** Site name, URL, title, description, map center/bounds/camera, community links. The files below import from here. |
+| `src/constants/map-terrain.ts` | Terrain source (Makiling) — disable if your campus is flat. Bounds and camera come from `campus.config.ts`. |
 | `public/room_info.json` | UPLB building seed → your buildings |
 | `src/constants/jeepney-routes.ts` + geometries | Delete if no campus transit overlay |
 | `scripts/import-amis-classes.ts` and friends | UPLB data sources (AMIS, OUR finals, OSA). Write your own importer for your registrar's export. |

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,13 +8,14 @@ import {
   MESSENGER_CONTRIBUTE_TARGET,
   MESSENGER_MAINTAIN_TARGET,
 } from "./src/constants/community-links.ts";
+import { campusCommunity, campusSite } from "./src/campus.config.ts";
 
 /** Local E2E + integration preview — Vercel adapter does not support `astro preview`. */
 const e2eNodeAdapter = process.env.ASTRO_E2E_NODE === "1";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://room-tba.uplbtools.me",
+  site: campusSite.url,
 
   integrations: [
     svelte(),
@@ -128,7 +129,7 @@ export default defineConfig({
 
   redirects: {
     "/contribute": "/?contribute=1",
-    "/discord": "https://discord.uplbtools.me",
+    "/discord": campusCommunity.discordUrl,
     "/messenger": MESSENGER_CONTRIBUTE_TARGET,
     "/messenger/contribute": MESSENGER_CONTRIBUTE_TARGET,
     "/messenger/maintain": MESSENGER_MAINTAIN_TARGET,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "generate:test-inventory": "bun run scripts/generate-test-inventory.ts",
     "post:test-inventory-discord": "bun run scripts/post-test-inventory-discord.ts",
     "check:readme": "bun run scripts/check-readme-drift.ts",
+    "fork:check": "bun run scripts/fork-check.ts",
     "install:agent-tooling": "bash scripts/install-agent-tooling.sh",
     "install:agent-plugins": "bash scripts/install-agent-plugins.sh",
     "install:shopped-skills": "bash scripts/install-shopped-skills.sh",

--- a/scripts/fork-check.ts
+++ b/scripts/fork-check.ts
@@ -1,0 +1,118 @@
+/**
+ * Scan tracked files for UPLB-specific strings a fork must replace.
+ *
+ * On upstream (uplbtools/room-tba) this reports many hits — that is expected,
+ * this is the UPLB app. Run it on YOUR fork after you think you have replaced
+ * everything. A clean run means you caught it all; remaining hits are things
+ * you forgot.
+ *
+ * Usage:
+ *   bun run fork:check            # report hits, exit 1 if any
+ *   bun run fork:check --silent   # exit code only (for your fork's CI)
+ *
+ * Wire it into your fork's CI after the upstream files are replaced.
+ */
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+type Marker = { pattern: RegExp; hint: string };
+
+const markers: Marker[] = [
+  { pattern: /\buplb\b/gi, hint: "UPLB name — rebrand to your campus." },
+  { pattern: /uplbtools/gi, hint: "UPLB Tools org/domain — your org/domain." },
+  {
+    pattern: /room-tba\.uplbtools\.me/gi,
+    hint: "Production URL — set to your domain (also astro.config.mjs `site:`).",
+  },
+  {
+    pattern: /(discord|messenger)\.uplbtools\.me/gi,
+    hint: "UPLB community subdomains — your community links, or delete.",
+  },
+  {
+    pattern: /m\.me\/j\/[A-Za-z0-9_-]+/gi,
+    hint: "UPLB Messenger group invite — your community link, or delete.",
+  },
+  { pattern: /\bMakiling\b/g, hint: "Mt. Makiling terrain — your terrain source, or disable 3D." },
+  {
+    pattern: /\bAMIS\b/g,
+    hint: "UPLB course system. You do not have AMIS — write your own class importer.",
+  },
+  { pattern: /\bSAIS\b/g, hint: "UPLB student system reference — repoint to your registrar." },
+  { pattern: /\bPSLH\b/g, hint: "UPLB building code (Physical Sciences Lecture Hall)." },
+  { pattern: /\bPhySci\b/g, hint: "UPLB building alias (Physical Sciences)." },
+  { pattern: /\bOble\b|\bOblation\b/g, hint: "UPLB landmark — your campus landmark, or remove copy." },
+  { pattern: /Los Ba[ñn]os/g, hint: "UPLB campus locale — your campus location." },
+  { pattern: /r\/peyups/gi, hint: "UPLB subreddit source credit — remove or replace." },
+  {
+    pattern: /121\.24125948460573|14\.16323736946326/g,
+    hint: "UPLB default map center — set to your campus center in map-terrain.ts.",
+  },
+];
+
+// Files that mention UPLB by design (this scanner, the fork guide that tells
+// you to replace UPLB strings). Everything else is a real "you forgot this".
+const allowList = [/scripts\/fork-check\.ts$/, /src\/pages\/wiki\/fork-for-your-campus\.astro$/];
+
+type Hit = { file: string; line: number; text: string; hint: string };
+
+function isBinary(buf: Buffer): boolean {
+  return buf.includes(0, 0, Math.min(buf.length, 8000));
+}
+
+function scan(): Hit[] {
+  const files = execSync("git ls-files", { encoding: "utf8" }).trim().split("\n");
+  const hits: Hit[] = [];
+  for (const file of files) {
+    if (allowList.some((re) => re.test(file))) continue;
+    let buf: Buffer;
+    try {
+      buf = readFileSync(file);
+    } catch {
+      continue;
+    }
+    if (isBinary(buf)) continue;
+    const text = buf.toString("utf8");
+    const lines = text.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      for (const { pattern, hint } of markers) {
+        pattern.lastIndex = 0;
+        if (pattern.test(line)) {
+          hits.push({ file, line: i + 1, text: line.trim().slice(0, 160), hint });
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+const silent = process.argv.includes("--silent");
+const hits = scan();
+
+if (hits.length === 0) {
+  if (!silent) console.log("fork:check passed — no UPLB-specific strings found.");
+  process.exit(0);
+}
+
+if (!silent) {
+  const byFile = new Map<string, Hit[]>();
+  for (const h of hits) {
+    const arr = byFile.get(h.file) ?? [];
+    arr.push(h);
+    byFile.set(h.file, arr);
+  }
+  console.error(`fork:check found ${hits.length} UPLB-specific hit(s) across ${byFile.size} file(s).\n`);
+  for (const [file, fileHits] of byFile) {
+    console.error(`  ${file}  (${fileHits.length})`);
+    for (const h of fileHits.slice(0, 5)) {
+      console.error(`    :${h.line}  ${h.hint}`);
+    }
+    if (fileHits.length > 5) {
+      console.error(`    … and ${fileHits.length - 5} more in this file.`);
+    }
+  }
+  console.error(
+    "\nReplace or delete these before deploying your fork. See /wiki/fork-for-your-campus.",
+  );
+}
+process.exit(1);

--- a/src/campus.config.ts
+++ b/src/campus.config.ts
@@ -1,0 +1,54 @@
+/**
+ * Single source of truth for campus-specific config.
+ *
+ * A fork changes this file (and the data — see /wiki/fork-for-your-campus).
+ * Run `bun run fork:check` after editing to catch stray UPLB strings elsewhere.
+ *
+ * Values are plain literals so astro.config.mjs can import this module at
+ * config-eval time (no process.env reads at module top level).
+ */
+
+export const campusSite = {
+  url: "https://room-tba.uplbtools.me",
+  name: "Room TBA",
+  title: "Room TBA | Find Rooms, Buildings, Colleges, and Divisions at UPLB",
+  description:
+    "Room TBA helps UPLB students find rooms, buildings, colleges, and divisions across the Los Banos campus.",
+} as const;
+
+export const campusMap: {
+  maxBounds: [[number, number], [number, number]];
+  defaultCamera: {
+    center: [number, number];
+    zoom: number;
+    pitch: number;
+    bearing: number;
+  };
+} = {
+  /** [lng, lat] — west/south corner, then east/north corner. */
+  maxBounds: [
+    // West/south: Mt. Makiling foothills, BSP Jamboree site, National Arts Center corridor.
+    [121.168, 14.095],
+    [121.335, 14.215],
+  ],
+  /** Default camera: center [lng, lat], zoom, pitch (0 = top-down, 60 = tilted 3D), bearing. */
+  defaultCamera: {
+    center: [121.24125948460573, 14.16323736946326],
+    zoom: 15.81,
+    pitch: 60,
+    bearing: -154.48,
+  },
+};
+
+export const campusCommunity = {
+  orgUrl: "https://uplbtools.me",
+  githubUrl: "https://github.com/uplbtools/room-tba",
+  discordUrl: "https://discord.uplbtools.me",
+  osaOrganizationsUrl: "https://uplbosa.org/orgs",
+  /** Messenger group chat invites (targets for redirect workers). */
+  messengerContributeTarget: "https://m.me/j/Aba1V0prvQyLrafZ/",
+  messengerMaintainTarget: "https://m.me/j/AbZtqMU8UUTiwQfn/",
+  /** Short links on a community subdomain (Cloudflare Worker). Delete if unused. */
+  messengerShortContributeUrl: "https://messenger.uplbtools.me/contribute",
+  messengerShortMaintainUrl: "https://messenger.uplbtools.me/maintain",
+} as const;

--- a/src/constants/community-links.ts
+++ b/src/constants/community-links.ts
@@ -1,22 +1,29 @@
-/** External UPLB Tools community and org links (also wired as short redirects in astro.config). */
+/** External community and org links (also wired as short redirects in astro.config).
+ *
+ * Campus-specific values live in src/campus.config.ts — a fork edits that one
+ * file. This module re-exports them under the names the rest of the app imports
+ * and derives the app-stable redirect URLs from the site URL. */
+import { campusCommunity, campusSite } from "../campus.config";
 
-/** Canonical production origin — literal so astro.config can import this module. */
-const ROOM_TBA_SITE_URL = "https://room-tba.uplbtools.me";
+/** Canonical production origin. */
+const ROOM_TBA_SITE_URL = campusSite.url;
 
-export const UPLB_TOOLS_URL = "https://uplbtools.me";
-export const GITHUB_ROOM_TBA_URL = "https://github.com/uplbtools/room-tba";
-export const DISCORD_URL = "https://discord.uplbtools.me";
-export const UPLB_OSA_ORGANIZATIONS_URL = "https://uplbosa.org/orgs";
+export const UPLB_TOOLS_URL = campusCommunity.orgUrl;
+export const GITHUB_ROOM_TBA_URL = campusCommunity.githubUrl;
+export const DISCORD_URL = campusCommunity.discordUrl;
+export const UPLB_OSA_ORGANIZATIONS_URL = campusCommunity.osaOrganizationsUrl;
 
 /** Facebook Messenger group chat invites (targets for redirect workers). */
-export const MESSENGER_CONTRIBUTE_TARGET = "https://m.me/j/Aba1V0prvQyLrafZ/";
-export const MESSENGER_MAINTAIN_TARGET = "https://m.me/j/AbZtqMU8UUTiwQfn/";
+export const MESSENGER_CONTRIBUTE_TARGET =
+  campusCommunity.messengerContributeTarget;
+export const MESSENGER_MAINTAIN_TARGET =
+  campusCommunity.messengerMaintainTarget;
 
-/** Short links on messenger.uplbtools.me (Cloudflare Worker). */
+/** Short links on a community subdomain (Cloudflare Worker). */
 export const MESSENGER_SHORT_CONTRIBUTE_URL =
-  "https://messenger.uplbtools.me/contribute";
+  campusCommunity.messengerShortContributeUrl;
 export const MESSENGER_SHORT_MAINTAIN_URL =
-  "https://messenger.uplbtools.me/maintain";
+  campusCommunity.messengerShortMaintainUrl;
 
 /** App-stable redirect URLs on room-tba (avoids messenger subdomain DNS cache misses). */
 export const MESSENGER_CONTRIBUTE_URL = `${ROOM_TBA_SITE_URL}/messenger/contribute`;

--- a/src/constants/map-terrain.ts
+++ b/src/constants/map-terrain.ts
@@ -1,4 +1,5 @@
 import { MAPTILER_KEY_PLACEHOLDER, withMaptilerKey } from "@lib/maptiler-key";
+import { campusMap } from "../campus.config";
 
 export const TERRAIN_SOURCE_ID = "makiling-terrain-dem";
 export const TERRAIN_HILLSHADE_LAYER_ID = "makiling-terrain-hillshade";
@@ -13,11 +14,8 @@ export function getTerrainTileJsonUrl(): string {
 export const TERRAIN_EXAGGERATION_OPTIONS = [1, 1.5, 2] as const;
 export const DEFAULT_TERRAIN_EXAGGERATION = 1.5;
 
-export const CAMPUS_MAX_BOUNDS: [[number, number], [number, number]] = [
-  // West/south: Mt. Makiling foothills, BSP Jamboree site, National Arts Center corridor.
-  [121.168, 14.095],
-  [121.335, 14.215],
-];
+export const CAMPUS_MAX_BOUNDS: [[number, number], [number, number]] =
+  campusMap.maxBounds;
 
 /** Flat object form for bounds checks (offline tiles, geolocation, admin APIs). */
 export const CAMPUS_BOUNDS = {
@@ -27,12 +25,7 @@ export const CAMPUS_BOUNDS = {
   maxLat: CAMPUS_MAX_BOUNDS[1][1],
 } as const;
 
-export const CAMPUS_DEFAULT_CAMERA = {
-  center: [121.24125948460573, 14.16323736946326] as [number, number],
-  zoom: 15.81,
-  pitch: 60,
-  bearing: -154.48,
-};
+export const CAMPUS_DEFAULT_CAMERA = campusMap.defaultCamera;
 
 export const MAKILING_TERRAIN_MAX_BOUNDS: [[number, number], [number, number]] =
   [

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,9 +1,9 @@
-export const SITE_URL = "https://room-tba.uplbtools.me";
-export const SITE_NAME = "Room TBA";
-export const DEFAULT_TITLE =
-  "Room TBA | Find Rooms, Buildings, Colleges, and Divisions at UPLB";
-export const DEFAULT_DESCRIPTION =
-  "Room TBA helps UPLB students find rooms, buildings, colleges, and divisions across the Los Banos campus.";
+import { campusSite } from "../campus.config";
+
+export const SITE_URL = campusSite.url;
+export const SITE_NAME = campusSite.name;
+export const DEFAULT_TITLE = campusSite.title;
+export const DEFAULT_DESCRIPTION = campusSite.description;
 export const DEFAULT_OG_IMAGE = "/og.png";
 export const OG_IMAGE_WIDTH = 1200;
 export const OG_IMAGE_HEIGHT = 630;

--- a/src/pages/wiki/fork-for-your-campus.astro
+++ b/src/pages/wiki/fork-for-your-campus.astro
@@ -135,33 +135,30 @@ bunx drizzle-kit push</code></pre>
         with an empty campus.
       </p>
 
-      <h3>4. Repoint the map to your campus</h3>
+      <h3>4. Edit <code>src/campus.config.ts</code> — the single config file</h3>
       <p>
-        Edit <code>src/constants/map-terrain.ts</code>:
+        This is the one file for campus-specific config. It holds the site
+        name, URL, title, description, the map center / bounds / camera, and
+        the community links. The rest of the app
+        (<code>site.ts</code>, <code>map-terrain.ts</code>,
+        <code>community-links.ts</code>, <code>astro.config.mjs</code>) imports
+        from here. Change the values, save, and you are done with the code-side
+        rebrand.
       </p>
       <ul>
-        <li><code>CAMPUS_MAX_BOUNDS</code> and <code>CAMPUS_BOUNDS</code> — the lng/lat box that keeps the camera on your campus.</li>
-        <li><code>CAMPUS_DEFAULT_CAMERA</code> — <code>center: [lng, lat]</code>, <code>zoom</code>, <code>pitch</code>, <code>bearing</code>. Pick a center point and a zoom that fits your campus.</li>
-        <li>If your campus has no hill like Mt. Makiling, remove or disable the terrain source (<code>TERRAIN_SOURCE_ID</code>, <code>getTerrainTileJsonUrl</code>). The 3D toggle just turns off.</li>
+        <li><code>campusSite</code> — <code>url</code>, <code>name</code>, <code>title</code>, <code>description</code>.</li>
+        <li><code>campusMap</code> — <code>maxBounds</code> (the lng/lat box that keeps the camera on your campus) and <code>defaultCamera</code> (<code>center: [lng, lat]</code>, <code>zoom</code>, <code>pitch</code>, <code>bearing</code>).</li>
+        <li><code>campusCommunity</code> — your org, GitHub, Discord, and Messenger links. Delete entries you do not have.</li>
       </ul>
-
-      <h3>5. Rename the app</h3>
       <p>
-        Edit <code>src/lib/site.ts</code>: <code>SITE_URL</code>,
-        <code>SITE_NAME</code>, <code>DEFAULT_TITLE</code>,
-        <code>DEFAULT_DESCRIPTION</code>. Edit <code>astro.config.mjs</code>
-        and change <code>site:</code> to your production domain.
+        If your campus has no hill like Mt. Makiling, also disable the terrain
+        source in <code>src/constants/map-terrain.ts</code>
+        (<code>TERRAIN_SOURCE_ID</code>, <code>getTerrainTileJsonUrl</code>).
+        The 3D toggle just turns off. The terrain IDs are not in
+        <code>campus.config.ts</code> yet — they are a follow-up.
       </p>
 
-      <h3>6. Rip the UPLB community links</h3>
-      <p>
-        Replace the URLs in <code>src/constants/community-links.ts</code> with
-        your own (or delete the entries). The status bar pulls from
-        <code>src/constants/status-bar-links.ts</code> — update or trim there
-        too.
-      </p>
-
-      <h3>7. Delete or replace the UPLB data files</h3>
+      <h3>5. Delete or replace the UPLB data files</h3>
       <ul>
         <li>Replace <code>public/room_info.json</code> with your buildings (or delete it and seed the DB directly).</li>
         <li>Delete <code>src/constants/jeepney-routes.ts</code> and <code>jeepney-geometries.json</code> if you have no campus transit overlay.</li>
@@ -169,14 +166,14 @@ bunx drizzle-kit push</code></pre>
         <li>Delete <code>src/pages/wiki/section-times.astro</code> (the UPLB section-code glossary) and its card on the wiki index.</li>
       </ul>
 
-      <h3>8. Start the dev server</h3>
+      <h3>6. Start the dev server</h3>
       <pre><code>bun dev</code></pre>
       <p>
         Open <code>http://localhost:4321</code>. The map loads with your new
         center and bounds. Nothing is on it yet because the DB is empty.
       </p>
 
-      <h3>9. Run fork:check to catch what you missed</h3>
+      <h3>7. Run fork:check to catch what you missed</h3>
       <pre><code>bun run fork:check</code></pre>
       <p>
         Scans the repo for hardcoded UPLB strings you forgot to replace

--- a/src/pages/wiki/fork-for-your-campus.astro
+++ b/src/pages/wiki/fork-for-your-campus.astro
@@ -175,6 +175,18 @@ bunx drizzle-kit push</code></pre>
         Open <code>http://localhost:4321</code>. The map loads with your new
         center and bounds. Nothing is on it yet because the DB is empty.
       </p>
+
+      <h3>9. Run fork:check to catch what you missed</h3>
+      <pre><code>bun run fork:check</code></pre>
+      <p>
+        Scans the repo for hardcoded UPLB strings you forgot to replace
+        (<code>uplb</code>, <code>uplbtools.me</code>, <code>AMIS</code>,
+        <code>Makiling</code>, <code>PSLH</code>, the UPLB map center coords,
+        Messenger invites, …). Reports file:line hits with hints. On a finished
+        fork it should report zero. Wire it into your fork's CI
+        (<code>--silent</code> for exit-code-only) so a stray UPLB string does
+        not sneak back in on a merge from upstream.
+      </p>
     </section>
 
     <section aria-labelledby="data">

--- a/src/pages/wiki/fork-for-your-campus.astro
+++ b/src/pages/wiki/fork-for-your-campus.astro
@@ -1,0 +1,430 @@
+---
+export const prerender = true;
+
+import WikiLayout from "@layouts/WikiLayout.astro";
+import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";
+
+const title = "Fork this for your campus | Room TBA Wiki";
+const description =
+  "What you actually have to change to run Room TBA for a different campus: the UPLB-specific data and glue to rip out, the config to repoint, and the parts that are write-your-own.";
+const structuredData = jsonLd(
+  webpageSchema({ title, description, path: "/wiki/fork-for-your-campus" }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Wiki", path: "/wiki" },
+    { name: "Fork for your campus", path: "/wiki/fork-for-your-campus" },
+  ]),
+);
+---
+
+<WikiLayout
+  {title}
+  {description}
+  canonicalPath="/wiki/fork-for-your-campus"
+  {structuredData}
+>
+  <article class="wiki-article">
+    <header class="article-hero">
+      <p class="wiki-eyebrow">For other campuses</p>
+      <h1 class="wiki-title">Fork this for your campus</h1>
+      <p class="wiki-lede">
+        Room TBA is built for UPLB. The license (MIT) lets you fork it. This is
+        not a "swap the logo and ship" kind of fork. A lot of the app is UPLB
+        data and UPLB-specific glue. Here is what you actually replace, in the
+        order that matters, with the real file paths.
+      </p>
+      <p class="article-meta">
+        Current as of v2.1.x. If the repo has moved, the file paths below are
+        still the map — re-check them.
+      </p>
+    </header>
+
+    <nav class="toc" aria-label="On this page">
+      <p class="toc__title">On this page</p>
+      <ol>
+        <li><a href="#what-is-generic">What you keep</a></li>
+        <li><a href="#what-is-uplb">What is UPLB-only</a></li>
+        <li><a href="#prereq">What you need before you start</a></li>
+        <li><a href="#steps">The actual steps</a></li>
+        <li><a href="#data">Loading your own data</a></li>
+        <li><a href="#deploy">Deploy</a></li>
+        <li><a href="#pain">The painful parts</a></li>
+        <li><a href="#license">License and credit</a></li>
+      </ol>
+    </nav>
+
+    <section aria-labelledby="what-is-generic">
+      <h2 id="what-is-generic">What you keep</h2>
+      <p>
+        The engine is generic. You do not rewrite these:
+      </p>
+      <ul>
+        <li>The map UI, search bar, side panel, and pin flyouts.</li>
+        <li>PGlite offline cache (the app answers "where is this room" with no signal).</li>
+        <li>The editor and the suggest-an-edit review queue.</li>
+        <li>The course planner and the personal-schedule routing.</li>
+        <li>Events on the map, alias synonym matching, share links.</li>
+        <li>The Drizzle schema. Tables for <code>buildings</code>, <code>rooms</code>, <code>classes</code>, <code>aliases</code>, <code>events</code>, <code>organizations</code>, <code>places</code>, <code>colleges</code>, <code>dorms</code>, <code>jeepney_routes</code>, and final exams are campus-shaped, not UPLB-shaped.</li>
+      </ul>
+    </section>
+
+    <section aria-labelledby="what-is-uplb">
+      <h2 id="what-is-uplb">What is UPLB-only (you rip this out or replace it)</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>File / thing</th><th>Why it is UPLB-only</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>src/lib/site.ts</code></td><td>Site name, URL, title, and description are UPLB.</td></tr>
+            <tr><td><code>src/constants/map-terrain.ts</code></td><td>Map bounds, default camera (center lng/lat, zoom, pitch), and the Mt. Makiling terrain source.</td></tr>
+            <tr><td><code>src/constants/community-links.ts</code> + <code>status-bar-links.ts</code></td><td>UPLB Tools, Discord, and Messenger links.</td></tr>
+            <tr><td><code>public/room_info.json</code></td><td>UPLB buildings, aliases, and walking directions. Seed file for aliases.</td></tr>
+            <tr><td><code>src/constants/jeepney-routes.ts</code> + <code>jeepney-geometries.json</code></td><td>UPLB jeepney routes. Delete if your campus has no equivalent.</td></tr>
+            <tr><td><code>scripts/import-amis-classes.ts</code></td><td>AMIS is UPLB's course system. You do not have AMIS.</td></tr>
+            <tr><td><code>scripts/import-final-exams.ts</code></td><td>Reads UPLB OUR finals JSON.</td></tr>
+            <tr><td><code>scripts/import-osa-orgs.ts</code> + <code>import-campus-offices.ts</code></td><td>UPLB org and office directories.</td></tr>
+            <tr><td><code>astro.config.mjs</code> <code>site</code></td><td>Hardcoded to <code>room-tba.uplbtools.me</code>.</td></tr>
+            <tr><td>The database contents</td><td>Every row is UPLB. The schema stays; the data goes.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        If a fork only changes the logo and the site name, it is still a UPLB
+        app pointing at UPLB data. That is the thing the license line in the
+        README is warning you about.
+      </p>
+    </section>
+
+    <section aria-labelledby="prereq">
+      <h2 id="prereq">What you need before you start</h2>
+      <ul>
+        <li>A GitHub account (to fork).</li>
+        <li><a href="https://bun.sh" class="wiki-link">Bun</a> 1.3+ on your machine.</li>
+        <li>A <a href="https://supabase.com" class="wiki-link">Supabase</a> project. Free tier is fine for a small campus.</li>
+        <li>A <a href="https://maptiler.com" class="wiki-link">MapTiler</a> key for vector and terrain tiles. Free tier exists; watch the quota.</li>
+        <li>Your campus data: a building list with coordinates, room codes, class schedules from your registrar or SAIS equivalent, and a final-exam schedule if you want that panel.</li>
+        <li>Somewhere to deploy. <a href="https://vercel.com" class="wiki-link">Vercel</a> free tier works; the app is built for the Vercel adapter.</li>
+      </ul>
+    </section>
+
+    <section aria-labelledby="steps">
+      <h2 id="steps">The actual steps</h2>
+
+      <h3>1. Fork and clone</h3>
+      <p>Fork <code>uplbtools/room-tba</code> on GitHub, then:</p>
+      <pre><code>git clone https://github.com/&lt;your-org&gt;/room-tba.git
+cd room-tba
+cp .env.example .env.local</code></pre>
+
+      <h3>2. Make a Supabase project and grab the URL</h3>
+      <p>
+        Create a project. In SQL settings, copy the <strong>session pooler</strong>
+        connection string (the one ending in <code>*.pooler.supabase.com</code>).
+        Paste it as <code>DATABASE_URL</code> in <code>.env.local</code>. Set
+        <code>ADMIN_PASSWORD</code> to something long and random — you need it
+        to log into the editor.
+      </p>
+
+      <h3>3. Install and create the tables</h3>
+      <pre><code>bun install
+bunx drizzle-kit push</code></pre>
+      <p>
+        <code>drizzle-kit push</code> creates every table from
+        <code>drizzle/schema.ts</code> in your Supabase Postgres. You start
+        with an empty campus.
+      </p>
+
+      <h3>4. Repoint the map to your campus</h3>
+      <p>
+        Edit <code>src/constants/map-terrain.ts</code>:
+      </p>
+      <ul>
+        <li><code>CAMPUS_MAX_BOUNDS</code> and <code>CAMPUS_BOUNDS</code> — the lng/lat box that keeps the camera on your campus.</li>
+        <li><code>CAMPUS_DEFAULT_CAMERA</code> — <code>center: [lng, lat]</code>, <code>zoom</code>, <code>pitch</code>, <code>bearing</code>. Pick a center point and a zoom that fits your campus.</li>
+        <li>If your campus has no hill like Mt. Makiling, remove or disable the terrain source (<code>TERRAIN_SOURCE_ID</code>, <code>getTerrainTileJsonUrl</code>). The 3D toggle just turns off.</li>
+      </ul>
+
+      <h3>5. Rename the app</h3>
+      <p>
+        Edit <code>src/lib/site.ts</code>: <code>SITE_URL</code>,
+        <code>SITE_NAME</code>, <code>DEFAULT_TITLE</code>,
+        <code>DEFAULT_DESCRIPTION</code>. Edit <code>astro.config.mjs</code>
+        and change <code>site:</code> to your production domain.
+      </p>
+
+      <h3>6. Rip the UPLB community links</h3>
+      <p>
+        Replace the URLs in <code>src/constants/community-links.ts</code> with
+        your own (or delete the entries). The status bar pulls from
+        <code>src/constants/status-bar-links.ts</code> — update or trim there
+        too.
+      </p>
+
+      <h3>7. Delete or replace the UPLB data files</h3>
+      <ul>
+        <li>Replace <code>public/room_info.json</code> with your buildings (or delete it and seed the DB directly).</li>
+        <li>Delete <code>src/constants/jeepney-routes.ts</code> and <code>jeepney-geometries.json</code> if you have no campus transit overlay.</li>
+        <li>Delete the UPLB import scripts you cannot reuse: <code>import-amis-classes.ts</code>, <code>import-final-exams.ts</code>, <code>import-osa-orgs.ts</code>, <code>import-campus-offices.ts</code>. Keep them as reference while you write your own.</li>
+        <li>Delete <code>src/pages/wiki/section-times.astro</code> (the UPLB section-code glossary) and its card on the wiki index.</li>
+      </ul>
+
+      <h3>8. Start the dev server</h3>
+      <pre><code>bun dev</code></pre>
+      <p>
+        Open <code>http://localhost:4321</code>. The map loads with your new
+        center and bounds. Nothing is on it yet because the DB is empty.
+      </p>
+    </section>
+
+    <section aria-labelledby="data">
+      <h2 id="data">Loading your own data</h2>
+      <p>
+        Two ways. Use both.
+      </p>
+      <p>
+        <strong>The in-app editor.</strong> Log in at
+        <code>/?editor=login</code> with your <code>ADMIN_PASSWORD</code>. Drop
+        pins, add buildings and rooms, set aliases. This is how you fix data
+        day-to-day and how volunteers contribute without touching the DB.
+      </p>
+      <p>
+        <strong>A seed script.</strong> For a first bulk load (every building,
+        every room, every class), write a script that reads your registrar's
+        export and upserts into Postgres. Use
+        <code>scripts/import-amis-classes.ts</code> as a <em>template for the
+        shape</em> — Drizzle upsert by natural key, term handling, the
+        class/room join — not the AMIS fetch. Your data source is different.
+        The import scripts read from files under <code>data/</code> (gitignored)
+        and write to <code>DATABASE_URL</code>; copy that pattern.
+      </p>
+      <p>
+        Class schedules are the hard part. Room TBA pulls from AMIS, which is
+        UPLB's system. You do not have AMIS. You need whatever export your
+        registrar or SAIS equivalent gives you — CSV, JSON, a scraped portal,
+        a PDF someone has to retype. Write one importer for it, point it at the
+        <code>classes</code> table, and rerun it each term.
+      </p>
+      <p>
+        After you change the Drizzle schema at all, regenerate the offline
+        cache schema so PGlite matches Postgres:
+      </p>
+      <pre><code>bun run generate:pglite-schema</code></pre>
+    </section>
+
+    <section aria-labelledby="deploy">
+      <h2 id="deploy">Deploy</h2>
+      <p>
+        Import your fork into Vercel. Set these env vars in the project
+        (Production and Preview):
+      </p>
+      <ul>
+        <li><code>DATABASE_URL</code> — your Supabase pooler URL.</li>
+        <li><code>ADMIN_PASSWORD</code> — same one you used locally.</li>
+        <li><code>ADMIN_SESSION_SECRET</code> — 32+ random chars, used to sign editor cookies.</li>
+        <li><code>ISR_BYPASS_TOKEN</code> — 32+ random chars, must match <code>bypassToken</code> in <code>astro.config.mjs</code>. Without it, editor publishes do not revalidate the SEO pages.</li>
+        <li><code>PUBLIC_MAPTILER_KEY</code> — your key.</li>
+        <li><code>PUBLIC_APP_ENV=production</code> on your production deploy; <code>staging</code> on preview.</li>
+      </ul>
+      <p>
+        Deploy. Push to your default branch and Vercel builds it. The build
+        needs <code>DATABASE_URL</code> or prerendered pages 500.
+      </p>
+    </section>
+
+    <section aria-labelledby="pain">
+      <h2 id="pain">The painful parts</h2>
+      <ul>
+        <li>
+          <strong>Class import is write-your-own.</strong> AMIS is UPLB-only.
+          Your registrar's export is the long pole. Budget time for it.
+        </li>
+        <li>
+          <strong>Map tiles cost money at scale.</strong> MapTiler free tier is
+          fine for a campus with a few thousand users. If the whole student
+          body hits it during enrollment, you may need a paid plan or a
+          self-hosted tile server.
+        </li>
+        <li>
+          <strong>The 3D terrain needs a DEM.</strong> If your campus is flat,
+          just disable the terrain source. No DEM, no 3D hills.
+        </li>
+        <li>
+          <strong>Supabase free tier pauses after a week of no activity.</strong>
+          Fine for a small campus. For high traffic, upgrade or self-host
+          Postgres.
+        </li>
+        <li>
+          <strong>You are maintaining a fork.</strong> Upstream moves. Rebase
+          pain is real. Keep your campus-specific changes in the clearly
+          UPLB-marked files above so merges do not stomp your data config.
+        </li>
+        <li>
+          <strong>The wiki page you are reading is UPLB-specific too.</strong>
+          Replace it with your own campus guide, or delete it.
+        </li>
+      </ul>
+    </section>
+
+    <section aria-labelledby="license">
+      <h2 id="license">License and credit</h2>
+      <p>
+        MIT. Keep the <code>LICENSE</code> file. You can run a fork for your
+        campus, sell hosting around it, teach with it. You do not have to ask.
+      </p>
+      <p>
+        Credit is free. The README credits the people who built this. Do not
+        strip those names and pass the work off as yours. If your fork takes
+        off, a line back to <code>uplbtools/room-tba</code> is good manners.
+      </p>
+    </section>
+  </article>
+</WikiLayout>
+
+<style>
+  .wiki-article {
+    max-width: 52rem;
+  }
+
+  .article-hero {
+    padding: 1rem 0 2.5rem;
+    border-bottom: 1px solid hsl(0, 0%, 88%);
+  }
+
+  .article-meta {
+    margin: 1rem 0 0;
+    color: hsl(0, 0%, 48%);
+    font-size: 0.8rem;
+  }
+
+  .toc {
+    margin: 2rem 0 0;
+    padding: 1rem 1.15rem;
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 0.85rem;
+    background: hsl(0, 0%, 99%);
+  }
+
+  .toc__title {
+    margin: 0;
+    font-size: 0.8125rem;
+    font-weight: 750;
+    color: hsl(0, 0%, 35%);
+  }
+
+  .toc ol {
+    margin: 0.5rem 0 0;
+    padding-left: 1.25rem;
+    color: hsl(0, 0%, 30%);
+    font-size: 0.875rem;
+    line-height: 1.65;
+  }
+
+  .toc a {
+    color: hsl(5, 53%, 32%);
+    text-decoration: underline;
+    text-underline-offset: 0.12em;
+  }
+
+  .wiki-article section {
+    margin-top: 2.5rem;
+  }
+
+  .wiki-article h2 {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.35rem, 3vw, 1.7rem);
+    letter-spacing: -0.02em;
+  }
+
+  .wiki-article h3 {
+    margin: 1.75rem 0 0.5rem;
+    font-size: 1.1rem;
+    letter-spacing: -0.01em;
+  }
+
+  .wiki-article p {
+    max-width: 46rem;
+    margin: 0.75rem 0 0;
+    color: hsl(0, 0%, 27%);
+    font-size: 1rem;
+    line-height: 1.72;
+  }
+
+  .wiki-article ul {
+    max-width: 46rem;
+    margin: 0.75rem 0 0;
+    padding-left: 1.25rem;
+    color: hsl(0, 0%, 27%);
+    font-size: 1rem;
+    line-height: 1.72;
+  }
+
+  .wiki-article li {
+    margin: 0.35rem 0;
+  }
+
+  .wiki-article code {
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.3rem;
+    background: hsl(0, 0%, 94%);
+    color: hsl(5, 40%, 30%);
+    font-size: 0.85em;
+  }
+
+  .wiki-article pre {
+    max-width: 46rem;
+    margin: 0.75rem 0 0;
+    padding: 1rem 1.15rem;
+    border: 1px solid hsl(0, 0%, 86%);
+    border-radius: 0.75rem;
+    background: hsl(0, 0%, 97%);
+    overflow-x: auto;
+    font-size: 0.85rem;
+    line-height: 1.6;
+  }
+
+  .wiki-article pre code {
+    padding: 0;
+    background: none;
+    color: hsl(0, 0%, 15%);
+    font-size: inherit;
+  }
+
+  .table-wrap {
+    overflow-x: auto;
+    border: 1px solid hsl(0, 0%, 86%);
+    border-radius: 1rem;
+    margin-top: 0.75rem;
+  }
+
+  table {
+    width: 100%;
+    min-width: 38rem;
+    border-collapse: collapse;
+    background: white;
+    font-size: 0.875rem;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid hsl(0, 0%, 90%);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    background: hsl(5, 22%, 97%);
+    color: hsl(0, 0%, 36%);
+    font-size: 0.75rem;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  td code,
+  th code {
+    font-size: 0.8em;
+  }
+</style>

--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -33,6 +33,15 @@ const structuredData = jsonLd(
 
   <section class="wiki-section" aria-labelledby="articles-heading">
     <h2 id="articles-heading">Articles</h2>
+    <a class="article-card" href="/wiki/fork-for-your-campus">
+      <span class="article-card__kicker">For other campuses · 6 min read</span>
+      <strong>Fork this for your campus</strong>
+      <span>
+        Room TBA is built for UPLB. Here is what you actually replace to run
+        it for a different campus — the UPLB data and glue to rip out, the
+        config to repoint, and the write-your-own parts (class import).
+      </span>
+    </a>
     <a class="article-card" href="/wiki/section-times">
       <span class="article-card__kicker">Class schedules · 12 min read</span>
       <strong>What times do section names correspond to?</strong>


### PR DESCRIPTION
Emergency preservation of smoke/combined-fork-prs state before VM destruction. Review and rebase as needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly docs and config indirection with the same UPLB literals; low runtime risk if `campus.config` imports stay valid for Astro config-time loading.
> 
> **Overview**
> Adds **multi-campus fork support** by introducing `src/campus.config.ts` as the single place for site URL/metadata, map bounds/camera, and community links. **`site.ts`**, **`map-terrain.ts`**, **`community-links.ts`**, and **`astro.config.mjs`** (canonical `site` and `/discord` redirect) now read from that module instead of hardcoded UPLB values.
> 
> Documents the workflow in a new README **“Fork this for your campus”** section and a full wiki article at `/wiki/fork-for-your-campus`, linked from the wiki index. Adds **`bun run fork:check`** (`scripts/fork-check.ts`) to scan tracked files for leftover UPLB-specific strings (with allowlist for the scanner and fork wiki); intended for fork CI via `--silent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8861e1f1f2399f4cc725029a7c825abd516b9ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->