### PR TITLE
fix: remove duplicate Donate link in site footer

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -19,11 +19,10 @@ const externalCommunityLinks = COMMUNITY_LINKS.filter(
     <span class="site-footer__group">
       {LEGAL_LINKS.map((link) => <a href={link.href}>{link.label}</a>)}
       <a href="/sponsors">Sponsors</a>
-      <a href="/donate">Donate</a>
+      <a href={DONATE_URL}>Donate</a>
     </span>
     <span class="site-footer__sep" aria-hidden="true">&middot;</span>
     <span class="site-footer__group">
-      <a href={DONATE_URL}>Donate</a>
       <a href={UPLB_TOOLS_URL} target="_blank" rel="noopener noreferrer">
         UPLB Tools
       </a>


### PR DESCRIPTION
Footer nav rendered Donate twice: hardcoded `/donate` in the site-pages group plus `DONATE_URL` in the external group (both resolve to `/donate`). Kept one, in the site-pages group, using the `DONATE_URL` constant.

Before: FAQ Privacy Terms Sponsors Donate · Donate UPLB Tools Discord Messenger
After: FAQ Privacy Terms Sponsors Donate · UPLB Tools Discord Messenger