### PR TITLE
fix(test): stop DormResult test dialing localhost:3000, fix stale CTA assertions

### DIFF
--- a/src/components/svelte/controls/DormResult.component.test.ts
+++ b/src/components/svelte/controls/DormResult.component.test.ts
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/svelte";
-import { beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import DormResultHost from "@test/components/DormResultHost.svelte";
 import type { DormData } from "@lib/types";
 import { queryStore } from "@lib/store.svelte";
@@ -46,6 +46,17 @@ function renderDormResult(testDorm: DormData) {
 describe("DormResult Kubo link", () => {
   beforeEach(() => {
     kuboDormDirectory.set(new Map());
+    // Mounting DormResult triggers loadKuboDormDirectory(); without a stub
+    // the real fetch dials localhost:3000 and kills CI (no dev server).
+    // 503 keeps the store untouched, so the directory set below stays.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 503 })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   test("renders a safe Kubo CTA for an API-confirmed dorm without mobile overflow", () => {
@@ -85,11 +96,16 @@ describe("DormResult Kubo link", () => {
     expect(link.querySelector("img")).toHaveAttribute("src", "/kubo-logo.png");
     expect(link.querySelector("img")).toHaveAttribute("alt", "");
 
+    // The CTA lives in the entity-actions row since the live-directory
+    // change, not in the dorm-details links row.
+    const actions = link.closest<HTMLElement>(".entity-actions");
+    expect(actions).not.toBeNull();
+    expectNoHorizontalOverflow(actions!);
+
     const links = container.querySelector<HTMLElement>(
       ".entity-dorm-details__links",
     );
     expect(links).not.toBeNull();
-    expect(links!.querySelector("a")).toBe(link);
     expectNoHorizontalOverflow(links!);
   });
 


### PR DESCRIPTION
Fixes the red `verify` step on staging (Component tests, `ECONNREFUSED ::1:3000`).

## Root cause
Mounting `DormResult` runs `$effect -> loadKuboDormDirectory()` (added in #756). Under happy-dom the relative fetch resolves to `localhost:3000`; CI has no server there, so undici's connection failure killed the whole vitest run.

## Fix
- Stub `fetch` with a 503 in the test file: no socket, and `loadKuboDormDirectory` leaves the directory store untouched, so the directory the test seeds stays in place.
- The network death was masking a second break: #756 moved the Kubo CTA from `.entity-dorm-details__links` into the `.entity-actions` row but the assertion still expected it as the first links-row anchor. Updated to assert the real container, overflow checks retained on both rows.

## Verify
`bun run test:components`: 136/136 pass locally with no dev server running (previously died on ECONNREFUSED).