### PR TITLE
feat(today): Today screen for the day's planned classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ No account needed to browse. Editors and contributors fix data in the same app (
 | Personal schedule route | Build a plan in Planner → Map tools → Schedule → pick a day, route stops |
 | Browse all classes | Status bar → Browse classes; search by course code |
 | Plan your classes | Planner view to build a draft schedule |
+| What do I have today | Today view (`/today`): your plan's classes for today, tomorrow, and the rest of the week |
 | Course Planner explainer | [Four-panel, screenshot-ready guide](https://room-tba.uplbtools.me/pubmat/course-planner/) |
 | Final exam time & room | Search course code → finals panel; room panel during finals week |
 | Academic calendar | [/calendar](https://room-tba.uplbtools.me/calendar) — term windows on a year timeline; also via the term picker |

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -70,6 +70,7 @@ export default defineConfig({
           /^\/planner(\/|\?|$)/,
           /^\/final-exams(\/|\?|$)/,
           /^\/calendar(\/|\?|$)/,
+          /^\/today(\/|\?|$)/,
           // Server redirects — must hit network, not offline app shell (#471).
           /^\/messenger(\/|\?|$)/,
           /^\/maintain(\/|\?|$)/,

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -58,6 +58,7 @@
   type MetadataProps = {
     initialSearch?: InitialSearchState;
     suppressLandingModal?: boolean;
+    openToday?: boolean;
     openPlanner?: boolean;
     openFinals?: boolean;
     openCalendar?: boolean;
@@ -508,6 +509,7 @@
 <Entry
   initialSearch={metadata.initialSearch}
   suppressLandingModal={metadata.suppressLandingModal ?? false}
+  openToday={metadata.openToday ?? false}
   openPlanner={metadata.openPlanner ?? false}
   openFinals={metadata.openFinals ?? false}
   openCalendar={metadata.openCalendar ?? false}

--- a/src/components/svelte/EntityUrlSync.svelte
+++ b/src/components/svelte/EntityUrlSync.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { getAppData } from "@lib/context";
-  import { createEntityUrlSync } from "@lib/entity-url-sync";
+  import { createEntityUrlSync, isScreenId } from "@lib/entity-url-sync";
   import { openCampusBrowse } from "@lib/browse-campus";
   import { getTransitStopIndex } from "@lib/transit-urls";
   import {
@@ -88,12 +88,7 @@
       editMode: mapEditStore.enabled,
       termId: termStore.activeTermId,
       defaultTermId: termStore.defaultTermId,
-      screen:
-        sidebarStore.panelOpen === "planner" ||
-        sidebarStore.panelOpen === "finals" ||
-        sidebarStore.panelOpen === "calendar"
-          ? sidebarStore.panelOpen
-          : null,
+      screen: isScreenId(sidebarStore.panelOpen) ? sidebarStore.panelOpen : null,
       transitRouteId: jeepneyStore.selectedRouteId,
       transitStopIndex: jeepneyStore.selectedStopIndex,
       transitRoute: transitStore.getRoute(jeepneyStore.selectedRouteId),

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -38,6 +38,7 @@
   import PlannerScreen from "@ui/planner/PlannerScreen.svelte";
   import FinalExamsScreen from "@ui/final-exams/FinalExamsScreen.svelte";
   import AcademicCalendarScreen from "@ui/calendar/AcademicCalendarScreen.svelte";
+  import TodayScreen from "@ui/today/TodayScreen.svelte";
   import EntityUrlSync from "@ui/EntityUrlSync.svelte";
   import EntityHoverPreview from "@ui/map/EntityHoverPreview.svelte";
   import "./map-chrome/map-chrome.css";
@@ -59,6 +60,7 @@
   type Props = {
     initialSearch?: InitialSearchState;
     suppressLandingModal?: boolean;
+    openToday?: boolean;
     openPlanner?: boolean;
     openFinals?: boolean;
     openCalendar?: boolean;
@@ -68,6 +70,7 @@
   const {
     initialSearch,
     suppressLandingModal = false,
+    openToday = false,
     openPlanner = false,
     openFinals = false,
     openCalendar = false,
@@ -207,6 +210,12 @@
     if (openCalendar) {
       void termStore.init();
       sidebarStore.changeOpened("calendar");
+    }
+
+    // /today deep link (prop set by today.astro), same shape.
+    if (openToday) {
+      void termStore.init();
+      sidebarStore.changeOpened("today");
     }
 
     const planParam = urlParams.get("plan");
@@ -414,6 +423,8 @@
           </div>
         </div>
       </div>
+    {:else if sidebarStore.panelOpen === "today"}
+      <TodayScreen />
     {:else if sidebarStore.panelOpen === "planner"}
       <PlannerScreen />
     {:else if sidebarStore.panelOpen === "finals"}

--- a/src/components/svelte/navigation/Sidebar.svelte
+++ b/src/components/svelte/navigation/Sidebar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import CalendarClock from "@lucide/svelte/icons/calendar-clock";
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
   import FileCheck from "@lucide/svelte/icons/file-check";
   import BookText from "@lucide/svelte/icons/book-text";
@@ -332,6 +333,17 @@
           {/each}
         </div>
       {/if}
+
+      <NavLink
+        onclick={() => {
+          sidebarStore.changeOpened("today");
+        }}
+        active={sidebarStore.panelOpen === "today"}
+        expanded={labeled}
+        tooltip="Today"
+      >
+        <CalendarClock size={20} />
+      </NavLink>
 
       <NavLink
         onclick={() => {

--- a/src/components/svelte/today/TodayScreen.component.test.ts
+++ b/src/components/svelte/today/TodayScreen.component.test.ts
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import TodayScreen from "@ui/today/TodayScreen.svelte";
+import {
+  plannerStore,
+  queryStore,
+  sidebarStore,
+  termStore,
+} from "@lib/store.svelte";
+import { mountAtWidth } from "@test/layout-assertions";
+import type { ClassMapValue } from "@lib/types";
+
+const row = (overrides: Partial<ClassMapValue> = {}): ClassMapValue => ({
+  id: 1,
+  courseCode: "CMSC 128",
+  section: "AB-1L",
+  type: "LEC",
+  schedule: ["MW 07:00AM-08:00AM"],
+  roomCode: "ICS MH1",
+  directions: null,
+  courseTitle: "Software Engineering",
+  roomId: 1,
+  termId: 1252,
+  ...overrides,
+});
+
+describe("TodayScreen", () => {
+  beforeEach(() => {
+    // Only Date is faked: Svelte's scheduler still needs real timers/rAF.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-27T04:00:00Z")); // Monday noon in Manila
+    localStorage.clear();
+    termStore.activeTermId = 1252;
+    plannerStore.plans = [];
+    plannerStore.activePlanIdByTerm = {};
+    sidebarStore.changeOpened("today");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("points an empty planner at the Planner instead of a blank screen", async () => {
+    render(TodayScreen);
+    expect(screen.getByText(/Add classes to see your day/)).toBeVisible();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Open the Planner" }),
+    );
+    expect(sidebarStore.panelOpen).toBe("planner");
+  });
+
+  test("lists today's classes in time order with a room link", async () => {
+    plannerStore.addOffering([row({ schedule: ["M 03:00PM-05:00PM"] })]);
+    plannerStore.addOffering([
+      row({
+        id: 2,
+        courseCode: "MATH 27",
+        section: "B-2",
+        schedule: ["MW 07:00AM-08:00AM"],
+        roomCode: "MB 101",
+      }),
+    ]);
+    mountAtWidth(320);
+    render(TodayScreen);
+
+    const today = screen.getByRole("region", { name: /^Today,/ });
+    expect(
+      [...today.querySelectorAll(".today-entry__time")].map((el) =>
+        el.textContent?.trim(),
+      ),
+    ).toEqual(["7:00 AM – 8:00 AM", "3:00 PM – 5:00 PM"]);
+
+    // MW puts the same room on Monday and Wednesday; click today's.
+    await fireEvent.click(
+      today.querySelector<HTMLButtonElement>(".today-entry__room")!,
+    );
+    expect(queryStore.category).toBe("room");
+    expect(queryStore.queryValue).toBe("MB 101");
+    // Opening a room leaves the screen for the map behind it.
+    expect(sidebarStore.panelOpen).toBe("map");
+  });
+
+  test("renders an explicit empty state per day and a distinct Sunday", () => {
+    plannerStore.addOffering([row({ schedule: ["M 07:00AM-08:00AM"] })]);
+    render(TodayScreen);
+
+    // Tuesday has nothing planned.
+    const tomorrow = screen.getByRole("region", { name: /^Tomorrow,/ });
+    expect(
+      tomorrow.querySelector(".today-day__empty")?.textContent?.trim(),
+    ).toBe("No classes.");
+
+    const sunday = screen.getByRole("region", { name: /^Sunday,/ });
+    expect(sunday).toHaveClass("today-day--weekend");
+    expect(sunday.querySelector(".today-day__empty")?.textContent?.trim()).toBe(
+      "No classes on Sundays.",
+    );
+  });
+});

--- a/src/components/svelte/today/TodayScreen.svelte
+++ b/src/components/svelte/today/TodayScreen.svelte
@@ -1,0 +1,388 @@
+<script lang="ts">
+  import ChevronLeft from "@lucide/svelte/icons/chevron-left";
+  import MapPin from "@lucide/svelte/icons/map-pin";
+  import { fly } from "svelte/transition";
+  import { MediaQuery } from "svelte/reactivity";
+  import { trapFocus } from "@lib/focus-trap";
+  import { fullScreenReveal } from "@lib/motion";
+  import {
+    plannerStore,
+    queryStore,
+    sidebarStore,
+    termStore,
+  } from "@lib/store.svelte";
+  import { buildAgenda } from "@lib/today-agenda";
+  import { formatTermDateRange, isDateWithinTerm } from "@lib/term-calendar";
+  import TermSelector from "@ui/TermSelector.svelte";
+
+  const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
+
+  let screenEl = $state<HTMLDivElement | null>(null);
+
+  // Read-only over the planner's saved plan for the active term (#774).
+  const sections = $derived(plannerStore.activePlan?.sections ?? []);
+  const hasPlan = $derived(sections.length > 0);
+  const days = $derived(buildAgenda(sections));
+
+  // A plan for a term that is not in session would otherwise read as "you have
+  // nothing all week"; say which window the term actually covers instead.
+  const offTermNote = $derived.by(() => {
+    const term = termStore.activeTerm;
+    if (!term || isDateWithinTerm(term, new Date())) return null;
+    const range = formatTermDateRange(term);
+    return range ? `${term.label} runs ${range}.` : null;
+  });
+
+  function close() {
+    sidebarStore.changeOpened("map");
+  }
+
+  function openRoom(roomCode: string) {
+    if (!roomCode) return;
+    queryStore.updateQuery({
+      type: "result",
+      category: "room",
+      value: roomCode,
+    });
+    queryStore.inputValue = roomCode;
+    close();
+  }
+
+  $effect(() => {
+    if (!screenEl) return;
+    return trapFocus(screenEl, { onEscape: close });
+  });
+</script>
+
+<div
+  bind:this={screenEl}
+  class="today-screen"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="today-screen-title"
+  in:fly={fullScreenReveal(reducedMotion.current)}
+>
+  <header class="today-header">
+    <button
+      type="button"
+      class="today-back"
+      onclick={close}
+      aria-label="Back to map"
+      title="Back to map"
+    >
+      <ChevronLeft size={18} aria-hidden="true" />
+      <span>Back to map</span>
+    </button>
+    <h1 class="today-title" id="today-screen-title">Today</h1>
+    {#if termStore.terms.length > 0}
+      <TermSelector variant="chip" />
+    {/if}
+  </header>
+
+  {#if offTermNote}
+    <p class="today-note" role="note">{offTermNote}</p>
+  {/if}
+
+  <div class="today-body">
+    {#if !hasPlan}
+      <p class="today-empty-plan">
+        Add classes to see your day.
+        <button type="button" onclick={() => sidebarStore.changeOpened("planner")}>
+          Open the Planner
+        </button>
+      </p>
+    {:else}
+      {#each days as day (day.dateKey)}
+        <section
+          class="today-day"
+          class:today-day--now={day.isToday}
+          class:today-day--weekend={day.isWeekend}
+          aria-label="{day.title}, {day.dateLabel}"
+        >
+          <h2 class="today-day__heading">
+            <span class="today-day__title">{day.title}</span>
+            <span class="today-day__date">{day.dateLabel}</span>
+          </h2>
+          {#if day.entries.length === 0}
+            <p class="today-day__empty">{day.emptyLabel}</p>
+          {:else}
+            <ul class="today-entries">
+              {#each day.entries as entry (entry.courseCode + entry.section + entry.type + entry.startMin)}
+                <li class="today-entry">
+                  <span class="today-entry__time">{entry.timeLabel}</span>
+                  <span class="today-entry__main">
+                    <span class="today-entry__course">
+                      {entry.courseCode}
+                      <span class="today-entry__type">{entry.type}</span>
+                      <span class="today-entry__section">{entry.section}</span>
+                    </span>
+                    {#if entry.courseTitle}
+                      <span class="today-entry__course-title">
+                        {entry.courseTitle}
+                      </span>
+                    {/if}
+                  </span>
+                  {#if entry.roomCode}
+                    <button
+                      type="button"
+                      class="today-entry__room"
+                      onclick={() => openRoom(entry.roomCode ?? "")}
+                      title="Open {entry.roomCode} on the map"
+                    >
+                      <MapPin size={14} aria-hidden="true" />
+                      {entry.roomCode}
+                    </button>
+                  {:else}
+                    <span class="today-entry__room today-entry__room--tba">
+                      Room TBA
+                    </span>
+                  {/if}
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </section>
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .today-screen {
+    z-index: 150;
+    display: flex;
+    flex: 1 1 auto;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem calc(1rem + env(safe-area-inset-bottom, 0px));
+    background: hsl(0, 0%, 98%);
+    pointer-events: auto;
+    overflow: hidden;
+  }
+
+  .today-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .today-back {
+    all: unset;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: hsl(5, 53%, 32%);
+    cursor: pointer;
+  }
+
+  .today-back:hover {
+    background: hsl(5, 30%, 94%);
+  }
+
+  .today-back:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+  }
+
+  .today-title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 800;
+    color: hsl(0, 0%, 12%);
+  }
+
+  .today-note {
+    margin: 0;
+    max-width: 52rem;
+    font-size: 0.8125rem;
+    color: hsl(0, 0%, 40%);
+  }
+
+  .today-body {
+    flex: 1;
+    min-width: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .today-empty-plan {
+    margin: 0;
+    max-width: 52rem;
+    font-size: 0.875rem;
+    color: hsl(0, 0%, 35%);
+  }
+
+  .today-empty-plan button {
+    all: unset;
+    margin-left: 0.25rem;
+    color: hsl(5, 53%, 32%);
+    font-weight: 700;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .today-empty-plan button:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+  }
+
+  .today-day {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    max-width: 52rem;
+    min-width: 0;
+  }
+
+  .today-day__heading {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0.25rem 0;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: hsl(0, 0%, 20%);
+  }
+
+  .today-day--now .today-day__title {
+    color: hsl(5, 53%, 32%);
+  }
+
+  .today-day__date {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: hsl(0, 0%, 45%);
+  }
+
+  .today-day__empty {
+    margin: 0;
+    padding: 0.5rem 0.75rem;
+    border: 1px dashed hsl(0, 0%, 82%);
+    border-radius: 0.625rem;
+    font-size: 0.8125rem;
+    color: hsl(0, 0%, 45%);
+  }
+
+  /* Weekends read as a different kind of day, not just an empty weekday. */
+  .today-day--weekend .today-day__heading {
+    color: hsl(0, 0%, 45%);
+  }
+
+  .today-day--weekend .today-day__empty {
+    background: hsl(0, 0%, 95%);
+    border-style: solid;
+    border-color: hsl(0, 0%, 88%);
+  }
+
+  .today-entries {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .today-entry {
+    display: grid;
+    grid-template-columns: 10rem minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid hsl(0, 0%, 90%);
+    border-radius: 0.625rem;
+    background: white;
+  }
+
+  .today-entry__time {
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: hsl(0, 0%, 25%);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .today-entry__main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .today-entry__course {
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: hsl(0, 0%, 15%);
+  }
+
+  .today-entry__type,
+  .today-entry__section {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 42%);
+  }
+
+  .today-entry__course-title {
+    font-size: 0.75rem;
+    color: hsl(0, 0%, 42%);
+    overflow-wrap: anywhere;
+  }
+
+  .today-entry__room {
+    all: unset;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    justify-self: end;
+    min-height: 2rem;
+    padding: 0.25rem 0.625rem;
+    border: 1px solid hsl(5, 53%, 82%);
+    border-radius: 999px;
+    color: hsl(5, 53%, 32%);
+    font-size: 0.75rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .today-entry__room:hover,
+  .today-entry__room:focus-visible {
+    background: hsl(5, 53%, 96%);
+  }
+
+  .today-entry__room:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 1px;
+  }
+
+  .today-entry__room--tba {
+    border-color: hsl(0, 0%, 85%);
+    color: hsl(0, 0%, 45%);
+    cursor: default;
+  }
+
+  .today-entry__room--tba:hover {
+    background: transparent;
+  }
+
+  @media (max-width: 48rem) {
+    .today-screen {
+      padding: 0.75rem 0.75rem calc(0.75rem + env(safe-area-inset-bottom, 0px));
+    }
+
+    /* Stack so a long course title never pushes the room chip off a 320px row. */
+    .today-entry {
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .today-entry__time {
+      grid-column: 1 / -1;
+    }
+  }
+</style>

--- a/src/lib/entity-url-sync.store.test.ts
+++ b/src/lib/entity-url-sync.store.test.ts
@@ -1,0 +1,19 @@
+// Vitest, not bun test: this module reaches store.svelte, which needs runes.
+import { describe, expect, it } from "vitest";
+import { isScreenId } from "./entity-url-sync";
+
+// A screen missing here never syncs its path, so the sidebar entry opens it
+// while the URL stays on "/" (unshareable, wrong on back/forward).
+describe("isScreenId", () => {
+  it("recognizes every full-screen route", () => {
+    expect(isScreenId("today")).toBe(true);
+    expect(isScreenId("planner")).toBe(true);
+    expect(isScreenId("finals")).toBe(true);
+    expect(isScreenId("calendar")).toBe(true);
+  });
+
+  it("rejects sidebar panels that are not screens", () => {
+    expect(isScreenId("map")).toBe(false);
+    expect(isScreenId("settings")).toBe(false);
+  });
+});

--- a/src/lib/entity-url-sync.ts
+++ b/src/lib/entity-url-sync.ts
@@ -51,11 +51,17 @@ const HOME_PATH = "/";
 // notes: bare island props, trailing slash, and the SW denylist in
 // astro.config.mjs must cover each path here).
 const SCREEN_PATHS = {
+  today: "/today",
   planner: "/planner",
   finals: "/final-exams",
   calendar: "/calendar",
 } as const;
 export type ScreenId = keyof typeof SCREEN_PATHS;
+
+/** Keeps callers from re-listing the screens; adding one only touches SCREEN_PATHS. */
+export function isScreenId(value: string): value is ScreenId {
+  return Object.hasOwn(SCREEN_PATHS, value);
+}
 
 /**
  * Only schedule-bearing surfaces carry ?term=. Establishments, offices/units,
@@ -177,7 +183,7 @@ export function createEntityUrlSync(context: EntityUrlSyncContext) {
     applyingFromHistory = true;
     try {
       termStore.applyFromUrl();
-      // Back/forward into or out of /planner, /final-exams toggles that screen.
+      // Back/forward into or out of /today, /planner, /final-exams toggles it.
       context.setScreen(
         SCREEN_BY_NORMALIZED_PATH.get(currentPathname()) ?? null,
       );

--- a/src/lib/stores/store-types.ts
+++ b/src/lib/stores/store-types.ts
@@ -31,6 +31,7 @@ export interface QueryStoreState {
 
 export type SidebarOpenType =
   | "map"
+  | "today"
   | "planner"
   | "finals"
   | "calendar"

--- a/src/lib/term-calendar.ts
+++ b/src/lib/term-calendar.ts
@@ -82,6 +82,7 @@ export function changeOfMatriculationLabel(
   });
 }
 
+/** YYYY-MM-DD for `date` as seen in Asia/Manila — the app's notion of "today". */
 export function toManilaDateKey(date: Date) {
   return date.toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
 }

--- a/src/lib/today-agenda.test.ts
+++ b/src/lib/today-agenda.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import { buildAgenda, formatTimeRange } from "./today-agenda";
+import type { PlannedSection } from "./planner/types";
+
+const section = (overrides: Partial<PlannedSection> = {}): PlannedSection => ({
+  courseCode: "CMSC 128",
+  section: "AB-1L",
+  type: "LEC",
+  schedule: ["MW 07:00AM-08:00AM"],
+  roomCode: "ICS MH1",
+  courseTitle: "Software Engineering",
+  ...overrides,
+});
+
+// 2026-07-27 is a Monday in Manila.
+const MONDAY_NOON_MANILA = new Date("2026-07-27T04:00:00Z");
+
+describe("buildAgenda", () => {
+  it("buckets today and tomorrow from the Manila calendar day", () => {
+    const days = buildAgenda(
+      [
+        section(),
+        section({
+          courseCode: "MATH 27",
+          section: "B-2",
+          type: "LEC",
+          schedule: ["TTh 10:00AM-11:30AM"],
+          roomCode: "MB 101",
+        }),
+      ],
+      { now: MONDAY_NOON_MANILA },
+    );
+
+    expect(days).toHaveLength(7);
+    expect(days[0].title).toBe("Today");
+    expect(days[0].dateKey).toBe("2026-07-27");
+    expect(days[0].entries.map((e) => e.courseCode)).toEqual(["CMSC 128"]);
+
+    expect(days[1].title).toBe("Tomorrow");
+    expect(days[1].dateKey).toBe("2026-07-28");
+    expect(days[1].entries.map((e) => e.courseCode)).toEqual(["MATH 27"]);
+
+    // Wednesday carries the second half of the MW lecture.
+    expect(days[2].title).toBe("Wednesday");
+    expect(days[2].entries.map((e) => e.courseCode)).toEqual(["CMSC 128"]);
+  });
+
+  it("orders a day's classes by start time", () => {
+    const [today] = buildAgenda(
+      [
+        section({ courseCode: "PE 2", schedule: ["M 03:00PM-05:00PM"] }),
+        section({ courseCode: "CMSC 128", schedule: ["M 07:00AM-08:00AM"] }),
+        section({ courseCode: "BIO 30", schedule: ["M 10:00AM-11:00AM"] }),
+      ],
+      { now: MONDAY_NOON_MANILA, days: 1 },
+    );
+
+    expect(today.entries.map((e) => e.courseCode)).toEqual([
+      "CMSC 128",
+      "BIO 30",
+      "PE 2",
+    ]);
+    expect(today.entries[0].timeLabel).toBe("7:00 AM – 8:00 AM");
+    expect(today.entries[2].timeLabel).toBe("3:00 PM – 5:00 PM");
+  });
+
+  it("rolls over at the Manila day boundary, not UTC", () => {
+    // 2026-07-27T17:00Z is already Tuesday 01:00 in Manila (UTC+8).
+    const [today] = buildAgenda([section()], {
+      now: new Date("2026-07-27T17:00:00Z"),
+      days: 1,
+    });
+    expect(today.dateKey).toBe("2026-07-28");
+
+    // One minute before Manila midnight it is still Monday.
+    const [stillMonday] = buildAgenda([section()], {
+      now: new Date("2026-07-27T15:59:00Z"),
+      days: 1,
+    });
+    expect(stillMonday.dateKey).toBe("2026-07-27");
+    expect(stillMonday.entries).toHaveLength(1);
+  });
+
+  it("marks the weekend and never schedules Sunday", () => {
+    const days = buildAgenda(
+      [section({ schedule: ["TThS 08:00AM-09:00AM"] })],
+      { now: MONDAY_NOON_MANILA },
+    );
+    const saturday = days.find((day) => day.dateKey === "2026-08-01");
+    const sunday = days.find((day) => day.dateKey === "2026-08-02");
+
+    expect(saturday?.isWeekend).toBe(true);
+    expect(saturday?.dayIndex).toBe(5);
+    expect(saturday?.entries).toHaveLength(1);
+
+    expect(sunday?.isWeekend).toBe(true);
+    expect(sunday?.dayIndex).toBeNull();
+    expect(sunday?.entries).toHaveLength(0);
+    expect(sunday?.emptyLabel).toBe("No classes on Sundays.");
+
+    expect(days[0].isWeekend).toBe(false);
+  });
+
+  it("returns empty days for an empty plan", () => {
+    const days = buildAgenda([], { now: MONDAY_NOON_MANILA });
+    expect(days).toHaveLength(7);
+    expect(days.every((day) => day.entries.length === 0)).toBe(true);
+    expect(days[0].emptyLabel).toBe("No classes today.");
+    expect(days[2].emptyLabel).toBe("No classes.");
+  });
+
+  it("skips stale and TBA sections", () => {
+    const days = buildAgenda(
+      [
+        section({ stale: true }),
+        section({ courseCode: "HIST 1", schedule: ["TBA"] }),
+      ],
+      { now: MONDAY_NOON_MANILA },
+    );
+    expect(days.every((day) => day.entries.length === 0)).toBe(true);
+  });
+});
+
+describe("formatTimeRange", () => {
+  it("formats noon and midnight without a zero hour", () => {
+    expect(formatTimeRange(0, 30)).toBe("12:00 AM – 12:30 AM");
+    expect(formatTimeRange(720, 780)).toBe("12:00 PM – 1:00 PM");
+  });
+});

--- a/src/lib/today-agenda.ts
+++ b/src/lib/today-agenda.ts
@@ -1,0 +1,144 @@
+// Today screen (#774): a read-only agenda over the planner's saved sections.
+// Day boundaries are Asia/Manila — the same notion of "today" the term
+// selector uses (term-calendar.ts).
+
+import { sectionBlocks } from "./planner/conflicts.js";
+import type { PlannedSection } from "./planner/types.js";
+import { toManilaDateKey } from "./term-calendar.js";
+
+export type AgendaEntry = {
+  courseCode: string;
+  section: string;
+  type: string;
+  roomCode: string | null;
+  courseTitle: string | null;
+  /** Minutes since midnight. */
+  startMin: number;
+  endMin: number;
+  /** "7:00 AM – 8:00 AM" */
+  timeLabel: string;
+};
+
+export type AgendaDay = {
+  /** YYYY-MM-DD, Asia/Manila. */
+  dateKey: string;
+  /** 0-5 = Mon-Sat (matches parseDays); null on Sunday, which AMIS never schedules. */
+  dayIndex: number | null;
+  /** "Today" | "Tomorrow" | "Wednesday" */
+  title: string;
+  /** "Jul 29" */
+  dateLabel: string;
+  isToday: boolean;
+  isWeekend: boolean;
+  /** Copy to show when `entries` is empty. */
+  emptyLabel: string;
+  entries: AgendaEntry[];
+};
+
+const WEEKDAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+/** Parse a YYYY-MM-DD key as a UTC instant so day math never crosses a zone. */
+function keyToUtc(dateKey: string): Date {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function addDays(dateKey: string, days: number): string {
+  const date = keyToUtc(dateKey);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+/** "7:00 AM" from minutes since midnight. */
+function formatClock(minutes: number): string {
+  const hour24 = Math.floor(minutes / 60) % 24;
+  const minute = minutes % 60;
+  const period = hour24 >= 12 ? "PM" : "AM";
+  const hour = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  return `${hour}:${String(minute).padStart(2, "0")} ${period}`;
+}
+
+export function formatTimeRange(startMin: number, endMin: number): string {
+  return `${formatClock(startMin)} – ${formatClock(endMin)}`;
+}
+
+/**
+ * Agenda for `days` consecutive Manila days starting with today.
+ *
+ * Stale sections (natural key gone after a term reimport) are left out — they
+ * are not classes anyone can attend; the planner lists them separately. TBA
+ * and unparseable schedule strings produce no blocks, so they drop out too.
+ */
+export function buildAgenda(
+  sections: PlannedSection[],
+  options: { now?: Date; days?: number } = {},
+): AgendaDay[] {
+  const todayKey = toManilaDateKey(options.now ?? new Date());
+  const dayCount = options.days ?? 7;
+
+  const byDayIndex = new Map<number, AgendaEntry[]>();
+  for (const section of sections) {
+    if (section.stale) continue;
+    for (const block of sectionBlocks(section)) {
+      const entries = byDayIndex.get(block.dayIndex) ?? [];
+      entries.push({
+        courseCode: section.courseCode,
+        section: section.section,
+        type: section.type,
+        roomCode: section.roomCode,
+        courseTitle: section.courseTitle ?? null,
+        startMin: block.startMin,
+        endMin: block.endMin,
+        timeLabel: formatTimeRange(block.startMin, block.endMin),
+      });
+      byDayIndex.set(block.dayIndex, entries);
+    }
+  }
+  for (const entries of byDayIndex.values()) {
+    entries.sort(
+      (a, b) =>
+        a.startMin - b.startMin || a.courseCode.localeCompare(b.courseCode),
+    );
+  }
+
+  return Array.from({ length: dayCount }, (_, offset) => {
+    const dateKey = addDays(todayKey, offset);
+    const weekday = keyToUtc(dateKey).getUTCDay(); // 0 = Sunday
+    const dayIndex = weekday === 0 ? null : weekday - 1;
+    const isToday = offset === 0;
+    return {
+      dateKey,
+      dayIndex,
+      title:
+        offset === 0
+          ? "Today"
+          : offset === 1
+            ? "Tomorrow"
+            : WEEKDAY_NAMES[weekday],
+      dateLabel: keyToUtc(dateKey).toLocaleDateString("en-PH", {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      }),
+      isToday,
+      // Saturday still carries classes at UPLB (midyear TTHS blocks); it is
+      // styled as a weekend but only Sunday gets the "never any classes" copy.
+      isWeekend: weekday === 0 || weekday === 6,
+      emptyLabel:
+        weekday === 0
+          ? "No classes on Sundays."
+          : isToday
+            ? "No classes today."
+            : "No classes.",
+      entries: dayIndex === null ? [] : (byDayIndex.get(dayIndex) ?? []),
+    };
+  });
+}

--- a/src/pages/today.astro
+++ b/src/pages/today.astro
@@ -1,0 +1,39 @@
+---
+import AppRoot from "@ui/AppRoot.svelte";
+import Layout from "@layouts/Layout.astro";
+import {
+  breadcrumbSchema,
+  jsonLd,
+  ogCardPath,
+  webpageSchema,
+  websiteSchema,
+} from "@lib/site";
+
+// Deep link to the Today agenda: /today?term=<crs_id>. Entry.svelte opens the
+// screen on this path; the term comes from ?term via termStore.
+const title = "Today | Room TBA";
+const description =
+  "Your UPLB classes today, tomorrow, and the rest of the week — in time order, with a link to each room on the campus map.";
+const structuredData = jsonLd(
+  websiteSchema(),
+  webpageSchema({ title, description, path: "/today" }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Today", path: "/today" },
+  ]),
+);
+---
+
+<Layout
+  title={title}
+  description={description}
+  canonicalPath="/today"
+  imagePath={ogCardPath({
+    title: "Today",
+    subtitle: "Your next UPLB classes at a glance",
+    kicker: "Today",
+  })}
+  structuredData={structuredData}
+>
+  <AppRoot client:only="svelte" openToday={true} suppressLandingModal={true} />
+</Layout>


### PR DESCRIPTION
Implements #774 — a Today screen answering "what do I have today, and where is it?" from the plan the user already saved in the Planner.

## What shipped (MVP scope)

- **`/today`** full screen: today's sections in time order (course code, section, activity type, time window, room), then tomorrow and the rest of the week (7 days).
- **Room links** open the existing room panel and sync the canonical `/room/<slug>/` URL — same `openRoom` path the Planner already uses. Sections without a room render an inert "Room TBA" chip.
- **Empty states per day** ("No classes today." / "No classes.") and a distinct weekend treatment; Sunday gets its own copy ("No classes on Sundays.") because AMIS never schedules it. Saturday stays a real class day (midyear `TTHS` blocks) but is styled as a weekend.
- **Empty planner** shows "Add classes to see your day. **Open the Planner**" instead of a blank week.
- **Asia/Manila day boundaries**, from `term-calendar.ts`'s `toManilaDateKey` — the same notion of "today" the term selector uses.
- **Sidebar entry** above Planner, plus direct URL / deep link.
- Off-term note: when the active term is not in session, the screen says which window it covers rather than implying an empty week.

## Reuse over reinvention

- `sectionBlocks()` (`src/lib/planner/conflicts.ts`) already parses AMIS day codes and times into `{dayIndex, startMin, endMin}` — no second day-code parser.
- `toManilaDateKey` / `isDateWithinTerm` / `formatTermDateRange` from `term-calendar.ts`.
- Screen registration copies `/planner` and `/final-exams` exactly: `SCREEN_PATHS` entry, workbox `navigateFallbackDenylist` regex that covers the query string (`/^\/today(\/|\?|$)/`), explicit island props (`openToday={true}`), and trailing-slash-normalized path comparison via the existing `SCREEN_BY_NORMALIZED_PATH`.
- `openRoom` mirrors `PlannerScreen.svelte`.

**One shared-code fix:** `EntityUrlSync.svelte` hard-coded the screen list (`panelOpen === "planner" || … === "finals"`), so a new screen would open but never sync its URL. Replaced with `isScreenId()` reading `SCREEN_PATHS` — adding a screen now touches one place. This also picked up `/calendar` (#769), which landed on staging while this branch was in flight.

## Tests

- `src/lib/today-agenda.test.ts` (bun): today/tomorrow bucketing, time ordering, Manila boundary rollover (17:00Z is already tomorrow in Manila; 15:59Z is not), weekend + Sunday detection, empty plan, stale/TBA sections excluded, 12-hour clock edges.
- `src/lib/entity-url-sync.store.test.ts` (vitest — the module reaches runes): every full-screen route is a registered `ScreenId`. This is the regression guard for the URL-sync drift above.
- `src/components/svelte/today/TodayScreen.component.test.ts` (vitest, fake `Date` only so Svelte's scheduler keeps real timers): empty-plan hint opens the Planner, today's classes list in time order with a working room link, per-day empty state and the distinct Sunday.

Local: `bun run test` 438 pass / 0 fail · `bunx vitest run` 160 pass / 0 fail · `bunx biome check` clean on touched files · `bun run build` green · `check:pwa-legal` + `check:readme` pass.

## Browser QA (local dev, real DB)

Verified at 1280px and 320px, 0 console errors: `/today` renders the agenda; today was a Sunday so the Sunday state showed live; a seeded plan listed Mon–Sat entries in time order; clicking `CEAT B-103` opened the room panel and pushed `/room/ceat-b-103-196/`; the sidebar Today entry pushed `/today`. No horizontal page overflow at 320px and the room chip stays inside its row.

## CI

**Gated E2E is intentionally not triggered on this PR** (no `run/e2e` label): a release is using the shared E2E database and concurrent runs exhaust its connection pool. Please run it serially once the release finishes.

## Deferred (issue's own nice-to-haves)

Next-class countdown + walk-time, per-day weather, and exam-day callouts from `final_exams` — all listed as defer in the issue.

Refs #774
