### PR TITLE
feat(classes): probable location for Room TBA sections (#846)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ No account needed to browse. Editors and contributors fix data in the same app (
 | Room schedule this sem | Term filter + timetable |
 | Personal schedule route | Build a plan in Planner → Map tools → Schedule → pick a day, route stops |
 | Browse all classes | Status bar → Browse classes; search by course code |
+| Section with no room yet | "No assigned room" rows hint the offering department and where the course usually meets (#846) |
 | Plan your classes | Planner view to build a draft schedule |
 | What do I have today | Today view (`/today`): your plan's classes for today, tomorrow, and the rest of the week |
 | Course Planner explainer | [Four-panel, screenshot-ready guide](https://room-tba.uplb.tools/pubmat/course-planner/) |
@@ -186,6 +187,7 @@ Install the [Biome VS Code extension](https://marketplace.visualstudio.com/items
 | `bun run import:osa-orgs` | Add the current public OSA organization directory (`DATABASE_URL`; safe to rerun) |
 | `bun run import:campus-offices` | Add missing campus offices and units (`DATABASE_URL`; safe to rerun) |
 | `bun run import:amis-classes` | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`) |
+| `bun run backfill:acad-orgs` | Rerun the AMIS import over the 9 cached term JSONs to fill `classes.acad_group`/`acad_org` (#846) |
 | `bun run import:final-exams` | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`) |
 
 Legacy **`data/info.db`** SQLite is only for old seed/export scripts (`bun:sqlite`, not runtime). Production uses Supabase Postgres via `DATABASE_URL`. Archived SQLite migrations live in `drizzle-migrations/`: do not edit; active schema is `drizzle/`.

--- a/data/acad-orgs.json
+++ b/data/acad-orgs.json
@@ -1,0 +1,113 @@
+{
+  "$comment": "AMIS acad_org (PeopleSoft department code) -> display name + college code (#846). Curated: add codes as editors confirm them; unknown codes degrade to the acad_group college code in the UI. `entityName` overrides the organizations-table entity to pin when it differs from `name`. Frequencies measured across the 9 in-repo term JSONs (1231-1261); every code here has >=498 class rows and a verified UPLB unit name.",
+  "LBICROPS": { "name": "Institute of Crop Science", "collegeCode": "CAFS" },
+  "LBIBS": { "name": "Institute of Biological Sciences", "collegeCode": "CAS" },
+  "LBIAS": { "name": "Institute of Animal Science", "collegeCode": "CAFS" },
+  "LBDHUM": { "name": "Department of Humanities", "collegeCode": "CAS" },
+  "LBIRNR": {
+    "name": "Institute of Renewable Natural Resources",
+    "collegeCode": "CFNR"
+  },
+  "LBIC": { "name": "Institute of Chemistry", "collegeCode": "CAS" },
+  "LBIABE": {
+    "name": "Institute of Agricultural and Biosystems Engineering",
+    "collegeCode": "CEAT"
+  },
+  "LBDFBS": {
+    "name": "Department of Forest Biological Sciences",
+    "collegeCode": "CFNR"
+  },
+  "LBDFPPS": {
+    "name": "Department of Forest Products and Paper Science",
+    "collegeCode": "CFNR"
+  },
+  "LBICS": { "name": "Institute of Computer Science", "collegeCode": "CAS" },
+  "LBSESAM": {
+    "name": "School of Environmental Science and Management",
+    "collegeCode": "SESAM"
+  },
+  "LBDSS": { "name": "Department of Social Sciences", "collegeCode": "CAS" },
+  "LBIHNF": {
+    "name": "Institute of Human Nutrition and Food",
+    "collegeCode": "CHE"
+  },
+  "LBIFST": {
+    "name": "Institute of Food Science and Technology",
+    "collegeCode": "CAFS"
+  },
+  "LBDSFFG": {
+    "name": "Department of Social Forestry and Forest Governance",
+    "collegeCode": "CFNR"
+  },
+  "LBIWEP": {
+    "name": "Institute of Weed Science, Entomology and Plant Pathology",
+    "collegeCode": "CAFS"
+  },
+  "LBIMS": {
+    "name": "Institute of Mathematical Sciences and Physics",
+    "collegeCode": "CAS",
+    "entityName": "Institute of Mathematical Sciences and Physics / New Mathematics Building"
+  },
+  "LBASI": { "name": "Agricultural Systems Institute", "collegeCode": "CAFS" },
+  "LBDAAE": {
+    "name": "Department of Agricultural and Applied Economics",
+    "collegeCode": "CEM"
+  },
+  "LBIGRD": {
+    "name": "Institute for Governance and Rural Development",
+    "collegeCode": "CPAF"
+  },
+  "LBINSTAT": { "name": "Institute of Statistics", "collegeCode": "CAS" },
+  "LBDCHE": {
+    "name": "Department of Chemical Engineering",
+    "collegeCode": "CEAT"
+  },
+  "LBDHK": { "name": "Department of Human Kinetics", "collegeCode": "CAS" },
+  "LBDEE": {
+    "name": "Department of Electrical Engineering",
+    "collegeCode": "CEAT"
+  },
+  "LBDE": { "name": "Department of Economics", "collegeCode": "CEM" },
+  "LBDDJ": {
+    "name": "Department of Development Journalism",
+    "collegeCode": "CDC"
+  },
+  "LBDVCS": {
+    "name": "Department of Veterinary Clinical Sciences",
+    "collegeCode": "CVM"
+  },
+  "LBDVPS": {
+    "name": "Department of Veterinary Paraclinical Sciences",
+    "collegeCode": "CVM"
+  },
+  "LBDAME": {
+    "name": "Department of Agribusiness Management and Entrepreneurship",
+    "collegeCode": "CEM"
+  },
+  "LBIoP": { "name": "Institute of Physics", "collegeCode": "CAS" },
+  "LBDHFDS": {
+    "name": "Department of Human and Family Development Studies",
+    "collegeCode": "CHE"
+  },
+  "LBDCERP": {
+    "name": "Department of Community and Environmental Resource Planning",
+    "collegeCode": "CHE"
+  },
+  "LBDIE": {
+    "name": "Department of Industrial Engineering",
+    "collegeCode": "CEAT"
+  },
+  "LBDBVS": {
+    "name": "Department of Basic Veterinary Sciences",
+    "collegeCode": "CVM"
+  },
+  "LBDCE": { "name": "Department of Civil Engineering", "collegeCode": "CEAT" },
+  "LBDENSC": {
+    "name": "Department of Engineering Science",
+    "collegeCode": "CEAT"
+  },
+  "LBDSDS": {
+    "name": "Department of Social Development Services",
+    "collegeCode": "CHE"
+  }
+}

--- a/docs/amis-com-refresh-runbook.md
+++ b/docs/amis-com-refresh-runbook.md
@@ -65,4 +65,14 @@ See [amis-contingency-runbook.md](./amis-contingency-runbook.md) for 403, rate l
 
 ## TBA sections
 
-Rows with no `facility_id` are **not imported** (no map pin). They appear in the import report under “Missing facility”. Product policy: list-only / no pin until a room is known: see issue #300.
+LEC/LAB/RCT/CPT rows whose facility is missing or unmatched import with `room_id NULL` (no map pin; they appear in the report under “Missing facility” / “unmatched facility”). The app shows them as “No assigned room” plus a hedged probable-location hint from the section’s department (`acad_org` decoded via `data/acad-orgs.json`) or its course/department room history (#846). Unmatched facility strings are still an alias problem: see issue #300.
+
+### Backfill `acad_group` / `acad_org` (#846)
+
+`classes.acad_group` and `classes.acad_org` (migration `drizzle/0042_add_class_acad_org.sql`) are populated by the importer. After applying the migration, rerunning the import over the 9 cached term JSONs fills them for existing rows (upsert by natural key; no AMIS fetch, no `--replace-term` needed):
+
+```sh
+DATABASE_URL=… bun run backfill:acad-orgs
+```
+
+(equivalent to `bun run import:amis-classes -- --term-id <id>` for 1231 1232 1241 1242 1243 1251 1252 1253 1261). Prod backfill is a maintainer step after merge — never run it from CI.

--- a/docs/fork-data-guide.md
+++ b/docs/fork-data-guide.md
@@ -89,6 +89,8 @@ retyped PDF) and flatten it to one row per meeting slot:
 | `building_code` | no | `BSC` | Extra match candidate `"<building_code> <room_code>"` for registrars with per-building room numbers |
 | `term_id` | yes | `101` | Must already exist in the `terms` table |
 | `course_title` | no | `General Biology` | |
+| `acad_group` | no | `CAS` | Registrar college code; powers the probable-location hint for roomless sections (#846) |
+| `acad_org` | no | `LBICS` | Registrar department code; decoded via `data/acad-orgs.json`. Blank = keep any existing DB value |
 
 JSON is the same shape: an array of flat objects with those keys.
 

--- a/drizzle/0042_add_class_acad_org.sql
+++ b/drizzle/0042_add_class_acad_org.sql
@@ -1,0 +1,7 @@
+-- Probable location for Room TBA sections (#846): AMIS carries a college code
+-- (acad_group, e.g. "CAS") and a PeopleSoft department code (acad_org, e.g.
+-- "LBICS") on every class row; store them so unassigned sections can be linked
+-- to their department. Backfill = rerun import:amis-classes per term JSON.
+ALTER TABLE "classes"
+ADD COLUMN IF NOT EXISTS "acad_group" varchar(8),
+ADD COLUMN IF NOT EXISTS "acad_org" varchar(16);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -257,6 +257,10 @@ export const classesTable = pgTable(
     roomId: integer("room_id"),
     courseTitle: text("course_title"),
     termId: integer("term_id"),
+    // AMIS college + department codes (#846), e.g. "CAS" / "LBICS". Decode
+    // table: data/acad-orgs.json.
+    acadGroup: varchar("acad_group", { length: 8 }),
+    acadOrg: varchar("acad_org", { length: 16 }),
     version: integer().default(1).notNull(),
     updatedAt: timestamp("updated_at", { mode: "string" })
       .defaultNow()

--- a/e2e/browse/probable-location.spec.ts
+++ b/e2e/browse/probable-location.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppBoot } from "../helpers/app";
+import { openAppSidebar } from "../helpers/map-tools";
+
+/**
+ * Room TBA probable location (#846). The seed creates E2E 101 section C (LEC)
+ * with no room; its sibling AB meets in E2E Test Hall, so the course-history
+ * fallback hints there. Assigned sections must never carry the hint.
+ */
+test.describe("probable location for Room TBA sections", () => {
+  test("class browse shows the hedged hint for the unassigned section", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForAppBoot(page);
+
+    const sidebar = await openAppSidebar(page);
+    await sidebar.getByRole("button", { name: /^classes$/i }).click();
+    await expect(page.getByText(/All classes/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await expect(
+      page.getByText("Usually meets around E2E Test Hall").first(),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByRole("button", {
+        name: /Show probable location of E2E 101 C on the map/i,
+      }),
+    ).toBeVisible();
+
+    // Exactly one hint: the assigned section (AB, in E2E-101) gets none.
+    await expect(page.getByText(/Usually meets around/)).toHaveCount(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "import:campus-offices": "bun run scripts/import-campus-office-directory.ts",
     "import:amis-classes": "bun run scripts/import-amis-classes.ts",
     "import:classes-generic": "bun run scripts/import-classes-generic.ts",
+    "backfill:acad-orgs": "for t in 1231 1232 1241 1242 1243 1251 1252 1253 1261; do bun run scripts/import-amis-classes.ts --term-id $t || exit 1; done",
     "import:final-exams": "bun run scripts/import-final-exams.ts",
     "release": "semantic-release",
     "release:dry": "semantic-release --dry-run"

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -76,6 +76,7 @@ const E2E_MIGRATION_FILES = [
   "0039_classes_keyset_index.sql",
   "0040_pre_drizzle_schema_backfill.sql",
   "0041_add_announcements.sql",
+  "0042_add_class_acad_org.sql",
 ] as const;
 
 /**
@@ -328,6 +329,15 @@ async function main() {
       `INSERT INTO classes (course_code, section, type, schedule, room_id, course_title, term_id, version)
        VALUES ('E2E 101', 'AB', 'LEC', ARRAY['MWF 08:00AM-09:00AM'], $1, 'E2E Course', $2, 1)`,
       [roomId, E2E_FIXTURES.termId],
+    );
+
+    // Room TBA section (#846): no room, uncurated acad_org, so the probable-
+    // location hint resolves via course history (section AB above meets in
+    // the seeded building).
+    await client.query(
+      `INSERT INTO classes (course_code, section, type, schedule, room_id, course_title, term_id, acad_group, acad_org, version)
+       VALUES ('E2E 101', 'C', 'LEC', ARRAY['TTh 10:00AM-11:00AM'], NULL, 'E2E Course', $1, 'E2E', 'LBE2E', 1)`,
+      [E2E_FIXTURES.termId],
     );
 
     await client.query(

--- a/scripts/import-amis-classes.ts
+++ b/scripts/import-amis-classes.ts
@@ -304,6 +304,8 @@ async function main() {
           schedule: classesTable.schedule,
           roomId: classesTable.roomId,
           termId: classesTable.termId,
+          acadGroup: classesTable.acadGroup,
+          acadOrg: classesTable.acadOrg,
         })
         .from(classesTable)
         .where(eq(classesTable.termId, options.termId)),
@@ -356,6 +358,8 @@ async function main() {
             schedule: row.schedule,
             roomId: row.roomId,
             termId: row.termId,
+            acadGroup: row.acadGroup,
+            acadOrg: row.acadOrg,
           })
           .where(eq(classesTable.id, id));
       }

--- a/scripts/import-classes-generic.ts
+++ b/scripts/import-classes-generic.ts
@@ -116,6 +116,8 @@ function resolveRooms(
       schedule: row.schedule,
       roomId,
       termId: row.termId,
+      acadGroup: row.acadGroup,
+      acadOrg: row.acadOrg,
     };
   });
 
@@ -194,6 +196,8 @@ async function main() {
           schedule: classesTable.schedule,
           roomId: classesTable.roomId,
           termId: classesTable.termId,
+          acadGroup: classesTable.acadGroup,
+          acadOrg: classesTable.acadOrg,
         })
         .from(classesTable)
         .where(inArray(classesTable.termId, termIds)),

--- a/src/components/svelte/room/Classes.component.test.ts
+++ b/src/components/svelte/room/Classes.component.test.ts
@@ -17,6 +17,19 @@ const roomlessClass: ClassMapValue = {
   courseTitle: "Undergraduate Thesis",
 };
 
+const tbaLecture: ClassMapValue = {
+  id: 2,
+  termId: 1252,
+  roomId: null,
+  courseCode: "CMSC 128",
+  roomCode: null,
+  section: "B",
+  type: "LEC",
+  schedule: ["TTh 10:00AM-11:00AM"],
+  directions: null,
+  courseTitle: "Software Engineering",
+};
+
 describe("Classes", () => {
   test("shows human label and no assigned room at 320px", () => {
     mountAtWidth(320);
@@ -25,5 +38,69 @@ describe("Classes", () => {
     expect(screen.getByText("Thesis")).toBeVisible();
     expect(screen.getByText(/No assigned room/)).toBeVisible();
     expect(screen.queryByRole("button", { name: "Open room" })).toBeNull();
+  });
+
+  test("renders the probable-location hint for a Room TBA section (#846)", () => {
+    mountAtWidth(320);
+    render(Classes, {
+      classes: [
+        {
+          ...tbaLecture,
+          probableLocation: {
+            source: "department",
+            deptName: "Institute of Computer Science",
+            collegeCode: "CAS",
+            orgName: "Institute of Computer Science (ICS)",
+          },
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText("Offered by Institute of Computer Science (CAS)"),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: "Show probable location of CMSC 128 B on the map",
+      }),
+    ).toBeVisible();
+  });
+
+  test("hedges with the modal building for history-sourced hints (#846)", () => {
+    mountAtWidth(320);
+    render(Classes, {
+      classes: [
+        {
+          ...tbaLecture,
+          probableLocation: {
+            source: "course-history",
+            collegeCode: "CAS",
+            buildingId: 7,
+            buildingName: "Physical Sciences Building",
+          },
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText("Usually meets around Physical Sciences Building"),
+    ).toBeVisible();
+    // No decoded department: no "Offered by" line.
+    expect(screen.queryByText(/Offered by/)).toBeNull();
+  });
+
+  test("shows no hint or pin for assigned sections and hint-less rows", () => {
+    mountAtWidth(320);
+    render(Classes, {
+      classes: [
+        { ...tbaLecture, id: 3, roomId: 9, roomCode: "ICS MH3" },
+        roomlessClass,
+      ],
+    });
+
+    expect(screen.queryByText(/Usually meets around|Offered by/)).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Show probable location/ }),
+    ).toBeNull();
   });
 });

--- a/src/components/svelte/room/Classes.svelte
+++ b/src/components/svelte/room/Classes.svelte
@@ -8,6 +8,7 @@
     offeringGroupKey,
   } from "@lib/class-offering-groups";
   import type { ClassOfferingGroup } from "@lib/class-offering-groups";
+  import type { ProbableLocation } from "@lib/probable-location";
   import type { ClassMapValue } from "@lib/types";
   import { plannerStore, queryStore, toastStore } from "@lib/store.svelte";
 
@@ -33,6 +34,27 @@
   function formatSchedule(schedule: string[] | null): string {
     if (!schedule?.length) return "Schedule TBA";
     return schedule.join(" · ");
+  }
+
+  /** "Offered by Institute of Computer Science (CAS)" — hedged, never "is at". */
+  function probableDeptLine(probable: ProbableLocation): string | null {
+    if (probable.deptName && probable.collegeCode) {
+      return `Offered by ${probable.deptName} (${probable.collegeCode})`;
+    }
+    if (probable.deptName) return `Offered by ${probable.deptName}`;
+    return null;
+  }
+
+  /** Select the department org / probable building; Map.svelte handles the camera. */
+  function showProbableLocation(probable: ProbableLocation) {
+    const target = probable.orgName
+      ? { category: "organization" as const, value: probable.orgName }
+      : probable.buildingName
+        ? { category: "building" as const, value: probable.buildingName }
+        : null;
+    if (!target) return;
+    queryStore.updateQuery({ type: "result", ...target });
+    queryStore.inputValue = target.value;
   }
 
   function planKey(group: ClassOfferingGroup): string | null {
@@ -105,6 +127,27 @@
               <div class="class-section-row__schedule">
                 {formatSchedule(sectionClass.schedule)}
               </div>
+              {#if !sectionClass.roomCode && sectionClass.probableLocation}
+                {@const probable = sectionClass.probableLocation}
+                <div class="class-section-row__probable">
+                  {#if probableDeptLine(probable)}
+                    <span>{probableDeptLine(probable)}</span>
+                  {/if}
+                  {#if probable.buildingName}
+                    <span>Usually meets around {probable.buildingName}</span>
+                  {/if}
+                  {#if probable.orgName || probable.buildingName}
+                    <button
+                      type="button"
+                      class="class-section-row__probable-pin"
+                      aria-label={`Show probable location of ${group.courseCode} ${group.section} on the map`}
+                      onclick={() => showProbableLocation(probable)}
+                    >
+                      Show on map
+                    </button>
+                  {/if}
+                </div>
+              {/if}
             </div>
             {#if showRoomLink && sectionClass.roomCode}
               <button
@@ -244,6 +287,36 @@
     font-size: 0.75rem;
     color: #555;
     line-height: 1.35;
+  }
+
+  /* Hedged Room TBA hint (#846) — subdued on purpose; the room link stays the
+     primary affordance. */
+  .class-section-row__probable {
+    margin-top: 0.25rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    column-gap: 0.5rem;
+    row-gap: 0.125rem;
+    font-size: 0.6875rem;
+    color: #777;
+    line-height: 1.4;
+  }
+
+  .class-section-row__probable-pin {
+    border: none;
+    background: none;
+    padding: 0.125rem 0;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    color: #777;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+  }
+
+  .class-section-row__probable-pin:hover {
+    color: hsl(5, 53%, 32%);
   }
 
   .class-section-row__open {

--- a/src/lib/acad-orgs.test.ts
+++ b/src/lib/acad-orgs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import rawAcadOrgs from "../../data/acad-orgs.json";
+import { decodeAcadOrg } from "./acad-orgs";
+
+describe("decodeAcadOrg (#846)", () => {
+  it("decodes a curated code", () => {
+    expect(decodeAcadOrg("LBICS")).toEqual({
+      name: "Institute of Computer Science",
+      collegeCode: "CAS",
+    });
+  });
+
+  it("matches mixed-case AMIS codes case-insensitively", () => {
+    expect(decodeAcadOrg("LBIoP")?.name).toBe("Institute of Physics");
+    expect(decodeAcadOrg("lbics")?.name).toBe("Institute of Computer Science");
+  });
+
+  it("returns null for uncurated, blank, and null codes", () => {
+    expect(decodeAcadOrg("LBNOPE")).toBeNull();
+    expect(decodeAcadOrg("")).toBeNull();
+    expect(decodeAcadOrg(null)).toBeNull();
+    expect(decodeAcadOrg(undefined)).toBeNull();
+    expect(decodeAcadOrg("$comment")).toBeNull();
+  });
+
+  it("every data-file entry has a non-empty name (and decodes)", () => {
+    for (const [code, entry] of Object.entries(rawAcadOrgs)) {
+      if (code.startsWith("$")) continue;
+      expect(typeof entry).toBe("object");
+      const { name } = entry as { name?: string };
+      expect(name && name.length > 0).toBe(true);
+      expect(decodeAcadOrg(code)?.name).toBe(name as string);
+    }
+  });
+});

--- a/src/lib/acad-orgs.ts
+++ b/src/lib/acad-orgs.ts
@@ -1,0 +1,35 @@
+/**
+ * Decode AMIS `acad_org` department codes (#846). Data file:
+ * data/acad-orgs.json — curated, editors extend it code by code; unknown
+ * codes return null and callers fall back to the `acad_group` college code
+ * (and room-history hints) instead.
+ */
+import rawAcadOrgs from "../../data/acad-orgs.json";
+
+export type AcadOrgEntry = {
+  /** Human department / institute name, e.g. "Institute of Computer Science". */
+  name: string;
+  /** College code as AMIS reports it in acad_group, e.g. "CAS". */
+  collegeCode?: string;
+  /** organizations.name to pin on the map when it differs from `name`. */
+  entityName?: string;
+};
+
+const entries = new Map<string, AcadOrgEntry>(
+  Object.entries(rawAcadOrgs as Record<string, unknown>)
+    .filter(
+      (pair): pair is [string, AcadOrgEntry] =>
+        !pair[0].startsWith("$") &&
+        typeof (pair[1] as AcadOrgEntry)?.name === "string",
+    )
+    // AMIS codes are mixed-case ("LBIoP"); match case-insensitively.
+    .map(([code, entry]) => [code.toUpperCase(), entry]),
+);
+
+/** Decode an AMIS acad_org code; null when uncurated (caller falls back). */
+export function decodeAcadOrg(
+  code: string | null | undefined,
+): AcadOrgEntry | null {
+  if (!code) return null;
+  return entries.get(code.trim().toUpperCase()) ?? null;
+}

--- a/src/lib/amis/import-classes.ts
+++ b/src/lib/amis/import-classes.ts
@@ -13,6 +13,8 @@ export type ClassInsertRow = {
   schedule: string[];
   roomId: number | null;
   termId: number;
+  acadGroup?: string | null;
+  acadOrg?: string | null;
 };
 
 export type ImportRowStats = {
@@ -285,6 +287,8 @@ export function resolveImportRows(
         schedule: row.schedule,
         roomId,
         termId: row.termId,
+        acadGroup: row.acadGroup,
+        acadOrg: row.acadOrg,
       });
       continue;
     }
@@ -310,6 +314,8 @@ export function resolveImportRows(
       schedule: row.schedule,
       roomId,
       termId: row.termId,
+      acadGroup: row.acadGroup,
+      acadOrg: row.acadOrg,
     });
   }
 
@@ -330,6 +336,8 @@ export function summarizeImportChanges(input: {
       courseTitle: string | null;
       schedule: string[] | null;
       roomId: number | null;
+      acadGroup?: string | null;
+      acadOrg?: string | null;
     }
   >;
 }): {
@@ -358,12 +366,19 @@ export function summarizeImportChanges(input: {
       continue;
     }
 
+    // acad fields compare only when the importer carries them (undefined =
+    // source has no such column, e.g. a generic file without acad_org) so a
+    // rerun neither clobbers nor spuriously "updates" AMIS-imported codes.
     const changed =
       existing.courseCode !== row.courseCode ||
       existing.section !== row.section ||
       existing.type !== row.type ||
       existing.courseTitle !== row.courseTitle ||
       existing.roomId !== row.roomId ||
+      (row.acadGroup !== undefined &&
+        (existing.acadGroup ?? null) !== row.acadGroup) ||
+      (row.acadOrg !== undefined &&
+        (existing.acadOrg ?? null) !== row.acadOrg) ||
       JSON.stringify(existing.schedule ?? []) !== JSON.stringify(row.schedule);
 
     if (changed) {

--- a/src/lib/amis/normalize-class.test.ts
+++ b/src/lib/amis/normalize-class.test.ts
@@ -129,7 +129,24 @@ describe("amis normalize", () => {
       schedule: ["MW 07:00AM-08:00AM"],
       termId: 1252,
       facilityCode: "PSLH A",
+      acadGroup: null,
+      acadOrg: null,
     });
+  });
+
+  it("carries acad_group and acad_org codes (#846)", () => {
+    const normalized = normalizeAmisClass(
+      {
+        course_code: "CMSC 128",
+        section: "A",
+        type: "LEC",
+        acad_group: "CAS",
+        acad_org: "LBICS",
+      },
+      1252,
+    );
+    expect(normalized?.acadGroup).toBe("CAS");
+    expect(normalized?.acadOrg).toBe("LBICS");
   });
 
   it("builds schedule from top-level date/time when class_dates is empty (CRS 1231)", () => {

--- a/src/lib/amis/normalize-class.ts
+++ b/src/lib/amis/normalize-class.ts
@@ -235,5 +235,7 @@ export function normalizeAmisClass(
     schedule,
     termId: Number(row.term_id ?? row.termId ?? termId),
     facilityCode: resolveFacilityCode(row),
+    acadGroup: asString(row.acad_group),
+    acadOrg: asString(row.acad_org),
   };
 }

--- a/src/lib/amis/types.ts
+++ b/src/lib/amis/types.ts
@@ -19,4 +19,8 @@ export type NormalizedAmisClass = {
   schedule: string[];
   termId: number;
   facilityCode: string | null;
+  /** AMIS college code, e.g. "CAS" (#846). */
+  acadGroup: string | null;
+  /** AMIS PeopleSoft department code, e.g. "LBICS" (#846). */
+  acadOrg: string | null;
 };

--- a/src/lib/generic-class-import.ts
+++ b/src/lib/generic-class-import.ts
@@ -27,6 +27,10 @@ export const GENERIC_CLASS_REQUIRED_HEADERS = [
 export const GENERIC_CLASS_OPTIONAL_HEADERS = [
   "building_code",
   "course_title",
+  // Registrar college / department codes (#846), e.g. "CAS" / "LBICS". Blank
+  // or missing = leave any existing DB value untouched.
+  "acad_group",
+  "acad_org",
 ] as const;
 
 export const GENERIC_CLASS_HEADERS = [
@@ -52,6 +56,9 @@ export type NormalizedGenericClass = {
   termId: number;
   /** Free-text room names to try against rooms + aliases, in order. */
   roomCandidates: string[];
+  /** Optional college / department codes; undefined = column not provided. */
+  acadGroup?: string;
+  acadOrg?: string;
 };
 
 const CLASS_TYPE_MAP: Record<string, "LEC" | "LAB"> = {
@@ -311,6 +318,8 @@ export function normalizeGenericClasses(
         schedule: [slot],
         termId: Number(values.term_id),
         roomCandidates: candidates,
+        acadGroup: values.acad_group || undefined,
+        acadOrg: values.acad_org || undefined,
       });
       continue;
     }
@@ -322,6 +331,12 @@ export function normalizeGenericClasses(
     }
     if (!existing.courseTitle && values.course_title) {
       existing.courseTitle = values.course_title;
+    }
+    if (!existing.acadGroup && values.acad_group) {
+      existing.acadGroup = values.acad_group;
+    }
+    if (!existing.acadOrg && values.acad_org) {
+      existing.acadOrg = values.acad_org;
     }
   }
   return [...byKey.values()];

--- a/src/lib/local/data/pglite-schema.generated.ts
+++ b/src/lib/local/data/pglite-schema.generated.ts
@@ -48,6 +48,8 @@ CREATE TABLE IF NOT EXISTS "classes" (
   "room_id" integer,
   "course_title" text,
   "term_id" integer,
+  "acad_group" varchar(8),
+  "acad_org" varchar(16),
   "version" integer DEFAULT 1 NOT NULL,
   "updated_at" text DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "directions" text
@@ -59,6 +61,8 @@ ALTER TABLE "classes" ADD COLUMN IF NOT EXISTS "schedule" text[];
 ALTER TABLE "classes" ADD COLUMN IF NOT EXISTS "room_id" integer;
 ALTER TABLE "classes" ADD COLUMN IF NOT EXISTS "course_title" text;
 ALTER TABLE "classes" ADD COLUMN IF NOT EXISTS "term_id" integer;
+ALTER TABLE "classes" ADD COLUMN IF NOT EXISTS "acad_group" varchar(8);
+ALTER TABLE "classes" ADD COLUMN IF NOT EXISTS "acad_org" varchar(16);
 ALTER TABLE "classes" ADD COLUMN IF NOT EXISTS "version" integer DEFAULT 1 NOT NULL;
 ALTER TABLE "classes" ADD COLUMN IF NOT EXISTS "updated_at" text DEFAULT CURRENT_TIMESTAMP NOT NULL;
 ALTER TABLE "classes" ADD COLUMN IF NOT EXISTS "directions" text;

--- a/src/lib/probable-location.test.ts
+++ b/src/lib/probable-location.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "bun:test";
+import {
+  findDeptEntity,
+  type HistoryRow,
+  type OrgEntityRow,
+  rankBuildingsByHistory,
+  resolveProbableLocation,
+} from "./probable-location";
+
+const icsOrg: OrgEntityRow = {
+  name: "Institute of Computer Science (ICS)",
+  lat: 14.1648,
+  lon: 121.2413,
+  buildingId: null,
+};
+
+const unlocatableOrg: OrgEntityRow = {
+  name: "Institute of Chemistry (IC)",
+  lat: null,
+  lon: null,
+  buildingId: null,
+};
+
+function history(
+  rows: Array<[buildingId: number, termId: number, sections: number]>,
+): HistoryRow[] {
+  return rows.map(([buildingId, termId, sections]) => ({
+    buildingId,
+    buildingName: `Building ${buildingId}`,
+    termId,
+    sections,
+  }));
+}
+
+describe("rankBuildingsByHistory (#846)", () => {
+  it("returns null on empty history", () => {
+    expect(rankBuildingsByHistory([])).toBeNull();
+  });
+
+  it("picks the modal building", () => {
+    const top = rankBuildingsByHistory(
+      history([
+        [1, 1251, 5],
+        [2, 1251, 2],
+      ]),
+    );
+    expect(top?.buildingId).toBe(1);
+    expect(top?.buildingName).toBe("Building 1");
+  });
+
+  it("weights newer terms higher (linear by term rank)", () => {
+    // Building 1: 3 sections in the oldest term (weight 1) = 3.
+    // Building 2: 2 sections in the newest term (weight 2) = 4.
+    const top = rankBuildingsByHistory(
+      history([
+        [1, 1231, 3],
+        [2, 1252, 2],
+      ]),
+    );
+    expect(top?.buildingId).toBe(2);
+  });
+
+  it("breaks exact score ties by the more recent building", () => {
+    // Both score 2×1: building 2 was seen in the newer term.
+    const top = rankBuildingsByHistory(
+      history([
+        [1, 1231, 2],
+        [2, 1252, 1],
+      ]),
+    );
+    expect(top?.buildingId).toBe(2);
+  });
+});
+
+describe("findDeptEntity", () => {
+  it("matches ignoring the (ACRONYM) suffix", () => {
+    expect(
+      findDeptEntity([icsOrg], "Institute of Computer Science")?.name,
+    ).toBe("Institute of Computer Science (ICS)");
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(findDeptEntity([icsOrg], "Department of Humanities")).toBeNull();
+  });
+});
+
+describe("resolveProbableLocation fallback order (#846)", () => {
+  const courseHistory = history([[10, 1252, 4]]);
+  const deptHistory = history([[20, 1252, 9]]);
+
+  it("1) department entity with a position wins, ignoring history", () => {
+    const location = resolveProbableLocation({
+      acadOrg: "LBICS",
+      acadGroup: "CAS",
+      orgs: [icsOrg],
+      courseHistory,
+      deptHistory,
+    });
+    expect(location).toEqual({
+      source: "department",
+      deptName: "Institute of Computer Science",
+      collegeCode: "CAS",
+      orgName: "Institute of Computer Science (ICS)",
+    });
+  });
+
+  it("2) course history when the department entity is missing or unpinned", () => {
+    const location = resolveProbableLocation({
+      acadOrg: "LBIC", // curated, but its entity has no position
+      acadGroup: "CAS",
+      orgs: [unlocatableOrg],
+      courseHistory,
+      deptHistory,
+    });
+    expect(location?.source).toBe("course-history");
+    expect(location?.buildingId).toBe(10);
+    expect(location?.deptName).toBe("Institute of Chemistry");
+  });
+
+  it("3) department history when course history is empty", () => {
+    const location = resolveProbableLocation({
+      acadOrg: "LBNOPE",
+      acadGroup: "CEAT",
+      orgs: [],
+      courseHistory: [],
+      deptHistory,
+    });
+    expect(location?.source).toBe("dept-history");
+    expect(location?.buildingId).toBe(20);
+    // Uncurated org: college code falls back to the row's acad_group.
+    expect(location?.collegeCode).toBe("CEAT");
+    expect(location?.deptName).toBeUndefined();
+  });
+
+  it("4) decoded name alone when there is no pin and no history", () => {
+    const location = resolveProbableLocation({
+      acadOrg: "LBDHUM",
+      acadGroup: "CAS",
+      orgs: [],
+      courseHistory: [],
+      deptHistory: [],
+    });
+    expect(location).toEqual({
+      source: "department",
+      deptName: "Department of Humanities",
+      collegeCode: "CAS",
+    });
+  });
+
+  it("5) null when nothing is known", () => {
+    expect(
+      resolveProbableLocation({
+        acadOrg: null,
+        acadGroup: null,
+        orgs: [icsOrg],
+        courseHistory: [],
+        deptHistory: [],
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/probable-location.ts
+++ b/src/lib/probable-location.ts
@@ -1,0 +1,160 @@
+/**
+ * Probable location for Room TBA sections (#846) — pure logic, no DB.
+ *
+ * Resolution order (see docs/amis-com-refresh-runbook.md § TBA sections):
+ *   1. Department link: acad_org → data/acad-orgs.json → the department's
+ *      organizations-table entity, when that entity has a map position.
+ *   2. Course history: modal building among same-course sections that have an
+ *      assigned room, across all terms, weighting newer terms higher.
+ *   3. Department history: same aggregate over the acad_org's sections.
+ *   4. Decoded department name alone (no pin).
+ * The service wrapper (src/lib/services/probable-location.ts) feeds this rows;
+ * keep everything here deterministic and unit-testable.
+ */
+import { decodeAcadOrg } from "./acad-orgs";
+import { normalizeAlias } from "./site";
+
+export type ProbableLocationSource =
+  | "department"
+  | "course-history"
+  | "dept-history";
+
+export type ProbableLocation = {
+  source: ProbableLocationSource;
+  /** Decoded department / institute name, when acad_org is curated. */
+  deptName?: string;
+  /** College code (decode entry first, else the row's acad_group). */
+  collegeCode?: string;
+  /** organizations.name to select on the map (department source only). */
+  orgName?: string;
+  /** Modal building (history sources only). */
+  buildingId?: number;
+  buildingName?: string;
+};
+
+/** One aggregate row: sections of a course/org that met in this building this term. */
+export type HistoryRow = {
+  buildingId: number;
+  buildingName: string;
+  termId: number;
+  sections: number;
+};
+
+export type OrgEntityRow = {
+  name: string;
+  lat: number | null;
+  lon: number | null;
+  buildingId: number | null;
+};
+
+/** Match a department name against org entities; "(ACRONYM)" suffixes on the
+ * entity name are ignored, mirroring scripts/seed-uplb-directory.ts. */
+export function findDeptEntity(
+  orgs: OrgEntityRow[],
+  wanted: string,
+): OrgEntityRow | null {
+  const wantedKey = normalizeAlias(wanted);
+  if (!wantedKey) return null;
+  for (const org of orgs) {
+    if (normalizeAlias(org.name) === wantedKey) return org;
+    const bare = org.name.replace(/\s*\([^)]*\)\s*$/, "");
+    if (bare !== org.name && normalizeAlias(bare) === wantedKey) return org;
+  }
+  return null;
+}
+
+function isLocatable(org: OrgEntityRow): boolean {
+  return (org.lat != null && org.lon != null) || org.buildingId != null;
+}
+
+/**
+ * Modal building over history rows; newer terms weigh more.
+ * ponytail: linear weight by chronological term rank (oldest=1); swap in a
+ * decay curve only if real data shows stale buildings still winning.
+ */
+export function rankBuildingsByHistory(
+  rows: HistoryRow[],
+): { buildingId: number; buildingName: string } | null {
+  if (rows.length === 0) return null;
+  const termIds = [...new Set(rows.map((row) => row.termId))].sort(
+    (a, b) => a - b,
+  );
+  const termWeight = new Map(termIds.map((id, index) => [id, index + 1]));
+  const scores = new Map<
+    number,
+    { buildingName: string; score: number; latestTermId: number }
+  >();
+  for (const row of rows) {
+    const weight = (termWeight.get(row.termId) ?? 1) * row.sections;
+    const current = scores.get(row.buildingId);
+    if (current) {
+      current.score += weight;
+      current.latestTermId = Math.max(current.latestTermId, row.termId);
+    } else {
+      scores.set(row.buildingId, {
+        buildingName: row.buildingName,
+        score: weight,
+        latestTermId: row.termId,
+      });
+    }
+  }
+  let best: {
+    buildingId: number;
+    buildingName: string;
+    score: number;
+    latestTermId: number;
+  } | null = null;
+  for (const [buildingId, entry] of scores) {
+    if (
+      !best ||
+      entry.score > best.score ||
+      (entry.score === best.score && entry.latestTermId > best.latestTermId)
+    ) {
+      best = { buildingId, ...entry };
+    }
+  }
+  return best
+    ? { buildingId: best.buildingId, buildingName: best.buildingName }
+    : null;
+}
+
+/**
+ * Full fallback order over already-fetched inputs. Callers may pass empty
+ * histories when they short-circuited fetching (department pin resolved).
+ */
+export function resolveProbableLocation(input: {
+  acadOrg: string | null;
+  acadGroup: string | null;
+  orgs: OrgEntityRow[];
+  courseHistory: HistoryRow[];
+  deptHistory: HistoryRow[];
+}): ProbableLocation | null {
+  const entry = decodeAcadOrg(input.acadOrg);
+  const collegeCode = entry?.collegeCode ?? input.acadGroup ?? undefined;
+  const deptName = entry?.name;
+
+  if (entry) {
+    const entity = findDeptEntity(input.orgs, entry.entityName ?? entry.name);
+    if (entity && isLocatable(entity)) {
+      return {
+        source: "department",
+        deptName,
+        collegeCode,
+        orgName: entity.name,
+      };
+    }
+  }
+
+  const viaCourse = rankBuildingsByHistory(input.courseHistory);
+  if (viaCourse) {
+    return { source: "course-history", deptName, collegeCode, ...viaCourse };
+  }
+
+  const viaDept = rankBuildingsByHistory(input.deptHistory);
+  if (viaDept) {
+    return { source: "dept-history", deptName, collegeCode, ...viaDept };
+  }
+
+  if (deptName) return { source: "department", deptName, collegeCode };
+  return null;
+}

--- a/src/lib/services/map-data-service.ts
+++ b/src/lib/services/map-data-service.ts
@@ -17,6 +17,7 @@ import { db } from "@lib/db";
 import { normalizeCourseCode } from "@lib/final-exams/normalize";
 import { normalizeAlias } from "@lib/site";
 import { normalizeDormListFields } from "@lib/string-lists";
+import { attachProbableLocations } from "./probable-location";
 import { getBuildCache } from "./ssg-cache";
 import type {
   BuildingData,
@@ -397,6 +398,8 @@ export async function queryClasses(options: {
 
     const hasMore = rows.length > limit;
     const page = hasMore ? rows.slice(0, limit) : rows;
+    // Room TBA sections get a server-computed location hint (#846).
+    await attachProbableLocations(page);
     const last = page.at(-1);
     const nextCursor =
       hasMore && last

--- a/src/lib/services/probable-location.ts
+++ b/src/lib/services/probable-location.ts
@@ -1,0 +1,203 @@
+/**
+ * Attach `probableLocation` to unassigned class sections (#846). Batched per
+ * response page: one classes lookup for acad codes, one organizations read,
+ * and at most two grouped history aggregates. Degrades to "no hint" on any
+ * failure so /api/classes keeps working before drizzle/0042 is applied.
+ * ponytail: no cache — hints ride the existing per-request query budget; add
+ * one if TBA-heavy pages show up hot in logs.
+ */
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import {
+  buildingsTable,
+  classesTable,
+  organizationsTable,
+  roomsTable,
+} from "@drizzle/schema";
+import { isRoomScheduledClassType } from "@lib/amis/room-scheduled-types";
+import { db } from "@lib/db";
+import {
+  type HistoryRow,
+  type ProbableLocation,
+  rankBuildingsByHistory,
+  resolveProbableLocation,
+} from "@lib/probable-location";
+import type { ClassMapValue } from "@lib/types";
+
+const historySelect = {
+  buildingId: buildingsTable.id,
+  buildingName: buildingsTable.buildingName,
+  termId: classesTable.termId,
+  sections: sql<number>`count(*)::int`,
+};
+
+function toHistoryRows(
+  rows: Array<{
+    key: string | null;
+    buildingId: number;
+    buildingName: string;
+    termId: number | null;
+    sections: number;
+  }>,
+): Map<string, HistoryRow[]> {
+  const byKey = new Map<string, HistoryRow[]>();
+  for (const row of rows) {
+    if (row.key == null || row.termId == null) continue;
+    const list = byKey.get(row.key) ?? [];
+    list.push({
+      buildingId: row.buildingId,
+      buildingName: row.buildingName,
+      termId: row.termId,
+      sections: row.sections,
+    });
+    byKey.set(row.key, list);
+  }
+  return byKey;
+}
+
+async function courseHistoryByCode(codes: string[]) {
+  if (codes.length === 0) return new Map<string, HistoryRow[]>();
+  const rows = await db
+    .select({ key: classesTable.courseCode, ...historySelect })
+    .from(classesTable)
+    .innerJoin(roomsTable, eq(roomsTable.id, classesTable.roomId))
+    .innerJoin(buildingsTable, eq(buildingsTable.id, roomsTable.buildingId))
+    .where(
+      and(
+        inArray(classesTable.courseCode, codes),
+        isNotNull(classesTable.termId),
+      ),
+    )
+    .groupBy(
+      classesTable.courseCode,
+      buildingsTable.id,
+      buildingsTable.buildingName,
+      classesTable.termId,
+    );
+  return toHistoryRows(rows);
+}
+
+async function deptHistoryByOrg(orgCodes: string[]) {
+  if (orgCodes.length === 0) return new Map<string, HistoryRow[]>();
+  const rows = await db
+    .select({ key: classesTable.acadOrg, ...historySelect })
+    .from(classesTable)
+    .innerJoin(roomsTable, eq(roomsTable.id, classesTable.roomId))
+    .innerJoin(buildingsTable, eq(buildingsTable.id, roomsTable.buildingId))
+    .where(
+      and(
+        inArray(classesTable.acadOrg, orgCodes),
+        isNotNull(classesTable.termId),
+      ),
+    )
+    .groupBy(
+      classesTable.acadOrg,
+      buildingsTable.id,
+      buildingsTable.buildingName,
+      classesTable.termId,
+    );
+  return toHistoryRows(rows);
+}
+
+/**
+ * Mutates `rows`, setting `probableLocation` on unassigned room-scheduled
+ * sections (LEC/LAB/RCT/CPT). Thesis-style sections are roomless by design
+ * and get no hint. Assigned sections are never touched.
+ */
+export async function attachProbableLocations(
+  rows: ClassMapValue[],
+): Promise<void> {
+  const candidates = rows.filter(
+    (row) =>
+      row.roomId == null &&
+      row.roomCode == null &&
+      isRoomScheduledClassType(row.type),
+  );
+  if (candidates.length === 0) return;
+
+  try {
+    // Separate query so a missing acad_group/acad_org column (migration not
+    // yet applied) only disables hints instead of breaking the class list.
+    const acadRows = await db
+      .select({
+        id: classesTable.id,
+        acadGroup: classesTable.acadGroup,
+        acadOrg: classesTable.acadOrg,
+      })
+      .from(classesTable)
+      .where(
+        inArray(
+          classesTable.id,
+          candidates.map((row) => row.id),
+        ),
+      );
+    const acadById = new Map(acadRows.map((row) => [row.id, row]));
+
+    const orgs = await db
+      .select({
+        name: organizationsTable.name,
+        lat: organizationsTable.lat,
+        lon: organizationsTable.lon,
+        buildingId: organizationsTable.buildingId,
+      })
+      .from(organizationsTable);
+
+    // First pass: department pin only (empty histories). Collect what is
+    // still unresolved so history aggregates run once, batched.
+    const unresolved: ClassMapValue[] = [];
+    for (const row of candidates) {
+      const acad = acadById.get(row.id);
+      const location = resolveProbableLocation({
+        acadOrg: acad?.acadOrg ?? null,
+        acadGroup: acad?.acadGroup ?? null,
+        orgs,
+        courseHistory: [],
+        deptHistory: [],
+      });
+      if (location?.orgName) {
+        row.probableLocation = location;
+      } else {
+        unresolved.push(row);
+      }
+    }
+    if (unresolved.length === 0) return;
+
+    const courseHistory = await courseHistoryByCode([
+      ...new Set(
+        unresolved
+          .map((row) => row.courseCode)
+          .filter((code): code is string => !!code),
+      ),
+    ]);
+    const stillUnresolved = unresolved.filter((row) => {
+      const ranked = rankBuildingsByHistory(
+        row.courseCode ? (courseHistory.get(row.courseCode) ?? []) : [],
+      );
+      return !ranked;
+    });
+    const deptHistory = await deptHistoryByOrg([
+      ...new Set(
+        stillUnresolved
+          .map((row) => acadById.get(row.id)?.acadOrg)
+          .filter((code): code is string => !!code),
+      ),
+    ]);
+
+    for (const row of unresolved) {
+      const acad = acadById.get(row.id);
+      const location = resolveProbableLocation({
+        acadOrg: acad?.acadOrg ?? null,
+        acadGroup: acad?.acadGroup ?? null,
+        orgs,
+        courseHistory: row.courseCode
+          ? (courseHistory.get(row.courseCode) ?? [])
+          : [],
+        deptHistory: acad?.acadOrg ? (deptHistory.get(acad.acadOrg) ?? []) : [],
+      });
+      if (location) row.probableLocation = location;
+    }
+  } catch (e) {
+    console.error("probable-location: skipping hints", e);
+  }
+}
+
+export type { ProbableLocation };

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -83,6 +83,8 @@ type ClassMapValue = {
   roomId: number | null;
   termId: number | null;
   id: number;
+  /** Server-computed hint for unassigned sections (#846); assigned sections never carry it. */
+  probableLocation?: import("./probable-location").ProbableLocation | null;
 };
 
 type FinalExamRow = {


### PR DESCRIPTION
Implements #846 (revised plan: department link primary, room history fallback).

## What changed

- **Schema:** `drizzle/0042_add_class_acad_org.sql` adds nullable `classes.acad_group` varchar(8) + `classes.acad_org` varchar(16); `drizzle/schema.ts` + regenerated `pglite-schema.generated.ts` (offline sync consumers untouched — the hint is API-only, offline shows nothing new, per the issue).
- **Importers:** `import:amis-classes` now stores both codes (normalizer, upsert diff, update set); `import:classes-generic` accepts them as optional columns (`docs/fork-data-guide.md`). Blank/absent generic columns never clobber AMIS-imported values, and reruns don't report spurious updates.
- **Decode file:** `data/acad-orgs.json` — top 37 `acad_org` codes by frequency across the 9 in-repo term JSONs, each verified against course prefixes (note: `LBIAS` = Institute of Animal Science, `LBASI` = Agricultural Systems Institute — the issue's original "Animal Science Institute" guess was backwards). Loader `src/lib/acad-orgs.ts`.
- **Service:** `src/lib/probable-location.ts` (pure: entity match, recency-weighted modal building, full fallback order) + `src/lib/services/probable-location.ts` (batched: 1 acad-code lookup, 1 organizations read, ≤2 grouped history aggregates per page). Attached in `queryClasses` only, for unassigned LEC/LAB/RCT/CPT rows — never assigned sections, never thesis-type sections.
- **UI:** `Classes.svelte` (class search, class browse, planner course search) renders "Offered by <dept> (<college>)" / "Usually meets around <building>" plus a subdued underlined "Show on map" button that selects the department org / building via `queryStore` — existing Map.svelte fly-to handles the camera, no direct maplibre calls.
- **Backfill:** `bun run backfill:acad-orgs` = importer rerun over the 9 cached term JSONs; runbook section rewritten (`docs/amis-com-refresh-runbook.md` § TBA sections).

## Maintainer steps after merge (not CI)

1. Apply `drizzle/0042_add_class_acad_org.sql` to Supabase **before/with** the staging deploy. Until then the code degrades gracefully: the acad-code lookup is isolated in its own try/catch, so `/api/classes` keeps serving and hints are simply absent.
2. Run the prod backfill: `DATABASE_URL=… bun run backfill:acad-orgs` (upsert over the 9 term JSONs; no AMIS fetch). **Not run in this PR — no prod/shared-dev DB was touched.**

## QA

Automated:
- `bun run lint` clean; `bun run check:readme` pass
- `bun run test` 502 pass (new: decode loader, ranking + fallback order, importer threading)
- `bun run test:components` 171 pass (new: hint + pin render, assigned/thesis rows excluded, @320px)
- `bun run build` pass
- New blocking e2e `e2e/browse/probable-location.spec.ts` (seeded unassigned `E2E 101 C`; reset script replays 0042 and seeds the fixture)

Manual / not covered:
- Pin fly-to visual check on staging (button → org/building selection is store-driven and covered by existing Map behavior, but not asserted end-to-end)
- Real-data hint quality (which departments resolve via entity vs history) is only observable after the prod backfill

## Residual risk

- Decode-file name guesses: 37 curated entries verified against course prefixes, but a wrong college/name would surface directly in UI copy; entries are trivially editable in `data/acad-orgs.json`.
- History fallback runs unindexed aggregates filtered by `course_code`/`acad_org` (seq scan over ~35k rows, only for pages containing TBA sections). Deliberately no cache/index per the revised plan; add `classes(course_code)` / `classes(acad_org)` indexes if these show up hot.
- "Recent sections met around X even though the dept pin says Y" supplement line (option b in the revised direction) was skipped to keep the API to one hint per section; noted in the issue.

Implements #846 (no auto-close): leaving the issue open until the prod backfill is confirmed, per the human-coordination rule.
