### PR TITLE
fix(test): restore the 20s integration timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format": "biome format --write .",
     "test": "bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts'",
     "test:components": "vitest run",
-    "test:integration": "bun test ./integration --preload ./integration/preload.ts --concurrency 1",
+    "test:integration": "bun test ./integration --preload ./integration/preload.ts --concurrency 1 --timeout 20000",
     "test:integration:live": "bash scripts/run-integration-preview.sh",
     "test:all": "bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts' && bun run test:components && bun run test:integration",
     "e2e": "playwright test",


### PR DESCRIPTION
Self-inflicted, caught by #767's e2e.

## What happened

#786 synced `package.json` and `CHANGELOG.md` from `main` to fix the version drift. Taking `package.json` **verbatim** was the mistake: `main` is behind `staging` on everything except the version, so the sync also reverted `0019848d`, which had added `--timeout 20000` to `test:integration` alongside the e2e schema isolation work.

Schema pinning costs a connection round trip, which pushed the proposals tests (already sitting at 4.5-5.0s) past bun's 5s default. #767's blocking e2e then failed at exactly `5000.45ms` on `proposals service > approval appends one ledger row`, which reads like the old shared-database flake but is not: it is the timeout that had already been fixed, silently removed.

## Fix

Restore the flag. Version stays 2.3.1, so the sync's actual purpose is preserved.

## Lesson for the next sync

Sync the version **field** and the changelog, not the whole file. `main` only ever leads on those two things; on everything else it trails staging by a full release cycle.