### PR TITLE
fix(transit): make route stops clickable

### DIFF
--- a/src/components/svelte/modal/JeepneyRouteModal.component.test.ts
+++ b/src/components/svelte/modal/JeepneyRouteModal.component.test.ts
@@ -29,6 +29,35 @@ describe("JeepneyRouteModal", () => {
     expectNoHorizontalOverflow(container);
   });
 
+  test("clicking a stop selects its route on the map, then the stop", () => {
+    const route = JEEPNEY_ROUTES[0];
+    jeepneyStore.modalRouteId = route.id;
+    jeepneyStore.selectedRouteId = null;
+    render(JeepneyRouteModal);
+
+    const stopIndex = 2;
+    screen
+      .getByRole("button", { name: new RegExp(route.stops[stopIndex].name) })
+      .click();
+
+    // Order matters: openStop bails when no route is selected, and selecting a
+    // different route clears the stop.
+    expect(jeepneyStore.selectedRouteId).toBe(route.id);
+    expect(jeepneyStore.selectedStopIndex).toBe(stopIndex);
+  });
+
+  test("the side panel copy opens the stop without re-selecting the route", () => {
+    const route = JEEPNEY_ROUTES[0];
+    jeepneyStore.openRouteOnMap(route.id);
+    render(JeepneyRouteModal, { props: { routeId: route.id } });
+
+    screen
+      .getByRole("button", { name: new RegExp(route.stops[1].name) })
+      .click();
+
+    expect(jeepneyStore.selectedStopIndex).toBe(1);
+  });
+
   test("shows an empty state when the route id is unknown", () => {
     jeepneyStore.modalRouteId = "does-not-exist";
     render(JeepneyRouteModal);

--- a/src/components/svelte/modal/JeepneyRouteModal.svelte
+++ b/src/components/svelte/modal/JeepneyRouteModal.svelte
@@ -25,6 +25,20 @@
     jeepneyStore.openRouteOnMap(route.id);
     modalStore.closeModal();
   }
+
+  function showStop(index: number) {
+    if (!route) return;
+    // openStop bails when no route is selected on the map, and openRouteOnMap
+    // clears the stop when the route changes, so the route has to come first.
+    // The side-panel copy (routeId set) is already showing this route, and its
+    // container swaps to JeepneyStopPanel on its own, so there is nothing to
+    // select and no modal to dismiss.
+    if (routeId === null) {
+      jeepneyStore.openRouteOnMap(route.id);
+      modalStore.closeModal();
+    }
+    jeepneyStore.openStop(index);
+  }
 </script>
 
 {#if route}
@@ -69,8 +83,14 @@
       <ol class="jeepney-modal__stops">
         {#each route.stops as stop, i (`${route.id}-${i}`)}
           <li>
-            <span class="jeepney-modal__stop-index">{i + 1}</span>
-            <span class="jeepney-modal__stop-name">{stop.name}</span>
+            <button
+              type="button"
+              class="jeepney-modal__stop"
+              onclick={() => showStop(i)}
+            >
+              <span class="jeepney-modal__stop-index">{i + 1}</span>
+              <span class="jeepney-modal__stop-name">{stop.name}</span>
+            </button>
           </li>
         {/each}
       </ol>
@@ -221,16 +241,31 @@
     flex-direction: column;
   }
 
+  /* Stays the positioning context for the connector line and the index badge;
+     the button inside is the actual row. */
   .jeepney-modal__stops li {
     position: relative;
     display: flex;
+  }
+
+  /* Global `button { all: unset }` means every box property is re-stated. */
+  .jeepney-modal__stop {
+    display: flex;
     align-items: center;
     gap: 0.625rem;
+    width: 100%;
     min-height: 2rem;
-    padding-left: 2.125rem;
+    padding: 0.125rem 0.25rem 0.125rem 2.125rem;
+    border-radius: 0.375rem;
     font-size: 0.875rem;
     font-weight: 500;
+    text-align: left;
     color: hsl(0, 0%, 10%);
+    cursor: pointer;
+  }
+
+  .jeepney-modal__stop:hover {
+    background: color-mix(in srgb, var(--route-color, #7b1113) 10%, white);
   }
 
   .jeepney-modal__stops li::before {


### PR DESCRIPTION
Clicking a stop in the jeepney route list did nothing.

## Cause

The list rendered each stop as a plain `<li>` with two `<span>`s. No handler, no button, nothing to click.

Everything downstream was already built and working:

- `jeepneyStore.openStop(i)` selects the stop and expands the side panel
- `Map.svelte` has an effect that flies the camera to the selected stop (with the rAF guard against `effect_update_depth_exceeded`)
- `MainControls` swaps the side panel to `JeepneyStopPanel`, which has prev/next
- The stop markers **on the map** already called `openStop`

Only the list in `JeepneyRouteModal` was never wired up.

## Fix

Each stop is a button now.

The two copies of this component behave differently, so the handler branches:

- **Modal** (`routeId === null`): selects the route on the map and closes itself, then opens the stop. Order matters, since `openStop` bails when no route is selected on the map and `openRouteOnMap` clears the selected stop when the route changes.
- **Side panel** (`routeId` set): already showing this route, and its container swaps to `JeepneyStopPanel` on its own, so it only opens the stop.

The `<li>` stays the positioning context for the connector line (`::before`) and the absolutely positioned index badge; the button is the row inside it. Every box property is re-stated because the global stylesheet applies `button { all: unset }`.

## Tests

Two added, covering the ordering constraint that is easy to break:

- clicking a stop in the modal ends with both `selectedRouteId` and `selectedStopIndex` set
- the side-panel copy opens the stop without re-selecting the route

`bun run test` 453 pass, `bun run test:components` 168 pass, lint 0 errors, build green.