### PR TITLE
fix(e2e): stop transit integration test deleting the seeded Playwright stop

### DIFF
--- a/integration/services/transit.integration.test.ts
+++ b/integration/services/transit.integration.test.ts
@@ -7,14 +7,19 @@ describeIntegration("jeepney stop service", () => {
   beforeAll(async () => {
     // A previous run's soft-removed stop still holds sort_order 0 and the
     // (route_id, sort_order) unique constraint would reject reusing it.
+    // Only clear leftovers from earlier test runs: the seeded "E2E Stop"
+    // (scripts/e2e-reset-db.ts) must survive because the Playwright deep-link
+    // spec (e2e/browse/transit-stop-panel.spec.ts) runs after this suite on
+    // the same database and navigates to /transit/e2e-route/e2e-stop.
     const pg = await import("pg");
     const client = new pg.default.Client({
       connectionString: integrationDatabaseUrl()!,
     });
     await client.connect();
-    await client.query("DELETE FROM jeepney_stops WHERE route_id = $1", [
-      "e2e-route",
-    ]);
+    await client.query(
+      "DELETE FROM jeepney_stops WHERE route_id = $1 AND name <> $2",
+      ["e2e-route", "E2E Stop"],
+    );
     await client.end();
   });
 


### PR DESCRIPTION
Fixes the standing red `e2e / e2e` check on `staging`: `e2e/browse/transit-stop-panel.spec.ts` ("stop panel never renders").

## Root cause

`integration/services/transit.integration.test.ts` `beforeAll` (added in 9df8097f, 2026-07-21, "feat(contributions): track direct editor publishes") runs:

```sql
DELETE FROM jeepney_stops WHERE route_id = 'e2e-route'
```

That wipes the seeded **"E2E Stop"** (`scripts/e2e-reset-db.ts`). CI runs one DB reset, then integration, then Playwright in the same job (`.github/workflows/e2e-reusable.yml`), so by the time `transit-stop-panel.spec.ts` deep-links to `/transit/e2e-route/e2e-stop`, the route has no stop whose slug resolves to `e2e-stop`. `EntityUrlSync.setTransit` gets `stopIndex = -1`, never calls `jeepneyStore.openStop`, and `.jeepney-stop-panel` never renders.

The error-context snapshot from staging run [30157282201](https://github.com/uplbtools/room-tba/actions/runs/30157282201) proves it: the E2E Route panel is open, but `Stops (1)` lists only `Suggested stop 1784981382439` — the leftover from the integration proposal test, with the seeded stop gone.

**Verdict: not an app regression, not spec drift — a test-fixture bug.** It hid for 4 days because every staging e2e run since 9df8097f died earlier at the integration stage (editor-history revert order dependence / proposals ledger contention); #763 + #765 fixed those today, unmasking the Playwright stage for the first time in run 30157282201.

## Fix

Scope the cleanup to test leftovers: `DELETE ... AND name <> 'E2E Stop'`. The unique-`(route_id, sort_order)` re-run rationale for the `beforeAll` still holds (stale `Integration stop` / `Suggested stop` rows are still cleared); the seeded fixture survives for Playwright.

## Local verification (dedicated E2E DB)

1. `bun run e2e:reset-db` → `jeepney_stops` on `e2e-route`: `[E2E Stop, sort 1, active]`
2. Pre-fix integration test → `[Integration stop (inactive, sort 0), Suggested stop (active, sort 1)]` — **E2E Stop deleted**, exact CI failure state reproduced
3. Reseed + post-fix integration test, run twice (idempotency: the original constraint concern) → 2 pass / 2 pass, `E2E Stop` survives at sort 1 both times, no `(route_id, sort_order)` conflict
4. `bun run e2e e2e/browse/transit-stop-panel.spec.ts --project=desktop-chrome` against that post-integration DB state (mirrors CI ordering) → **1 passed (20.9s)**

Biome clean on the touched file.
