### PR TITLE
feat(presence): replace the fabricated online counter with real session presence

### DIFF
--- a/drizzle/0043_add_presence.sql
+++ b/drizzle/0043_add_presence.sql
@@ -1,0 +1,13 @@
+-- Real presence for the "N online" counter: clients heartbeat an anonymous
+-- random session id every 30s and the API counts distinct sids seen recently.
+-- Privacy: sid is a client-generated UUID in sessionStorage, never an account
+-- or an IP. Rows are pruned opportunistically by /api/presence, so the table
+-- stays at roughly the number of concurrent sessions.
+CREATE TABLE IF NOT EXISTS presence (
+  sid           VARCHAR(64) PRIMARY KEY,
+  last_seen_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Both hot paths (count within the window, prune past the TTL) filter on
+-- last_seen_at alone.
+CREATE INDEX IF NOT EXISTS idx_presence_last_seen ON presence (last_seen_at);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -743,3 +743,15 @@ export const sponsorImpressionsTable = pgTable("sponsor_impressions", {
   userAgent: text("user_agent"),
   pagePath: text("page_path"),
 });
+
+// Anonymous presence heartbeats behind the "N online" counter. A sid is a
+// random client-generated UUID held in sessionStorage — never an account, a
+// user id, or an IP. Server-only: deliberately absent from the PGlite
+// SYNCED_TABLES set so it never reaches the browser cache. Rows are pruned
+// opportunistically by /api/presence.
+export const presenceTable = pgTable("presence", {
+  sid: varchar({ length: 64 }).primaryKey(),
+  lastSeenAt: timestamp("last_seen_at", { withTimezone: true, mode: "string" })
+    .defaultNow()
+    .notNull(),
+});

--- a/e2e/advisory/online-counter.spec.ts
+++ b/e2e/advisory/online-counter.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import { waitForAppBoot } from "../helpers/app";
+
+/**
+ * The counter used to invent a number (random 20-150, random-walked). These
+ * specs pin it to the API: whatever /api/presence returns is what shows, and a
+ * failing request shows "--" rather than a plausible-looking lie.
+ */
+test.describe("online counter @advisory", () => {
+  test("renders the count /api/presence returns", async ({ page }) => {
+    await page.route("**/api/presence", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ online: 42 }),
+      }),
+    );
+
+    await page.goto("/");
+    await waitForAppBoot(page);
+
+    const counter = page.locator(".online-counter").first();
+    await expect(counter).toBeVisible({ timeout: 10_000 });
+    await expect(counter).toContainText("42 online", { timeout: 10_000 });
+  });
+
+  test("posts an anonymous sid and nothing else", async ({ page }) => {
+    const bodies: string[] = [];
+    await page.route("**/api/presence", (route) => {
+      bodies.push(route.request().postData() ?? "");
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ online: 5 }),
+      });
+    });
+
+    await page.goto("/");
+    await waitForAppBoot(page);
+    await expect(page.locator(".online-counter").first()).toContainText(
+      "5 online",
+      { timeout: 10_000 },
+    );
+
+    expect(bodies.length).toBeGreaterThan(0);
+    const payload = JSON.parse(bodies[0]!);
+    expect(Object.keys(payload)).toEqual(["sid"]);
+    expect(payload.sid).toMatch(/^[a-zA-Z0-9-]{8,64}$/);
+  });
+
+  test("shows -- instead of a made-up number when the API fails", async ({
+    page,
+  }) => {
+    await page.route("**/api/presence", (route) => route.abort());
+
+    await page.goto("/");
+    await waitForAppBoot(page);
+
+    const counter = page.locator(".online-counter").first();
+    await expect(counter).toBeVisible({ timeout: 10_000 });
+    await expect(counter).toContainText("--", { timeout: 10_000 });
+    await expect(counter).not.toContainText(/\d+ online/);
+  });
+});

--- a/integration/services/presence.integration.test.ts
+++ b/integration/services/presence.integration.test.ts
@@ -1,0 +1,234 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { integrationDatabaseUrl, skipWithoutE2eDb } from "../helpers/env";
+import { connectE2eClient } from "../../scripts/e2e-schema";
+
+const describeIntegration = skipWithoutE2eDb() ? describe.skip : describe;
+
+/** Every sid this suite writes starts with this, so cleanup never touches real rows. */
+const TEST_PREFIX = "itest";
+
+function testSid(label: string): string {
+  // Kept inside /^[a-zA-Z0-9-]{8,64}$/ on purpose — dashes and alnum only.
+  return `${TEST_PREFIX}-${label}-${Date.now()}`;
+}
+
+async function callPresence(body: unknown): Promise<Response> {
+  const { POST } = await import("../../src/pages/api/presence");
+  const request = new Request("http://localhost/api/presence", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+  // The handler only reads `request`; the rest of APIContext is unused.
+  return (await (POST as (ctx: { request: Request }) => Promise<Response>)({
+    request,
+  })) as Response;
+}
+
+async function withClient<T>(
+  run: (client: Awaited<ReturnType<typeof connectE2eClient>>) => Promise<T>,
+): Promise<T> {
+  const client = await connectE2eClient(integrationDatabaseUrl()!);
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+}
+
+async function purgeTestRows(): Promise<void> {
+  await withClient((client) =>
+    client.query("DELETE FROM presence WHERE sid LIKE $1", [
+      `${TEST_PREFIX}-%`,
+    ]),
+  );
+}
+
+/** Rows the endpoint would count as online right now. */
+async function onlineSids(): Promise<string[]> {
+  return withClient(async (client) => {
+    const { rows } = await client.query<{ sid: string }>(
+      "SELECT sid FROM presence WHERE last_seen_at > now() - interval '90 seconds'",
+    );
+    return rows.map((row) => row.sid);
+  });
+}
+
+async function sidRowCount(sid: string): Promise<number> {
+  return withClient(async (client) => {
+    const { rows } = await client.query<{ count: string }>(
+      "SELECT count(*)::int AS count FROM presence WHERE sid = $1",
+      [sid],
+    );
+    return Number(rows[0]?.count ?? 0);
+  });
+}
+
+async function seedRow(sid: string, ageInterval: string): Promise<void> {
+  await withClient((client) =>
+    client.query(
+      `INSERT INTO presence (sid, last_seen_at) VALUES ($1, now() - interval '${ageInterval}')
+       ON CONFLICT (sid) DO UPDATE SET last_seen_at = EXCLUDED.last_seen_at`,
+      [sid],
+    ),
+  );
+}
+
+describeIntegration("presence endpoint", () => {
+  beforeAll(purgeTestRows);
+  afterAll(purgeTestRows);
+
+  describe("sid validation", () => {
+    test("rejects junk sids without writing a row", async () => {
+      const before = await withClient(async (client) => {
+        const { rows } = await client.query<{ count: string }>(
+          "SELECT count(*)::int AS count FROM presence",
+        );
+        return Number(rows[0]?.count ?? 0);
+      });
+
+      for (const junk of [
+        "short",
+        "a".repeat(65),
+        "'; DROP TABLE presence; --",
+        "has spaces in it",
+        "under_scores_not_allowed",
+        42,
+        null,
+        { sid: "nested" },
+      ]) {
+        const res = await callPresence({ sid: junk });
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "invalid sid" });
+      }
+
+      const after = await withClient(async (client) => {
+        const { rows } = await client.query<{ count: string }>(
+          "SELECT count(*)::int AS count FROM presence",
+        );
+        return Number(rows[0]?.count ?? 0);
+      });
+      expect(after).toBe(before);
+    });
+
+    test("rejects a body that is not JSON", async () => {
+      const res = await callPresence("not json at all");
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "invalid body" });
+    });
+
+    test("accepts a real crypto.randomUUID() and never caches the response", async () => {
+      const sid = testSid("uuid");
+      const res = await callPresence({ sid });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+      const body = (await res.json()) as { online: number };
+      expect(body.online).toBeGreaterThanOrEqual(1);
+      expect(await onlineSids()).toContain(sid);
+    });
+  });
+
+  test("upsert is idempotent for the same sid", async () => {
+    const sid = testSid("idem");
+
+    const first = (await (await callPresence({ sid })).json()) as {
+      online: number;
+    };
+    const firstSeen = await withClient(async (client) => {
+      const { rows } = await client.query<{ last_seen_at: string }>(
+        "SELECT last_seen_at FROM presence WHERE sid = $1",
+        [sid],
+      );
+      return rows[0]?.last_seen_at;
+    });
+
+    const second = (await (await callPresence({ sid })).json()) as {
+      online: number;
+    };
+    const third = (await (await callPresence({ sid })).json()) as {
+      online: number;
+    };
+
+    // One session is one row no matter how many heartbeats it sends.
+    expect(await sidRowCount(sid)).toBe(1);
+    expect(second.online).toBe(first.online);
+    expect(third.online).toBe(first.online);
+
+    // …and the heartbeat still refreshes the timestamp.
+    const lastSeen = await withClient(async (client) => {
+      const { rows } = await client.query<{ last_seen_at: string }>(
+        "SELECT last_seen_at FROM presence WHERE sid = $1",
+        [sid],
+      );
+      return rows[0]?.last_seen_at;
+    });
+    expect(new Date(lastSeen!).getTime()).toBeGreaterThanOrEqual(
+      new Date(firstSeen!).getTime(),
+    );
+  });
+
+  test("count reflects only sessions inside the 90s window", async () => {
+    const live = testSid("live");
+    const stale = testSid("stale");
+
+    // Older than the window but younger than the 10 min prune TTL.
+    await seedRow(stale, "5 minutes");
+    const res = (await (await callPresence({ sid: live })).json()) as {
+      online: number;
+    };
+
+    const counted = await onlineSids();
+    expect(counted).toContain(live);
+    expect(counted).not.toContain(stale);
+
+    // The stale session is excluded from the count but still on the table.
+    expect(await sidRowCount(stale)).toBe(1);
+    expect(res.online).toBe(counted.length);
+  });
+
+  describe("prune", () => {
+    const realRandom = Math.random;
+    afterEach(() => {
+      Math.random = realRandom;
+    });
+
+    test("removes rows past the 10 minute TTL", async () => {
+      const live = testSid("prune-live");
+      const dead = testSid("prune-dead");
+      const borderline = testSid("prune-borderline");
+
+      await seedRow(dead, "11 minutes");
+      await seedRow(borderline, "9 minutes");
+      expect(await sidRowCount(dead)).toBe(1);
+
+      // Prune is sampled at 10% of requests; force this one to take the branch.
+      Math.random = () => 0;
+      const res = await callPresence({ sid: live });
+      expect(res.status).toBe(200);
+
+      expect(await sidRowCount(dead)).toBe(0);
+      expect(await sidRowCount(borderline)).toBe(1);
+      expect(await sidRowCount(live)).toBe(1);
+    });
+
+    test("leaves stale rows alone when the request is not sampled", async () => {
+      const live = testSid("nosample-live");
+      const dead = testSid("nosample-dead");
+
+      await seedRow(dead, "11 minutes");
+
+      Math.random = () => 0.99;
+      await callPresence({ sid: live });
+
+      expect(await sidRowCount(dead)).toBe(1);
+    });
+  });
+});

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -80,6 +80,7 @@ const E2E_MIGRATION_FILES = [
   "0040_pre_drizzle_schema_backfill.sql",
   "0041_add_announcements.sql",
   "0042_add_class_acad_org.sql",
+  "0043_add_presence.sql",
 ] as const;
 
 /**

--- a/src/components/svelte/OnlineCounter.component.test.ts
+++ b/src/components/svelte/OnlineCounter.component.test.ts
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import OnlineCounter from "@ui/OnlineCounter.svelte";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("OnlineCounter", () => {
+  test("renders the count the API reports", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ online: 7 })),
+    );
+
+    render(OnlineCounter);
+
+    expect(await screen.findByText(/7 online/)).toBeInTheDocument();
+  });
+
+  test("shows -- and never a made-up number when the request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+
+    render(OnlineCounter);
+
+    expect(await screen.findByText("--")).toBeInTheDocument();
+    // Regression guard: the old counter invented a number between 20 and 150.
+    expect(screen.queryByText(/\d+ online/)).toBeNull();
+  });
+
+  test("shows -- when the API answers with an error status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "invalid sid" }, 400)),
+    );
+
+    render(OnlineCounter);
+
+    expect(await screen.findByText("--")).toBeInTheDocument();
+  });
+
+  test("keeps the last known count when a later heartbeat fails", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ online: 12 }))
+      .mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+
+    render(OnlineCounter);
+    await vi.waitFor(() => expect(screen.getByText(/12 online/)).toBeTruthy());
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByText(/12 online/)).toBeInTheDocument();
+  });
+
+  test("posts only an anonymous sessionStorage sid, reused across heartbeats", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ online: 3 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+
+    render(OnlineCounter);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/presence");
+    const body = JSON.parse(init.body as string);
+
+    // Privacy: the payload is a random session id and nothing else.
+    expect(Object.keys(body)).toEqual(["sid"]);
+    expect(body.sid).toMatch(/^[a-zA-Z0-9-]{8,64}$/);
+    expect(sessionStorage.getItem("rt-presence-sid")).toBe(body.sid);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    const [, secondInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(secondInit.body as string).sid).toBe(body.sid);
+  });
+
+  test("stops heartbeating after unmount", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ online: 3 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+
+    const { unmount } = render(OnlineCounter);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    unmount();
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/svelte/OnlineCounter.svelte
+++ b/src/components/svelte/OnlineCounter.svelte
@@ -1,16 +1,44 @@
 <script lang="ts">
   import { onMount } from "svelte";
 
+  /**
+   * Real presence: heartbeat an anonymous session id to /api/presence and show
+   * the count it returns. The id is a random UUID scoped to this tab's
+   * sessionStorage — never tied to an account, and nothing else is sent.
+   */
   let online = $state(0);
-  
+
+  const HEARTBEAT_MS = 30_000;
+  const SID_KEY = "rt-presence-sid";
+
+  function sessionId() {
+    let sid = sessionStorage.getItem(SID_KEY);
+    if (!sid) {
+      sid = crypto.randomUUID();
+      sessionStorage.setItem(SID_KEY, sid);
+    }
+    return sid;
+  }
+
+  async function heartbeat() {
+    try {
+      const response = await fetch("/api/presence", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sid: sessionId() }),
+      });
+      if (!response.ok) return;
+      const data = (await response.json()) as { online?: number };
+      if (typeof data.online === "number") online = data.online;
+    } catch {
+      // Offline or API down: keep the last known count (0 renders as "--").
+    }
+  }
+
   onMount(() => {
-    online = Math.floor(Math.random() * (150 - 20) + 20);
-    
-    const interval = setInterval(() => {
-      const change = Math.floor(Math.random() * 5) - 2;
-      online = Math.max(1, online + change);
-    }, 5000);
-    
+    heartbeat();
+    const interval = setInterval(heartbeat, HEARTBEAT_MS);
+
     return () => clearInterval(interval);
   });
 </script>

--- a/src/lib/presence.test.ts
+++ b/src/lib/presence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { ONLINE_WINDOW_SECONDS, isValidSid } from "./presence";
+
+describe("isValidSid", () => {
+  test("accepts a real crypto.randomUUID()", () => {
+    expect(isValidSid(crypto.randomUUID())).toBe(true);
+  });
+
+  test("accepts the shortest and longest allowed ids", () => {
+    expect(isValidSid("a".repeat(8))).toBe(true);
+    expect(isValidSid("a".repeat(64))).toBe(true);
+  });
+
+  test("rejects ids outside the varchar(64) bounds", () => {
+    expect(isValidSid("a".repeat(7))).toBe(false);
+    expect(isValidSid("a".repeat(65))).toBe(false);
+    expect(isValidSid("")).toBe(false);
+  });
+
+  test("rejects junk and injection-shaped input", () => {
+    for (const junk of [
+      "'; DROP TABLE presence; --",
+      "../../etc/passwd",
+      "<script>alert(1)</script>",
+      "session id with spaces",
+      "sid\nwith\nnewlines",
+      "sid_with_underscore",
+      "sid.with.dots",
+      "🙂🙂🙂🙂🙂🙂🙂🙂",
+    ]) {
+      expect(isValidSid(junk)).toBe(false);
+    }
+  });
+
+  test("rejects non-string bodies", () => {
+    for (const notAString of [undefined, null, 42, {}, [], true]) {
+      expect(isValidSid(notAString)).toBe(false);
+    }
+  });
+});
+
+describe("presence window", () => {
+  test("is longer than the 30s client heartbeat so one miss is survivable", () => {
+    expect(ONLINE_WINDOW_SECONDS).toBeGreaterThan(2 * 30);
+  });
+});

--- a/src/lib/presence.ts
+++ b/src/lib/presence.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared constants + validation for the anonymous presence counter
+ * (`/api/presence`, `OnlineCounter.svelte`).
+ *
+ * Privacy: a presence session id is a random `crypto.randomUUID()` the client
+ * keeps in `sessionStorage`. It is never tied to an account and we never log
+ * or store IP addresses, user agents, or any analytics alongside it.
+ *
+ * Kept free of `@lib/db` so the trust-boundary check stays unit-testable in
+ * the always-on `bun run test` tier (that tier has no `astro:env/server`).
+ */
+
+/** Sessions seen within this window count as online. */
+export const ONLINE_WINDOW_SECONDS = 90;
+
+/** Rows past this age are dead weight and get pruned. */
+export const PRESENCE_TTL_MINUTES = 10;
+
+/** Fraction of heartbeats that also prune, so no cron job is needed. */
+export const PRUNE_SAMPLE_RATE = 0.1;
+
+/** Client UUIDs only: hex and dashes, length-bounded to the `varchar(64)` column. */
+const SID_PATTERN = /^[a-zA-Z0-9-]{8,64}$/;
+
+export function isValidSid(sid: unknown): sid is string {
+  return typeof sid === "string" && SID_PATTERN.test(sid);
+}

--- a/src/pages/api/presence.ts
+++ b/src/pages/api/presence.ts
@@ -1,0 +1,73 @@
+import type { APIRoute } from "astro";
+import { sql } from "drizzle-orm";
+import { presenceTable } from "@drizzle/schema";
+import { db } from "@lib/db";
+import {
+  ONLINE_WINDOW_SECONDS,
+  PRESENCE_TTL_MINUTES,
+  PRUNE_SAMPLE_RATE,
+  isValidSid,
+} from "@lib/presence";
+
+export const prerender = false;
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      // A shared cache would serve one visitor's count to everyone.
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+/**
+ * Presence heartbeat: the client POSTs its random session id every 30s and
+ * gets back the number of distinct sessions seen in the last 90s.
+ *
+ * Privacy: the session id is a client-generated UUID kept in `sessionStorage`,
+ * never tied to an account. This endpoint stores nothing else — no IP address,
+ * no user agent, no page path, no analytics event. The row is a sid and a
+ * timestamp, and it is deleted once the session goes stale.
+ */
+export const POST: APIRoute = async ({ request }) => {
+  let sid: unknown;
+  try {
+    ({ sid } = await request.json());
+  } catch {
+    return json({ error: "invalid body" }, 400);
+  }
+  if (!isValidSid(sid)) {
+    return json({ error: "invalid sid" }, 400);
+  }
+
+  await db
+    .insert(presenceTable)
+    .values({ sid })
+    .onConflictDoUpdate({
+      target: presenceTable.sid,
+      set: { lastSeenAt: sql`now()` },
+    });
+
+  // Opportunistic prune so the table stays tiny — no cron job to own.
+  // ponytail: sampled on the request path; move to a cron if presence ever
+  // grows past what a single DELETE on an indexed column can absorb.
+  if (Math.random() < PRUNE_SAMPLE_RATE) {
+    await db
+      .delete(presenceTable)
+      .where(
+        sql`${presenceTable.lastSeenAt} < now() - make_interval(mins => ${PRESENCE_TTL_MINUTES})`,
+      );
+  }
+
+  const [row] = await db
+    .select({ online: sql<number>`count(*)::int` })
+    .from(presenceTable)
+    .where(
+      sql`${presenceTable.lastSeenAt} > now() - make_interval(secs => ${ONLINE_WINDOW_SECONDS})`,
+    );
+
+  // The caller's own heartbeat is already committed, so the floor is 1.
+  return json({ online: row?.online ?? 1 }, 200);
+};

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -62,6 +62,13 @@ import {
             the map may use your coordinates locally to show where you are. We do
             not persist your live GPS track on our servers.
           </li>
+          <li>
+            <strong>Online counter.</strong> To show how many people are using the
+            map right now, your browser sends a random session id (kept only for
+            the current tab) every 30 seconds. It is not linked to an account, and
+            we store nothing else with it — no IP address, no user agent. The id is
+            deleted once the session has been idle for 10 minutes.
+          </li>
         </ul>
 
         <h3>Contributors and editors (signed in)</h3>


### PR DESCRIPTION
## What and why

**The online counter was showing users random numbers.** `OnlineCounter.svelte` seeded itself with `Math.floor(Math.random() * (150 - 20) + 20)` on mount — a random integer between 20 and 150 — then random-walked it by ±2 every 5 seconds, all behind a pulsing green "live" dot. Nothing was ever measured. A student reading "61 online" was reading a number the browser invented one second earlier.

This replaces it with real presence, ported from the `room-tba-upd` fork (commit `019a6234`).

## How it works

- **`presence` table** — `sid varchar(64) primary key`, `last_seen_at timestamptz not null default now()`, plus an index on `last_seen_at` (both hot paths filter on it alone).
- **`POST /api/presence`** — validates `sid` against `/^[a-zA-Z0-9-]{8,64}$/`, upserts with `last_seen_at = now()`, opportunistically prunes rows older than 10 minutes on ~10% of requests (no cron to own), and returns `{ online }` = count of distinct sids seen in the last 90s, with `Cache-Control: no-store`.
- **Client** — a random `crypto.randomUUID()` kept in `sessionStorage`, heartbeat on mount then every 30s. On any failure it keeps the last known count; 0 renders as `--` rather than a plausible-looking lie. The 90s window is deliberately longer than two heartbeats so one dropped request does not blink a user offline.

The counter's visual design and CSS are untouched — only the data source changed.

## Privacy

This counts anonymous sessions and nothing else. The sid is a random UUID scoped to one browser tab, never tied to an account. **No IP address, no user agent, no page path, no analytics event** is stored or logged alongside it — the row is a sid and a timestamp, deleted once the session goes stale. Stated in comments on the table, the migration, the endpoint, and the component, and surfaced to users in a new bullet on `/privacy` under "Browsing the map (no account)".

`presence` is **deliberately absent from `SYNCED_TABLES`** in `scripts/generate-pglite-schema.ts` — it is server-only and must never sync into the browser's offline cache. Verified: `bun run generate:pglite-schema` produces no diff, and `presence` appears zero times in the generated PGlite schema.

## ⚠️ Migration number collision

This adds **`drizzle/0043_add_presence.sql`**. The in-flight **#795** branch also currently uses `0043`. **Whichever of the two merges second must renumber to `0044`** (and update its entry in the `E2E_MIGRATION_FILES` list in `scripts/e2e-reset-db.ts`). Migration `0043` was added to that replay list here, following the pattern `0042` used.

## QA summary

**Automated — all run locally and green:**

| Check | Result |
| --- | --- |
| `bun run lint` | clean, 0 errors (2 remaining warnings are pre-existing CSS specificity notes in files this PR does not touch) |
| `bun run test` | 540 pass / 0 fail — includes 6 new sid-validation unit tests |
| `bun run test:components` | 202 pass / 0 fail across 53 files — includes 6 new counter tests |
| presence integration suite | 7 pass / 0 fail against real Postgres on the E2E project |
| `bun run check:readme` | passed |
| `bun run build` | completed |
| `bun run generate:pglite-schema` | no diff — presence correctly not synced |

**Test coverage added:**

- `src/lib/presence.test.ts` — sid validation rejects junk, injection-shaped strings, out-of-bounds lengths, and non-strings. `src/lib/presence.ts` is deliberately free of `@lib/db` so this trust-boundary check runs in the always-on `bun run test` tier, which has no `astro:env/server`.
- `integration/services/presence.integration.test.ts` — junk sids return 400 and write no row; non-JSON body returns 400; response is `no-store`; **upsert is idempotent** (one row per sid across three heartbeats, count unchanged, timestamp still refreshed); **count reflects only the 90s window** (a 5-minute-old row stays on the table but is excluded); **prune removes rows past the 10 minute TTL** while sparing a 9-minute-old row, with `Math.random` stubbed to force the sampled branch deterministically, plus the inverse case (unsampled request leaves stale rows alone).
- `src/components/svelte/OnlineCounter.component.test.ts` — renders the API value, falls back to `--` on both a thrown fetch and a non-ok status, keeps the last known count when a later heartbeat fails, posts only `{ sid }` and reuses it across heartbeats, and stops heartbeating after unmount. Fetch is mocked throughout; no network.
- `e2e/advisory/online-counter.spec.ts` — advisory tier, `/api/presence` stubbed via `page.route`. No `networkidle` waits.

**Which test tiers and why:** the blocking Playwright suite needs a preview server plus seeded DB that I could not stand up here, so the browser-level check went to the advisory tier. The behaviors that matter are covered deterministically by the integration and component tiers instead, which is why the e2e spec is thin.

**Not covered by automation:** the counter has not been eyeballed in a real browser against a live database, so the visual result of a real multi-session count is unverified (see residual risk).

## Residual risk

- **Migration number collision with #795** — the one thing a reviewer must actively handle. Called out above.
- **Migration not yet applied to staging or production.** `0043` was applied only to the E2E project to run the integration suite. Deploying before the migration runs means every heartbeat throws on a missing table and the counter sits at `--`. Unlike `/api/sponsor-event`, this endpoint does **not** swallow a missing-table error — that felt wrong for a counter whose entire purpose is to stop lying, but it does mean migration ordering matters at deploy time.
- **Write on every heartbeat.** One upsert per session per 30s. Fine at campus scale; if presence ever outgrows what a single indexed `DELETE` absorbs, the prune moves to a cron (flagged with a `ponytail:` comment at the branch).
- **Prune is sampled, not guaranteed.** A very low-traffic period can leave stale rows sitting past the TTL. They are already excluded from the count by the 90s window, so this is table size, not correctness.
- **The count is global, not per-page.** Every visitor on any route heartbeats, so "N online" means "using Room TBA", not "looking at the map". That matches what the old fake number implied, and the counter lives in the map chrome.
- **Tab-scoped `sessionStorage`** means one person with three tabs counts as three sessions. Intentional — `localStorage` would persist a stable id across sessions, which is a worse privacy trade for a nicer number.
