### PR TITLE
style: fix biome formatting drift in AMIS import files

### DIFF
--- a/scripts/import-amis-classes.ts
+++ b/scripts/import-amis-classes.ts
@@ -53,7 +53,10 @@ import {
   resolveImportRows,
   summarizeImportChanges,
 } from "@lib/amis/import-classes";
-import { extractClassRows, normalizeAmisClass } from "@lib/amis/normalize-class";
+import {
+  extractClassRows,
+  normalizeAmisClass,
+} from "@lib/amis/normalize-class";
 import {
   amisExportContainsInstructorPii,
   sanitizeAmisRows,
@@ -160,7 +163,10 @@ async function refreshSyncKey(
     .where(eq(updateTable.tableName, tableName));
 }
 
-function inferTermIdFromPayload(payload: unknown, rows: AmisClassRow[]): number {
+function inferTermIdFromPayload(
+  payload: unknown,
+  rows: AmisClassRow[],
+): number {
   const envelope = payload as { term_id?: number; termId?: number };
   if (Number.isFinite(envelope.term_id)) return Number(envelope.term_id);
   if (Number.isFinite(envelope.termId)) return Number(envelope.termId);

--- a/src/lib/amis/normalize-class.ts
+++ b/src/lib/amis/normalize-class.ts
@@ -220,7 +220,8 @@ export function normalizeAmisClass(
   row: AmisClassRow,
   termId: number,
 ): NormalizedAmisClass | null {
-  const courseCode = asString(row["course_code"]) ?? asString(row["courseCode"]);
+  const courseCode =
+    asString(row["course_code"]) ?? asString(row["courseCode"]);
   const section = asString(row["section"]);
   if (!courseCode || !section) return null;
 


### PR DESCRIPTION
## Summary
- \`origin/main\` currently fails \`biome ci\` on 2 files (\`scripts/import-amis-classes.ts\`, \`src/lib/amis/normalize-class.ts\`) — pure formatting drift, no logic change.
- Found this while auditing why all 6 open dependabot PRs showed a failing \`verify\` check: they all inherit this same pre-existing failure from the main snapshot they're based on, unrelated to whatever dependency each one bumps.

## Test plan
- [x] \`bunx biome ci .\` clean (0 errors)
- [x] \`bun test src/lib src/constants\` — 354 pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace and line-wrapping only; no logic, imports, or runtime behavior changes.
> 
> **Overview**
> Restores **`biome ci`** compliance on `scripts/import-amis-classes.ts` and `src/lib/amis/normalize-class.ts` by applying Biome’s expected line breaks only—no behavior changes.
> 
> In the import script, multi-line import paths and the `inferTermIdFromPayload` signature are reformatted. In `normalizeAmisClass`, the `courseCode` assignment is split across lines the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3619b58dc583bb31bf8ecdfe4755ef9c560ad27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->