### PR TITLE
fix(og): drop the redundant wordmark headline on the default card

### DIFF
--- a/src/pages/og.png.ts
+++ b/src/pages/og.png.ts
@@ -42,7 +42,10 @@ function clamp(value: string | null, max: number): string {
 
 export const GET: APIRoute = async ({ url }) => {
   // Exact-URL content is passed by the page: t=title, s=subtitle, k=kicker.
-  const title = clamp(url.searchParams.get("t"), 90) || "Room TBA";
+  // No title param means a page that did not name itself (the homepage).
+  // The wordmark badge already brands the card, so repeating "Room TBA" as
+  // the headline made it appear three times: site name, badge, headline.
+  const title = clamp(url.searchParams.get("t"), 90);
   const subtitle = clamp(url.searchParams.get("s"), 96);
   const kicker = clamp(url.searchParams.get("k"), 40);
 
@@ -161,23 +164,26 @@ export const GET: APIRoute = async ({ url }) => {
             maxWidth: 1040,
           },
         },
-        h(
-          "div",
-          {
-            style: {
-              // block + lineClamp keeps entity names inside the card.
-              display: "block",
-              lineClamp: 2,
-              fontSize: title.length > 42 ? 60 : title.length > 30 ? 72 : 86,
-              fontWeight: 700,
-              lineHeight: 1.04,
-              letterSpacing: "-0.03em",
-              color: WHITE,
-              textShadow: "0 3px 10px rgba(0, 0, 0, 0.55)",
-            },
-          },
-          title,
-        ),
+        title
+          ? h(
+              "div",
+              {
+                style: {
+                  // block + lineClamp keeps entity names inside the card.
+                  display: "block",
+                  lineClamp: 2,
+                  fontSize:
+                    title.length > 42 ? 60 : title.length > 30 ? 72 : 86,
+                  fontWeight: 700,
+                  lineHeight: 1.04,
+                  letterSpacing: "-0.03em",
+                  color: WHITE,
+                  textShadow: "0 3px 10px rgba(0, 0, 0, 0.55)",
+                },
+              },
+              title,
+            )
+          : h("div", { style: { display: "flex" } }),
         subtitle
           ? h(
               "div",


### PR DESCRIPTION
The name "Room TBA" appeared **three times** in one share preview: the `og:site_name` line above the image, the wordmark badge inside it, and the headline baked into the image.

## Cause

`src/pages/og.png.ts` defaulted `title` to `"Room TBA"` when no `t=` param was passed. The homepage passes none, so its card rendered the brand as its own headline. Entity pages were never affected, since they pass a real title (`t=Physical Sciences Building`).

## Fix

No title means no headline. The badge already carries the brand.

## Verified by rendering both variants

Built the node target and hit the live route rather than reasoning about it:

- **Default card** (`/og.png`): campus photo plus the badge, nothing else.
- **Entity card** (`/og.png?t=Physical+Sciences+Building&s=College+of+Arts+and+Sciences&k=Building`): unchanged. Headline, subtitle, and the BUILDING kicker all still render.

Both returned 200. `bun run test` 431 pass, biome clean, build green.

Follows #767, which made these cards vary by query string at all.