### PR TITLE
fix(ci): stop failing fork PRs on secrets they cannot have

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,10 @@ jobs:
       - name: Build
         if: github.actor != 'dependabot[bot]'
         env:
-          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+          # Fork PRs get no secrets, and the build only needs this variable to
+          # exist for env-schema validation — nothing queries at build time.
+          # Without the fallback every outside contribution fails here (#790).
+          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL || 'postgresql://placeholder:placeholder@127.0.0.1:5432/placeholder' }}
           DD_GIT_COMMIT_SHA: ${{ github.sha }}
           DD_GIT_REPOSITORY_URL: https://github.com/${{ github.repository }}
           DD_GIT_BRANCH: ${{ github.ref_name }}
@@ -111,7 +114,15 @@ jobs:
       - name: Install dependencies
         run: mkdir -p node_modules && bun install --frozen-lockfile
 
+      # A fork PR has no database credentials, so this check cannot run. Say so
+      # plainly and pass, rather than failing on infrastructure the contributor
+      # has no way to fix (#790). A maintainer runs it on the mirrored branch.
       - name: Schema tables present
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
         run: bun run check:migrations
+
+      - name: Schema check skipped (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Skipped — fork PRs cannot access database secrets. A maintainer will run this before merge."

--- a/.github/workflows/e2e-advisory.yml
+++ b/.github/workflows/e2e-advisory.yml
@@ -18,6 +18,7 @@ jobs:
   e2e-advisory:
     if: |
       github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.action == 'ready_for_review' ||
       (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
       (github.event.action == 'reopened' && github.event.pull_request.draft == false) ||

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,7 @@ jobs:
   e2e:
     if: |
       github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.action == 'ready_for_review' ||
       (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
       (github.event.action == 'reopened' && github.event.pull_request.draft == false) ||

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,21 @@ Open http://localhost:4321. More setup help: [docs/developer-guide.md](docs/deve
 
 **Production:** features merge to `staging` first. Release to production is a separate **`staging` → `main`** PR (maintainers).
 
+### What CI does on your PR
+
+If you forked the repo, GitHub will not give your pull request access to our
+secrets. That is a GitHub security rule, not a judgement about your change.
+
+- **`verify`** (lint, unit tests, component tests, build) runs normally. This is
+  the check to watch.
+- **`migrations`** reports a skip notice, because the schema check needs
+  database credentials your fork cannot see.
+- **The end-to-end suites do not run.** A maintainer runs them from a branch on
+  this repo before merging.
+
+If you have push access here, branch directly on this repo instead of forking
+and the full stack runs.
+
 ### Picking up a campus issue
 
 If someone filed a `data` or `qa` issue without code:


### PR DESCRIPTION
Closes #790.

## The problem

Every fork pull request showed red checks regardless of content. #789 was a four-file UI change that ran clean locally; on CI it failed the build (`EnvInvalidVariables: DATABASE_URL is missing`), the schema check, and both e2e suites. GitHub withholds repository secrets from fork PRs by design, so this hits every outside contributor.

The cost is worse than the noise: when everything is red by default, a genuinely broken fork PR looks identical to a good one, and contributors learn to ignore CI.

## What changed

**Build now survives without credentials.** I tested this rather than assuming it: with `dist`, `.vercel/output` and `.astro` deleted and a bogus connection string pointing at a closed port, `bun run build` completes and `/changelog` renders with content. The variable only needs to exist for Astro's env-schema validation; nothing queries the database at build time. So the Build step falls back to a placeholder when the secret is empty.

**The schema check reports a skip instead of a failure.** It genuinely needs a database, so on fork PRs it emits a GitHub notice explaining why it did not run.

**The e2e suites are not scheduled for fork PRs.** They cannot work without secrets, and a 40-minute job that fails in 41 seconds helps nobody. A maintainer runs them from a branch on this repo before merging, which is already what happens in practice.

**CONTRIBUTING.md** now states plainly what a contributor should expect from each check.

## Deliberately not done

`pull_request_target` would hand our credentials to code from forks. Not worth it to make a check green.

## Verify

- Clean build with an unreachable database: passes (evidence above)
- All three workflow files parse as YAML; conditionals inspected after parsing rather than eyeballed
- Same-repo branches are untouched: secrets resolve and every check runs as before