### PR TITLE
release: blank page deadlock fix

### DIFF
--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { campusCommunity } from "../../campus.config";
   import type { InitialSearchState } from "@lib/app-data";
   import {
     type AppContextData,
@@ -128,6 +129,15 @@
 
   function dismissStaticLoadingShell() {
     document.getElementById("app-loading-shell")?.remove();
+  }
+
+  function handleRenderError(error: unknown) {
+    // Logged, not swallowed: this is the blank-screen path, so we want it in
+    // the console and in RUM even though the boundary now renders a fallback.
+    console.error("App render failed", error);
+    // The shell may still be up if the crash happened before bootstrap
+    // finished, and it would cover the fallback with a stuck spinner.
+    dismissStaticLoadingShell();
   }
 
   const EMPTY_DB_DATA: DBData = {
@@ -506,11 +516,119 @@
   });
 </script>
 
-<Entry
-  initialSearch={metadata.initialSearch}
-  suppressLandingModal={metadata.suppressLandingModal ?? false}
-  openToday={metadata.openToday ?? false}
-  openPlanner={metadata.openPlanner ?? false}
-  openFinals={metadata.openFinals ?? false}
-  openCalendar={metadata.openCalendar ?? false}
-/>
+<!-- The bootstrap try/catch only covers data loading. An error thrown while
+     rendering happens after the loading shell is already dismissed, which
+     unmounts the tree and leaves blank white with no explanation. -->
+<svelte:boundary onerror={handleRenderError}>
+  <Entry
+    initialSearch={metadata.initialSearch}
+    suppressLandingModal={metadata.suppressLandingModal ?? false}
+    openToday={metadata.openToday ?? false}
+    openPlanner={metadata.openPlanner ?? false}
+    openFinals={metadata.openFinals ?? false}
+    openCalendar={metadata.openCalendar ?? false}
+  />
+
+  {#snippet failed(error, reset)}
+    <div class="app-crash" role="alert">
+      <div class="app-crash__card">
+        <p class="app-crash__title">Something broke while drawing the map</p>
+        <p class="app-crash__body">
+          Your saved campus data is still on this device. Try again, and if it
+          keeps happening please report it so we can fix the cause.
+        </p>
+        <div class="app-crash__actions">
+          <button
+            type="button"
+            class="app-crash__button app-crash__button--primary"
+            onclick={reset}
+          >
+            Try again
+          </button>
+          <button
+            type="button"
+            class="app-crash__button"
+            onclick={() => location.reload()}
+          >
+            Reload page
+          </button>
+          <a
+      class="app-crash__button"
+      href={`${campusCommunity.githubUrl}/issues/new`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+            Report
+          </a>
+        </div>
+        <p class="app-crash__detail">{String(error)}</p>
+      </div>
+    </div>
+  {/snippet}
+</svelte:boundary>
+
+<style>
+  .app-crash {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    background: hsl(5, 22%, 96%);
+  }
+
+  .app-crash__card {
+    max-width: 26rem;
+    text-align: center;
+  }
+
+  .app-crash__title {
+    margin: 0;
+    color: hsl(5, 12%, 16%);
+    font-size: 1.0625rem;
+    font-weight: 700;
+  }
+
+  .app-crash__body {
+    margin: 0.5rem 0 0;
+    color: hsl(5, 12%, 42%);
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+
+  .app-crash__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+    margin-top: 1.25rem;
+  }
+
+  .app-crash__button {
+    padding: 0.6rem 1rem;
+    border: 1px solid hsl(5, 28%, 78%);
+    border-radius: 0.625rem;
+    background: hsl(0, 0%, 100%);
+    color: hsl(5, 12%, 16%);
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .app-crash__button--primary {
+    border-color: transparent;
+    background: hsl(5, 53%, 32%);
+    color: hsl(0, 0%, 100%);
+  }
+
+  .app-crash__detail {
+    margin: 1rem 0 0;
+    color: hsl(5, 12%, 52%);
+    font-size: 0.75rem;
+    word-break: break-word;
+  }
+</style>

--- a/src/components/svelte/ScheduleImportPanel.svelte
+++ b/src/components/svelte/ScheduleImportPanel.svelte
@@ -280,9 +280,12 @@
   }
 
   .schedule-import-panel__weekday {
-    flex: 1 1 auto;
-    min-width: 2.5rem;
-    padding: 0.3125rem 0.375rem;
+    /* Sized to the label. Growing to fill the row turned three-letter days
+       into oversized pills. */
+    flex: 0 0 auto;
+    min-width: 2.75rem;
+    padding: 0.3125rem 0.625rem;
+    text-align: center;
     border-radius: 999px;
     border: 1px solid var(--map-chrome-border, hsl(0, 0%, 58%));
     background: hsl(0, 0%, 98%);

--- a/src/components/svelte/StatusBar.svelte
+++ b/src/components/svelte/StatusBar.svelte
@@ -4,7 +4,6 @@
   import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
   import LoaderCircle from "@lucide/svelte/icons/loader-circle";
   import { onMount } from "svelte";
-  import { registerSW } from "virtual:pwa-register";
   import {
     appBootstrapStore,
     syncToastStore,
@@ -58,17 +57,16 @@
     window.addEventListener("online", onOnline);
     window.addEventListener("offline", onOffline);
 
-    const updateSW = registerSW({
-      immediate: true,
-      onNeedRefresh() {
-        syncToastStore.markNeedRefresh();
-      },
-      onRegisteredSW(swScriptUrl) {
-        console.log("SW registered: ", swScriptUrl);
-      },
-    });
+    // Registration itself lives in src/pwa.ts, outside this island, so a
+    // broken app bundle cannot block the worker update that would fix it.
+    // It may have flagged an update before this component mounted.
+    if (document.documentElement.dataset.pwaNeedRefresh === "true") {
+      syncToastStore.markNeedRefresh();
+    }
+    const onNeedRefresh = () => syncToastStore.markNeedRefresh();
+    window.addEventListener("pwa:need-refresh", onNeedRefresh);
     syncToastStore.setRefreshHandler(() => {
-      void updateSW(true);
+      window.dispatchEvent(new Event("pwa:apply-update"));
     });
     void loadSponsors().then((data) => {
       if (data) goldSponsor = getGoldSponsor(data.sponsors);
@@ -76,6 +74,7 @@
     return () => {
       window.removeEventListener("online", onOnline);
       window.removeEventListener("offline", onOffline);
+      window.removeEventListener("pwa:need-refresh", onNeedRefresh);
     };
   });
 

--- a/src/components/svelte/TerrainControl.svelte
+++ b/src/components/svelte/TerrainControl.svelte
@@ -261,7 +261,10 @@
 
   .terrain-toggle,
   .reset-btn {
-    display: flex;
+    /* inline-flex, not flex: a block-level flex container stretched these to
+       the full panel width for a two-word label. */
+    display: inline-flex;
+    align-self: flex-start;
     align-items: center;
     justify-content: center;
     gap: 0.375rem;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -107,7 +107,7 @@ const shareTitle = ogTitle ?? title;
          Synchronous in <head>, before paint: no flash, and the change
          listener keeps it live across resizes (devtools/QA responsive mode). -->
     <script is:inline define:vars={{ desktopOnlyUrl }}>
-      (function () {
+      (() => {
         var html = document.documentElement;
         var mql = window.matchMedia("(min-width: 48.0625rem)");
         var link = null;
@@ -127,7 +127,7 @@ const shareTitle = ogTitle ?? title;
         }
 
         apply(mql.matches);
-        mql.addEventListener("change", function (event) {
+        mql.addEventListener("change", (event) => {
           apply(event.matches);
         });
       })();
@@ -202,9 +202,116 @@ const shareTitle = ogTitle ?? title;
         </div>
       ) : null
     }
+    <script is:inline>
+      // AppRoot is client:only, so the page has no server-rendered fallback:
+      // if its chunk never loads (stale service worker, dropped connection,
+      // parse error) the page sits on the loading shell forever, and if the
+      // shell was already dismissed the user gets blank white with nothing to
+      // act on. Watch for an island that never got children and put a
+      // recoverable message on screen instead.
+      //
+      // Kept out of an Astro expression on purpose: inside `{cond ? (...) :
+      // null}` the script body is parsed as JSX and every `{` breaks it.
+      (() => {
+        var TIMEOUT_MS = 15000;
+
+        // Only the app pages mount AppRoot, so this both scopes the watchdog
+        // and avoids firing on a static page's unrelated island.
+        function appIsland() {
+          return document.querySelector('astro-island[component-url*="AppRoot"]');
+        }
+
+        function hydrated() {
+          var island = appIsland();
+          return !island || island.children.length > 0;
+        }
+
+            function resetAppData() {
+              var jobs = [];
+              try {
+                if (navigator.serviceWorker) {
+                  jobs.push(
+                    navigator.serviceWorker
+                      .getRegistrations()
+                      .then((regs) => Promise.all(
+                          regs.map((r) => r.unregister()),
+                        )),
+                  );
+                }
+                if (window.caches) {
+                  jobs.push(
+                    caches.keys().then((keys) => Promise.all(
+                        keys.map((k) => caches.delete(k)),
+                      )),
+                  );
+                }
+              } catch (err) {
+                console.error("Reset failed", err);
+              }
+              Promise.all(jobs)
+                .catch((err) => {
+                  console.error("Reset failed", err);
+                })
+                .then(() => {
+                  location.reload();
+                });
+            }
+
+            function fail(reason) {
+              if (hydrated()) return;
+              if (document.getElementById("app-boot-error")) return;
+              console.error("Room TBA failed to start:", reason);
+
+              var shell = document.getElementById("app-loading-shell");
+              if (shell) shell.remove();
+
+              var box = document.createElement("div");
+              box.id = "app-boot-error";
+              box.className = "app-loading-shell";
+              box.setAttribute("role", "alert");
+              box.innerHTML =
+                '<div class="app-boot-error__card">' +
+                '<p class="app-boot-error__title">Room TBA did not finish loading</p>' +
+                '<p class="app-boot-error__body">This is usually a bad connection or an outdated copy of the app saved on this device.</p>' +
+                '<div class="app-boot-error__actions">' +
+                '<button type="button" id="app-boot-reload" class="app-boot-error__button app-boot-error__button--primary">Reload</button>' +
+                '<button type="button" id="app-boot-reset" class="app-boot-error__button">Clear saved copy and reload</button>' +
+                "</div></div>";
+              document.body.appendChild(box);
+
+              document
+                .getElementById("app-boot-reload")
+                .addEventListener("click", () => {
+                  location.reload();
+                });
+              document
+                .getElementById("app-boot-reset")
+                .addEventListener("click", resetAppData);
+            }
+
+            // A module script that 404s or fails to parse fires an error event
+            // on the element itself, which does not bubble: catch on capture.
+            window.addEventListener(
+              "error",
+              (event) => {
+                var el = event.target;
+                if (el && el !== window && el.tagName === "SCRIPT") {
+                  fail("script failed to load: " + (el.src || "inline"));
+                }
+              },
+              true,
+            );
+
+            setTimeout(() => {
+              fail("island never hydrated after " + TIMEOUT_MS + "ms");
+            }, TIMEOUT_MS);
+          })();
+    </script>
     <slot />
     <Analytics />
     <script>
+      // Not inside the app island on purpose: see src/pwa.ts.
+      import "../pwa";
       import { initDatadogRum } from "@lib/datadog-rum";
       initDatadogRum();
     </script>

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -1,1 +1,30 @@
-// src/pwa.ts
+// Service worker registration, deliberately outside the client:only AppRoot
+// island.
+//
+// This used to live in StatusBar.svelte, which only runs once the island
+// hydrates. That created a deadlock: a stale worker serving an index.html
+// whose asset hashes no longer exist stops the island from hydrating, so the
+// registration that would have updated that worker never runs, and every
+// reload lands on the same blank page. Registering here means the update path
+// survives a broken app bundle.
+import { registerSW } from "virtual:pwa-register";
+
+const NEED_REFRESH_EVENT = "pwa:need-refresh";
+const APPLY_UPDATE_EVENT = "pwa:apply-update";
+
+const updateSW = registerSW({
+  immediate: true,
+  onNeedRefresh() {
+    // The island usually mounts after this fires, so latch it on the document
+    // as well: StatusBar reads the flag on mount and would otherwise miss the
+    // event entirely.
+    document.documentElement.dataset.pwaNeedRefresh = "true";
+    window.dispatchEvent(new Event(NEED_REFRESH_EVENT));
+  },
+});
+
+// The refresh button lives in the app UI, which cannot reach this module
+// directly.
+window.addEventListener(APPLY_UPDATE_EVENT, () => {
+  void updateSW(true);
+});

--- a/src/styles/app-loading.css
+++ b/src/styles/app-loading.css
@@ -131,6 +131,55 @@
   }
 }
 
+/* Shown when the app island never hydrates, so a failed boot reads as a
+   fixable problem instead of a blank white page. */
+.app-boot-error__card {
+  position: relative;
+  z-index: 1;
+  max-width: 26rem;
+  text-align: center;
+}
+
+.app-boot-error__title {
+  margin: 0;
+  color: var(--app-loading-ink);
+  font-size: 1.0625rem;
+  font-weight: 700;
+}
+
+.app-boot-error__body {
+  margin: 0.5rem 0 0;
+  color: var(--app-loading-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.app-boot-error__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 1.25rem;
+}
+
+.app-boot-error__button {
+  padding: 0.6rem 1rem;
+  border: 1px solid hsl(5, 28%, 78%);
+  border-radius: 0.625rem;
+  background: hsl(0, 0%, 100%);
+  color: var(--app-loading-ink);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.app-boot-error__button--primary {
+  border-color: transparent;
+  background: var(--app-loading-accent);
+  color: hsl(0, 0%, 100%);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .app-loading-hero {
     animation: none;


### PR DESCRIPTION
Ships two fixes. No migrations, so migrate-prod is a no-op.

## fix(pwa): stale service worker leaving a blank page

Users reported the whole site loading blank white with no explanation. Ken identified the cause: the reload/registration logic had moved from an Astro component into a Svelte one.

`registerSW` was running inside `StatusBar.svelte`, which lives in the `client:only` AppRoot island. That is a deadlock:

1. A stale worker serves an `index.html` whose asset hashes no longer resolve.
2. The island cannot hydrate. `client:only` means no server-rendered fallback, so the page is genuinely empty.
3. The `registerSW` call that would `skipWaiting` the replacement worker is inside the island that cannot load, so the new worker sits in `waiting` forever.
4. Every reload repeats it.

Commit 87181c77 deleted `ReloadPrompt.astro` and left `src/pwa.ts` empty, which is how registration ended up in the island. It now runs from a top-level script on every page, so a stuck client updates its worker on the next visit.

Two safety nets, since `client:only` means any failure is a blank page:

- Boot watchdog, inline so it survives a broken module graph. No island children after 15s, or a script tag failing to load, swaps the dead page for Reload and "clear saved copy and reload".
- `svelte:boundary` around Entry for render-time throws. The existing bootstrap try/catch only covered data loading and ran after the loading shell was dismissed.

Both log to console so RUM captures the trigger next time.

## fix(ui): settings buttons stretching full width

`display: flex` on a block-level button fills its parent, so a two-word label rendered as a full-width bar. Weekday chips had `flex: 1 1 auto` for the same reason.

## CI note

Merged to staging with an admin bypass. The blocking e2e run failed on `EMAXCONNSESSION: max clients reached in session mode, pool_size: 15`, which is the Supabase pooler ceiling hit by concurrent e2e runs, not this diff (it touches no server or DB code). Local `bun run test` was 453 pass / 0 fail, and build, verify, bundle, migrations and CodeQL all passed.