### PR TITLE
fix(dorms): require name agreement before rendering a Kubo CTA

### DIFF
--- a/src/lib/kubo-dorms.test.ts
+++ b/src/lib/kubo-dorms.test.ts
@@ -114,6 +114,30 @@ describe("getKuboDormCta", () => {
     expect(getKuboDormCta(new Map(), 13, "Westbrook Residences")).toBeNull();
   });
 
+  test("suppresses the CTA when the id-matched record names a different dorm", () => {
+    // Live incident 2026-07-25: Kubo served demo rows whose roomTbaDormIds
+    // pointed at real dorms ("Maple Court Residence" on Men's RH id).
+    const record = {
+      ...acceptingDirectory.dorms[0],
+      roomTbaDormId: 1,
+      name: "Maple Court Residence",
+    };
+    expect(
+      getKuboDormCta(new Map([[1, record]]), 1, "Men's Residence Hall"),
+    ).toBeNull();
+  });
+
+  test.each([
+    ["Scholar's Dormitory", "Scholars Dormitory"],
+    ["New Dormitory Residence Hall", "New Dormitory RH"],
+    ["Arable Premier", "Arable Premier Residences"],
+  ])("accepts name variant %s vs %s", (kuboName, dormName) => {
+    const record = { ...acceptingDirectory.dorms[0], name: kuboName };
+    expect(
+      getKuboDormCta(new Map([[15, record]]), 15, dormName),
+    ).not.toBeNull();
+  });
+
   test("starts empty so an unconfirmed link is never shown", () => {
     let directory: KuboDormDirectory | undefined;
     const unsubscribe = kuboDormDirectory.subscribe((value) => {

--- a/src/lib/kubo-dorms.ts
+++ b/src/lib/kubo-dorms.ts
@@ -66,6 +66,17 @@ export function getKuboDormCta(
   const match = directory.get(dormId);
   if (!match) return null;
 
+  // Trust boundary: Kubo's feed has served placeholder roomTbaDormIds that
+  // collide with real dorms (2026-07-25, demo rows mapped onto Men's RH and
+  // New Dormitory RH). An id match alone must not render a reservation CTA;
+  // the names have to agree too.
+  if (!dormNamesMatch(match.name, dormName)) {
+    console.warn(
+      `Kubo directory: dorm id ${dormId} name mismatch ("${match.name}" vs "${dormName}"); CTA suppressed`,
+    );
+    return null;
+  }
+
   if (match.reservationStatus === "accepting" && match.reservationUrl) {
     return {
       href: match.reservationUrl,
@@ -114,6 +125,23 @@ export async function loadKuboDormDirectory(
   });
 
   return loadPromise;
+}
+
+// ponytail: loose containment after normalization; "Residence Hall" folds to
+// "RH" so registrar-style names match. Upgrade to an explicit id->slug
+// allowlist if Kubo's data quality stays rough.
+function normalizeDormName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .replace(/residencehall/g, "rh");
+}
+
+export function dormNamesMatch(kuboName: string, dormName: string): boolean {
+  const a = normalizeDormName(kuboName);
+  const b = normalizeDormName(dormName);
+  if (!a || !b) return false;
+  return a === b || a.includes(b) || b.includes(a);
 }
 
 function toDirectory(records: KuboDormRecord[]): KuboDormDirectory {


### PR DESCRIPTION
Trust-boundary guard for the Kubo live directory (follow-up to #756).

## Why
Today's live feed returned exactly two dorms, both Kubo demo/seed rows, with `roomTbaDormId` 1 and 4. Those ids belong to Men's Residence Hall and New Dormitory RH, so staging rendered wrong-dorm reservation CTAs on two UP halls. Matching is id-only; nothing validated the payload against our data.

## What
- `getKuboDormCta` now requires the record's `name` to loosely match the Room TBA dorm name (lowercase, strip non-alphanumerics, fold "Residence Hall" to "RH", then containment). Mismatch: CTA suppressed + `console.warn`.
- Fails closed at the same choke point every caller uses; no schema or API changes.
- Tests: the live incident case (Maple Court on id 1 vs Men's RH) suppressed; variants (`Scholar's`/`Scholars`, `Residence Hall`/`RH`, partial names) still pass. `bun run test` 406/406.

Kubo side still needs to fix their feed (seed rows + real listings for Arable/Scholar's dropped); this guard just makes their bad data harmless to us.