### PR TITLE
fix(e2e): make history revert integration test order-independent

### DIFF
--- a/integration/services/history.integration.test.ts
+++ b/integration/services/history.integration.test.ts
@@ -36,12 +36,25 @@ describeIntegration("editor history revert integration", () => {
     }>("SELECT version, directions FROM buildings WHERE id = $1", [buildingId]);
     const startVersion = original.rows[0]?.version ?? 1;
 
+    // Prime a history row of our own: after a DB reset this building has no
+    // history, and bun's test-file order is not guaranteed, so we cannot rely
+    // on another test file having edited it first (broke when the order
+    // shifted and this file ran right after the reset).
+    const base = `history-base-${Date.now()}`;
+    const primed = await updateBuilding(
+      buildingId,
+      { directions: base },
+      startVersion,
+      "e2e-admin",
+    );
+    expect(primed?.directions).toBe(base);
+
     // Make an edit we will restore over.
     const marker = `history-test-${Date.now()}`;
     const edited = await updateBuilding(
       buildingId,
       { directions: marker },
-      startVersion,
+      primed?.version ?? startVersion + 1,
       "e2e-admin",
     );
     expect(edited?.directions).toBe(marker);
@@ -67,7 +80,9 @@ describeIntegration("editor history revert integration", () => {
     const [latest] = await getEntityHistory("building", buildingId);
     expect(latest.action).toBe("revert");
     expect(latest.summary).toBe("integration revert test");
-  });
+    // Three sequential writes against the remote E2E DB can brush past bun's
+    // 5s default; give the round-trips room like the room test below.
+  }, 30_000);
 
   test("room revert restores the room code (snapshot stores it as `code`)", async () => {
     const { updateRoom } = await import("@lib/services/admin-service");


### PR DESCRIPTION
## Root cause

`integration/services/history.integration.test.ts` ("revert restores the snapshot and records a revert history row") had a latent test-file-order dependency. Line 50 asserted `entries.length >= 2` after making only **one** edit itself — it silently relied on some *other* integration test file (in practice `admin.integration.test.ts` > "updateBuilding bumps version") having already edited the `E2E Test Hall` fixture so a prior `editor_history` row existed.

`scripts/e2e-reset-db.ts` truncates `editor_history` before every CI run, and `bun test` discovers files in readdir order, which is not guaranteed:

- Green-era run [29808546148](https://github.com/uplbtools/room-tba/actions/runs/29808546148) (2026-07-21): order was `... admin -> ... -> history ...` — admin seeded the history row, line 50 passed.
- Failing run [30153584772](https://github.com/uplbtools/room-tba/actions/runs/30153584772) (#756 merge): order shifted to `map-data -> history -> ... -> admin` — history ran right after the reset, its single edit produced exactly 1 row, and line 50 failed deterministically:

```
Expected: >= 2
Received: 1
    at integration/services/history.integration.test.ts:50:28
```

#756 (kubo-dorm-links) touched none of `integration/`, `scripts/`, `.github/`, or `package.json` — its tree change merely reshuffled bun's file discovery order and exposed the dependency. This is not a regression in the revert code path (both sibling tests in the file kept passing).

The proposals-service timeouts / stale-version 409s seen on some runs are the separate shared-E2E-DB concurrency flake and are not addressed here.

## Fix

Make the test self-sufficient: prime its own prior history row with an initial `updateBuilding` edit before the marker edit, so `entries[1]` exists regardless of which file runs first. Also gives the test the same 30s timeout the sibling room test already has (three sequential writes against the remote E2E DB can brush past bun's 5s default).

## Verification

- Local repro: after `bun run e2e:reset-db`, the unfixed test fails with exactly the CI assertion (`Expected: >= 2, Received: 1` at line 50).
- After the fix: reset again, all 3 tests in the file pass.
- `bunx biome check integration/services/history.integration.test.ts` clean.
