### PR TITLE
ci: Claude auto-review + @claude mentions

### DIFF
--- a/.github/workflows/claude-noaislop.yml
+++ b/.github/workflows/claude-noaislop.yml
@@ -12,19 +12,28 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
-      - uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            SHA: ${{ github.sha }}
-            This push just landed on main. Run git diff HEAD~1..HEAD and inspect ONLY human-facing prose in the changes: markdown, site copy in components, UI strings, READMEs, changelogs, docs. Ignore code identifiers, lockfiles, config, tests. If the diff has no prose changes, output "no prose" and stop; do not comment.
-            Otherwise fetch the writing rules from https://raw.githubusercontent.com/realrossmanngroup/no_ai_slop_writing_rules/main/CLAUDE.md and judge the changed prose against them: em dashes, banned intensifiers and transitions, hedging, AI-tell phrases and structures.
-            If violations exist, post ONE commit comment (gh api repos/${{ github.repository }}/commits/${{ github.sha }}/comments -f body='...') listing each: file, offending text, and a plain direct rewrite. If clean, post nothing.
-          claude_args: --allowed-tools "Bash(git diff:*),Bash(git show:*),Bash(git log:*),WebFetch,Bash(gh api:*)"
+          fetch-depth: 20
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Slop check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          range="$BEFORE..$AFTER"
+          case "$BEFORE" in 0000000*) range="HEAD~1..HEAD";; esac
+          git rev-parse "$BEFORE" >/dev/null 2>&1 || range="HEAD~1..HEAD"
+          prompt=$(cat <<EOF
+          A push landed on main of $REPO (range $range). Run: git diff $range. Inspect ONLY human-facing prose in the changes: markdown, site copy in components, UI strings, READMEs, changelogs, docs. Ignore code identifiers, lockfiles, config, tests. If the diff contains no prose changes, output "no prose" and stop; do not comment.
+          Otherwise fetch the writing rules from https://raw.githubusercontent.com/realrossmanngroup/no_ai_slop_writing_rules/main/CLAUDE.md and judge the changed prose against them: em dashes, banned intensifiers and transitions, hedging, AI-tell phrases and structures.
+          If violations exist, post ONE commit comment (gh api repos/$REPO/commits/$AFTER/comments -f body='...') listing each: file, offending text, and a plain direct rewrite. If clean, post nothing.
+          EOF
+          )
+          claude -p "$prompt" --allowedTools "Bash(git diff:*),Bash(git show:*),Bash(git log:*),WebFetch,Bash(gh api:*)"

--- a/.github/workflows/claude-noaislop.yml
+++ b/.github/workflows/claude-noaislop.yml
@@ -1,0 +1,30 @@
+name: NoAISlop review
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: noaislop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  slop:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            SHA: ${{ github.sha }}
+            This push just landed on main. Run git diff HEAD~1..HEAD and inspect ONLY human-facing prose in the changes: markdown, site copy in components, UI strings, READMEs, changelogs, docs. Ignore code identifiers, lockfiles, config, tests. If the diff has no prose changes, output "no prose" and stop; do not comment.
+            Otherwise fetch the writing rules from https://raw.githubusercontent.com/realrossmanngroup/no_ai_slop_writing_rules/main/CLAUDE.md and judge the changed prose against them: em dashes, banned intensifiers and transitions, hedging, AI-tell phrases and structures.
+            If violations exist, post ONE commit comment (gh api repos/${{ github.repository }}/commits/${{ github.sha }}/comments -f body='...') listing each: file, offending text, and a plain direct rewrite. If clean, post nothing.
+          claude_args: --allowed-tools "Bash(git diff:*),Bash(git show:*),Bash(git log:*),WebFetch,Bash(gh api:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,5 +25,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Review this pull request for real problems only: bugs, security issues, broken edge cases, data-loss risks, and spec or test drift. Read the diff with gh pr diff; read surrounding code when the diff alone is ambiguous. Leave short inline comments on specific lines for each finding, then one summary comment (or just "LGTM" if nothing found). No praise, no style nits, no em dashes anywhere.
-          claude_args: --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*)"
+            Review this pull request for real problems only: bugs, security issues, broken edge cases, data-loss risks, and spec or test drift. Read the diff with gh pr diff; read surrounding code when the diff alone is ambiguous. Leave short inline comments on specific lines for each finding (mcp inline tool if available, else gh api repos/OWNER/REPO/pulls/N/comments), then ALWAYS post one summary comment via gh pr comment (or just "LGTM" if nothing found). No praise, no style nits, no em dashes anywhere.
+          claude_args: --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,29 @@
+name: Claude review
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request for real problems only: bugs, security issues, broken edge cases, data-loss risks, and spec or test drift. Read the diff with gh pr diff; read surrounding code when the diff alone is ambiguous. Leave short inline comments on specific lines for each finding, then one summary comment (or just "LGTM" if nothing found). No praise, no style nits, no em dashes anywhere.
+          claude_args: --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,32 @@
+name: Claude
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds claude-code-action: auto-review on PR open (skips dependabot + drafts), @claude mention handler on issues/PRs. Replaces Copilot reviewer. CLAUDE_CODE_OAUTH_TOKEN secret already set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New automation uses OAuth secrets and grants write access on some workflows (commit comments, @claude handler), plus outbound fetches for writing rules; no application runtime code changes.
> 
> **Overview**
> Adds **three GitHub Actions workflows** that wire **Claude Code** into the repo via `CLAUDE_CODE_OAUTH_TOKEN` and `anthropics/claude-code-action@v1` (or the global CLI for the slop job).
> 
> **`claude-review.yml`** runs on PR **opened** / **ready_for_review** (skips Dependabot and drafts). It reviews for substantive issues only and posts inline findings plus a single summary PR comment.
> 
> **`claude.yml`** runs when **`@claude`** appears in issue/PR/review text, with broader **write** permissions on contents, PRs, and issues.
> 
> **`claude-noaislop.yml`** runs on **push to `main`**. It diffs the push range, flags human-facing prose against rules fetched from an external repo, and may post **one commit comment** via the GitHub API when violations are found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5cb335a5f02e68b488ea7c9acbc96b0016a43f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->