### PR TITLE
feat(wiki): git-backed authors, history, and Wikipedia-style layout

### DIFF
--- a/src/components/wiki/WikiProvenance.astro
+++ b/src/components/wiki/WikiProvenance.astro
@@ -1,0 +1,70 @@
+---
+import { wikiProvenance } from "@lib/wiki-provenance";
+
+type Props = {
+  /** Repo-relative path of the page source, e.g. src/pages/wiki/foo.astro */
+  sourcePath: string;
+};
+
+const { sourcePath } = Astro.props;
+const { authors, revisions, lastEdited, historyUrl, editUrl } =
+  wikiProvenance(sourcePath);
+
+const dateFormat = new Intl.DateTimeFormat("en-PH", { dateStyle: "long" });
+const lastEditedLabel = lastEdited
+  ? dateFormat.format(new Date(lastEdited))
+  : null;
+---
+
+<p class="wiki-provenance">
+  {
+    authors.length > 0 && (
+      <span class="wiki-provenance__authors">
+        By{" "}
+        {authors.map((author, i) => (
+          <>
+            {i > 0 && ", "}
+            {author.github ? (
+              <a
+                class="wiki-link"
+                href={`https://github.com/${author.github}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {author.name}
+              </a>
+            ) : (
+              author.name
+            )}
+          </>
+        ))}
+      </span>
+    )
+  }
+  {
+    lastEditedLabel && (
+      <span>
+        {" · "}Last edited {lastEditedLabel}
+        {" · "}{revisions} {revisions === 1 ? "revision" : "revisions"}
+      </span>
+    )
+  }
+  <span>
+    {" · "}<a class="wiki-link" href={historyUrl} target="_blank" rel="noopener noreferrer">History</a>
+    {" · "}<a class="wiki-link" href={editUrl} target="_blank" rel="noopener noreferrer">Edit on GitHub</a>
+  </span>
+</p>
+
+<style>
+  .wiki-provenance {
+    margin: 1rem 0 0;
+    color: hsl(0, 0%, 46%);
+    font-size: 0.8125rem;
+    line-height: 1.7;
+  }
+
+  .wiki-provenance__authors {
+    font-weight: 650;
+    color: hsl(0, 0%, 32%);
+  }
+</style>

--- a/src/layouts/WikiLayout.astro
+++ b/src/layouts/WikiLayout.astro
@@ -132,6 +132,40 @@ const { title, description, canonicalPath, structuredData = [] } = Astro.props;
     line-height: 1.65;
   }
 
+  /* Wikipedia-style article shell on wide screens: the page's own "On this
+     page" nav becomes a sticky left rail, body copy flows in the right
+     column. Pure CSS so each article keeps its inline TOC markup. */
+  @media (min-width: 68rem) {
+    .wiki-page article.wiki-article {
+      display: grid;
+      grid-template-columns: 15rem minmax(0, 1fr);
+      column-gap: 3rem;
+      align-items: start;
+      max-width: none;
+    }
+
+    .wiki-page article.wiki-article > * {
+      grid-column: 2;
+      min-width: 0;
+    }
+
+    .wiki-page article.wiki-article > .article-hero {
+      grid-column: 1 / -1;
+    }
+
+    .wiki-page article.wiki-article > .toc {
+      /* ponytail: span 99 = "all rows"; implicit grids reject negative
+         lines and no article is near 99 sections. */
+      grid-column: 1;
+      grid-row: 2 / span 99;
+      position: sticky;
+      top: 1.25rem;
+      margin: 2.5rem 0 0;
+      max-height: calc(100vh - 2.5rem);
+      overflow-y: auto;
+    }
+  }
+
   @media (max-width: 36rem) {
     .wiki-page {
       width: min(100% - 1.25rem, 62rem);

--- a/src/lib/wiki-provenance.ts
+++ b/src/lib/wiki-provenance.ts
@@ -1,0 +1,69 @@
+// Build-time only: runs git against the repo the site is built from.
+import { execFileSync } from "node:child_process";
+
+export type WikiAuthor = {
+  name: string;
+  github?: string;
+  commits: number;
+};
+
+export type WikiProvenance = {
+  authors: WikiAuthor[];
+  revisions: number;
+  lastEdited: string | null;
+  historyUrl: string;
+  editUrl: string;
+};
+
+const REPO_URL = "https://github.com/uplbtools/room-tba";
+const NOREPLY = /^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/;
+
+/**
+ * Authorship of a wiki page from its git history, plus GitHub history and
+ * edit URLs. Identities are merged by GitHub username (noreply emails) or
+ * email local part, so "Stimmie <...@up.edu.ph>" and
+ * "smmariquit <...@users.noreply.github.com>" count as one author.
+ */
+export function wikiProvenance(sourcePath: string): WikiProvenance {
+  const historyUrl = `${REPO_URL}/commits/main/${sourcePath}`;
+  const editUrl = `${REPO_URL}/edit/main/${sourcePath}`;
+  let log = "";
+  try {
+    log = execFileSync(
+      "git",
+      ["log", "--follow", "--format=%an%x09%ae%x09%aI", "--", sourcePath],
+      { encoding: "utf8" },
+    ).trim();
+  } catch {
+    // ponytail: no .git or shallow CI clone; the GitHub links still work.
+  }
+  if (!log) {
+    return { authors: [], revisions: 0, lastEdited: null, historyUrl, editUrl };
+  }
+
+  const byKey = new Map<string, WikiAuthor>();
+  const lines = log.split("\n");
+  for (const line of lines) {
+    const [name, email = ""] = line.split("\t");
+    if (!name) continue;
+    const github = NOREPLY.exec(email)?.[1];
+    const key = (github ?? email.split("@")[0] ?? name).toLowerCase();
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.commits += 1;
+      // Newest commits come first; a github handle can surface later.
+      existing.github ??= github;
+    } else {
+      byKey.set(key, { name, github, commits: 1 });
+    }
+  }
+
+  return {
+    authors: [...byKey.values()].sort((a, b) => b.commits - a.commits),
+    revisions: lines.length,
+    // %aI, newest first.
+    lastEdited: lines[0]?.split("\t")[2] ?? null,
+    historyUrl,
+    editUrl,
+  };
+}

--- a/src/pages/wiki/fork-for-your-campus.astro
+++ b/src/pages/wiki/fork-for-your-campus.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import WikiLayout from "@layouts/WikiLayout.astro";
+import WikiProvenance from "../../components/wiki/WikiProvenance.astro";
 import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";
 
 const title = "Fork this for your campus | Room TBA Wiki";
@@ -37,6 +38,7 @@ const structuredData = jsonLd(
         Current as of v2.1.x. If the repo has moved, the file paths below are
         still the map — re-check them.
       </p>
+      <WikiProvenance sourcePath="src/pages/wiki/fork-for-your-campus.astro" />
     </header>
 
     <nav class="toc" aria-label="On this page">

--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -3,6 +3,45 @@ export const prerender = true;
 
 import WikiLayout from "@layouts/WikiLayout.astro";
 import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";
+import { wikiProvenance } from "@lib/wiki-provenance";
+
+const articles = [
+  {
+    href: "/faq",
+    kicker: "Student FAQ · 3 min read",
+    title: "Frequently asked questions",
+    blurb:
+      "Where the 3D building models come from, whether Room TBA is official UPLB, how class and room data is updated, and how to report wrong data. Short, plain-language answers for students.",
+    sourcePath: "src/pages/faq.astro",
+  },
+  {
+    href: "/wiki/fork-for-your-campus",
+    kicker: "For other campuses · 6 min read",
+    title: "Fork this for your campus",
+    blurb:
+      "Room TBA is built for UPLB. Here is what you actually replace to run it for a different campus — the UPLB data and glue to rip out, the config to repoint, and the write-your-own parts (class import).",
+    sourcePath: "src/pages/wiki/fork-for-your-campus.astro",
+  },
+  {
+    href: "/wiki/section-times",
+    kicker: "Class schedules · 12 min read",
+    title: "What times do section names correspond to?",
+    blurb:
+      "Exhaustive glossary: letter ladders, NSTP/HK/GI/residency, MS/PhD numbers, every AMIS type, plus oldest→newest term trends (what moved vs what only looks bigger in Room TBA).",
+    sourcePath: "src/pages/wiki/section-times.astro",
+  },
+].map((article) => {
+  const { authors, lastEdited } = wikiProvenance(article.sourcePath);
+  return {
+    ...article,
+    authors: authors.map((a) => a.name).join(", "),
+    lastEdited: lastEdited
+      ? new Intl.DateTimeFormat("en-PH", { dateStyle: "medium" }).format(
+          new Date(lastEdited),
+        )
+      : null,
+  };
+});
 
 const title = "Wiki | Room TBA";
 const description =
@@ -33,33 +72,23 @@ const structuredData = jsonLd(
 
   <section class="wiki-section" aria-labelledby="articles-heading">
     <h2 id="articles-heading">Articles</h2>
-    <a class="article-card" href="/faq">
-      <span class="article-card__kicker">Student FAQ · 3 min read</span>
-      <strong>Frequently asked questions</strong>
-      <span>
-        Where the 3D building models come from, whether Room TBA is official
-        UPLB, how class and room data is updated, and how to report wrong
-        data. Short, plain-language answers for students.
-      </span>
-    </a>
-    <a class="article-card" href="/wiki/fork-for-your-campus">
-      <span class="article-card__kicker">For other campuses · 6 min read</span>
-      <strong>Fork this for your campus</strong>
-      <span>
-        Room TBA is built for UPLB. Here is what you actually replace to run
-        it for a different campus — the UPLB data and glue to rip out, the
-        config to repoint, and the write-your-own parts (class import).
-      </span>
-    </a>
-    <a class="article-card" href="/wiki/section-times">
-      <span class="article-card__kicker">Class schedules · 12 min read</span>
-      <strong>What times do section names correspond to?</strong>
-      <span>
-        Exhaustive glossary: letter ladders, NSTP/HK/GI/residency, MS/PhD
-        numbers, every AMIS type, plus oldest→newest term trends (what moved
-        vs what only looks bigger in Room TBA).
-      </span>
-    </a>
+    <div class="article-grid">
+      {
+        articles.map((article) => (
+          <a class="article-card" href={article.href}>
+            <span class="article-card__kicker">{article.kicker}</span>
+            <strong>{article.title}</strong>
+            <span>{article.blurb}</span>
+            {article.lastEdited && (
+              <span class="article-card__provenance">
+                Updated {article.lastEdited}
+                {article.authors && ` · ${article.authors}`}
+              </span>
+            )}
+          </a>
+        ))
+      }
+    </div>
   </section>
 
   <section class="wiki-section" aria-labelledby="resources-heading">
@@ -90,11 +119,18 @@ const structuredData = jsonLd(
     font-size: 1.25rem;
   }
 
+  /* Fill the page column instead of hugging the left edge. */
+  .article-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr));
+    gap: 1rem;
+    align-items: stretch;
+  }
+
   .article-card {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    max-width: 42rem;
     padding: 1.25rem;
     border: 1px solid hsl(5, 28%, 82%);
     border-radius: 1rem;
@@ -123,9 +159,16 @@ const structuredData = jsonLd(
     line-height: 1.2;
   }
 
-  .article-card > span:last-child {
+  .article-card > span:nth-of-type(2) {
     color: hsl(0, 0%, 35%);
     line-height: 1.55;
+  }
+
+  .article-card__provenance {
+    margin-top: auto;
+    padding-top: 0.5rem;
+    color: hsl(0, 0%, 48%);
+    font-size: 0.75rem;
   }
 
   .resource-links {

--- a/src/pages/wiki/section-times.astro
+++ b/src/pages/wiki/section-times.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 
 import WikiLayout from "@layouts/WikiLayout.astro";
+import WikiProvenance from "../../components/wiki/WikiProvenance.astro";
 import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";
 
 const title = "What times do UPLB section names correspond to? | Room TBA Wiki";
@@ -456,6 +457,7 @@ const structuredData = jsonLd(
         (87.5%). Term-trend pass: July 16, 2026 · AMIS caches 1231→1261 + prod
         row counts.
       </p>
+      <WikiProvenance sourcePath="src/pages/wiki/section-times.astro" />
     </header>
 
     <nav class="toc" aria-label="On this page">


### PR DESCRIPTION
Turns the wiki pages into a functional git-backed wiki.

## What
- **Provenance from git, at build time**: `src/lib/wiki-provenance.ts` runs `git log --follow` per article, merges author identities (noreply GitHub handles + email local parts), and returns authors, revision count, last-edited date.
- **`WikiProvenance.astro` byline** on both articles: `By smmariquit · Last edited July 16, 2026 · 9 revisions · History · Edit on GitHub`. History/Edit links go to GitHub, so editing is PR-based like any OSS wiki.
- **Wikipedia-style article layout**: on wide screens the existing inline "On this page" nav becomes a sticky left rail (pure CSS in WikiLayout, both articles share the markup). Mobile unchanged.
- **Index spacing fix**: article cards now fill the page column in a responsive grid (they hugged the left edge before) and carry `Updated <date> · <authors>`.

## Notes
- Vercel shallow clones may truncate git history, so byline counts can undercount on prod builds; the GitHub History link is always complete. Marked with a `ponytail:` comment.
- No DB, no in-app editor. If Wikipedia-grade in-app editing is wanted, that is a separate feature (contributor-account editor + revisions table).

## Verify
- `bun run build` green, provenance present in built HTML
- Screenshots at 1280 + 375: sticky rail on desktop, clean stack on mobile, no horizontal scroll