### PR TITLE
fix(e2e): point the reset list at the renamed 0040 backfill

### DIFF
--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -73,7 +73,7 @@ const E2E_MIGRATION_FILES = [
   "0036_add_building_cr_facilities.sql",
   "0037_editor_credits_profiles.sql",
   "0038_sponsor_impressions.sql",
-  "0039_pre_drizzle_schema_backfill.sql",
+  "0040_pre_drizzle_schema_backfill.sql",
 ] as const;
 
 /**


### PR DESCRIPTION
One-line follow-up to my own renumber in #781.

When I renamed `0039_pre_drizzle_schema_backfill.sql` to `0040_` (to free 0039 for #768's keyset index), I missed the reference in `E2E_MIGRATION_FILES`. That list is what the **public** schema path reads, so `bun run e2e:reset-db` without `E2E_SCHEMA` set now throws ENOENT locally. CI stayed green because the run-schema path globs `drizzle/*.sql` instead of using the list.

Verified every one of the 24 listed filenames resolves to a real file, so there is no second dangling entry.