### PR TITLE
fix: stop nav tooltips flashing when the sidebar collapses

### DIFF
--- a/src/components/svelte/navigation/NavLink.svelte
+++ b/src/components/svelte/navigation/NavLink.svelte
@@ -112,13 +112,16 @@
       z-index: 999;
       width: max-content;
       font-size: 0.75rem;
-      transition: opacity 0.125s;
     }
     .icon {
       color: hsl(0, 0%, 50%);
     }
+    /* Fade only on hover-in; anywhere else opacity snaps. A transition on the
+       base rule made every inline label (opacity 1) fade out as a fixed-
+       position popup at stale coords when the rail collapsed (#755). */
     &:hover .tooltip {
       opacity: 1;
+      transition: opacity 0.125s;
     }
   }
   .nav-link--expanded {


### PR DESCRIPTION
Fixes #755

## Root cause
`NavLink.svelte` put `transition: opacity 0.125s` on the base `.tooltip` rule. Collapsing the rail removes `.nav-link--expanded`, so every inline label (opacity 1) reverts to fixed-popup styling and fades to 0 over 125ms, at stale `--tooltip-x/--tooltip-y` coords (only set on mouseenter/focus). Result: dark tooltip pills flash scattered over the map, exactly as in the issue screenshot. Same mechanism for the contributor sublinks, they use the same component.

## Fix
Move the opacity transition into `:hover .tooltip`. Hover tooltips still fade in; on collapse (or any other state change) opacity snaps with no fade-out, so nothing flashes.

## Verify
- `bun run test` green
- `vitest run Sidebar.component.test.ts` 3/3 pass
- `biome check` clean

CSS-only change, no e2e added (transition-timing flash is not reliably assertable).