### PR TITLE
feat(today): one-tap day route with walking totals (#839)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ No account needed to browse. Editors and contributors fix data in the same app (
 | Personal schedule route | Build a plan in Planner → Map tools → Schedule → pick a day, route stops |
 | Browse all classes | Status bar → Browse classes; search by course code |
 | Plan your classes | Planner view to build a draft schedule |
-| What do I have today | Today view (`/today`): your plan's classes for today, tomorrow, and the rest of the week |
+| What do I have today | Today view (`/today`): your plan's classes for today, tomorrow, and the rest of the week; one tap routes the day on the map with total walking time and distance (`/today?route=1`) |
 | Course Planner explainer | [Four-panel, screenshot-ready guide](https://room-tba.uplb.tools/pubmat/course-planner/) |
 | Final exam time & room | Search course code → finals panel; room panel during finals week |
 | Academic calendar | [/calendar](https://room-tba.uplb.tools/calendar) — term windows on a year timeline; also via the term picker |

--- a/e2e/smoke/today-route.spec.ts
+++ b/e2e/smoke/today-route.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { suppressLandingModal } from "../helpers/app";
+import { suppressLandingModal, waitForAppBoot } from "../helpers/app";
 import { openAppSidebar } from "../helpers/map-tools";
 import { E2E_FIXTURES } from "../../scripts/e2e-reset-db";
 
@@ -101,6 +101,22 @@ test.describe("today day route", () => {
     await expect(page.getByRole("dialog", { name: "Today" })).toBeVisible();
     await expect(page.getByText(/15 min walk\s*·\s*1\.2 km/)).toBeVisible({
       timeout: 15_000,
+    });
+  });
+
+  test("status-bar chip routes today's classes from the map", async ({
+    page,
+  }) => {
+    await prepareDayRoutePage(page);
+    await page.goto("/");
+    await waitForAppBoot(page);
+
+    // Hidden-not-disabled surface: it only exists with routable classes today.
+    const chip = page.getByRole("button", { name: "Route my day" });
+    await expect(chip).toBeVisible({ timeout: 30_000 });
+    await chip.click();
+    await expect(page.locator(".schedule-route-stop-pin")).toHaveCount(2, {
+      timeout: 30_000,
     });
   });
 

--- a/e2e/smoke/today-route.spec.ts
+++ b/e2e/smoke/today-route.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect, type Page } from "@playwright/test";
+import { suppressLandingModal } from "../helpers/app";
+import { openAppSidebar } from "../helpers/map-tools";
+import { E2E_FIXTURES } from "../../scripts/e2e-reset-db";
+
+// #839: one-tap day route from /today. Class matching runs against the seeded
+// E2E classes (MWF, scripts/e2e-reset-db.ts), so the clock is pinned to a
+// Monday inside the fixture term; OSRM is an external service, so the route
+// fetch is mocked and the asserted totals derive from the mocked leg below.
+const FIXED_MONDAY = new Date("2026-08-03T09:00:00+08:00");
+
+const OSRM_DAY_ROUTE = {
+  code: "Ok",
+  routes: [
+    {
+      distance: 1200,
+      duration: 900,
+      // polyline5 of building coords → a point ~250 m north-east.
+      geometry: "kumuAo|~bV_I{J",
+      legs: [{ distance: 1200, duration: 900, steps: [], summary: "" }],
+    },
+  ],
+  waypoints: [
+    { location: [E2E_FIXTURES.buildingLon, E2E_FIXTURES.buildingLat] },
+    { location: [121.2431, 14.1671] },
+  ],
+};
+
+const PLANNER_SEED = JSON.stringify({
+  v: 1,
+  plans: [
+    {
+      id: "e2e-day-route",
+      label: "A",
+      termId: E2E_FIXTURES.termId,
+      sections: [
+        {
+          courseCode: "E2E 101",
+          section: "AB",
+          type: "LEC",
+          schedule: ["MWF 08:00AM-09:00AM"],
+          roomCode: E2E_FIXTURES.roomCode,
+          courseTitle: "E2E Course",
+        },
+        {
+          courseCode: "E2E 102",
+          section: "AB",
+          type: "LEC",
+          schedule: ["MWF 09:00AM-10:00AM"],
+          roomCode: E2E_FIXTURES.roomCode,
+          courseTitle: "E2E Course 2",
+        },
+      ],
+    },
+  ],
+  activePlanIdByTerm: { [String(E2E_FIXTURES.termId)]: "e2e-day-route" },
+});
+
+async function prepareDayRoutePage(page: Page) {
+  await page.clock.setFixedTime(FIXED_MONDAY);
+  await page.route("**/routed-foot/**", (route) =>
+    route.fulfill({ json: OSRM_DAY_ROUTE }),
+  );
+  await suppressLandingModal(page);
+  await page.addInitScript(
+    (planner) => localStorage.setItem("room-tba-planner", planner),
+    PLANNER_SEED,
+  );
+}
+
+async function waitForTodayScreen(page: Page) {
+  const shell = page.locator("#app-loading-shell");
+  if ((await shell.count()) > 0) {
+    await shell.waitFor({ state: "detached", timeout: 120_000 });
+  }
+  return page.getByRole("dialog", { name: "Today" });
+}
+
+test.describe("today day route", () => {
+  test("Route my day routes today's classes on the map and shows walking totals", async ({
+    page,
+  }) => {
+    await prepareDayRoutePage(page);
+    await page.goto("/today");
+    const today = await waitForTodayScreen(page);
+    await expect(today).toBeVisible();
+
+    const routeButton = today.getByRole("button", { name: "Route my day" });
+    await expect(routeButton).toBeEnabled();
+    await routeButton.click();
+
+    // Routing leaves the agenda so the map with the route is visible.
+    await expect(today).toBeHidden({ timeout: 30_000 });
+    await expect(page.locator(".schedule-route-stop-pin")).toHaveCount(2, {
+      timeout: 15_000,
+    });
+
+    // Totals from the mocked OSRM legs surface back on the agenda screen.
+    const sidebar = await openAppSidebar(page);
+    await sidebar.getByRole("button", { name: "Today" }).click();
+    await expect(page.getByRole("dialog", { name: "Today" })).toBeVisible();
+    await expect(page.getByText(/15 min walk\s*·\s*1\.2 km/)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("/today?route=1 deep link routes the day on load", async ({ page }) => {
+    await prepareDayRoutePage(page);
+    await page.goto("/today?route=1");
+    await waitForTodayScreen(page);
+
+    // The agenda auto-routes and hands over to the map.
+    await expect(page.getByRole("dialog", { name: "Today" })).toBeHidden({
+      timeout: 30_000,
+    });
+    await expect(page.locator(".schedule-route-stop-pin")).toHaveCount(2, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -329,6 +329,13 @@ async function main() {
        VALUES ('E2E 101', 'AB', 'LEC', ARRAY['MWF 08:00AM-09:00AM'], $1, 'E2E Course', $2, 1)`,
       [roomId, E2E_FIXTURES.termId],
     );
+    // Second class on the same days so a planned day has the two routable
+    // stops the day route needs (e2e/smoke/today-route.spec.ts, #839).
+    await client.query(
+      `INSERT INTO classes (course_code, section, type, schedule, room_id, course_title, term_id, version)
+       VALUES ('E2E 102', 'AB', 'LEC', ARRAY['MWF 09:00AM-10:00AM'], $1, 'E2E Course 2', $2, 1)`,
+      [roomId, E2E_FIXTURES.termId],
+    );
 
     await client.query(
       `INSERT INTO final_exams (term_id, course_code, section, course_title, room_id, exam_date, starts_at, ends_at, source, version)

--- a/src/components/svelte/DayRouteChip.svelte
+++ b/src/components/svelte/DayRouteChip.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import Route from "@lucide/svelte/icons/route";
+  import { sidebarStore } from "@lib/store.svelte";
+  import { routableTodayWeekday, routeToday } from "@lib/today-route";
+  import MapChromeActionChip from "./map-chrome/MapChromeActionChip.svelte";
+
+  // Status-bar surface for the day route (#839). Hidden entirely when there
+  // is nothing to route today — space in the bottom band is scarce, so no
+  // disabled state here (the /today button carries the hints).
+  const visible = $derived(routableTodayWeekday() !== null);
+  let routing = $state(false);
+
+  async function handleClick() {
+    if (routing) return;
+    routing = true;
+    try {
+      if (await routeToday()) {
+        // No-op on the map; leaves the settings/contributors panel so the
+        // routed map is visible, same promise as the /today button.
+        sidebarStore.changeOpened("map");
+      }
+    } finally {
+      routing = false;
+    }
+  }
+</script>
+
+{#if visible}
+  <MapChromeActionChip
+    onclick={handleClick}
+    ariaBusy={routing}
+    ariaLabel="Route my day"
+    title="Route today's classes on the map"
+  >
+    <Route size={14} aria-hidden="true" />
+    <span class="day-route-chip__label">
+      {routing ? "Routing…" : "Route my day"}
+    </span>
+  </MapChromeActionChip>
+{/if}
+
+<style>
+  /* The bottom band already crowds at 320px (online counter + legend +
+     location); keep the icon and drop the label there, like the other
+     compact chip triggers. */
+  @media (max-width: 30rem) {
+    .day-route-chip__label {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -59,6 +59,7 @@
   import StagingBanner from "./StagingBanner.svelte";
   import AnnouncementBar from "./AnnouncementBar.svelte";
   import KeyboardShortcutsPopup from "./map-chrome/KeyboardShortcutsPopup.svelte";
+  import DayRouteChip from "./DayRouteChip.svelte";
   import OnlineCounter from "./OnlineCounter.svelte";
   import { MediaQuery } from "svelte/reactivity";
   import type { RecentSearch } from "@lib/types";
@@ -449,6 +450,7 @@
                 </div>
               {/if}
               <div class="bottom-chrome__triggers">
+                <DayRouteChip />
                 <OnlineCounter />
                 <MapLegend trigger="chip" />
                 <LocationButton embedded />

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -17,6 +17,7 @@
     jeepneyStore,
     appBootstrapStore,
     plannerStore,
+    scheduleRouteStore,
     termStore,
     sidebarStore,
     announcementsStore,
@@ -203,15 +204,16 @@
 
     // /route/<from>/<to> sends its two endpoints here as slugs. Resolving them
     // against loaded campus data (rather than passing coordinates in the URL)
-    // keeps the link stable when an editor moves a pin.
+    // keeps the link stable when an editor moves a pin. On /today the same
+    // param means "route my day" instead (handled below).
     const routeParam = urlParams.get("route");
-    if (routeParam) {
+    if (routeParam && !openToday) {
       const [fromSlug, toSlug] = routeParam.split(",");
       const waypoints = [fromSlug, toSlug]
         .map((slug) => (slug ? findCampusPointBySlug(appData(), slug) : null))
         .filter((point): point is [number, number] => point !== null);
       if (waypoints.length === 2) {
-        locationStore.setWaypoints(waypoints);
+        locationStore.setRouteWaypoints(waypoints);
       }
       window.history.replaceState({}, "", window.location.pathname);
     }
@@ -242,6 +244,10 @@
     if (openToday) {
       void termStore.init();
       sidebarStore.changeOpened("today");
+      // /today?route=1 routes today's classes once the screen mounts (#839).
+      if (routeParam === "1") {
+        scheduleRouteStore.pendingDayRoute = true;
+      }
     }
 
     const planParam = urlParams.get("plan");

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -44,6 +44,7 @@
     trackSponsorImpression,
   } from "@lib/sponsor-tracking";
   import { fade } from "svelte/transition";
+  import { sumRouteLegs } from "@lib/campus-route";
   import MapLibreGlDirections from "@maplibre/maplibre-gl-directions";
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
   import X from "@lucide/svelte/icons/x";
@@ -1861,6 +1862,12 @@
           directions = new MapLibreGlDirections(mapStore.mapInstance, {
             api: "https://routing.openstreetmap.de/routed-foot/route/v1",
             profile: "foot",
+          });
+          // Walking totals for the routed day (#839): the OSRM response the
+          // map already fetched carries per-leg distance/duration.
+          directions.on("fetchroutesend", (event) => {
+            const legs = event.data?.directions?.routes?.[0]?.legs;
+            scheduleRouteStore.setRouteTotals(legs ? sumRouteLegs(legs) : null);
           });
         }
       };

--- a/src/components/svelte/ScheduleImportPanel.svelte
+++ b/src/components/svelte/ScheduleImportPanel.svelte
@@ -7,6 +7,7 @@
   } from "@lib/store.svelte";
   import { onMount, untrack } from "svelte";
   import { flip } from "svelte/animate";
+  import { formatDistance, formatDuration } from "@lib/campus-route";
   import { formatMinutes } from "@lib/schedule-import/day-stops";
   import { WEEKDAY_LABELS, WEEKDAYS } from "@lib/schedule-import/types";
 
@@ -40,7 +41,15 @@
     const key = planKey;
     if (key === lastPlanKey) return;
     lastPlanKey = key;
-    untrack(() => void scheduleRouteStore.importFromPlanner());
+    untrack(() => {
+      // Same plan already imported (e.g. routed from /today, #839): keep the
+      // store's matches and active route instead of clearing them on mount.
+      const storeKey = scheduleRouteStore.importedRows
+        .map((r) => `${r.courseCode}::${r.section}::${r.type}::${r.schedule.join("|")}`)
+        .join(";");
+      if (scheduleRouteStore.hasImport && storeKey === key) return;
+      void scheduleRouteStore.importFromPlanner();
+    });
   });
 
   function selectWeekday(day: Weekday) {
@@ -173,6 +182,13 @@
             {/each}
           </ul>
         </details>
+      {/if}
+
+      {#if routeActive && scheduleRouteStore.routeTotals}
+        <p class="schedule-import-panel__totals">
+          Total walk: {formatDuration(scheduleRouteStore.routeTotals.seconds)} ·
+          {formatDistance(scheduleRouteStore.routeTotals.meters)}
+        </p>
       {/if}
 
       <div class="schedule-import-panel__route-actions">
@@ -398,6 +414,13 @@
   .schedule-import-panel__gap {
     font-size: 0.75rem;
     color: hsl(0, 0%, 40%);
+  }
+
+  .schedule-import-panel__totals {
+    margin: 0;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: hsl(5, 53%, 22%);
   }
 
   .schedule-import-panel__empty,

--- a/src/components/svelte/today/TodayScreen.component.test.ts
+++ b/src/components/svelte/today/TodayScreen.component.test.ts
@@ -4,6 +4,7 @@ import TodayScreen from "@ui/today/TodayScreen.svelte";
 import {
   plannerStore,
   queryStore,
+  scheduleRouteStore,
   sidebarStore,
   termStore,
 } from "@lib/store.svelte";
@@ -33,6 +34,8 @@ describe("TodayScreen", () => {
     termStore.activeTermId = 1252;
     plannerStore.plans = [];
     plannerStore.activePlanIdByTerm = {};
+    scheduleRouteStore.clearImport();
+    scheduleRouteStore.pendingDayRoute = false;
     sidebarStore.changeOpened("today");
   });
 
@@ -79,6 +82,30 @@ describe("TodayScreen", () => {
     expect(queryStore.queryValue).toBe("MB 101");
     // Opening a room leaves the screen for the map behind it.
     expect(sidebarStore.panelOpen).toBe("map");
+  });
+
+  // #839: the day-route action stays visible when unusable — disabled with a
+  // hint — so users learn it exists.
+  test("Route my day is enabled when today has classes", () => {
+    plannerStore.addOffering([row({ schedule: ["M 07:00AM-08:00AM"] })]);
+    render(TodayScreen);
+
+    expect(screen.getByRole("button", { name: /Route my day/ })).toBeEnabled();
+  });
+
+  test("Route my day is disabled with a hint when today has no classes", () => {
+    plannerStore.addOffering([row({ schedule: ["T 07:00AM-08:00AM"] })]);
+    render(TodayScreen);
+
+    expect(screen.getByRole("button", { name: /Route my day/ })).toBeDisabled();
+    expect(screen.getByText("No classes to route today.")).toBeVisible();
+  });
+
+  test("Route my day is disabled with a Planner hint when there is no plan", () => {
+    render(TodayScreen);
+
+    expect(screen.getByRole("button", { name: /Route my day/ })).toBeDisabled();
+    expect(screen.getByText("Add classes in the Planner first.")).toBeVisible();
   });
 
   test("renders an explicit empty state per day and a distinct Sunday", () => {

--- a/src/components/svelte/today/TodayScreen.svelte
+++ b/src/components/svelte/today/TodayScreen.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import MapPin from "@lucide/svelte/icons/map-pin";
+  import Route from "@lucide/svelte/icons/route";
   import { fly } from "svelte/transition";
   import { MediaQuery } from "svelte/reactivity";
+  import { formatDistance, formatDuration } from "@lib/campus-route";
   import { trapFocus } from "@lib/focus-trap";
   import { fullScreenReveal } from "@lib/motion";
+  import { WEEKDAYS } from "@lib/schedule-import/types";
   import {
+    locationStore,
     plannerStore,
     queryStore,
+    scheduleRouteStore,
     sidebarStore,
     termStore,
   } from "@lib/store.svelte";
@@ -36,6 +41,54 @@
   function close() {
     sidebarStore.changeOpened("map");
   }
+
+  // One-tap day route (#839): today's agenda mapped onto the schedule-route
+  // weekday plumbing the Map tools flyout already uses.
+  const today = $derived(days[0] ?? null);
+  const todayWeekday = $derived(
+    today?.dayIndex == null ? null : (WEEKDAYS[today.dayIndex] ?? null),
+  );
+  const canRouteToday = $derived(
+    hasPlan && todayWeekday !== null && (today?.entries.length ?? 0) > 0,
+  );
+  const routeHint = $derived.by(() => {
+    if (canRouteToday) return null;
+    if (!hasPlan) return "Add classes in the Planner first.";
+    if (todayWeekday === null) return "No classes on Sundays.";
+    return "No classes to route today.";
+  });
+  const routedToday = $derived(
+    todayWeekday !== null &&
+      scheduleRouteStore.routedWeekday === todayWeekday &&
+      locationStore.routeWaypoints !== null,
+  );
+  let routing = $state(false);
+
+  async function routeMyDay() {
+    if (routing || !todayWeekday) return;
+    routing = true;
+    try {
+      // Always re-import: the store may hold a stale plan (or nothing) when
+      // the Map tools schedule panel was never opened this session.
+      const imported = await scheduleRouteStore.importFromPlanner();
+      if (!imported) return;
+      scheduleRouteStore.routeDay(todayWeekday);
+      // Leave the overlay only when a route actually drew; failures keep the
+      // agenda visible with the store's toast explaining why.
+      if (scheduleRouteStore.routedWeekday === todayWeekday) close();
+    } finally {
+      routing = false;
+    }
+  }
+
+  // /today?route=1 deep link (flag set by Entry.svelte before this mounts).
+  // Consumed only once terms have loaded: the plan is keyed by the active
+  // term, so at mount canRouteToday is still false and the flag would drop.
+  $effect(() => {
+    if (!scheduleRouteStore.pendingDayRoute || !termStore.loaded) return;
+    scheduleRouteStore.pendingDayRoute = false;
+    if (canRouteToday) void routeMyDay();
+  });
 
   function openRoom(roomCode: string) {
     if (!roomCode) return;
@@ -79,6 +132,26 @@
   {#if offTermNote}
     <p class="today-note" role="note">{offTermNote}</p>
   {/if}
+
+  <div class="today-route">
+    <button
+      type="button"
+      class="today-route__button"
+      disabled={!canRouteToday || routing}
+      onclick={routeMyDay}
+    >
+      <Route size={16} aria-hidden="true" />
+      {routing ? "Routing…" : "Route my day"}
+    </button>
+    {#if routeHint}
+      <span class="today-route__hint">{routeHint}</span>
+    {:else if routedToday && scheduleRouteStore.routeTotals}
+      <span class="today-route__totals">
+        {formatDuration(scheduleRouteStore.routeTotals.seconds)} walk ·
+        {formatDistance(scheduleRouteStore.routeTotals.meters)}
+      </span>
+    {/if}
+  </div>
 
   <div class="today-body">
     {#if !hasPlan}
@@ -198,6 +271,55 @@
     max-width: 52rem;
     font-size: 0.8125rem;
     color: hsl(0, 0%, 40%);
+  }
+
+  .today-route {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    max-width: 52rem;
+  }
+
+  .today-route__button {
+    all: unset;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.4375rem 0.875rem;
+    border: 1px solid hsl(5, 53%, 32%);
+    border-radius: 999px;
+    background: hsl(5, 53%, 32%);
+    color: #fff;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .today-route__button:hover:not(:disabled) {
+    background: hsl(5, 53%, 38%);
+  }
+
+  .today-route__button:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 2px;
+  }
+
+  .today-route__button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .today-route__hint,
+  .today-route__totals {
+    font-size: 0.8125rem;
+    color: hsl(0, 0%, 40%);
+  }
+
+  .today-route__totals {
+    font-weight: 600;
+    color: hsl(5, 53%, 22%);
   }
 
   .today-body {

--- a/src/components/svelte/today/TodayScreen.svelte
+++ b/src/components/svelte/today/TodayScreen.svelte
@@ -17,6 +17,7 @@
     termStore,
   } from "@lib/store.svelte";
   import { buildAgenda } from "@lib/today-agenda";
+  import { routableTodayWeekday, routeToday } from "@lib/today-route";
   import { formatTermDateRange, isDateWithinTerm } from "@lib/term-calendar";
 
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
@@ -42,15 +43,14 @@
     sidebarStore.changeOpened("map");
   }
 
-  // One-tap day route (#839): today's agenda mapped onto the schedule-route
-  // weekday plumbing the Map tools flyout already uses.
+  // One-tap day route (#839): predicate + action shared with the status-bar
+  // chip via today-route.ts, mapped onto the schedule-route weekday plumbing
+  // the Map tools flyout already uses.
   const today = $derived(days[0] ?? null);
   const todayWeekday = $derived(
     today?.dayIndex == null ? null : (WEEKDAYS[today.dayIndex] ?? null),
   );
-  const canRouteToday = $derived(
-    hasPlan && todayWeekday !== null && (today?.entries.length ?? 0) > 0,
-  );
+  const canRouteToday = $derived(routableTodayWeekday() !== null);
   const routeHint = $derived.by(() => {
     if (canRouteToday) return null;
     if (!hasPlan) return "Add classes in the Planner first.";
@@ -65,17 +65,12 @@
   let routing = $state(false);
 
   async function routeMyDay() {
-    if (routing || !todayWeekday) return;
+    if (routing) return;
     routing = true;
     try {
-      // Always re-import: the store may hold a stale plan (or nothing) when
-      // the Map tools schedule panel was never opened this session.
-      const imported = await scheduleRouteStore.importFromPlanner();
-      if (!imported) return;
-      scheduleRouteStore.routeDay(todayWeekday);
       // Leave the overlay only when a route actually drew; failures keep the
       // agenda visible with the store's toast explaining why.
-      if (scheduleRouteStore.routedWeekday === todayWeekday) close();
+      if (await routeToday()) close();
     } finally {
       routing = false;
     }

--- a/src/lib/campus-route.test.ts
+++ b/src/lib/campus-route.test.ts
@@ -4,6 +4,7 @@ import {
   formatDistance,
   formatDuration,
   nearestPlace,
+  sumRouteLegs,
   toCampusRoute,
   type RoutePlace,
 } from "./campus-route";
@@ -240,5 +241,31 @@ describe("formatting", () => {
     expect(formatDuration(20)).toBe("1 min");
     expect(formatDuration(3600)).toBe("1 hr");
     expect(formatDuration(3900)).toBe("1 hr 5 min");
+  });
+});
+
+describe("sumRouteLegs", () => {
+  test("sums distance and duration across a day route's legs", () => {
+    expect(
+      sumRouteLegs([
+        { distance: 420.4, duration: 300.2 },
+        { distance: 812.9, duration: 610.5 },
+      ]),
+    ).toEqual({ meters: 1233, seconds: 911 });
+  });
+
+  test("skips legs the OSRM response left non-numeric", () => {
+    expect(
+      sumRouteLegs([
+        { distance: 100, duration: 80 },
+        { distance: undefined, duration: 80 },
+        { annotation: undefined },
+      ]),
+    ).toEqual({ meters: 100, seconds: 80 });
+  });
+
+  test("null when no leg carries numbers", () => {
+    expect(sumRouteLegs([])).toBeNull();
+    expect(sumRouteLegs([{ distance: "1", duration: null }])).toBeNull();
   });
 });

--- a/src/lib/campus-route.ts
+++ b/src/lib/campus-route.ts
@@ -139,6 +139,35 @@ export async function fetchCampusRoute(
   }
 }
 
+export type RouteTotals = {
+  meters: number;
+  seconds: number;
+};
+
+/**
+ * Total walking distance/time across OSRM route legs (a day route has one leg
+ * per stop-to-stop hop). Legs come from the map's directions response, whose
+ * types leave distance/duration untyped, so non-numeric legs are skipped;
+ * null when nothing summable remains.
+ */
+export function sumRouteLegs(
+  legs: readonly { distance?: unknown; duration?: unknown }[],
+): RouteTotals | null {
+  let meters = 0;
+  let seconds = 0;
+  let counted = false;
+  for (const leg of legs) {
+    if (typeof leg.distance === "number" && typeof leg.duration === "number") {
+      meters += leg.distance;
+      seconds += leg.duration;
+      counted = true;
+    }
+  }
+  return counted
+    ? { meters: Math.round(meters), seconds: Math.round(seconds) }
+    : null;
+}
+
 export function formatDuration(seconds: number): string {
   const minutes = Math.max(1, Math.round(seconds / 60));
   if (minutes < 60) return `${minutes} min`;

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -3,6 +3,7 @@
 import { CAMPUS_BOUNDS } from "@constants/map-terrain";
 import { getJSONFetch, getLocalRoomByCode } from "../local/data/utils.js";
 import type { BuildingTypeFilter } from "@constants/building-types";
+import type { RouteTotals } from "../campus-route.js";
 import { orderDayStops, type Weekday } from "../schedule-import/day-stops.js";
 import { matchImportedScheduleRows } from "../schedule-import/match-classes.js";
 import type { ClassQueryPage } from "../classes-api.js";
@@ -740,6 +741,10 @@ class ScheduleRouteStore {
   matches = $state<ScheduleMatchResult[]>([]);
   selectedWeekday = $state<Weekday>("M");
   routedWeekday: Weekday | null = $state(null);
+  /** Walking totals for the routed day, from the map's OSRM response (#839). */
+  routeTotals: RouteTotals | null = $state(null);
+  /** One-shot /today?route=1 deep link: route today's classes on mount (#839). */
+  pendingDayRoute = $state(false);
   focusedStopIndex: number | null = $state(null);
   matching = $state(false);
   importError: string | null = $state(null);
@@ -897,12 +902,22 @@ class ScheduleRouteStore {
 
   clearRoute = () => {
     this.routedWeekday = null;
+    this.routeTotals = null;
     this.focusedStopIndex = null;
     locationStore.clearRouteWaypoints();
   };
 
+  /**
+   * Map.svelte forwards these from the directions fetch; a 2-point
+   * destination route fires the same event, so only a routed day keeps them.
+   */
+  setRouteTotals = (totals: RouteTotals | null) => {
+    this.routeTotals = this.routedWeekday === null ? null : totals;
+  };
+
   routeDay = (weekday: Weekday = this.selectedWeekday) => {
     this.selectedWeekday = weekday;
+    this.routeTotals = null;
     this.persist();
     const stops = orderDayStops(this.matches, weekday);
     const stopCoords = stops

--- a/src/lib/stores/schedule-route.store.test.ts
+++ b/src/lib/stores/schedule-route.store.test.ts
@@ -128,4 +128,25 @@ describe("ScheduleRouteStore", () => {
     expect(scheduleRouteStore.focusedStopIndex).toBeNull();
     expect(locationStore.routeWaypoints).toBeNull();
   });
+
+  test("route totals only stick while a day is routed", async () => {
+    seedPlan();
+    await scheduleRouteStore.importFromPlanner();
+
+    // The map fires fetchroutesend for 2-point destination routes too; with
+    // no routed day those totals must not attach to the schedule route.
+    scheduleRouteStore.setRouteTotals({ meters: 100, seconds: 60 });
+    expect(scheduleRouteStore.routeTotals).toBeNull();
+
+    locationStore.coords = [121.24, 14.16];
+    scheduleRouteStore.routeDay("M");
+    scheduleRouteStore.setRouteTotals({ meters: 1200, seconds: 900 });
+    expect(scheduleRouteStore.routeTotals).toEqual({
+      meters: 1200,
+      seconds: 900,
+    });
+
+    scheduleRouteStore.clearRoute();
+    expect(scheduleRouteStore.routeTotals).toBeNull();
+  });
 });

--- a/src/lib/today-route.ts
+++ b/src/lib/today-route.ts
@@ -1,0 +1,45 @@
+// One-tap day route (#839): the predicate and action shared by the /today
+// "Route my day" button and the status-bar chip, so the two surfaces can
+// never disagree about when a day is routable.
+
+import { WEEKDAYS, type Weekday } from "./schedule-import/types";
+import { plannerStore, scheduleRouteStore, termStore } from "./store.svelte";
+import { formatTermDateRange, isDateWithinTerm } from "./term-calendar";
+import { buildAgenda } from "./today-agenda";
+
+/**
+ * Today's weekday token when the active plan has classes today; null hides
+ * or disables the day-route surfaces. Mirrors TodayScreen's off-term note:
+ * a plan for a term that is not in session has nothing to attend today.
+ */
+export function routableTodayWeekday(): Weekday | null {
+  const term = termStore.activeTerm;
+  if (
+    term &&
+    !isDateWithinTerm(term, new Date()) &&
+    formatTermDateRange(term)
+  ) {
+    return null;
+  }
+  const sections = plannerStore.activePlan?.sections ?? [];
+  if (sections.length === 0) return null;
+  const today = buildAgenda(sections, { days: 1 })[0];
+  if (!today || today.dayIndex === null || today.entries.length === 0) {
+    return null;
+  }
+  return WEEKDAYS[today.dayIndex] ?? null;
+}
+
+/**
+ * Route today's classes on the map; true when a route actually drew.
+ * Always re-imports the plan: the schedule-route store may hold a stale plan
+ * (or nothing) when its panel was never opened this session. Failures speak
+ * through the store's own toasts.
+ */
+export async function routeToday(): Promise<boolean> {
+  const weekday = routableTodayWeekday();
+  if (weekday === null) return false;
+  if (!(await scheduleRouteStore.importFromPlanner())) return false;
+  scheduleRouteStore.routeDay(weekday);
+  return scheduleRouteStore.routedWeekday === weekday;
+}


### PR DESCRIPTION
## Who are you?

- [x] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.

## Summary

Surfaces the day-route feature (previously 4 unlabeled interactions deep) on three surfaces: a one-tap **Route my day** button on `/today`, a **status-bar chip** on the map's bottom band (visible only when the active plan has classes today — hidden, not disabled), and a shareable `/today?route=1` deep link. Total walking time + distance for a routed day show next to the /today button and in the ScheduleImportPanel result area. Totals come from the OSRM response the map already fetches (`fetchroutesend` legs → `sumRouteLegs()`); the predicate + action are shared via `src/lib/today-route.ts` so the surfaces cannot disagree. No new APIs are called.

Also fixes two adjacent bugs found while wiring this: `Entry.svelte` called the nonexistent `locationStore.setWaypoints` (the `/?route=from,to` deep link from #829 would throw once both slugs resolved), and `ScheduleImportPanel` cleared any active day route on mount even when the store already held the same plan, which would have killed a `/today`-initiated route the moment the panel opened.

**Linked issues:** Refs #839 (items 1, 2, 4, plus a status-bar chip variant of item 3; the first-week landing-modal hint is not in this PR)

## Developer checklist

- [x] `bun run test` (475 pass) + `bun run test:components` (172 pass)
- [x] `bun run lint` (no errors; 2 warnings + 5 infos pre-existing)
- [x] Linked issue commented with this PR URL
- [x] **Heavy CI:** blocking e2e at `e2e/smoke/today-route.spec.ts` (3 tests); `run/e2e` label added after the chip commit

## QA Summary (code changes)

Automated:

- [x] Biome format passed (`bun run lint`)
- [x] Unit tests passed: `bun run test` incl. new `sumRouteLegs` tests; Vitest store test for `routeTotals` gating; TodayScreen component tests for the disabled/enabled/hint states (now exercising the shared `routableTodayWeekday()` predicate)
- [ ] E2E + integration: gated CI rerunning via `run/e2e` (first runs died on the documented shared-pooler `EMAXCONNSESSION` contention — several other PRs ran E2E simultaneously; not a spec failure, the preview never started)
- [x] Full lint passed (local)
- [x] Build passed (local): `bun run build` (twice, once per commit)

If map chrome, editor, or side panel changed:

- [x] Verified at 320px: `/today` route row and the bottom-band chip do not overflow (`scrollWidth` = viewport); chip collapses to icon-only below 30rem per the band's compact-chip pattern
- [x] Chip mounts in the bottom Entry zone (`bottom-chrome__triggers`), no new fixed overlays (map-layout.mdc)

Manual browser QA (local dev server, real prod data + real OSRM, term 1261, clock pinned to a Wednesday with 3 planned classes across CEAT/ICOPED/CEM):

- Route my day (/today): enabled with classes today; tap routes 3 stops, draws the polyline, closes the overlay
- Status-bar chip: visible on the map with routable classes today; tap routes the same 3 stops; hidden entirely with no plan; icon-only at 320px
- Totals: "15 min walk · 1.1 km" next to the /today button; "Total walk: 15 min · 1.1 km" + "Re-route day" in the schedule panel; route survives opening the panel
- Disabled states on /today: no plan → "Add classes in the Planner first."; no classes today → "No classes to route today."
- Deep link `/today?route=1`: auto-routes on load and hands over to the map
- Console: only pre-existing local noise (MapTiler 403 dev key fallback, Vercel insights 404 in dev)

Known gaps:

- One class today + no location fix still yields the existing "Need at least two stops" toast (pre-existing routeDay behavior)
- Pre-existing race: `?term=` on a cold `/today` load can be stripped by URL sync before terms load (unrelated; `?route=1` is immune because Entry captures the search synchronously)
- On very large terms (~13k classes) matching pages through `/api/classes` and routing takes several seconds; button shows "Routing…" meanwhile (pre-existing ScheduleRouteStore cost)
- The chip's predicate counts classes with or without rooms (same predicate as the /today button by design); an all-TBA day routes to the existing "No routable classes" toast

Follow-up:

- #839 landing-modal first-week hint intentionally not included

## Issues updated (maintainers / detailed specs)

- [x] Linked issue(s) commented with this PR
- [x] Acceptance criteria / paths updated on issue body

## Test plan

1. Build a plan in `/planner` for the active term with 2+ classes today, in rooms with pins.
2. Map view: a "Route my day" chip appears in the bottom band → tap → numbered stops + walking route.
3. Open `/today` → **Route my day** → same route; reopen Today → totals next to the button.
4. Map tools → Schedule: totals line under the stops, "Re-route day", route not cleared by opening the panel.
5. `/today?route=1` → routes on load. Empty plan → /today button disabled with hint, chip absent from the map.