### PR TITLE
docs(wiki): add UPCAT at UPLB guide for examinees and parents

### DIFF
--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -15,6 +15,14 @@ const articles = [
     sourcePath: "src/pages/faq.astro",
   },
   {
+    href: "/wiki/upcat-at-uplb",
+    kicker: "UPCAT at UPLB · 8 min read",
+    title: "Taking the UPCAT at UP Los Baños",
+    blurb:
+      "For examinees and the parents driving them, August 1 and 2, 2026. What the test permit does and does not tell you, the two campus jeepney routes, and how to save the campus map before mobile data gets congested.",
+    sourcePath: "src/pages/wiki/upcat-at-uplb.astro",
+  },
+  {
     href: "/wiki/fork-for-your-campus",
     kicker: "For other campuses · 6 min read",
     title: "Fork this for your campus",

--- a/src/pages/wiki/upcat-at-uplb.astro
+++ b/src/pages/wiki/upcat-at-uplb.astro
@@ -1,0 +1,898 @@
+---
+export const prerender = true;
+
+import WikiLayout from "@layouts/WikiLayout.astro";
+import WikiProvenance from "../../components/wiki/WikiProvenance.astro";
+import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";
+
+const title = "Taking the UPCAT at UP Los Baños | Room TBA Wiki";
+const description =
+  "A first-timer's guide to the UPCAT at UPLB on August 1 and 2, 2026: what the test permit does and does not tell you, how to get on campus, and how to load the campus map before mobile data gets congested.";
+
+/** What the UP Office of Admissions says the permit carries. */
+const permitFields = [
+  { field: "Identification number", note: "Your examinee number. Bring it written down somewhere else too." },
+  { field: "Place", note: "The test center. At UPLB this is a campus, not a room." },
+  { field: "Date", note: "Which of the two exam days is yours. Check it now, not on the morning." },
+  { field: "Time", note: "When to report. Being early is the whole strategy." },
+  { field: "PIN", note: "Used with your identification number." },
+  { field: "Name", note: "Must match the ID you bring." },
+  { field: "High school", note: "The school you are testing from." },
+] as const;
+
+const permitOmissions = [
+  "Your room.",
+  "Your building.",
+  "Your seat.",
+  "Which entrance or gate to use.",
+] as const;
+
+/** jeepney_routes + jeepney_stops, Room TBA production database. */
+const jeepneyRoutes = [
+  {
+    id: "Kaliwa / Kanan",
+    links:
+      "Olivarez Plaza in Los Baños town and the UPLB academic core, passing Raymundo Gate, the Main Library, the dormitories, and CEAT.",
+    stops: 20,
+  },
+  {
+    id: "Forestry",
+    links:
+      "The Forestry jeep terminal up to the upper Forestry campus, past the Main Library area, Narra Bridge, and the University Health Service.",
+    stops: 7,
+  },
+] as const;
+
+const fareRegular = 13;
+const fareDiscounted = 11;
+
+/** Kaliwa order. Kanan runs the same loop in reverse. */
+const kaliwaKananStops = [
+  "Olivarez Plaza Mall",
+  "Robinsons Town Mall",
+  "Carabao Park / DevCom",
+  "Raymundo Gate",
+  "CAP-CSI",
+  "Sacay",
+  "Main Library",
+  "Graduate School / Umali",
+  "Women's Dormitory",
+  "Men's Dormitory",
+  "Baker Hall",
+  "Animal Husbandry",
+  "Agronomy Building",
+  "College of Engineering and Agro-Industrial Technology",
+  "Senior's Social Garden",
+  "Headquarters",
+  "St. Therese / Math Building",
+  "Makiling School",
+  "Carabao Park / Landbank",
+  "Olivarez Plaza Mall",
+] as const;
+
+const forestryStops = [
+  "Forestry Jeep Terminal",
+  "CEM Jeepney Stop",
+  "OVCRE Annex Building",
+  "Narra Bridge",
+  "Maria Makiling Statue",
+  "UP University Health Service",
+  "Forest Biological Sciences Building",
+] as const;
+
+/** places table, category census. */
+const placeCategories = [
+  { category: "Landmark", count: 19, useful: "Meeting points. Easier to name over the phone than a building code." },
+  { category: "Tourist spot", count: 15, useful: "Mostly Makiling and the Forestry campus. Not where you want to be on exam morning." },
+  { category: "Food", count: 11, useful: "Split between on-campus canteens and the strip just outside Raymundo Gate." },
+  { category: "Transport", count: 2, useful: "Parking and a campus stop." },
+  { category: "Service", count: 2, useful: "Chapels near the campus core." },
+] as const;
+
+const foodOnCampus = [
+  { name: "Student Union Canteen", where: "Student Union Building, central main campus", what: "Food stalls inside the student center." },
+  { name: "DTRI Dairy Bar", where: "DTRI complex, southeastern main campus", what: "Fresh milk, cheese, and ice cream from the dairy institute." },
+  { name: "SEARCA Canteen", where: "SEARCA building, central main campus", what: "Canteen in the SEARCA building." },
+  { name: "IRRI Cafeteria", where: "IRRI headquarters campus", what: "Open to visitors, but it is a separate campus from the academic core." },
+] as const;
+
+const foodOutside = [
+  { name: "R.M. Cadapan's Canteen", where: "Raymundo Gate area, Batong Malake", what: "Long-standing budget canteen near campus." },
+  { name: "Aling Glo's Restaurant", where: "Grove area, Batong Malake", what: "Budget eatery popular with students." },
+  { name: "But First, Coffee", where: "Grove area, Batong Malake", what: "Cafe just outside campus." },
+  { name: "Black And Brew Cafe", where: "Grove area, Batong Malake", what: "Coffee shop near the Vega Centre strip." },
+  { name: "Vega Centre", where: "Grove area, Batong Malake", what: "Commercial arcade with food stalls and services." },
+  { name: "Vraja Cuisine", where: "Campus oval area near UPLB Alumni Plaza", what: "Vegetarian and vegan cafe." },
+] as const;
+
+const waitingSpots = [
+  { name: "Carabao Park (UPCA Alumni Plaza)", why: "Plaza with the carabao head sculptures. The first thing most people recognise coming in, and a jeepney stop in both loop directions." },
+  { name: "Freedom Park and the UPLB Grandstand", why: "Open ground along the campus oval with the grandstand for seating." },
+  { name: "Seniors' Social Garden", why: "Garden between Freedom Park and the Mathematics Building. Also a Kaliwa / Kanan stop." },
+  { name: "Oblation Park", why: "Fronts B.M. Gonzalez Hall, the main administration building. Unmistakable over the phone." },
+  { name: "UPLB Alumni Plaza and the Carillon Tower", why: "Campus oval area. Visible landmark to steer someone toward." },
+] as const;
+
+const cannotAnswer = [
+  {
+    question: "Which room am I in?",
+    answer:
+      "Nobody can tell you in advance. The examiner assigns seats on the day. Room TBA holds 530 room records for UPLB and not one of them is your UPCAT room, because that assignment does not exist in any public data until an examiner reads it out.",
+  },
+  {
+    question: "Where exactly do I report on the UPLB campus?",
+    answer:
+      "Not published as of the date on this page. See the section above for who publishes it and where to watch.",
+  },
+  {
+    question: "Which buildings are being used?",
+    answer:
+      "Not published. Guessing from where classes normally meet would be a guess, and a wrong one puts you on the far side of a large campus.",
+  },
+  {
+    question: "Is that canteen open on exam day?",
+    answer:
+      "Unknown. Room TBA stores no opening hours for any of its 49 places, and both exam days fall on a weekend.",
+  },
+  {
+    question: "Where can I park?",
+    answer:
+      "Not published for exam day. The app records two transport entries and neither is an exam-day parking arrangement.",
+  },
+] as const;
+
+const structuredData = jsonLd(
+  webpageSchema({ title, description, path: "/wiki/upcat-at-uplb" }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Wiki", path: "/wiki" },
+    { name: "UPCAT at UPLB", path: "/wiki/upcat-at-uplb" },
+  ]),
+);
+---
+
+<WikiLayout
+  {title}
+  {description}
+  canonicalPath="/wiki/upcat-at-uplb"
+  {structuredData}
+>
+  <article class="wiki-article">
+    <header class="article-hero">
+      <p class="wiki-eyebrow">UPCAT at UPLB</p>
+      <h1 class="wiki-title">Taking the UPCAT at UP Los Baños</h1>
+      <p class="wiki-lede">
+        You have a test permit, a date, and a campus you have never walked. This
+        page covers the part Room TBA is actually good for, which is getting a
+        stranger from a gate to a building, and is blunt about the parts nobody
+        has published yet. Written for the examinee and for the parent doing the
+        driving and the waiting.
+      </p>
+      <p class="article-meta">
+        UPCAT for AY 2027 to 2028 is on <strong>August 1 and 2, 2026</strong>, a
+        Saturday and a Sunday. Campus figures on this page are a census of the
+        Room TBA production database on July 27, 2026: 52 buildings, 530 rooms,
+        2 jeepney routes, 27 stops, 49 places, 79 name aliases. UPLB
+        campus-specific exam instructions were <strong>not published</strong> at
+        the time of writing.
+      </p>
+      <WikiProvenance sourcePath="src/pages/wiki/upcat-at-uplb.astro" />
+    </header>
+
+    <nav class="toc" aria-label="On this page">
+      <p class="toc__title">On this page</p>
+      <ol>
+        <li><a href="#start-here">The short version</a></li>
+        <li><a href="#offline">Load the campus map before you arrive</a></li>
+        <li><a href="#permit">What the permit says, and what it does not</a></li>
+        <li><a href="#not-published">What UPLB has not published yet</a></li>
+        <li><a href="#getting-there">Getting to campus and moving around it</a></li>
+        <li><a href="#finding-the-building">Finding a building once someone names it</a></li>
+        <li><a href="#parent">For the parent who waits</a></li>
+        <li><a href="#cannot">What no app can tell you, including this one</a></li>
+        <li><a href="#sources">Sources</a></li>
+      </ol>
+    </nav>
+
+    <section aria-labelledby="start-here">
+      <h2 id="start-here">The short version</h2>
+      <ul class="break-list">
+        <li>
+          <strong>Your permit has no room on it.</strong> It never did. The
+          examiner assigns your seat on the day and you do not get to choose it.
+        </li>
+        <li>
+          <strong>Download the campus map tonight, on wifi.</strong> Not at the
+          gate. Thousands of people will be sharing the same cell towers on the
+          same morning.
+        </li>
+        <li>
+          <strong>Check which of the two days is yours.</strong> The permit
+          carries the date. August 1 is a Saturday, August 2 is a Sunday.
+        </li>
+        <li>
+          <strong>Watch for the UPLB advisory.</strong> The campus-specific
+          instructions (where to report, what time, gates) come from the UPLB
+          Office of the University Registrar and the UP Office of Admissions,
+          usually only days before. They were not out when this page was
+          written.
+        </li>
+        <li>
+          <strong>Arrive early enough to be lost and still be fine.</strong>
+          UPLB is a large, spread-out campus. Walking from one end of the
+          academic core to the other is not a five-minute thing.
+        </li>
+      </ul>
+    </section>
+
+    <aside class="article-callout article-callout--action" aria-labelledby="offline">
+      <h2 id="offline">Load the campus map before you arrive</h2>
+      <p>
+        This is the single most useful thing this site can do for you, and it
+        only works if you do it <em>before</em> exam morning. Room TBA stores
+        the campus map and directory on your device, so it keeps working with no
+        signal. Mobile data around a test center with thousands of examinees and
+        their families is congested at exactly the moment you need it.
+      </p>
+      <p><strong>Do this the night before, on home wifi:</strong></p>
+      <ol class="steps">
+        <li>Open the map at <code>room-tba.uplbtools.me</code>.</li>
+        <li>
+          In the sidebar, open <strong>Offline maps</strong> (the cloud with the
+          down arrow).
+        </li>
+        <li>
+          Tap <strong>Download campus map</strong>. This saves the map tiles
+          covering the campus so the map still draws with no connection.
+        </li>
+        <li>
+          Tap <strong>Download campus directory</strong>. This saves the
+          buildings, rooms, and places, so search and walking directions still
+          work offline.
+        </li>
+      </ol>
+      <p>
+        The panel shows how many tiles were saved and how much space they took,
+        so you can confirm it actually finished rather than hoping. If you are
+        installing Room TBA to your home screen, do that first, then download.
+      </p>
+      <p class="figure-note">
+        One honest limit: the offline copy is the <em>map app</em>. This wiki
+        page is served fresh from the network and is not part of the offline
+        bundle, so read it or screenshot it now rather than planning to open it
+        from the queue.
+      </p>
+    </aside>
+
+    <section aria-labelledby="permit">
+      <h2 id="permit">What the permit says, and what it does not</h2>
+      <p>
+        Test permits went out in July. Most of the panic on the morning comes
+        from people expecting the permit to be more specific than it is. It is
+        not a seat assignment. It is proof you are expected somewhere.
+      </p>
+      <p class="table-hint">Scroll sideways for the full table.</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">On the permit</th>
+              <th scope="col">What to do with it</th>
+            </tr>
+          </thead>
+          <tbody>
+            {permitFields.map((row) => (
+              <tr>
+                <td><strong>{row.field}</strong></td>
+                <td>{row.note}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 id="permit-omissions">Not on the permit</h3>
+      <ul class="break-list">
+        {permitOmissions.map((item) => (
+          <li>{item}</li>
+        ))}
+      </ul>
+      <p>
+        The UP Office of Admissions is explicit about this. At test centers that
+        use several rooms or several buildings, the address on the permit is a
+        <strong> centralized reporting location</strong>. You go there first,
+        and you are directed to your room from there on the day. The examiner
+        assigns seats. Examinees may not choose their seat, their room, or their
+        building.
+      </p>
+      <p>
+        UPLB is exactly that kind of center. It is a whole campus, so treat the
+        permit as telling you which campus and which morning, and nothing
+        finer.
+      </p>
+      <p class="figure-note">
+        UP Los Baños appears under Region 4-A on the UP Office of Admissions
+        list of UPCAT test centers. That page carries no year, so read it as a
+        standing list of centers rather than a confirmed roster for this
+        particular cycle. For scale: the previous cycle, UPCAT 2026, used 117
+        testing centers nationwide.
+      </p>
+    </section>
+
+    <aside class="article-callout" aria-labelledby="not-published">
+      <h2 id="not-published">What UPLB has not published yet</h2>
+      <p>
+        We are not going to guess this part. A confident guess about where to
+        report could send a teenager to the wrong side of a large campus on the
+        morning of the exam, and there is no recovering from that at 6am.
+      </p>
+      <p>As of the date on this page, we could not establish any of these:</p>
+      <ul class="break-list">
+        <li>The reporting venue or assembly area on the UPLB campus.</li>
+        <li>Which buildings or rooms are being used.</li>
+        <li>Gate arrangements, or which gate examinees should enter through.</li>
+        <li>The reporting time UPLB itself is asking examinees to follow.</li>
+        <li>Parking, drop-off arrangements, or a designated waiting area for parents.</li>
+        <li>Any shuttle service between a drop-off point and the venue.</li>
+      </ul>
+      <p><strong>Who actually publishes this, and where to watch:</strong></p>
+      <ul class="break-list">
+        <li>
+          <strong>UPLB Office of the University Registrar</strong>, at
+          <a class="wiki-link" href="https://our.uplb.edu.ph" target="_blank" rel="noopener noreferrer">our.uplb.edu.ph</a>
+          and on its Facebook page. Campus-specific instructions usually appear
+          only days before the exam.
+        </li>
+        <li>
+          <strong>UP Office of Admissions</strong>, at
+          <a class="wiki-link" href="https://upcat.up.edu.ph" target="_blank" rel="noopener noreferrer">upcat.up.edu.ph</a>
+          and on its Facebook page, for system-wide instructions.
+        </li>
+      </ul>
+      <p>
+        If someone hands you a screenshot naming a venue, check it against one
+        of those two before you act on it. Screenshots of last year's advisory
+        circulate every year.
+      </p>
+      <p class="figure-note">
+        Are you a UPLB student, staff member, or volunteer holding the official
+        advisory? This page has an <strong>Edit on GitHub</strong> link in the
+        byline above. Adding the sourced venue and reporting time here, with the
+        link to the official post, is a genuinely useful ten minutes.
+      </p>
+    </aside>
+
+    <section aria-labelledby="getting-there">
+      <h2 id="getting-there">Getting to campus and moving around it</h2>
+      <p>
+        Room TBA records two jeepney routes for UPLB, with 27 stops between
+        them. These are the ordinary campus routes, not exam-day arrangements.
+      </p>
+      <p class="table-hint">Scroll sideways for the full table.</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Route</th>
+              <th scope="col">What it links</th>
+              <th scope="col">Stops</th>
+            </tr>
+          </thead>
+          <tbody>
+            {jeepneyRoutes.map((route) => (
+              <tr>
+                <td><strong>{route.id}</strong></td>
+                <td>{route.links}</td>
+                <td class="num">{route.stops}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p class="figure-note">
+        Recorded fare on both routes: {fareRegular} pesos regular,
+        {" "}{fareDiscounted} pesos discounted. Fares change and the app is not
+        the authority on them. Carry coins and small bills.
+      </p>
+
+      <h3 id="kaliwa-kanan">Kaliwa and Kanan are the same loop</h3>
+      <p>
+        This confuses first-timers more than anything else on campus.
+        <strong> Kaliwa</strong> and <strong>Kanan</strong> are not two
+        different destinations. They are one loop, and the name tells you which
+        way the jeep turns after it enters the UPLB gate. Kaliwa turns left and
+        hits Carabao Park / DevCom first. Kanan turns right and serves the same
+        stops in reverse, hitting Carabao Park / Landbank first.
+      </p>
+      <p>
+        Practically: if the building you want is early in the Kaliwa order, take
+        Kaliwa. If it is near the end, Kanan gets you there in a few stops
+        instead of most of the loop. If you get it wrong you still arrive, just
+        the long way around, which on exam morning is the difference that
+        matters.
+      </p>
+      <p>Kaliwa order, from the town side:</p>
+      <ol class="stop-list">
+        {kaliwaKananStops.map((stop) => (
+          <li>{stop}</li>
+        ))}
+      </ol>
+      <p class="figure-note">
+        The loop opens and closes at Olivarez Plaza Mall, which is why it
+        appears twice. Kanan runs this list bottom to top.
+      </p>
+
+      <h3 id="forestry-route">The Forestry route</h3>
+      <p>
+        A separate route climbing to the upper Forestry campus. Worth knowing
+        mostly so you do not board it by accident, and because the University
+        Health Service sits on it.
+      </p>
+      <ol class="stop-list">
+        {forestryStops.map((stop) => (
+          <li>{stop}</li>
+        ))}
+      </ol>
+    </section>
+
+    <section aria-labelledby="finding-the-building">
+      <h2 id="finding-the-building">Finding a building once someone names it</h2>
+      <p>
+        This is the moment Room TBA is built for. A proctor, a marshal, or a
+        sheet on a wall says a building name. You have never heard it before.
+        You have a few minutes.
+      </p>
+      <p>
+        Type the name into the search bar. All 52 UPLB buildings in the app
+        carry written walking directions from a person who knows the campus, not
+        generated text. They read like this:
+      </p>
+      <blockquote class="quote">
+        <p>
+          "In front of CAS Annex 1, to the left of SEARCA. Has multiple wings
+          housing the Institute of Biological Sciences and the Institute of Weed
+          Science, Entomology, and Plant Pathology."
+        </p>
+        <footer>Biological Sciences Building</footer>
+      </blockquote>
+      <blockquote class="quote">
+        <p>
+          "From the main gate, walk towards the Oblation statue. The Physical
+          Sciences Building is the wide building to the right of Oble."
+        </p>
+        <footer>Francisco O. Santos Hall</footer>
+      </blockquote>
+      <p>
+        The app also holds 79 name aliases, so the nickname or acronym you were
+        given resolves to the real building. Searching <code>BioSci</code>,
+        <code>AMPED</code>, or <code>Catambay Hall</code> lands on the right
+        pin. That matters when the person giving you directions uses campus
+        slang and you are hearing it for the first time.
+      </p>
+      <p>
+        Tap the result and the map centres on the building with its pin, so you
+        get both the words and the picture. Both work with no signal if you
+        downloaded the directory.
+      </p>
+    </section>
+
+    <section aria-labelledby="parent">
+      <h2 id="parent">For the parent who waits</h2>
+      <p>
+        You will be here for hours, on a campus built for 4,000 hectares of
+        agriculture research rather than for waiting. Two things shape the day:
+        it is a weekend, and UPLB is spread out.
+      </p>
+      <p>
+        <strong>Weekend hours are the thing to plan around.</strong> August 1 is
+        a Saturday and August 2 is a Sunday. Campus canteens and offices
+        generally keep weekday hours. Room TBA records 49 places but stores no
+        opening hours for any of them, so treat every canteen below as "might be
+        closed" and bring water, food, and something to sit on. Do not build
+        your morning around a specific canteen being open.
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Category</th>
+              <th scope="col">Entries</th>
+              <th scope="col">Useful on exam day?</th>
+            </tr>
+          </thead>
+          <tbody>
+            {placeCategories.map((row) => (
+              <tr>
+                <td><strong>{row.category}</strong></td>
+                <td class="num">{row.count}</td>
+                <td>{row.useful}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 id="food-on-campus">Food on campus</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Place</th>
+              <th scope="col">Where</th>
+              <th scope="col">What it is</th>
+            </tr>
+          </thead>
+          <tbody>
+            {foodOnCampus.map((row) => (
+              <tr>
+                <td><strong>{row.name}</strong></td>
+                <td>{row.where}</td>
+                <td>{row.what}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 id="food-outside">Food just outside, near Raymundo Gate</h3>
+      <p>
+        The strip in Batong Malake (locals call the area the Grove) is outside
+        the campus but close to Raymundo Gate, which is a named jeepney stop.
+        More of it is likely to be open on a weekend than the campus canteens
+        are.
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Place</th>
+              <th scope="col">Where</th>
+              <th scope="col">What it is</th>
+            </tr>
+          </thead>
+          <tbody>
+            {foodOutside.map((row) => (
+              <tr>
+                <td><strong>{row.name}</strong></td>
+                <td>{row.where}</td>
+                <td>{row.what}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 id="waiting-spots">Places to wait, and to name over the phone</h3>
+      <p>
+        Pick one landmark and agree on it before your examinee walks off.
+        Building names all sound alike to someone who has never been here.
+        Landmarks do not.
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Landmark</th>
+              <th scope="col">Why it works</th>
+            </tr>
+          </thead>
+          <tbody>
+            {waitingSpots.map((row) => (
+              <tr>
+                <td><strong>{row.name}</strong></td>
+                <td>{row.why}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p>
+        Practical notes. The University Health Service is on the Forestry
+        jeepney route if anyone needs it. Do not plan to walk back and forth
+        across campus during the exam, because the distances are larger than
+        they look on a phone screen. And download the map on your own phone
+        too, not just your examinee's, since you are the one who will be
+        navigating while they are inside.
+      </p>
+    </section>
+
+    <section aria-labelledby="cannot">
+      <h2 id="cannot">What no app can tell you, including this one</h2>
+      <p>
+        Being clear about the gaps is more useful than filling them with
+        confident guesses.
+      </p>
+      <p class="table-hint">Scroll sideways for the full table.</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Question</th>
+              <th scope="col">Honest answer</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cannotAnswer.map((row) => (
+              <tr>
+                <td><strong>{row.question}</strong></td>
+                <td>{row.answer}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p>
+        Room TBA is a map of a campus, kept by volunteers. It is good at
+        "where is that building and how do I walk there". It is not the
+        registrar, it is not the UP Office of Admissions, and it is not
+        official. For anything about the exam itself, those two offices are the
+        only sources that count.
+      </p>
+    </section>
+
+    <section aria-labelledby="sources">
+      <h2 id="sources">Sources</h2>
+      <ul class="break-list">
+        <li>
+          <a class="wiki-link" href="https://upcat.up.edu.ph" target="_blank" rel="noopener noreferrer">upcat.up.edu.ph</a>
+          for what the test permit carries, the centralized reporting location
+          rule, and seat assignment.
+        </li>
+        <li>
+          <a class="wiki-link" href="https://upcat.up.edu.ph/htmls/upcat_testcenters.html" target="_blank" rel="noopener noreferrer">UPCAT test centers list</a>,
+          where UP Los Baños appears under Region 4-A. Undated, so treat it as a
+          standing list.
+        </li>
+        <li>
+          <a class="wiki-link" href="https://newsinfo.inquirer.net/2164711" target="_blank" rel="noopener noreferrer">Inquirer</a>
+          and
+          <a class="wiki-link" href="https://www.gmanetwork.com/news/topstories/nation/978774" target="_blank" rel="noopener noreferrer">GMA News</a>
+          for the August 1 and 2, 2026 exam dates.
+        </li>
+        <li>
+          <a class="wiki-link" href="https://our.uplb.edu.ph" target="_blank" rel="noopener noreferrer">UPLB Office of the University Registrar</a>
+          for UPLB campus instructions, when they are published.
+        </li>
+        <li>
+          Campus figures on this page come from the Room TBA production
+          database, read on July 27, 2026.
+        </li>
+      </ul>
+    </section>
+
+    <p class="article-back"><a class="wiki-link" href="/wiki">Back to the Wiki</a></p>
+  </article>
+</WikiLayout>
+
+<style>
+  .wiki-article {
+    max-width: 52rem;
+  }
+
+  .article-hero {
+    padding: 1rem 0 2.5rem;
+    border-bottom: 1px solid hsl(0, 0%, 88%);
+  }
+
+  .article-meta {
+    margin: 1rem 0 0;
+    color: hsl(0, 0%, 48%);
+    font-size: 0.8rem;
+    line-height: 1.6;
+  }
+
+  .toc {
+    margin: 2rem 0 0;
+    padding: 1rem 1.15rem;
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 0.85rem;
+    background: hsl(0, 0%, 99%);
+  }
+
+  .toc__title {
+    margin: 0;
+    font-size: 0.8125rem;
+    font-weight: 750;
+    color: hsl(0, 0%, 35%);
+  }
+
+  .toc ol {
+    margin: 0.5rem 0 0;
+    padding-left: 1.25rem;
+    color: hsl(0, 0%, 30%);
+    font-size: 0.875rem;
+    line-height: 1.65;
+  }
+
+  .toc a {
+    color: hsl(5, 53%, 32%);
+    text-decoration: underline;
+    text-underline-offset: 0.12em;
+  }
+
+  .wiki-article section,
+  .article-callout {
+    margin-top: 2.5rem;
+  }
+
+  .wiki-article h2 {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.35rem, 3vw, 1.7rem);
+    letter-spacing: -0.02em;
+  }
+
+  .wiki-article h3 {
+    margin: 1.75rem 0 0.5rem;
+    font-size: 1.1rem;
+    letter-spacing: -0.01em;
+  }
+
+  .wiki-article p {
+    max-width: 46rem;
+    margin: 0.75rem 0 0;
+    color: hsl(0, 0%, 27%);
+    font-size: 1rem;
+    line-height: 1.72;
+  }
+
+  .wiki-article code {
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.3rem;
+    background: hsl(0, 0%, 94%);
+    color: hsl(5, 40%, 30%);
+    font-size: 0.85em;
+  }
+
+  .break-list {
+    margin: 0.85rem 0 0;
+    padding-left: 1.15rem;
+    color: hsl(0, 0%, 27%);
+    font-size: 1rem;
+    line-height: 1.72;
+    max-width: 46rem;
+  }
+
+  .break-list li + li {
+    margin-top: 0.4rem;
+  }
+
+  .steps {
+    margin: 0.85rem 0 0;
+    padding-left: 1.35rem;
+    color: hsl(0, 0%, 27%);
+    font-size: 1rem;
+    line-height: 1.72;
+    max-width: 46rem;
+  }
+
+  .steps li + li {
+    margin-top: 0.4rem;
+  }
+
+  .stop-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.35rem 1.5rem;
+    margin: 0.85rem 0 0;
+    padding-left: 1.35rem;
+    color: hsl(0, 0%, 27%);
+    font-size: 0.9375rem;
+    line-height: 1.55;
+  }
+
+  .quote {
+    max-width: 46rem;
+    margin: 1rem 0 0;
+    padding: 0.6rem 0 0.6rem 1.1rem;
+    border-left: 1px solid hsl(0, 0%, 82%);
+  }
+
+  .quote p {
+    margin: 0;
+    font-size: 0.9375rem;
+  }
+
+  .quote footer {
+    margin-top: 0.4rem;
+    color: hsl(0, 0%, 46%);
+    font-size: 0.8125rem;
+    font-weight: 650;
+  }
+
+  .table-hint {
+    display: none;
+  }
+
+  .table-wrap {
+    overflow-x: auto;
+    border: 1px solid hsl(0, 0%, 86%);
+    border-radius: 1rem;
+    margin-top: 0.75rem;
+  }
+
+  table {
+    width: 100%;
+    min-width: 34rem;
+    border-collapse: collapse;
+    background: white;
+    font-size: 0.875rem;
+  }
+
+  th,
+  td {
+    padding: 0.7rem 0.75rem;
+    border-bottom: 1px solid hsl(0, 0%, 90%);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    background: hsl(5, 22%, 97%);
+    color: hsl(0, 0%, 36%);
+    font-size: 0.75rem;
+    letter-spacing: 0.02em;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  td.num {
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .wiki-article .figure-note {
+    margin-top: 0.6rem;
+    color: hsl(0, 0%, 46%);
+    font-size: 0.8rem;
+    line-height: 1.55;
+  }
+
+  .article-callout {
+    padding: 1.25rem 1.35rem;
+    border: 1px solid hsl(5, 35%, 88%);
+    border-radius: 0.85rem;
+    background: hsl(5, 34%, 97%);
+  }
+
+  .article-callout h2 {
+    font-size: 1.2rem;
+  }
+
+  .article-callout p:first-of-type {
+    margin-top: 0;
+  }
+
+  .article-callout--action {
+    border-color: hsl(150, 30%, 78%);
+    background: hsl(150, 35%, 97%);
+  }
+
+  .article-back {
+    padding-top: 1.5rem;
+    border-top: 1px solid hsl(0, 0%, 88%);
+  }
+
+  @media (max-width: 36rem) {
+    .article-hero {
+      padding-top: 0.5rem;
+    }
+
+    th,
+    td {
+      padding: 0.6rem;
+    }
+
+    .wiki-article .table-hint {
+      display: block;
+      margin: 0.5rem 0 0;
+      color: hsl(0, 0%, 46%);
+      font-size: 0.8rem;
+    }
+
+    .stop-list {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/pages/wiki/upcat-at-uplb.astro
+++ b/src/pages/wiki/upcat-at-uplb.astro
@@ -7,17 +7,59 @@ import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";
 
 const title = "Taking the UPCAT at UP Los Baños | Room TBA Wiki";
 const description =
-  "A first-timer's guide to the UPCAT at UPLB on August 1 and 2, 2026: what the test permit does and does not tell you, how to get on campus, and how to load the campus map before mobile data gets congested.";
+  "A first-timer's guide to the UPCAT at UPLB on August 1 and 2, 2026: what the test permit does and does not tell you, what to bring, how to get on campus, and how to load the campus map before mobile data gets congested.";
 
 /** What the UP Office of Admissions says the permit carries. */
 const permitFields = [
   { field: "Identification number", note: "Your examinee number. Bring it written down somewhere else too." },
   { field: "Place", note: "The test center. At UPLB this is a campus, not a room." },
   { field: "Date", note: "Which of the two exam days is yours. Check it now, not on the morning." },
-  { field: "Time", note: "When to report. Being early is the whole strategy." },
+  { field: "Time", note: "Your session, either the 6:30 am morning session or the 12:30 pm afternoon session." },
   { field: "PIN", note: "Used with your identification number." },
   { field: "Name", note: "Must match the ID you bring." },
   { field: "High school", note: "The school you are testing from." },
+] as const;
+
+/** UP General Information Bulletin, upcat.up.edu.ph/htmls/aboutupcat.html */
+const bringItems = [
+  "Your test permit, printed. You present it and hand it in to test personnel.",
+  "Your school ID, or any valid government-issued ID.",
+  "At least two good quality pencils.",
+  "A sharpener.",
+  "A rubber eraser.",
+  "Water.",
+  "Snacks.",
+] as const;
+
+const bannedItems = [
+  "Cellphones",
+  "Smartwatches",
+  "Calculating devices",
+  "Cameras",
+] as const;
+
+/**
+ * UPLB OVCCA traffic advisory for the previous cycle (exam held August 2 and 3,
+ * 2025). Listed for expectation-setting only. NOT a prediction for 2026.
+ */
+const lastCycleBuildings = [
+  "IBS",
+  "CAS (two locations)",
+  "CDC",
+  "IMS (New Math building)",
+  "PHYSCI",
+  "CEAT",
+  "ASI",
+  "EE",
+  "IAS",
+  "CVM",
+] as const;
+
+const lastCycleGates = [
+  "Main Gate",
+  "Jamboree Gate",
+  "Central Experiment Station (CES) Gate",
+  "Institute of Animal Science (IAS) Gate",
 ] as const;
 
 const permitOmissions = [
@@ -127,7 +169,7 @@ const cannotAnswer = [
   {
     question: "Which buildings are being used?",
     answer:
-      "Not published. Guessing from where classes normally meet would be a guess, and a wrong one puts you on the far side of a large campus.",
+      "Not published for this cycle. Last cycle UPLB used ten scattered locations, so expect to be sent to one of many buildings rather than to a single hall. Which one is yours is not knowable in advance.",
   },
   {
     question: "Is that canteen open on exam day?",
@@ -172,9 +214,11 @@ const structuredData = jsonLd(
         UPCAT for AY 2027 to 2028 is on <strong>August 1 and 2, 2026</strong>, a
         Saturday and a Sunday. Campus figures on this page are a census of the
         Room TBA production database on July 27, 2026: 52 buildings, 530 rooms,
-        2 jeepney routes, 27 stops, 49 places, 79 name aliases. UPLB
-        campus-specific exam instructions were <strong>not published</strong> at
-        the time of writing.
+        2 jeepney routes, 27 stops, 49 places, 79 name aliases. Exam details
+        come from the UP General Information Bulletin. UPLB campus-specific
+        instructions (venue, gates, reporting point) were
+        <strong>not published</strong> at the time of writing; last cycle they
+        appeared one day before the exam.
       </p>
       <WikiProvenance sourcePath="src/pages/wiki/upcat-at-uplb.astro" />
     </header>
@@ -185,7 +229,9 @@ const structuredData = jsonLd(
         <li><a href="#start-here">The short version</a></li>
         <li><a href="#offline">Load the campus map before you arrive</a></li>
         <li><a href="#permit">What the permit says, and what it does not</a></li>
+        <li><a href="#bring">What to bring, and what is banned</a></li>
         <li><a href="#not-published">What UPLB has not published yet</a></li>
+        <li><a href="#last-cycle">What last cycle looked like at UPLB</a></li>
         <li><a href="#getting-there">Getting to campus and moving around it</a></li>
         <li><a href="#finding-the-building">Finding a building once someone names it</a></li>
         <li><a href="#parent">For the parent who waits</a></li>
@@ -207,8 +253,15 @@ const structuredData = jsonLd(
           same morning.
         </li>
         <li>
-          <strong>Check which of the two days is yours.</strong> The permit
-          carries the date. August 1 is a Saturday, August 2 is a Sunday.
+          <strong>Check which day and which session is yours.</strong> The
+          permit carries both. There is a 6:30 am morning session and a 12:30 pm
+          afternoon session. August 1 is a Saturday, August 2 is a Sunday.
+        </li>
+        <li>
+          <strong>The test runs about five hours.</strong> Bring water and
+          snacks, which UP explicitly tells you to bring. Leave your phone and
+          your smartwatch with your parent, because both are banned during the
+          test.
         </li>
         <li>
           <strong>Watch for the UPLB advisory.</strong> The campus-specific
@@ -257,10 +310,12 @@ const structuredData = jsonLd(
         installing Room TBA to your home screen, do that first, then download.
       </p>
       <p class="figure-note">
-        One honest limit: the offline copy is the <em>map app</em>. This wiki
+        Two honest limits. The offline copy is the <em>map app</em>; this wiki
         page is served fresh from the network and is not part of the offline
         bundle, so read it or screenshot it now rather than planning to open it
-        from the queue.
+        from the queue. And cellphones are banned during the test itself, so the
+        map helps you get there and helps whoever is waiting for you, not you
+        inside the room.
       </p>
     </aside>
 
@@ -311,11 +366,74 @@ const structuredData = jsonLd(
         finer.
       </p>
       <p class="figure-note">
-        UP Los Baños appears under Region 4-A on the UP Office of Admissions
-        list of UPCAT test centers. That page carries no year, so read it as a
-        standing list of centers rather than a confirmed roster for this
-        particular cycle. For scale: the previous cycle, UPCAT 2026, used 117
-        testing centers nationwide.
+        On the UP Office of Admissions list of UPCAT test centers, the entire
+        entry under Region 4-A (CALABARZON) reads
+        <strong>"UP Los Baños, LAGUNA"</strong>. That is all of it. No street,
+        no building. It is also the only Laguna entry on the list. That page
+        carries no year, so read it as a standing list of centers rather than a
+        confirmed roster for this particular cycle. For scale, the previous
+        cycle used 117 testing centers nationwide.
+      </p>
+
+      <h3 id="reporting-time">What time to be there</h3>
+      <p>
+        Read your permit first and follow it over anything on this page. If you
+        need a number to plan around before then, note that the two official UP
+        pages currently disagree with each other:
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Source</th>
+              <th scope="col">Says to be there by</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>General Information Bulletin</strong>, which names the August 2026 dates directly</td>
+              <td>6:00 am (morning), 12:00 nn (afternoon)</td>
+            </tr>
+            <tr>
+              <td><strong>upcat.up.edu.ph homepage</strong>, older generic copy</td>
+              <td>6:30 am (morning), 12:00 nn (afternoon)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        The sessions themselves start at 6:30 am and 12:30 pm. The bulletin is
+        the page written for this cycle, so plan for
+        <strong>6:00 am or 12:00 nn</strong> and treat the earlier arrival as
+        the safe one. Arriving early costs you nothing. Arriving late can cost
+        you the exam.
+      </p>
+    </section>
+
+    <section aria-labelledby="bring">
+      <h2 id="bring">What to bring, and what is banned</h2>
+      <p>
+        From the UP General Information Bulletin. The test runs about five
+        hours, which is why water and snacks are on the list rather than
+        optional extras.
+      </p>
+      <h3 id="bring-list">Bring</h3>
+      <ul class="break-list">
+        {bringItems.map((item) => (
+          <li>{item}</li>
+        ))}
+      </ul>
+      <h3 id="banned-list">Not allowed during the test</h3>
+      <ul class="break-list">
+        {bannedItems.map((item) => (
+          <li>{item}</li>
+        ))}
+      </ul>
+      <p>
+        Plan for the phone rule in advance. Decide before you leave the house
+        who holds the phone during the exam, and agree on a meeting landmark
+        with whoever brought you, because you will not be able to call them when
+        you come out.
       </p>
     </section>
 
@@ -335,7 +453,15 @@ const structuredData = jsonLd(
         <li>Parking, drop-off arrangements, or a designated waiting area for parents.</li>
         <li>Any shuttle service between a drop-off point and the venue.</li>
       </ul>
-      <p><strong>Who actually publishes this, and where to watch:</strong></p>
+      <p>
+        One caveat on that list, because it matters. The UPLB websites sit
+        behind a bot check that refused every automated attempt we made to read
+        them, so "we could not find it" here means we could not find it through
+        search, not that we read the pages and saw nothing.
+        <strong>Open them yourself in a normal browser.</strong> That is not a
+        formality; it is the actual next step.
+      </p>
+      <p><strong>Who publishes this, and where to watch:</strong></p>
       <ul class="break-list">
         <li>
           <strong>UPLB Office of the University Registrar</strong>, at
@@ -344,15 +470,26 @@ const structuredData = jsonLd(
           only days before the exam.
         </li>
         <li>
+          <strong>UPLB Office of the Vice Chancellor for Community Affairs
+          (OVCCA)</strong>, which is who published the campus traffic and gate
+          advisory last cycle.
+        </li>
+        <li>
           <strong>UP Office of Admissions</strong>, at
           <a class="wiki-link" href="https://upcat.up.edu.ph" target="_blank" rel="noopener noreferrer">upcat.up.edu.ph</a>
           and on its Facebook page, for system-wide instructions.
         </li>
       </ul>
       <p>
+        <strong>Expect this late.</strong> Last cycle the UPLB traffic advisory
+        went out on August 1, 2025 for an exam on August 2. One day. So keep
+        checking right up to the night before, and do not read silence today as
+        a sign that nothing is coming.
+      </p>
+      <p>
         If someone hands you a screenshot naming a venue, check it against one
-        of those two before you act on it. Screenshots of last year's advisory
-        circulate every year.
+        of those sources before you act on it. Last year's advisory circulates
+        again every year, and it looks exactly as official as this year's.
       </p>
       <p class="figure-note">
         Are you a UPLB student, staff member, or volunteer holding the official
@@ -361,6 +498,50 @@ const structuredData = jsonLd(
         link to the official post, is a genuinely useful ten minutes.
       </p>
     </aside>
+
+    <section aria-labelledby="last-cycle">
+      <h2 id="last-cycle">What last cycle looked like at UPLB</h2>
+      <p class="warning-line">
+        Everything in this section describes the <strong>previous</strong> exam,
+        held August 2 and 3, 2025. It is here to set your expectations about the
+        shape of the day. It is <strong>not</strong> a prediction, and none of
+        these buildings or gates is confirmed for 2026. Do not go to any of them
+        because you read it here.
+      </p>
+      <p>
+        UPLB published a campus traffic advisory for that exam. The useful thing
+        it reveals is structural, and it is very likely to hold again:
+        <strong>UPLB does not run the UPCAT in one hall.</strong> The advisory
+        marked testing centers at ten separate locations spread across the
+        campus:
+      </p>
+      <ul class="chip-list">
+        {lastCycleBuildings.map((b) => (
+          <li>{b}</li>
+        ))}
+      </ul>
+      <p>
+        It also named four gates as entrances and exits, and closed a list of
+        interior campus roads for the weekend:
+      </p>
+      <ul class="chip-list">
+        {lastCycleGates.map((g) => (
+          <li>{g}</li>
+        ))}
+      </ul>
+      <p>
+        UPLB reported welcoming close to <strong>10,000 examinees</strong> over
+        those two days. That is the number to keep in mind when you think about
+        traffic at the gate, queues, and whether mobile data will work.
+      </p>
+      <p>
+        <strong>What to take from this.</strong> Assume you will be told a
+        building name and sent walking, possibly a long way, and that the road
+        you expected to drive down may be closed. That is the exact situation
+        this app is for. It is also why the building name you are given is worth
+        typing into the search bar the moment you hear it.
+      </p>
+    </section>
 
     <section aria-labelledby="getting-there">
       <h2 id="getting-there">Getting to campus and moving around it</h2>
@@ -634,9 +815,15 @@ const structuredData = jsonLd(
       <h2 id="sources">Sources</h2>
       <ul class="break-list">
         <li>
+          <a class="wiki-link" href="https://upcat.up.edu.ph/htmls/aboutupcat.html" target="_blank" rel="noopener noreferrer">UP General Information Bulletin</a>
+          for the permit contents, the session times, the arrival times, what to
+          bring, the prohibited items, and the five-hour duration. This is the
+          page that names the August 2026 dates directly, so prefer it over the
+          homepage where the two disagree.
+        </li>
+        <li>
           <a class="wiki-link" href="https://upcat.up.edu.ph" target="_blank" rel="noopener noreferrer">upcat.up.edu.ph</a>
-          for what the test permit carries, the centralized reporting location
-          rule, and seat assignment.
+          for the centralized reporting location rule and seat assignment.
         </li>
         <li>
           <a class="wiki-link" href="https://upcat.up.edu.ph/htmls/upcat_testcenters.html" target="_blank" rel="noopener noreferrer">UPCAT test centers list</a>,
@@ -652,6 +839,18 @@ const structuredData = jsonLd(
         <li>
           <a class="wiki-link" href="https://our.uplb.edu.ph" target="_blank" rel="noopener noreferrer">UPLB Office of the University Registrar</a>
           for UPLB campus instructions, when they are published.
+        </li>
+        <li>
+          The UPLB OVCCA traffic advisory for the previous cycle (exam of August
+          2 and 3, 2025) for the last-cycle testing locations, gates, and road
+          closures, and
+          <a class="wiki-link" href="https://uplb.edu.ph/all-news/pahinungod-spearheads-pencil-donation-drive-at-upcat-2026-in-uplb/" target="_blank" rel="noopener noreferrer">UPLB news</a>
+          for the roughly 10,000 examinees figure. Both describe last cycle, not
+          this one.
+        </li>
+        <li>
+          <a class="wiki-link" href="https://www.philstar.com/nation/2025/08/02/2462559/lists-117-upcat-testing-centers-nationwide" target="_blank" rel="noopener noreferrer">Philstar</a>
+          for the 117 testing centers used in the previous cycle.
         </li>
         <li>
           Campus figures on this page come from the Room TBA production
@@ -741,6 +940,35 @@ const structuredData = jsonLd(
     background: hsl(0, 0%, 94%);
     color: hsl(5, 40%, 30%);
     font-size: 0.85em;
+  }
+
+  .wiki-article .warning-line {
+    padding: 0.75rem 0.9rem;
+    border: 1px solid hsl(38, 60%, 78%);
+    border-radius: 0.65rem;
+    background: hsl(45, 75%, 96%);
+    color: hsl(0, 0%, 22%);
+    font-size: 0.9375rem;
+    line-height: 1.65;
+  }
+
+  .chip-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    max-width: 46rem;
+    margin: 0.85rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .chip-list li {
+    padding: 0.3rem 0.6rem;
+    border: 1px solid hsl(0, 0%, 87%);
+    border-radius: 0.5rem;
+    background: hsl(0, 0%, 98%);
+    color: hsl(0, 0%, 30%);
+    font-size: 0.875rem;
   }
 
   .break-list {


### PR DESCRIPTION
## Why now

UPCAT 2027 is on **August 1 and 2, 2026** (a Saturday and a Sunday). UPLB is a designated test center. Thousands of first-time visitors, mostly nervous teenagers with a parent who has also never been here, arrive in a few days. This article is written for that person.

New page at `/wiki/upcat-at-uplb`, registered on the wiki index.

## What it leads with

The thing the app is genuinely good at here: **getting a stranger from a gate to a building**, plus the most useful practical tip we can give, which is **download the campus map and directory before arriving** because mobile data on campus will be congested. The offline callout gives the exact taps (sidebar → Offline maps → Download campus map → Download campus directory).

## Grounded in real repo data

Census of the production DB, read July 27, 2026:

| Claim on the page | Source |
| --- | --- |
| 2 jeepney routes, 27 stops, fares 13 / 11 | `jeepney_routes`, `jeepney_stops` |
| Kaliwa and Kanan are one loop, direction after the gate | `jeepney_routes.direction_note` |
| Full Kaliwa stop order (20) and Forestry (7) | `jeepney_stops.sort_order` |
| 52 buildings, all with hand-written walking directions | `buildings.directions` (52/52 non-empty) |
| 79 name aliases so nicknames resolve | `aliases` |
| 49 places, split on-campus vs just outside Raymundo Gate | `places` |
| No place has opening hours, and both exam days are a weekend | `places.hours` null for all 49 |
| 530 rooms, none of which is your exam room | `rooms` |

> Heads up: the brief said 9 jeepney routes and 50 places. The DB actually has **2 routes** and **49 places**. The page uses the real numbers.

## What a research pass added

A sourcing pass against the UP General Information Bulletin found things the first draft was missing:

- **Sessions.** The permit carries a **6:30 am or 12:30 pm session**, not just a date. "Check which day is yours" was incomplete advice.
- **A conflict between two official pages, shown honestly.** The Bulletin (which names the August 2026 dates directly) says be there by **6:00 am / 12:00 nn**; the `upcat.up.edu.ph` homepage still says **6:30 am**. The page recommends the Bulletin, shows both, and says the permit overrides everything.
- **What to bring and what is banned.** Cellphones *and smartwatches* are prohibited during the test. This is now reflected in the offline callout: the map helps you get there and helps whoever waits, not you inside the room.
- **The exact test-center string:** the whole Region 4-A entry is `UP Los Baños, LAGUNA`. No street, no building. Strongest possible evidence for the article's central point.
- **A previous-cycle section, fenced in a warning box.** Per the official UPLB OVCCA traffic advisory, last cycle UPLB ran the exam across **ten scattered locations** with four named gates and interior road closures, and welcomed close to **10,000 examinees**. Labelled repeatedly as last cycle and explicitly not a prediction. It earns its place because it sets the right expectation (you will be sent walking to one of many buildings) without claiming which one.

## What it deliberately does NOT say

**The 2026 UPLB reporting venue, assembly area, gate arrangements, and reporting point are not invented.** The article names who publishes them (UPLB OUR, UPLB OVCCA, UP Office of Admissions) and warns against acting on circulated screenshots of last year's advisory.

It also notes that last cycle's advisory landed **one day before** the exam, so readers should keep checking rather than read today's silence as "nothing is coming."

**Honesty fix worth reviewing:** `our.uplb.edu.ph`, `uplb.edu.ph`, and `ovcca.uplb.edu.ph` sit behind a Cloudflare bot check that refused every automated read (WebFetch, headless Playwright, curl with a browser UA, even the Wayback crawler). So the page says *we could not find it via search*, not *we read the pages and there was nothing*, and tells readers to open them in a real browser. **A human with a normal browser should confirm before we imply UPLB has published nothing.**

Left blank on purpose for a campus volunteer: the venue and reporting time, with an explicit invitation in the callout pointing at the "Edit on GitHub" link in the byline.

## Verify

- [x] `bun run build` passes (the `Astro.request.headers` warnings are pre-existing and also fire on untouched pages)
- [x] `bunx biome check` clean on both touched files
- [x] `bun run test` 431 pass, 0 fail
- [x] `bun run check:readme` passes
- [x] Rendered locally and read at **320px** and **1280px**

Layout verification (measured, not eyeballed):

- 320px: `documentElement.scrollWidth === clientWidth === 320`. Zero elements overflow outside their `.table-wrap` scroll containers. The "Scroll sideways" hint shows, matching `section-times.astro`.
- 1280px: `scrollWidth === clientWidth === 1280`, no overflow. TOC becomes the sticky sidebar; stop lists and chip lists go multi-column.
- Provenance renders after commit: "By smmariquit · Last edited July 27, 2026 · History · Edit on GitHub".
- Only console error is Astro's dev-toolbar `504 Outdated Optimize Dep`, unrelated to this page.

The Vercel preview on this PR renders the page live, which is better evidence than a pasted screenshot for a prerendered page. Please read `/wiki/upcat-at-uplb` there at narrow width.

## Conventions

Copies `section-times.astro` / `fork-for-your-campus.astro` structure exactly: `WikiLayout`, `wiki-eyebrow` / `wiki-title` / `wiki-lede`, `article-meta`, `toc` nav, `<section aria-labelledby>` blocks, `WikiProvenance`, `breadcrumbSchema` + `webpageSchema`. No em dashes (verified: zero in the file).

## CI note

Opened as a **draft with no `run/e2e` label** on purpose: a serial CI queue is running and concurrent e2e runs exhaust the shared database's connection pool. **Gated e2e is pending** and should be triggered once the queue is clear. This PR is content-only (one new `.astro` page plus an entry in the wiki index array) and touches no runtime code paths.
