### PR TITLE
fix(backup): run bun install before R2 upload

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.12" # pin: avoid bun 1.3.14 frozen-lockfile regression
+      - name: Install dependencies
+        run: mkdir -p node_modules && bun install --frozen-lockfile
       - name: Run backup
         id: dump
         env:


### PR DESCRIPTION
Nightly backup has two stacked failures:

1. PROD_DATABASE_URL secret had a stale password: pg_dump failed with auth error. Fixed by rotating the secret (done outside this PR).
2. With the dump working, the R2 upload step died: `Cannot find module '@smithy/core/schema'` because the workflow never runs `bun install`, so bun auto-installs @aws-sdk/client-s3 with a skewed @smithy set from the runner cache.

This adds the same frozen-lockfile install step the other workflows use.

Verified via workflow_dispatch on this branch (run link in comments).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds a standard dependency install step; no application or production runtime behavior is modified.
> 
> **Overview**
> The nightly **database backup** workflow now runs **`bun install --frozen-lockfile`** (with `mkdir -p node_modules`) after checkout and Bun setup, before the dump and R2 upload steps.
> 
> This aligns **backup.yml** with **CI** and other workflows so the R2 upload script gets lockfile-resolved AWS/Smithy dependencies instead of failing at runtime with a missing `@smithy/core/schema` module when Bun auto-installs on demand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b793f2434da83777c8a7cdb9c9fa2e17b13326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->