### PR TITLE
docs: impact numbers, SECURITY.md, community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ _Schedules, buildings, jeepney routes, and "where is PSLH 1?" on one campus map.
 
 No account needed to browse. Editors and contributors fix data in the same app (login popup on the map, not a separate admin site).
 
+## By the numbers
+
+- **58 buildings** and their rooms mapped, searchable, and routable on one campus map
+- **94,000+ class sections** imported across **9 academic terms** (AY 2023 to present)
+- **~21,000 page views** in the 30 days to Aug 2026, measured during term break (Vercel Analytics; peaks land in enlistment and exam weeks)
+- **20 contributors**, 30+ tagged releases, and a [good-first-issue queue](https://github.com/uplbtools/room-tba/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) for student developers
+- Campus map data published as **open data** under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+- Serving [UPLB](https://uplb.edu.ph), a campus of roughly 12,000 students, and built to be [forked for other campuses](#fork-this-for-your-campus)
+
 > **Data note:** Room and class listings are updated each term by volunteers. The active term follows the academic calendar (midyear Jun–Jul, 2nd sem Jan–May, etc.). **Class search** lists lecture, lab, thesis, special problem, and similar sections; ones without a room in AMIS show as unassigned. **Room schedules** list only lecture and lab sections with assigned rooms. Wrong schedule? [Open an issue](https://github.com/uplbtools/room-tba/issues/new/choose).
 
 ---
@@ -213,7 +222,7 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for how to help:
 - **Write code:** branch off `staging`, PR to `staging` ([developer guide](docs/developer-guide.md))
 - **Maintainers / agents:** [AGENTS.md](AGENTS.md) · [agent tooling](docs/agent-tooling.md) (`bun run install:agent-tooling` + `install:agent-plugins` once per machine)
 
-[Good first issues](https://github.com/uplbtools/room-tba/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · **Data:** label `data` · **QA:** label `qa`
+[Good first issues](https://github.com/uplbtools/room-tba/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · **Data:** label `data` · **QA:** label `qa` · **Chat with the team:** [Messenger](https://messenger.uplbtools.me/contribute)
 
 Implementers: [issue hygiene](docs/issue-hygiene.md) · [PR QA process](docs/agentic-qa-process.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported versions
+
+Only the deployed production app ([room-tba.uplb.tools](https://room-tba.uplb.tools)) and the latest release receive security fixes.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for security problems.
+
+- Preferred: [GitHub private vulnerability reporting](https://github.com/uplbtools/room-tba/security/advisories/new)
+- Or contact the maintainer privately: [stimmie.dev](https://stimmie.dev)
+
+Include steps to reproduce and the affected URL or endpoint. You should hear back within a few days; fixes for confirmed reports ship as fast as the team can manage (this is a volunteer student project).
+
+## Scope notes
+
+- Editor/admin actions are password-gated; report any way to write data without the editor login.
+- Donations run through PayMongo checkout; no card or wallet details touch our servers.
+- Campus map data is public by design (CC-BY); "data you can read without login" is usually not a vulnerability.

--- a/docs/vercel-oss-application.md
+++ b/docs/vercel-oss-application.md
@@ -1,0 +1,62 @@
+# Vercel Open Source Program — application prep
+
+Findings from a verified multi-source research pass (2026-08-03) plus the repo
+work done for readiness. Owner: maintainer. Goal: apply in the next window.
+
+## Why we fit (research-backed)
+
+- **Stars are not a criterion.** The application form (Typeform `oQ2C4mve`,
+  reached via vercel.link/oss-apply) never asks for a star count. Its traction
+  question: "Please provide evidence of active development. (e.g., recent
+  commits, releases, signup numbers)" — usage numbers are explicitly sanctioned.
+- **End-user apps get in every cohort.** Five cohorts so far (Spring 2025 to
+  Spring 2026, ~139 projects); each included end-user apps (Rallly, Zoonk,
+  KanaDojo, Workout Cool, KDE Connect). Fall 2025 was roughly a third end-user
+  apps.
+- **Low-star precedents:** Gitvizz (100+ stars, 200+ active users),
+  YourDigitalRights.org (~121 stars), KanaDojo (student-facing learning app, no
+  star count cited, impact framed as "growing global user base"). Vercel's own
+  cohort posts describe end-user apps by usage, not stars (Answer Overflow:
+  1.5M MAU; Vecto3d: 40k site visits; Triplex: "a few hundred people each week").
+- **Eligibility is structural:** fully open source and staying so, hosted (or
+  intending to host) on Vercel for the program duration, Code of Conduct,
+  credits used only for the project, Vercel Team ID supplied. We satisfy all
+  of these today.
+- FAQ: "Can I apply if my project is just starting? Absolutely — projects at
+  all stages."
+
+## Process logistics
+
+- Windows are announced on the Vercel Community forum by staff (Amy Egan);
+  Spring 2026 opened 2026-05-20, cohort announced 2026-06-29. Windows are
+  short (~1.5 weeks) and recur roughly every 3 months. **Watch the forum;
+  applications reopen around August 2026.**
+- One staffer personally reads applications. The impact question is
+  open-ended, ~1000 characters. Grant: $3,600 platform credits for 12 months +
+  OSS starter pack; projects graduate after a year.
+- No public record of rejections or concrete selection rubric exists, so odds
+  beyond eligibility are unquantified.
+
+## Our application skeleton (fill numbers at submit time)
+
+- **What it is:** open-source campus map + class finder for UPLB (~12k
+  students); rooms, schedules, walking routes, offline PWA.
+- **Traction (usage, not stars):** ~21k page views/30d measured off-term
+  (July 2026, Vercel Analytics; term-time peaks land in enlistment weeks),
+  20 contributors, 30+ releases, 94k+ class sections across 9 terms,
+  58 buildings, CC-BY open campus data.
+- **Growth:** fork-for-your-campus guide, UP Diliman port in progress,
+  template for other PH universities.
+- **Why credits matter:** donation-funded student project; credits directly
+  cover the Vercel bill (see docs/funding-model.md).
+- Already hosted on Vercel (SSR + API routes + ISR). Team ID: from the Vercel
+  dashboard at submit time.
+
+## Readiness work landed (2026-08-03)
+
+- README "By the numbers" + SECURITY.md + Messenger link (this PR)
+- Org profile at github.com/uplbtools (uplbtools/.github)
+- Repo topics fixed (astro/vercel/philippines/open-data/university)
+- Repo Discussions enabled; org Discussions needs one click in org settings
+- Still open: publish the UPD fork under the org, term-time usage numbers,
+  infra costs in docs/funding-model.md


### PR DESCRIPTION
## What

- README **By the numbers** section: 58 buildings, 94k+ class sections across 9 terms, ~21k pageviews/30d (off-term, Vercel Analytics), 20 contributors, CC-BY open data, fork-for-your-campus pointer.
- New **SECURITY.md**: private vulnerability reporting via GitHub advisories, scope notes.
- Contributing section now links the Messenger contribute channel.

## Why

Vercel OSS program application (reopens August). Criteria are measurable impact, community standards, growth potential; this makes them visible in the repo.

## QA

- `bun run check:readme` passes.
- Biome check on changed files passes.
- Docs-only; no build needed.

Numbers sourced from prod API (`/api/buildings`), `data/amis-*.json` counts, and `vercel metrics vercel.analytics_pageview.count --prod --since 30d` (20,997).