### PR TITLE
feat(map): highlight my class buildings + zoom-gated POI pins

### DIFF
--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -32,6 +32,9 @@
     termStore,
     syncToastStore,
     transitStore,
+    plannerStore,
+    plannerBuildingsStore,
+    plannerRoomCodes,
   } from "@lib/store.svelte";
   import { untrack } from "svelte";
   import { onMount } from "svelte";
@@ -294,6 +297,9 @@
   });
 
   onMount(() => {
+    // Hydrate saved planner plans so the "My classes" highlight knows the
+    // user's class rooms without the planner screen ever being opened.
+    plannerStore.init();
     void loadSponsors().then((data) => {
       if (data) sponsoredPlacePins = getSponsoredPlacePins(data.sponsors);
     });
@@ -979,6 +985,12 @@
   }
 
   let zoomLevel = $state(0);
+  // Progressive disclosure, Google Maps style: low-priority POI pins (orgs,
+  // offices, landmarks, establishments) only appear once zoomed in enough.
+  // Buildings and dorms always show. Active (searched) and sponsored pins
+  // bypass the gate so deep links and paid placements never vanish.
+  const POI_MIN_ZOOM = 15.5;
+  const poiPinsVisible = $derived(zoomLevel >= POI_MIN_ZOOM);
   const SIDEPANEL_WIDTH = 25.75 * 16;
   const md = new MediaQuery("max-width:48rem");
   let editChromeEl = $state<HTMLElement | null>(null);
@@ -1720,6 +1732,9 @@
         if (!terrainStore.enabled || !sourceErrorMatchesTerrain(event)) return;
         failTerrain(map, TERRAIN_TILE_FAILURE_MESSAGE);
       };
+      // Sync once on bind — zoomLevel starts at 0, and pin/label zoom gates
+      // must reflect the real camera before the first zoom event fires.
+      handleZoom();
       map.on("zoom", handleZoom);
       map.on("error", handleMapError);
       return () => {
@@ -2600,6 +2615,29 @@
     return linkedActiveEventDormIds.has(dormId);
   }
 
+  // "My classes" highlight (#see MapViewStore.highlightMyBuildings): emphasize
+  // buildings hosting the active planner plan's classes, dim every other pin.
+  // Same shape as the event-focus dimming above.
+  const activePlannerRoomCodes = $derived(
+    plannerRoomCodes(plannerStore.activePlan?.sections ?? []),
+  );
+  const classHighlightActive = $derived(
+    mapViewStore.highlightMyBuildings && activePlannerRoomCodes.length > 0,
+  );
+
+  $effect(() => {
+    if (!mapViewStore.highlightMyBuildings) return;
+    void plannerBuildingsStore.load(activePlannerRoomCodes);
+  });
+
+  function isMyClassBuilding(buildingId: number): boolean {
+    return classHighlightActive && plannerBuildingsStore.buildingIds.has(buildingId);
+  }
+
+  function isBuildingDimmedForClassHighlight(buildingId: number): boolean {
+    return classHighlightActive && !plannerBuildingsStore.buildingIds.has(buildingId);
+  }
+
   let linkedActiveEventBuildingIds = $derived.by(() => {
     if (!loaded) return new Set<number>();
     return new Set(
@@ -2978,7 +3016,8 @@
                     active={activeBuildingName === building.buildingName}
                     editable={canDragPin(editKey)}
                     editing={selectedEditKey === editKey}
-                    dimmed={isBuildingDimmedForEventFocus(building.id)}
+                    dimmed={isBuildingDimmedForEventFocus(building.id) ||
+                      isBuildingDimmedForClassHighlight(building.id)}
                     eventLinked={isBuildingEventLinked(building.id)}
                     hovered={hoveredEditKey === editKey}
                     saveState={savingEditKey === editKey
@@ -2989,7 +3028,8 @@
                           ? "failed"
                           : "idle"}
                     labelVisible={zoomLevel >= 17 ||
-                      activeBuildingName === building.buildingName}
+                      activeBuildingName === building.buildingName ||
+                      isMyClassBuilding(building.id)}
                     useCentralHoverPreview={centralHoverPreview}
                     {previewSuppressed}
                     onpointerenter={(event) =>
@@ -3059,7 +3099,8 @@
                     label={dorm.dormName}
                     tone={dorm.isUpManaged ? "dorm" : "privateDorm"}
                     active={activeDormName === dorm.dormName}
-                    dimmed={isDormDimmedForEventFocus(dorm.id)}
+                    dimmed={isDormDimmedForEventFocus(dorm.id) ||
+                      classHighlightActive}
                     eventLinked={isDormEventLinked(dorm.id)}
                     editable={canDragPin(editKey)}
                     editing={selectedEditKey === editKey}
@@ -3087,7 +3128,7 @@
           {/each}
 
           {#each filteredPlaces as place (`place:${place.id}`)}
-            {#if place.lat != null && place.lon != null}
+            {#if place.lat != null && place.lon != null && (poiPinsVisible || sponsoredPlacePins.has(place.name) || (queryStore.category === "place" && queryStore.inputValue === place.name))}
               {@const centralHoverPreview = shouldShowEntityHoverPreview()}
               {@const previewSuppressed =
                 centralHoverPreview &&
@@ -3099,6 +3140,7 @@
                   tone={isLandmarkPlace(place) ? "landmark" : "establishment"}
                   active={queryStore.category === "place" &&
                     queryStore.inputValue === place.name}
+                  dimmed={classHighlightActive && pinSponsorId === undefined}
                   labelVisible={zoomLevel >= 17 ||
                     (queryStore.category === "place" &&
                       queryStore.inputValue === place.name)}
@@ -3126,6 +3168,7 @@
 
         {#if !mapViewStore.eventsOnly}
           {#each filteredOrganizations as { org, lat, lon } (`org:${org.id}`)}
+            {#if poiPinsVisible || activeOrgName === org.name}
             {@const centralHoverPreview = shouldShowEntityHoverPreview()}
             {@const previewSuppressed =
               centralHoverPreview &&
@@ -3137,6 +3180,7 @@
                   ? "organization"
                   : "office"}
                 active={activeOrgName === org.name}
+                dimmed={classHighlightActive}
                 labelVisible={zoomLevel >= 17 || activeOrgName === org.name}
                 useCentralHoverPreview={centralHoverPreview}
                 {previewSuppressed}
@@ -3152,6 +3196,7 @@
                 {/if}
               </MapEntityPin>
             </Marker>
+            {/if}
           {/each}
         {/if}
       </MapLibre>

--- a/src/components/svelte/MapViewControls.component.test.ts
+++ b/src/components/svelte/MapViewControls.component.test.ts
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test } from "vitest";
+import MapViewControls from "./MapViewControls.svelte";
+import { mapViewStore, plannerStore, termStore } from "@lib/store.svelte";
+import { mountAtWidth } from "@test/layout-assertions";
+
+describe("MapViewControls My classes toggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    plannerStore.plans = [];
+    plannerStore.activePlanIdByTerm = {};
+    mapViewStore.showAll();
+  });
+
+  test("disabled with a hint when the planner has no classes at 320px", () => {
+    mountAtWidth(320);
+    render(MapViewControls, { props: { embedded: true, variant: "modes" } });
+
+    const toggle = screen.getByRole("button", {
+      name: /Add classes in the Planner/,
+    }) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+    expect(screen.getByText("Add classes in the Planner first.")).toBeTruthy();
+  });
+
+  test("enabled and flips highlight mode when a plan has classes", async () => {
+    termStore.activeTermId = 1252;
+    plannerStore.addOffering([
+      {
+        id: 1,
+        courseCode: "CMSC 128",
+        section: "AB",
+        type: "LEC",
+        schedule: ["MW 07:00AM-08:00AM"],
+        roomCode: "ICS MH",
+        directions: null,
+        courseTitle: "Software Engineering",
+        roomId: 1,
+        termId: 1252,
+      },
+    ]);
+
+    mountAtWidth(320);
+    render(MapViewControls, { props: { embedded: true, variant: "modes" } });
+
+    const toggle = screen.getByRole("button", {
+      name: /Highlight the buildings/,
+    }) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+
+    toggle.click();
+    expect(mapViewStore.highlightMyBuildings).toBe(true);
+  });
+});

--- a/src/components/svelte/MapViewControls.svelte
+++ b/src/components/svelte/MapViewControls.svelte
@@ -6,8 +6,15 @@
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import Box from "@lucide/svelte/icons/box";
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
+  import GraduationCap from "@lucide/svelte/icons/graduation-cap";
   import MapIcon from "@lucide/svelte/icons/map";
-  import { mapStore, mapViewStore, terrainStore } from "@lib/store.svelte";
+  import {
+    mapStore,
+    mapViewStore,
+    plannerStore,
+    terrainStore,
+  } from "@lib/store.svelte";
+  import { onMount } from "svelte";
   import { THREE_D_PITCH, isMap2DPitch } from "@constants/map-dimension";
   import {
     enterFlatMapDimension,
@@ -36,12 +43,26 @@
   let bearing = $state(0);
   let pitch = $state(0);
 
+  // Hydrate saved plans so the "My classes" toggle knows whether the user has
+  // any planned classes (init is idempotent, localStorage only).
+  onMount(() => plannerStore.init());
+
   const northRotation = $derived(-NORTH_ICON_OFFSET - bearing);
   const is2D = $derived(isMap2DPitch(pitch));
   const pinModeTitle = $derived(
     mapViewStore.eventsOnly
       ? "Showing event pins only. Switch to all pins."
       : "Showing all pins. Switch to event pins only.",
+  );
+  const hasPlannerClasses = $derived(
+    (plannerStore.activePlan?.sections.length ?? 0) > 0,
+  );
+  const classHighlightTitle = $derived(
+    !hasPlannerClasses
+      ? "Add classes in the Planner to highlight their buildings."
+      : mapViewStore.highlightMyBuildings
+        ? "Highlighting your class buildings. Switch back to normal pins."
+        : "Highlight the buildings your planned classes are in.",
   );
   const cameraModeTitle = $derived(
     is2D
@@ -142,6 +163,29 @@
         </span>
       </span>
     </button>
+
+    <div class="divider"></div>
+
+    <button
+      class="control mode-toggle class-highlight-toggle"
+      class:active={mapViewStore.highlightMyBuildings}
+      onclick={mapViewStore.toggleHighlightMyBuildings}
+      disabled={!hasPlannerClasses}
+      title={classHighlightTitle}
+      aria-label={classHighlightTitle}
+      aria-pressed={mapViewStore.highlightMyBuildings}
+    >
+      <GraduationCap size={18} aria-hidden="true" />
+      <span class="control-copy">
+        <span class="control-kicker">My classes</span>
+        <span class="control-value">
+          {mapViewStore.highlightMyBuildings ? "Highlighted" : "Off"}
+        </span>
+      </span>
+    </button>
+    {#if !hasPlannerClasses}
+      <p class="control-hint">Add classes in the Planner first.</p>
+    {/if}
 
     <div class="divider"></div>
 
@@ -403,6 +447,29 @@
   .pin-toggle:hover {
     border-color: hsl(5, 34%, 68%);
     background-color: hsl(0, 78%, 97%);
+  }
+
+  .class-highlight-toggle {
+    border-color: hsl(5, 34%, 78%);
+    background-color: hsl(0, 100%, 99%);
+  }
+
+  .class-highlight-toggle:hover:not(:disabled) {
+    border-color: hsl(5, 34%, 68%);
+    background-color: hsl(0, 78%, 97%);
+  }
+
+  .class-highlight-toggle:disabled {
+    border-color: hsl(0, 0%, 88%);
+    background-color: hsl(0, 0%, 98%);
+  }
+
+  .control-hint {
+    margin: 0;
+    padding: 0 0.25rem;
+    color: hsl(0, 0%, 45%);
+    font-size: 0.625rem;
+    line-height: 1.3;
   }
 
   .camera-toggle {

--- a/src/lib/stores/data-stores.svelte.ts
+++ b/src/lib/stores/data-stores.svelte.ts
@@ -2,6 +2,7 @@ import {
   getJSONFetch,
   getBuildingIdsWithClasses,
   getLocalClassesForRoom,
+  getLocalRoomByCode,
 } from "../local/data/utils.js";
 import { parseTermIdFromSearch, syncTermQueryParam } from "../term-url.js";
 import {
@@ -188,5 +189,64 @@ export class ClassVenuesStore {
     } catch (e) {
       console.error("Failed to load class venues:", e);
     }
+  };
+}
+
+/** Distinct, normalized room codes from planner sections. TBA rooms (null)
+ * are dropped — they have no building to highlight. */
+export function plannerRoomCodes(
+  sections: { roomCode: string | null }[],
+): string[] {
+  return [
+    ...new Set(
+      sections
+        .map((section) => section.roomCode?.trim().toUpperCase())
+        .filter((code): code is string => !!code),
+    ),
+  ];
+}
+
+/**
+ * Building ids for the rooms in the user's active planner plan. Powers the
+ * "My classes" map highlight: planner sections carry room codes; each code
+ * resolves to its building via PGlite first, then the rooms API — the same
+ * room→building path ScheduleRouteStore uses for schedule routing.
+ */
+export class PlannerBuildingsStore {
+  buildingIds = $state<Set<number>>(new Set());
+  private _cache = new Map<string, number | null>();
+  private _requestId = 0;
+
+  load = async (roomCodes: string[]) => {
+    const requestId = ++this._requestId;
+    const ids = await Promise.all(
+      roomCodes.map((code) => this.#resolveBuildingId(code)),
+    );
+    // Ignore stale responses if a newer load started meanwhile.
+    if (requestId !== this._requestId) return;
+    this.buildingIds = new Set(ids.filter((id): id is number => id !== null));
+  };
+
+  #resolveBuildingId = async (roomCode: string): Promise<number | null> => {
+    const cached = this._cache.get(roomCode);
+    if (cached !== undefined) return cached;
+    let buildingId: number | null = null;
+    try {
+      const local = await getLocalRoomByCode(roomCode);
+      const room =
+        local ??
+        (
+          await getJSONFetch<{ data: { buildingId: number | null } | null }>(
+            `/api/rooms?code=${encodeURIComponent(roomCode)}`,
+          )
+        ).data;
+      buildingId = room?.buildingId ?? null;
+    } catch (e) {
+      console.error(`Failed to resolve building for room ${roomCode}:`, e);
+      // Do not cache failures — a later load (e.g. back online) can retry.
+      return null;
+    }
+    this._cache.set(roomCode, buildingId);
+    return buildingId;
   };
 }

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -145,9 +145,12 @@ import {
   TermStore,
   RoomClassesStore,
   ClassVenuesStore,
+  PlannerBuildingsStore,
 } from "./data-stores.svelte";
 import { PlannerStore } from "./planner-store.svelte";
 import { TransitStore } from "./transit-store.svelte";
+
+export { plannerRoomCodes } from "./data-stores.svelte";
 
 class LocationStore {
   coords: [number, number] | null = $state(null);
@@ -928,6 +931,7 @@ export const queryStore = new QueryStore();
 export const termStore = new TermStore();
 export const roomClassesStore = new RoomClassesStore();
 export const classVenuesStore = new ClassVenuesStore();
+export const plannerBuildingsStore = new PlannerBuildingsStore();
 export const plannerStore = new PlannerStore(() => termStore.activeTermId);
 export const scheduleRouteStore = new ScheduleRouteStore();
 export const offlineStore = new OfflineStore();

--- a/src/lib/stores/map-stores.store.test.ts
+++ b/src/lib/stores/map-stores.store.test.ts
@@ -84,6 +84,23 @@ describe("MapViewStore", () => {
     expect(store.showOrgs).toBe(true);
     expect(store.showPlaces).toBe(true);
   });
+
+  test("highlightMyBuildings toggles and leaves events-only mode", () => {
+    const store = new MapViewStore();
+    store.toggleEventsOnly();
+    store.toggleHighlightMyBuildings();
+    expect(store.highlightMyBuildings).toBe(true);
+    expect(store.eventsOnly).toBe(false);
+    store.toggleHighlightMyBuildings();
+    expect(store.highlightMyBuildings).toBe(false);
+  });
+
+  test("showAll clears the class-building highlight", () => {
+    const store = new MapViewStore();
+    store.toggleHighlightMyBuildings();
+    store.showAll();
+    expect(store.highlightMyBuildings).toBe(false);
+  });
 });
 
 describe("Building3DStore", () => {

--- a/src/lib/stores/map-stores.svelte.ts
+++ b/src/lib/stores/map-stores.svelte.ts
@@ -14,6 +14,8 @@ export class MapViewStore {
   // map legend so users can declutter the map (#18b).
   showOrgs: boolean = $state(true);
   showPlaces: boolean = $state(true);
+  // Emphasize buildings hosting the user's planner classes; dim other pins.
+  highlightMyBuildings: boolean = $state(false);
 
   toggleEventsOnly = () => {
     this.eventsOnly = !this.eventsOnly;
@@ -27,10 +29,18 @@ export class MapViewStore {
     this.showPlaces = !this.showPlaces;
   };
 
+  toggleHighlightMyBuildings = () => {
+    this.highlightMyBuildings = !this.highlightMyBuildings;
+    // Events-only hides building pins entirely — pointless combined with a
+    // building highlight, so leave that mode when highlighting.
+    if (this.highlightMyBuildings) this.eventsOnly = false;
+  };
+
   showAll = () => {
     this.eventsOnly = false;
     this.showOrgs = true;
     this.showPlaces = true;
+    this.highlightMyBuildings = false;
   };
 }
 

--- a/src/lib/stores/planner-buildings.store.test.ts
+++ b/src/lib/stores/planner-buildings.store.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { getJSONFetch, getLocalRoomByCode } = vi.hoisted(() => ({
+  getJSONFetch: vi.fn(),
+  getLocalRoomByCode: vi.fn(),
+}));
+
+vi.mock("../local/data/utils.js", () => ({
+  getJSONFetch,
+  getLocalRoomByCode,
+  getBuildingIdsWithClasses: vi.fn(),
+  getLocalClassesForRoom: vi.fn(),
+}));
+
+import {
+  PlannerBuildingsStore,
+  plannerRoomCodes,
+} from "./data-stores.svelte.js";
+
+describe("plannerRoomCodes", () => {
+  test("normalizes, dedupes, and drops TBA (null) rooms", () => {
+    expect(
+      plannerRoomCodes([
+        { roomCode: "icb 12" },
+        { roomCode: "ICB 12" },
+        { roomCode: " PSLH-A " },
+        { roomCode: null },
+        { roomCode: "" },
+      ]),
+    ).toEqual(["ICB 12", "PSLH-A"]);
+  });
+
+  test("empty plan yields no codes", () => {
+    expect(plannerRoomCodes([])).toEqual([]);
+  });
+});
+
+describe("PlannerBuildingsStore", () => {
+  beforeEach(() => {
+    getJSONFetch.mockReset();
+    getLocalRoomByCode.mockReset();
+    getLocalRoomByCode.mockResolvedValue(null);
+    getJSONFetch.mockResolvedValue({ data: null });
+  });
+
+  test("resolves building ids from PGlite first", async () => {
+    getLocalRoomByCode.mockImplementation(async (code: string) => ({
+      buildingId: code === "ICB 12" ? 7 : 9,
+    }));
+
+    const store = new PlannerBuildingsStore();
+    await store.load(["ICB 12", "PSLH-A"]);
+
+    expect(store.buildingIds).toEqual(new Set([7, 9]));
+    expect(getJSONFetch).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the rooms API and skips rooms without a building", async () => {
+    getJSONFetch.mockImplementation(async (url: string) =>
+      url.includes("ICB%2012") || url.includes("ICB 12")
+        ? { data: { buildingId: 4 } }
+        : { data: { buildingId: null } },
+    );
+
+    const store = new PlannerBuildingsStore();
+    await store.load(["ICB 12", "ORPHAN 1"]);
+
+    expect(store.buildingIds).toEqual(new Set([4]));
+    expect(getJSONFetch).toHaveBeenCalledWith(
+      `/api/rooms?code=${encodeURIComponent("ICB 12")}`,
+    );
+  });
+
+  test("caches resolved rooms across loads", async () => {
+    getLocalRoomByCode.mockResolvedValue({ buildingId: 3 });
+
+    const store = new PlannerBuildingsStore();
+    await store.load(["NL"]);
+    await store.load(["NL"]);
+
+    expect(getLocalRoomByCode).toHaveBeenCalledTimes(1);
+    expect(store.buildingIds).toEqual(new Set([3]));
+  });
+
+  test("does not cache failures so a later load can retry", async () => {
+    getJSONFetch.mockRejectedValueOnce(new Error("offline"));
+
+    const store = new PlannerBuildingsStore();
+    await store.load(["NL"]);
+    expect(store.buildingIds).toEqual(new Set());
+
+    getJSONFetch.mockResolvedValueOnce({ data: { buildingId: 5 } });
+    await store.load(["NL"]);
+    expect(store.buildingIds).toEqual(new Set([5]));
+  });
+});


### PR DESCRIPTION
## What

Addresses student feedback (Aleeza): *"is there an option to highlight the buildings u have classes in? theres so many icons bro"* — plus the team follow-up on taming icon overload with Google-Maps-style progressive disclosure.

### 1. "My classes" highlight (primary)

- New **My classes** toggle in **Map tools → View**, right next to the existing Pins (Events/All) and 2D/3D toggles (`MapViewControls.svelte`, `mapViewStore.highlightMyBuildings`).
- When on: buildings hosting the **active planner plan's** classes stay full-strength with their labels pinned visible; every other pin (other buildings, dorms, orgs/offices, landmarks/establishments) gets the existing `dimmed` treatment. This reuses the event-focus dimming pattern in `Map.svelte` (`isBuildingDimmedForEventFocus` et al.) — no new visual system.
- **Schedule → building mapping:** planner sections carry `roomCode`; new `PlannerBuildingsStore` resolves each distinct code to its `buildingId` via `getLocalRoomByCode` (PGlite) first, falling back to `/api/rooms?code=` — the same room→building path `ScheduleRouteStore` already uses for schedule routing. Per-room cache, stale-response guard, failures not cached so a later toggle retries.
- **Empty planner:** the toggle is disabled with a hint ("Add classes in the Planner first.") instead of silently doing nothing. Enabling the highlight also exits events-only pin mode (events-only hides building pins entirely, so combining them would show nothing).
- Sponsored place pins are exempt from dimming (ad-policy: always-visible placement).
- Event pins are not dimmed (they are temporal overlays with their own component); can follow up if wanted.

### 2. Progressive disclosure by zoom (secondary — shipped)

- Org/office and landmark/establishment pins now render only at **zoom ≥ 15.5** (`POI_MIN_ZOOM`), following the existing `zoomLevel >= 17` label-gating precedent. Buildings and dorms always show.
- Actively searched pins and sponsored pins bypass the gate so deep links and paid placements never vanish.
- Fixed a latent bug this exposed: `zoomLevel` started at 0 and only synced on the first `zoom` event; it now syncs once when the map instance binds.

## Not done / skipped

- No Playwright e2e in this PR — coverage is at the store + component level per the task scope. Happy to add a browse-spec follow-up if wanted.
- Event pins are not dimmed by the highlight (see above).

## QA evidence

- `bunx vitest run src/lib/stores/planner-buildings.store.test.ts src/lib/stores/map-stores.store.test.ts src/components/svelte/MapViewControls.component.test.ts` — 19 tests pass (new: room-code normalization/dedupe, PGlite-first + API-fallback resolution, cache/retry behavior, toggle disabled/enabled + events-only interplay, showAll reset).
- `bun run test` — 402 pass.
- `bun run test:components` — 143/144 pass; the 1 failure (`DormResult.component.test.ts` Kubo CTA) is pre-existing on clean staging in this environment (needs a live server on 127.0.0.1:3000, `ECONNREFUSED`).
- `bunx biome check` on all changed files — clean. (Repo-wide `bun run lint` flags 2 untouched files, a local biome 2.5.2 vs lockfile 2.5.4 version artifact.)
- `bun run build` — completes.
- Manual browser QA still needed for: dim/label rendering feel at 320px/768px, and POI pins appearing/disappearing across the 15.5 zoom boundary.