### PR TITLE
fix: pre-release review findings

### DIFF
--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   staging-smoke:
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       STAGING_BASE_URL: https://staging.room-tba.uplbtools.me
     steps:
@@ -21,4 +20,7 @@ jobs:
           bun-version: "1.3.12" # pin: bun 1.3.14 broke --frozen-lockfile
       - run: mkdir -p node_modules && bun install --frozen-lockfile
       - run: bunx playwright install chromium --with-deps
+      # Advisory, but on the step: a job-level continue-on-error reports the
+      # whole run as success, so a red smoke test looked green in gh run list.
       - run: bun run e2e:staging
+        continue-on-error: true

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,6 +17,12 @@ const e2eNodeAdapter = process.env.ASTRO_E2E_NODE === "1";
 export default defineConfig({
   site: campusSite.url,
 
+  // Astro's HTML compressor drops the newline+indent that prettier inserts
+  // after a closing inline tag, welding words together in prose: "activity
+  // type(LEC" instead of "activity type (LEC". The saved bytes are not worth
+  // corrupting the wiki and FAQ copy.
+  compressHTML: false,
+
   integrations: [
     svelte(),
     AstroPWA({

--- a/drizzle/0040_pre_drizzle_schema_backfill.sql
+++ b/drizzle/0040_pre_drizzle_schema_backfill.sql
@@ -3,6 +3,10 @@
 -- captured by a migration, so replaying the chain into an empty schema (an E2E
 -- run schema, a fork, a fresh local DB) produced a structure the app rejects.
 -- Every statement is a no-op where the live shape already matches.
+-- Fail fast rather than queue behind a slow query: these ALTERs take
+-- ACCESS EXCLUSIVE on live tables, and every read would stack behind them.
+SET lock_timeout = '3s';
+--> statement-breakpoint
 DO $$
 BEGIN
   CREATE TYPE "building_type" AS ENUM ('admin', 'non-admin');

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -986,6 +986,9 @@
   // bypass the gate so deep links and paid placements never vanish.
   const POI_MIN_ZOOM = 15.5;
   const poiPinsVisible = $derived(zoomLevel >= POI_MIN_ZOOM);
+  $effect(() => {
+    mapViewStore.poiPinsZoomVisible = poiPinsVisible;
+  });
   const SIDEPANEL_WIDTH = 25.75 * 16;
   const md = new MediaQuery("max-width:48rem");
   let editChromeEl = $state<HTMLElement | null>(null);

--- a/src/components/svelte/MapLegend.svelte
+++ b/src/components/svelte/MapLegend.svelte
@@ -23,6 +23,15 @@
 
   let { embedded = false, trigger = "icon" }: Props = $props();
 
+  /** Org/place pins answer to the toggle AND a zoom gate, so "Shown" alone
+   * would lie when the user is zoomed out past it. */
+  function legendState(on: boolean): string {
+    if (!on) return "Hidden — tap to toggle.";
+    return mapViewStore.poiPinsZoomVisible
+      ? "Shown — tap to toggle."
+      : "Shown when you zoom in — tap to toggle.";
+  }
+
   const panelId = "legend";
   const open = $derived(floatingControlPanelStore.openPanel === panelId);
   const showPanel = $derived(embedded || open);
@@ -222,7 +231,7 @@
               <span class="legend-copy">
                 <span class="legend-label">Orgs, units &amp; offices</span>
                 <span class="legend-description">
-                  {mapViewStore.showOrgs ? "Shown" : "Hidden"} — tap to toggle.
+                  {legendState(mapViewStore.showOrgs)}
                 </span>
               </span>
             </button>
@@ -237,7 +246,7 @@
               <span class="legend-copy">
                 <span class="legend-label">Landmarks &amp; establishments</span>
                 <span class="legend-description">
-                  {mapViewStore.showPlaces ? "Shown" : "Hidden"} — tap to toggle.
+                  {legendState(mapViewStore.showPlaces)}
                 </span>
               </span>
             </button>

--- a/src/components/svelte/MapViewControls.svelte
+++ b/src/components/svelte/MapViewControls.svelte
@@ -361,9 +361,15 @@
   }
 
   .control:disabled {
-    color: hsl(0, 0%, 75%);
+    color: hsl(0, 0%, 52%);
     cursor: default;
     background-color: transparent;
+  }
+
+  /* The kicker's 0.72 opacity stacked on the disabled grey left the label at
+     1.76:1, so the row read as blank rather than disabled. */
+  .control:disabled .control-kicker {
+    opacity: 1;
   }
 
   .north-btn {

--- a/src/components/svelte/navigation/NavLink.svelte
+++ b/src/components/svelte/navigation/NavLink.svelte
@@ -82,6 +82,9 @@
 <style>
   .nav-link {
     position: relative;
+    /* The href variant is an <a>, so it inherited the global anchor underline
+       and read differently from its button siblings (Wiki, Discord, Donate). */
+    text-decoration: none;
     padding: 0.5rem 0rem;
     display: flex;
     align-items: center;

--- a/src/layouts/WikiLayout.astro
+++ b/src/layouts/WikiLayout.astro
@@ -136,6 +136,13 @@ const { title, description, canonicalPath, structuredData = [] } = Astro.props;
      page" nav becomes a sticky left rail, body copy flows in the right
      column. Pure CSS so each article keeps its inline TOC markup. */
   @media (min-width: 68rem) {
+    /* The rail eats 15rem + 3rem out of the same box the prose sits in, which
+       squeezed wide tables into clipping while margin sat empty. Give the page
+       back what the rail takes. */
+    .wiki-page:has(article.wiki-article) {
+      width: min(80rem, calc(100% - 2rem));
+    }
+
     .wiki-page article.wiki-article {
       display: grid;
       grid-template-columns: 15rem minmax(0, 1fr);

--- a/src/lib/kubo-dorms.test.ts
+++ b/src/lib/kubo-dorms.test.ts
@@ -130,12 +130,21 @@ describe("getKuboDormCta", () => {
   test.each([
     ["Scholar's Dormitory", "Scholars Dormitory"],
     ["New Dormitory Residence Hall", "New Dormitory RH"],
-    ["Arable Premier", "Arable Premier Residences"],
-  ])("accepts name variant %s vs %s", (kuboName, dormName) => {
+  ])("accepts spelling variant %s vs %s", (kuboName, dormName) => {
     const record = { ...acceptingDirectory.dorms[0], name: kuboName };
     expect(
       getKuboDormCta(new Map([[15, record]]), 15, dormName),
     ).not.toBeNull();
+  });
+
+  test.each([
+    // Prod really has both of these; one name contains the other, so a
+    // placeholder id would otherwise render a CTA for the wrong building.
+    ["Forestry Residence Hall", "New Forestry Residence Hall"],
+    ["Arable Premier", "Arable Premier Residences"],
+  ])("rejects the near-miss %s vs %s", (kuboName, dormName) => {
+    const record = { ...acceptingDirectory.dorms[0], name: kuboName };
+    expect(getKuboDormCta(new Map([[15, record]]), 15, dormName)).toBeNull();
   });
 
   test("starts empty so an unconfirmed link is never shown", () => {

--- a/src/lib/kubo-dorms.ts
+++ b/src/lib/kubo-dorms.ts
@@ -127,9 +127,11 @@ export async function loadKuboDormDirectory(
   return loadPromise;
 }
 
-// ponytail: loose containment after normalization; "Residence Hall" folds to
-// "RH" so registrar-style names match. Upgrade to an explicit id->slug
-// allowlist if Kubo's data quality stays rough.
+// Exact match after normalization: "Residence Hall" folds to "RH" so
+// registrar-style spellings still agree. Containment is deliberately NOT
+// allowed — prod has sibling dorms where one name contains the other
+// ("Forestry Residence Hall" inside "New Forestry Residence Hall"), so a
+// placeholder id from Kubo could otherwise light up the wrong building.
 function normalizeDormName(value: string): string {
   return value
     .toLowerCase()
@@ -141,7 +143,7 @@ export function dormNamesMatch(kuboName: string, dormName: string): boolean {
   const a = normalizeDormName(kuboName);
   const b = normalizeDormName(dormName);
   if (!a || !b) return false;
-  return a === b || a.includes(b) || b.includes(a);
+  return a === b;
 }
 
 function toDirectory(records: KuboDormRecord[]): KuboDormDirectory {

--- a/src/lib/stores/map-stores.svelte.ts
+++ b/src/lib/stores/map-stores.svelte.ts
@@ -16,6 +16,9 @@ export class MapViewStore {
   showPlaces: boolean = $state(true);
   // Emphasize buildings hosting the user's planner classes; dim other pins.
   highlightMyBuildings: boolean = $state(false);
+  /** Org/place pins are also zoom-gated in Map.svelte. The legend reads this
+   * so its toggles cannot claim "Shown" while the gate is hiding them. */
+  poiPinsZoomVisible: boolean = $state(true);
 
   toggleEventsOnly = () => {
     this.eventsOnly = !this.eventsOnly;


### PR DESCRIPTION
Findings from the correctness review run against `origin/main...origin/staging` before the release. None of these blocked the release; all four are cheap and worth having in it.

## Kubo name guard admitted sibling dorms
`dormNamesMatch` ended with `a === b || a.includes(b) || b.includes(a)`. Prod has dorm 7 "Forestry Residence Hall" and dorm 8 "New Forestry Residence Hall"; `"newforestryrh".includes("forestryrh")` is true. Since the guard exists precisely because Kubo has shipped placeholder `roomTbaDormId`s, a placeholder landing on id 8 named "Forestry Residence Hall" would have rendered a reservation link for the wrong building. Now exact-match after normalization; the "Residence Hall" to "RH" fold still covers the registrar-spelling case. Added the Forestry pair as a regression test.

## Legend lied about zoom-gated pins
`POI_MIN_ZOOM = 15.5` hides org/office/landmark/establishment pins, but the legend's toggles still read "Shown". Zoom out, tap the toggle, nothing changes and nothing explains why. The legend now reads the gate via `mapViewStore.poiPinsZoomVisible` and says "Shown when you zoom in".

## staging-smoke reported red runs as green
`continue-on-error: true` sat on the **job**, so a failed smoke test produced a run with conclusion `success`. It has been failing on the Kubo CTA assertion and nobody would have seen it. Moved to the step: still advisory, no longer dishonest.

## Migration 0040 had no lock_timeout
The `ALTER COLUMN ... TYPE` statements are verified no-ops on prod (columns are already `double precision`, no dependent views, no index rebuild), but they still take ACCESS EXCLUSIVE on `buildings` and `dorms`. Without a timeout, a slow query holding a lock would stall every read behind it. `SET lock_timeout = '3s'` makes a contended run fail fast and roll back.

## Verify
`bun run test` 407 pass, `test:components` 150 pass, biome clean, `bun run build` green.