### PR TITLE
feat(data): record editor history for bulk maintenance operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Read the right doc for the task; do not rely on this file alone for detailed che
 | Map chrome, Entry zones, flyouts, 320/768 layout  | [.cursor/rules/map-layout.mdc](.cursor/rules/map-layout.mdc) + [docs/map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md)                        |
 | Side panel / entity detail views                  | [.cursor/rules/side-panel.mdc](.cursor/rules/side-panel.mdc)                                                                                   |
 | Drizzle, API routes, migrations, PGlite           | [.cursor/rules/data-and-migrations.mdc](.cursor/rules/data-and-migrations.mdc)                                                                 |
+| Bulk / direct-database edits, audit trail         | [docs/bulk-data-history.md](docs/bulk-data-history.md)                                                                                          |
 | Stores and client state                           | [.cursor/rules/svelte-stores.mdc](.cursor/rules/svelte-stores.mdc)                                                                             |
 | PR QA evidence and reporting                      | [docs/agentic-qa-process.md](docs/agentic-qa-process.md)                                                                                       |
 | **Tests for an issue / test backlog**             | [docs/issue-test-matrix.md](docs/issue-test-matrix.md) + [docs/testing.md](docs/testing.md) + [docs/test-inventory.md](docs/test-inventory.md) |
@@ -467,6 +468,7 @@ Map and side-panel layout rules are detailed in glob-scoped Cursor rules; read t
 - Use optimistic concurrency for editor writes. Send the version the client last saw, and return `409 Conflict` with the latest row if it is stale.
 - Missing client versions are a transitional compatibility fallback only; new editor surfaces should send versions.
 - Current entity tables store the latest state. `editor_history` stores the audit timeline.
+- **Direct-database edits record history too.** A merge script, one-off SQL, or import fixup that changes campus data must write `editor_history` rows in the same run — `bun run record:bulk-history` or `recordBulkHistory()` in [`src/lib/services/bulk-history.ts`](src/lib/services/bulk-history.ts). See [docs/bulk-data-history.md](docs/bulk-data-history.md).
 - Reverts should create new history entries instead of rewriting or deleting old history.
 - Every admin write should refresh the relevant sync key so clients can detect changed data.
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Install the [Biome VS Code extension](https://marketplace.visualstudio.com/items
 | `bun run import:amis-classes` | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`) |
 | `bun run backfill:acad-orgs` | Rerun the AMIS import over the 9 cached term JSONs to fill `classes.acad_group`/`acad_org` (#846) |
 | `bun run import:final-exams` | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`) |
+| `bun run record:bulk-history` | Record `editor_history` rows for a maintenance/bulk data operation (`DATABASE_URL`; dry run unless `--apply`; see `docs/bulk-data-history.md`) |
+| `bun run backfill:bulk-history` | One-off: backfill history for the 2026-08-03/04 direct-database corrections (`DATABASE_URL`; dry run unless `--apply`) |
 
 Legacy **`data/info.db`** SQLite is only for old seed/export scripts (`bun:sqlite`, not runtime). Production uses Supabase Postgres via `DATABASE_URL`. Archived SQLite migrations live in `drizzle-migrations/`: do not edit; active schema is `drizzle/`.
 

--- a/docs/bulk-data-history.md
+++ b/docs/bulk-data-history.md
@@ -1,0 +1,127 @@
+# Bulk data operations and the audit trail
+
+`editor_history` is the audit timeline for campus data. Every edit made through
+the app writes a row there ([`recordEditorHistory`](../src/lib/services/admin-service.ts)).
+Edits made **directly against the database** — a merge script, a one-off SQL
+fixup, an import correction — do not, so the entity's history silently claims
+nothing happened. That is the gap this page closes.
+
+**Rule: a maintenance script that changes campus data records history in the
+same run.** Not "later", not in a spreadsheet.
+
+## The helper
+
+[`src/lib/services/bulk-history.ts`](../src/lib/services/bulk-history.ts)
+writes the same row shape the app writes, with:
+
+| Field        | Value                                                                       |
+| ------------ | --------------------------------------------------------------------------- |
+| `entityType` | `room`, `building`, `alias`, `proposal`, …                                  |
+| `entityId`   | the affected row, or `0` when the operation spans rows with no single id    |
+| `before` / `after` | what changed, as JSON                                                 |
+| `editedBy`   | an actor label — `maintenance-script` by default, never a person's name     |
+| `summary`    | `[bulk:<opKey>] <reason>` — the free-text reason, prefixed with the op key  |
+
+Scripts cannot import `@lib/db` (it reads `astro:env/server`, which only exists
+inside Astro), so the caller passes its own Drizzle instance. `openDb()` in
+[`scripts/record-bulk-history.ts`](../scripts/record-bulk-history.ts) does that
+in five lines.
+
+### Idempotency
+
+The `opKey` is stamped into the summary, so re-running a backfill skips any
+`(entityType, entityId, opKey)` already present. A half-finished run is safe to
+resume; a nervous second run is a no-op.
+
+Pick a dated, kebab-case key: `2026-08-03-duplicate-room-merge`.
+
+### Dry run is the default
+
+`recordBulkHistory()` writes nothing unless the caller passes `dryRun: false`,
+and both scripts require `--apply` on the command line. Writing to the audit log
+of the production database should take a deliberate keystroke.
+
+## Recording a new operation
+
+From a script:
+
+```ts
+import { recordBulkHistory } from "../src/lib/services/bulk-history";
+import { openDb } from "./record-bulk-history";
+
+const { db, close } = openDb();
+await recordBulkHistory(
+  db,
+  rooms.map((room) => ({
+    opKey: "2026-09-01-room-code-fix",
+    entityType: "room",
+    entityId: room.id,
+    before: { roomCode: room.before },
+    after: { roomCode: room.after },
+    reason: "collapsed double spaces introduced by the 2019 import",
+  })),
+  { dryRun: !apply },
+);
+await close();
+```
+
+Or from a JSON file, without writing a script:
+
+```sh
+bun run record:bulk-history -- --ops ops.json            # dry run, prints the plan
+bun run record:bulk-history -- --ops ops.json --apply    # write
+```
+
+`ops.json` is a JSON array of `BulkOperation`. Bad input (an op key with
+spaces, an over-long `entityType`, a missing reason) fails before any write.
+
+## Maintainer: backfilling 2026-08-03 / 04
+
+The corrections made on 2026-08-03 and 2026-08-04 ran as direct SQL and left no
+history. [`scripts/backfill-bulk-history.ts`](../scripts/backfill-bulk-history.ts)
+records them after the fact:
+
+| Op key                              | What it records                                                                                  |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `2026-08-03-sds-rooms-to-che`       | 7 rooms moved from CVM-IAS Communal to the CHE Building (the SDS fix)                            |
+| `2026-08-03-room-building-audit`    | 31 rooms given their correct building by a manual audit                                          |
+| `2026-08-03-duplicate-room-merge`   | 16 duplicate room groups merged: 222 class/final-exam rows repointed, 15 rooms deleted, spellings kept as aliases |
+| `2026-08-04-sds-therio-aliases`     | SDS and therio alias insertions                                                                  |
+| `2026-08-04-proposal-28-directions` | proposal #28's patch edited to strip an internal admin note from `directions`                    |
+
+Review the plan first, then apply:
+
+```sh
+bun run backfill:bulk-history                # dry run — prints every row it would write
+bun run backfill:bulk-history -- --apply     # maintainer only, writes to DATABASE_URL
+```
+
+Re-running after `--apply` prints `5 operations: 0 new, 5 already recorded`.
+
+### Snapshots
+
+If the pre-operation JSON dumps are still on disk, the script enriches the
+`before` payload and writes one row per affected room instead of a single
+summary row. It looks in `--snapshots <dir>`, else under
+`/tmp/claude-1000/-home-stimmie-dev-uplbtools-room-tba/*/scratchpad/`, for:
+
+- `room-merge-snapshot.json` — the duplicate-room candidates and their referencing rows
+- `rooms-building-snapshot.json` — rooms before the building audit
+- `rooms-map-snapshot.json` — room map positions
+
+Missing snapshots are not an error; the operation is still recorded, with counts
+instead of per-room detail. The merge snapshot deliberately does **not** get
+per-room rows: it records which rooms were *candidates*, not which were kept, so
+per-room rows would attach "merged" history to rooms that were never touched.
+
+If the snapshots are gone entirely, hand the list in directly:
+
+```sh
+bun run backfill:bulk-history -- --ops ops.json
+```
+
+## Tests
+
+[`src/lib/services/bulk-history.test.ts`](../src/lib/services/bulk-history.test.ts)
+covers the row shape, the column-limit validation, idempotent replay, and the
+backfill operation list. It runs in `bun run test`.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "import:classes-generic": "bun run scripts/import-classes-generic.ts",
     "backfill:acad-orgs": "for t in 1231 1232 1241 1242 1243 1251 1252 1253 1261; do bun run scripts/import-amis-classes.ts --term-id $t || exit 1; done",
     "import:final-exams": "bun run scripts/import-final-exams.ts",
+    "record:bulk-history": "bun run scripts/record-bulk-history.ts",
+    "backfill:bulk-history": "bun run scripts/backfill-bulk-history.ts",
     "release": "semantic-release",
     "release:dry": "semantic-release --dry-run"
   },

--- a/scripts/backfill-bulk-history.ts
+++ b/scripts/backfill-bulk-history.ts
@@ -1,0 +1,245 @@
+/**
+ * One-off: write the missing `editor_history` rows for the direct-to-database
+ * corrections made on 2026-08-03 / 2026-08-04. Those ran as raw SQL and merge
+ * scripts, so they left no audit trail — this closes the gap after the fact.
+ *
+ * Dry run by default. Idempotent: each operation carries a dated op key and a
+ * second run skips whatever is already recorded (see `bulk-history.ts`).
+ *
+ * Usage:
+ *   bun run scripts/backfill-bulk-history.ts                        # dry run
+ *   bun run scripts/backfill-bulk-history.ts --snapshots <dir>      # richer before-state
+ *   bun run scripts/backfill-bulk-history.ts --ops ops.json         # supply the list instead
+ *   bun run scripts/backfill-bulk-history.ts --apply                # maintainer only
+ *
+ * Snapshots are the JSON dumps taken before each operation
+ * (`room-merge-snapshot.json`, `rooms-building-snapshot.json`,
+ * `rooms-map-snapshot.json`). When a snapshot is missing the operation is
+ * still recorded, as one summary row with the counts instead of one row per
+ * affected entity. See docs/bulk-data-history.md.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import type { BulkOperation } from "../src/lib/services/bulk-history";
+import { recordBulkHistory } from "../src/lib/services/bulk-history";
+import {
+  flagValue,
+  openDb,
+  readOperations,
+  reportResult,
+} from "./record-bulk-history";
+
+/** Where the maintainer session left its pre-operation dumps. */
+const DEFAULT_SNAPSHOT_ROOT =
+  "/tmp/claude-1000/-home-stimmie-dev-uplbtools-room-tba";
+
+export const SNAPSHOT_NAMES = [
+  "room-merge-snapshot.json",
+  "rooms-building-snapshot.json",
+  "rooms-map-snapshot.json",
+] as const;
+
+export type SnapshotName = (typeof SNAPSHOT_NAMES)[number];
+export type Snapshots = Partial<Record<SnapshotName, unknown>>;
+
+type RoomSnapshotRow = {
+  id: number;
+  room_code?: string;
+  building_id?: number | null;
+};
+
+/** Candidate directories, newest session first, that may hold the snapshots. */
+function snapshotDirs(explicit?: string): string[] {
+  if (explicit) return [explicit];
+  if (!existsSync(DEFAULT_SNAPSHOT_ROOT)) return [];
+  return readdirSync(DEFAULT_SNAPSHOT_ROOT)
+    .map((session) => join(DEFAULT_SNAPSHOT_ROOT, session, "scratchpad"))
+    .filter((dir) => existsSync(dir));
+}
+
+export function loadSnapshots(explicitDir?: string): Snapshots {
+  const found: Snapshots = {};
+  for (const dir of snapshotDirs(explicitDir)) {
+    for (const name of SNAPSHOT_NAMES) {
+      const path = join(dir, name);
+      if (found[name] || !existsSync(path)) continue;
+      found[name] = JSON.parse(readFileSync(path, "utf8"));
+    }
+  }
+  return found;
+}
+
+function rowsOf(snapshot: unknown): RoomSnapshotRow[] {
+  const rooms = (snapshot as { rooms?: unknown } | undefined)?.rooms;
+  return Array.isArray(rooms) ? (rooms as RoomSnapshotRow[]) : [];
+}
+
+/** Row counts per referencing table, without inlining hundreds of ids. */
+function refCounts(snapshot: unknown): Record<string, number> {
+  const refs = (snapshot as { refs?: Record<string, unknown[]> } | undefined)
+    ?.refs;
+  if (!refs) return {};
+  return Object.fromEntries(
+    Object.entries(refs).map(([table, rows]) => [
+      table,
+      Array.isArray(rows) ? rows.length : 0,
+    ]),
+  );
+}
+
+/**
+ * The operations performed on prod on 2026-08-03 / 04.
+ *
+ * ponytail: one summary row per operation, `entityId: 0`, unless a snapshot
+ * supplies the affected ids — the merge snapshot records the candidate rooms
+ * but not which of them were kept, so per-room rows there would attach
+ * "merged" history to rooms that were never touched.
+ */
+export function buildBackfillOperations(
+  snapshots: Snapshots = {},
+): BulkOperation[] {
+  const buildingRooms = rowsOf(snapshots["rooms-building-snapshot.json"]);
+  const mapRooms = rowsOf(snapshots["rooms-map-snapshot.json"]);
+  const mergeSnapshot = snapshots["room-merge-snapshot.json"];
+  const mergeRooms = rowsOf(mergeSnapshot);
+
+  const operations: BulkOperation[] = [];
+
+  operations.push({
+    opKey: "2026-08-03-sds-rooms-to-che",
+    entityType: "room",
+    entityId: 0,
+    action: "bulk-update",
+    before: { buildingName: "CVM-IAS Communal", rooms: 7 },
+    after: { buildingName: "CHE Building", rooms: 7 },
+    reason:
+      "SDS fix: 7 rooms were filed under CVM-IAS Communal but are physically in the CHE Building; moved to the correct building.",
+  });
+
+  operations.push({
+    opKey: "2026-08-03-room-building-audit",
+    entityType: "room",
+    entityId: 0,
+    action: "bulk-update",
+    before: {
+      note: "rooms with a missing or wrong building_id",
+      rooms: buildingRooms.length || 31,
+    },
+    after: {
+      note: "building_id corrected from the manual room/building audit",
+      rooms: buildingRooms.length || 31,
+      roomIds: buildingRooms.map((room) => room.id),
+    },
+    reason:
+      "Room/building audit: 31 rooms were given their correct building after a manual pass over unmatched and mis-filed rooms.",
+  });
+
+  // Per-room rows when the pre-audit snapshot is available.
+  for (const room of buildingRooms) {
+    operations.push({
+      opKey: "2026-08-03-room-building-audit",
+      entityType: "room",
+      entityId: room.id,
+      action: "bulk-update",
+      before: room,
+      after: { id: room.id, note: "building corrected by the audit" },
+      reason: `Room/building audit: corrected the building of ${room.room_code ?? `room #${room.id}`}.`,
+    });
+  }
+
+  operations.push({
+    opKey: "2026-08-03-duplicate-room-merge",
+    entityType: "room",
+    entityId: 0,
+    action: "merge",
+    before: {
+      duplicateGroups: 16,
+      candidateRooms: mergeRooms,
+      references: refCounts(mergeSnapshot),
+    },
+    after: {
+      roomsDeleted: 15,
+      rowsRepointed: 222,
+      repointedTables: ["classes", "final_exams"],
+      note: "dropped spellings kept as aliases so search and imports still resolve them",
+    },
+    reason:
+      "Merged 16 duplicate room groups: 222 class and final-exam rows were repointed at the canonical room, 15 duplicate rooms deleted, and every dropped spelling preserved as an alias.",
+  });
+
+  operations.push({
+    opKey: "2026-08-04-sds-therio-aliases",
+    entityType: "alias",
+    entityId: 0,
+    action: "create",
+    before: null,
+    after: { note: "SDS and therio room aliases inserted" },
+    reason:
+      "Inserted the SDS and therio aliases so AMIS facility strings for those rooms match an existing room instead of being skipped.",
+  });
+
+  operations.push({
+    opKey: "2026-08-04-proposal-28-directions",
+    entityType: "proposal",
+    entityId: 28,
+    action: "bulk-update",
+    before: { note: "directions patch carried an internal admin note" },
+    after: { note: "admin note stripped from the directions field" },
+    reason:
+      "Edited proposal #28's patch to strip an internal admin note that would have been published verbatim into the room's directions.",
+  });
+
+  if (mapRooms.length > 0) {
+    operations.push({
+      opKey: "2026-08-03-room-map-snapshot",
+      entityType: "room",
+      entityId: 0,
+      action: "bulk-update",
+      before: { rooms: mapRooms.length },
+      after: { roomIds: mapRooms.map((room) => room.id) },
+      reason:
+        "Map-position snapshot taken alongside the 2026-08-03 room corrections.",
+    });
+  }
+
+  return operations;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const opsPath = flagValue(argv, "--ops");
+  const snapshots = loadSnapshots(flagValue(argv, "--snapshots"));
+
+  if (opsPath) {
+    console.log(`Operations from ${opsPath}`);
+  } else {
+    const names = Object.keys(snapshots);
+    console.log(
+      names.length > 0
+        ? `Snapshots found: ${names.join(", ")}`
+        : "No snapshots found; recording summary rows only.",
+    );
+  }
+
+  const operations = opsPath
+    ? readOperations(opsPath)
+    : buildBackfillOperations(snapshots);
+
+  const { db, close } = openDb();
+  try {
+    const result = await recordBulkHistory(db, operations, {
+      dryRun: !argv.includes("--apply"),
+    });
+    reportResult(result);
+  } finally {
+    await close();
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/record-bulk-history.ts
+++ b/scripts/record-bulk-history.ts
@@ -1,0 +1,99 @@
+/**
+ * Record `editor_history` rows for a maintenance / bulk data operation.
+ *
+ * Any script that edits campus data directly should end by handing its
+ * operations to this wrapper (or to `recordBulkHistory` in
+ * `src/lib/services/bulk-history.ts`), otherwise the edit is invisible in the
+ * entity's history and the audit trail lies.
+ *
+ * Usage:
+ *   bun run record:bulk-history -- --ops ops.json            # dry run
+ *   bun run record:bulk-history -- --ops ops.json --apply    # write
+ *   bun run record:bulk-history -- --ops ops.json --actor import-amis
+ *
+ * `ops.json` is a JSON array of `BulkOperation` (see bulk-history.ts):
+ *   [{ "opKey": "2026-08-04-room-code-fix", "entityType": "room",
+ *      "entityId": 412, "action": "bulk-update",
+ *      "before": { "roomCode": "CAS  101" }, "after": { "roomCode": "CAS 101" },
+ *      "reason": "collapsed a double space introduced by the 2019 import" }]
+ *
+ * Re-running is safe: rows already carrying the same op key are skipped.
+ */
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import pg from "pg";
+import { readFileSync } from "node:fs";
+import {
+  BULK_ACTOR,
+  recordBulkHistory,
+  type BulkHistoryResult,
+  type BulkOperation,
+} from "../src/lib/services/bulk-history";
+import { loadEnv } from "./load-env";
+
+/** Open a pool against `DATABASE_URL`; scripts cannot use `@lib/db` (astro:env). */
+export function openDb(): { db: NodePgDatabase; close: () => Promise<void> } {
+  loadEnv();
+  const connectionString = process.env.DATABASE_URL?.trim();
+  if (!connectionString) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+  const pool = new pg.Pool({ connectionString });
+  return { db: drizzle(pool), close: () => pool.end() };
+}
+
+export function flagValue(argv: string[], flag: string): string | undefined {
+  const index = argv.indexOf(flag);
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+export function readOperations(path: string): BulkOperation[] {
+  const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${path} must contain a JSON array of operations`);
+  }
+  return parsed as BulkOperation[];
+}
+
+/** Shared reporting for this CLI and the one-off backfill. */
+export function reportResult(result: BulkHistoryResult): void {
+  for (const row of result.pending) {
+    console.log(`  + ${row.entityType} #${row.entityId} — ${row.summary}`);
+  }
+  console.log(
+    `\n${result.rows.length} operation(s): ${result.pending.length} new, ${result.skipped} already recorded.`,
+  );
+  if (result.dryRun) {
+    console.log("Dry run. Pass --apply to write.");
+  } else {
+    console.log(`Wrote ${result.written} history row(s).`);
+  }
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const opsPath = flagValue(argv, "--ops");
+  if (!opsPath) {
+    console.error("--ops <file.json> is required");
+    process.exit(1);
+  }
+  const { db, close } = openDb();
+  try {
+    const result = await recordBulkHistory(db, readOperations(opsPath), {
+      actor: flagValue(argv, "--actor") ?? BULK_ACTOR,
+      dryRun: !argv.includes("--apply"),
+    });
+    reportResult(result);
+  } finally {
+    await close();
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/src/lib/services/bulk-history.test.ts
+++ b/src/lib/services/bulk-history.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "bun:test";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import {
+  buildBackfillOperations,
+  loadSnapshots,
+} from "../../../scripts/backfill-bulk-history";
+import {
+  BULK_ACTOR,
+  bulkRowKey,
+  bulkSummary,
+  pendingRows,
+  recordBulkHistory,
+  toHistoryRow,
+  type BulkHistoryRow,
+  type BulkOperation,
+} from "./bulk-history";
+
+const op: BulkOperation = {
+  opKey: "2026-08-03-test-op",
+  entityType: "room",
+  entityId: 42,
+  before: { buildingId: 1 },
+  after: { buildingId: 2 },
+  reason: "moved to the right building",
+};
+
+/** Minimal stand-in for the Drizzle query builders this module uses. */
+function fakeDb(
+  seen: { entityType: string; entityId: number; summary: string }[],
+) {
+  const inserted: BulkHistoryRow[] = [];
+  const db = {
+    select: () => ({ from: () => ({ where: async () => seen }) }),
+    insert: () => ({
+      values: async (rows: BulkHistoryRow[]) => {
+        inserted.push(...rows);
+      },
+    }),
+  } as unknown as NodePgDatabase;
+  return { db, inserted };
+}
+
+describe("toHistoryRow", () => {
+  it("stamps the op key into the summary and defaults action + actor", () => {
+    const row = toHistoryRow(op);
+    expect(row.summary).toBe(
+      "[bulk:2026-08-03-test-op] moved to the right building",
+    );
+    expect(row.action).toBe("bulk-update");
+    expect(row.editedBy).toBe(BULK_ACTOR);
+    expect(row.entityType).toBe("room");
+    expect(row.entityId).toBe(42);
+    expect(row.before).toEqual({ buildingId: 1 });
+    expect(row.after).toEqual({ buildingId: 2 });
+    expect(row.versionBefore).toBeNull();
+  });
+
+  it("keeps an explicit action and actor", () => {
+    const row = toHistoryRow({ ...op, action: "merge" }, "import-amis");
+    expect(row.action).toBe("merge");
+    expect(row.editedBy).toBe("import-amis");
+  });
+
+  it("rejects input that would violate the editor_history columns", () => {
+    expect(() => toHistoryRow({ ...op, opKey: "Has Spaces" })).toThrow(/opKey/);
+    expect(() => toHistoryRow({ ...op, opKey: "brack]et" })).toThrow(/opKey/);
+    expect(() => toHistoryRow({ ...op, entityType: "x".repeat(33) })).toThrow(
+      /entityType/,
+    );
+    expect(() => toHistoryRow({ ...op, entityId: -1 })).toThrow(/entityId/);
+    expect(() => toHistoryRow({ ...op, entityId: 1.5 })).toThrow(/entityId/);
+    expect(() => toHistoryRow({ ...op, reason: "  " })).toThrow(/reason/);
+    expect(() => toHistoryRow({ ...op, action: "a".repeat(33) })).toThrow(
+      /action/,
+    );
+    expect(() => toHistoryRow(op, "a".repeat(101))).toThrow(/actor/);
+  });
+});
+
+describe("bulkRowKey", () => {
+  it("reads the op key back out of a stored summary", () => {
+    expect(
+      bulkRowKey({
+        entityType: "room",
+        entityId: 7,
+        summary: bulkSummary("2026-08-03-merge", "why"),
+      }),
+    ).toBe("room:7:2026-08-03-merge");
+  });
+
+  it("does not match non-bulk history rows", () => {
+    expect(
+      bulkRowKey({ entityType: "room", entityId: 7, summary: "edited pin" }),
+    ).toBe("room:7:");
+  });
+});
+
+describe("pendingRows", () => {
+  it("skips operations already recorded for the same entity", () => {
+    const rows = [toHistoryRow(op)];
+    const seen = [
+      {
+        entityType: "room",
+        entityId: 42,
+        summary: bulkSummary("2026-08-03-test-op", "different wording"),
+      },
+    ];
+    expect(pendingRows(rows, seen)).toEqual([]);
+  });
+
+  it("keeps the same op key against a different entity", () => {
+    const rows = [toHistoryRow(op)];
+    const seen = [
+      {
+        entityType: "room",
+        entityId: 43,
+        summary: bulkSummary("2026-08-03-test-op", "other room"),
+      },
+    ];
+    expect(pendingRows(rows, seen)).toHaveLength(1);
+  });
+
+  it("collapses duplicates inside one batch", () => {
+    const rows = [toHistoryRow(op), toHistoryRow(op)];
+    expect(pendingRows(rows, [])).toHaveLength(1);
+  });
+});
+
+describe("recordBulkHistory", () => {
+  it("writes nothing on a dry run", async () => {
+    const { db, inserted } = fakeDb([]);
+    const result = await recordBulkHistory(db, [op]);
+    expect(result.dryRun).toBe(true);
+    expect(result.pending).toHaveLength(1);
+    expect(result.written).toBe(0);
+    expect(inserted).toEqual([]);
+  });
+
+  it("inserts only the rows that are not already recorded", async () => {
+    const second: BulkOperation = { ...op, entityId: 43 };
+    const { db, inserted } = fakeDb([
+      {
+        entityType: "room",
+        entityId: 42,
+        summary: bulkSummary("2026-08-03-test-op", "already there"),
+      },
+    ]);
+    const result = await recordBulkHistory(db, [op, second], { dryRun: false });
+    expect(result.skipped).toBe(1);
+    expect(result.written).toBe(1);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.entityId).toBe(43);
+  });
+
+  it("is idempotent: a second run against its own output writes nothing", async () => {
+    const first = fakeDb([]);
+    await recordBulkHistory(first.db, [op], { dryRun: false });
+    const replay = fakeDb(
+      first.inserted.map((row) => ({
+        entityType: row.entityType,
+        entityId: row.entityId,
+        summary: row.summary as string,
+      })),
+    );
+    const result = await recordBulkHistory(replay.db, [op], { dryRun: false });
+    expect(result.written).toBe(0);
+    expect(replay.inserted).toEqual([]);
+  });
+});
+
+describe("buildBackfillOperations", () => {
+  const operations = buildBackfillOperations();
+
+  it("covers every 2026-08-03/04 direct-database operation", () => {
+    expect(operations.map((entry) => entry.opKey)).toEqual([
+      "2026-08-03-sds-rooms-to-che",
+      "2026-08-03-room-building-audit",
+      "2026-08-03-duplicate-room-merge",
+      "2026-08-04-sds-therio-aliases",
+      "2026-08-04-proposal-28-directions",
+    ]);
+  });
+
+  it("produces rows the recorder accepts", () => {
+    for (const entry of operations)
+      expect(() => toHistoryRow(entry)).not.toThrow();
+  });
+
+  it("pins proposal #28 to its real entity id", () => {
+    const proposal = operations.find(
+      (entry) => entry.opKey === "2026-08-04-proposal-28-directions",
+    );
+    expect(proposal?.entityType).toBe("proposal");
+    expect(proposal?.entityId).toBe(28);
+  });
+
+  it("records the merge counts that the snapshot cannot recover", () => {
+    const merge = operations.find(
+      (entry) => entry.opKey === "2026-08-03-duplicate-room-merge",
+    );
+    expect(merge?.action).toBe("merge");
+    expect(merge?.after).toMatchObject({
+      roomsDeleted: 15,
+      rowsRepointed: 222,
+    });
+  });
+
+  it("emits one row per room when the building snapshot is available", () => {
+    const withSnapshot = buildBackfillOperations({
+      "rooms-building-snapshot.json": {
+        rooms: [
+          { id: 101, room_code: "CAS 101", building_id: null },
+          { id: 102, room_code: "CAS 102", building_id: null },
+        ],
+      },
+    });
+    const perRoom = withSnapshot.filter(
+      (entry) =>
+        entry.opKey === "2026-08-03-room-building-audit" && entry.entityId > 0,
+    );
+    expect(perRoom.map((entry) => entry.entityId)).toEqual([101, 102]);
+    expect(
+      pendingRows(
+        withSnapshot.map((entry) => toHistoryRow(entry)),
+        [],
+      ),
+    ).toHaveLength(withSnapshot.length);
+  });
+
+  it("tolerates a missing snapshot directory", () => {
+    expect(loadSnapshots("/nonexistent/scratchpad")).toEqual({});
+  });
+});

--- a/src/lib/services/bulk-history.ts
+++ b/src/lib/services/bulk-history.ts
@@ -1,0 +1,186 @@
+/**
+ * Audit trail for bulk / maintenance data operations.
+ *
+ * Direct-to-database corrections (merge scripts, one-off SQL, import fixups)
+ * bypass the app's editor write path, so they leave no `editor_history` row
+ * and an entity's history silently claims nothing happened. This writes the
+ * same row shape the app writes (`recordEditorHistory` in `admin-service.ts`)
+ * for work that ran outside it.
+ *
+ * Scripts cannot import `@lib/db` — it reads `astro:env/server`, which only
+ * exists inside Astro — so the caller passes its own Drizzle instance.
+ *
+ * Idempotency: the operation's `opKey` is stamped into the summary as
+ * `[bulk:<opKey>] <reason>`. Re-running skips any (entityType, entityId,
+ * opKey) already present, so a half-finished backfill is safe to resume.
+ */
+
+import { like } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { editorHistoryTable } from "@drizzle/schema";
+
+/** Actor label for rows written by a maintenance script rather than a person. */
+export const BULK_ACTOR = "maintenance-script";
+
+const DEFAULT_ACTION = "bulk-update";
+const SUMMARY_PREFIX = "[bulk:";
+/** `]` is excluded so the prefix parses back out of the summary unambiguously. */
+const OP_KEY_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const OP_KEY_FROM_SUMMARY = /^\[bulk:([^\]]+)\]/;
+
+// Column limits from `editor_history` in drizzle/schema.ts.
+const MAX_ENTITY_TYPE = 32;
+const MAX_ACTION = 32;
+const MAX_ACTOR = 100;
+
+export type BulkOperation = {
+  /** Stable slug for this operation; the idempotency key. */
+  opKey: string;
+  entityType: string;
+  /** The affected row's id, or `0` when the operation spans rows whose ids are not recoverable. */
+  entityId: number;
+  /** Defaults to `bulk-update`; use `merge`, `delete`, `create`… when it fits. */
+  action?: string;
+  before?: unknown;
+  after?: unknown;
+  /** Free text: why this ran. Stored in the summary after the op key. */
+  reason: string;
+  versionBefore?: number | null;
+  versionAfter?: number | null;
+};
+
+export type BulkHistoryRow = typeof editorHistoryTable.$inferInsert;
+
+type SeenRow = {
+  entityType: string;
+  entityId: number;
+  summary: string | null;
+};
+
+export function bulkSummary(opKey: string, reason: string): string {
+  return `${SUMMARY_PREFIX}${opKey}] ${reason}`;
+}
+
+/** Identity of a bulk row: same entity + same operation = already recorded. */
+export function bulkRowKey(row: SeenRow): string {
+  const opKey = row.summary?.match(OP_KEY_FROM_SUMMARY)?.[1] ?? "";
+  return `${row.entityType}:${row.entityId}:${opKey}`;
+}
+
+function assert(ok: unknown, message: string): asserts ok {
+  if (!ok) throw new Error(`bulk-history: ${message}`);
+}
+
+/** Validate one operation and render it as an `editor_history` insert. */
+export function toHistoryRow(
+  op: BulkOperation,
+  actor: string = BULK_ACTOR,
+): BulkHistoryRow {
+  assert(
+    OP_KEY_PATTERN.test(op.opKey ?? ""),
+    `opKey must match ${OP_KEY_PATTERN} (got ${JSON.stringify(op.opKey)})`,
+  );
+  assert(
+    typeof op.entityType === "string" &&
+      op.entityType.length > 0 &&
+      op.entityType.length <= MAX_ENTITY_TYPE,
+    `entityType must be 1-${MAX_ENTITY_TYPE} chars (op ${op.opKey})`,
+  );
+  assert(
+    Number.isInteger(op.entityId) && op.entityId >= 0,
+    `entityId must be a non-negative integer (op ${op.opKey})`,
+  );
+  assert(
+    typeof op.reason === "string" && op.reason.trim().length > 0,
+    `reason is required (op ${op.opKey})`,
+  );
+  const action = op.action ?? DEFAULT_ACTION;
+  assert(
+    action.length > 0 && action.length <= MAX_ACTION,
+    `action must be 1-${MAX_ACTION} chars (op ${op.opKey})`,
+  );
+  assert(
+    actor.length > 0 && actor.length <= MAX_ACTOR,
+    `actor must be 1-${MAX_ACTOR} chars (op ${op.opKey})`,
+  );
+
+  return {
+    entityType: op.entityType,
+    entityId: op.entityId,
+    action,
+    before: op.before ?? null,
+    after: op.after ?? null,
+    versionBefore: op.versionBefore ?? null,
+    versionAfter: op.versionAfter ?? null,
+    editedBy: actor,
+    summary: bulkSummary(op.opKey, op.reason.trim()),
+  };
+}
+
+/** Drop rows already in `seen`, and collapse duplicates inside the batch itself. */
+export function pendingRows(
+  rows: BulkHistoryRow[],
+  seen: Iterable<SeenRow>,
+): BulkHistoryRow[] {
+  const keys = new Set<string>();
+  for (const row of seen) keys.add(bulkRowKey(row));
+  const pending: BulkHistoryRow[] = [];
+  for (const row of rows) {
+    const key = bulkRowKey({
+      entityType: row.entityType,
+      entityId: row.entityId,
+      summary: row.summary ?? null,
+    });
+    if (keys.has(key)) continue;
+    keys.add(key);
+    pending.push(row);
+  }
+  return pending;
+}
+
+export type BulkHistoryResult = {
+  rows: BulkHistoryRow[];
+  pending: BulkHistoryRow[];
+  skipped: number;
+  written: number;
+  dryRun: boolean;
+};
+
+/**
+ * Record history for a batch of maintenance operations.
+ *
+ * Dry run by default — writing to the audit log of a production database is
+ * an explicit act, so the caller must pass `dryRun: false`.
+ */
+export async function recordBulkHistory(
+  db: NodePgDatabase,
+  operations: BulkOperation[],
+  options: { actor?: string; dryRun?: boolean } = {},
+): Promise<BulkHistoryResult> {
+  const { actor = BULK_ACTOR, dryRun = true } = options;
+  const rows = operations.map((op) => toHistoryRow(op, actor));
+
+  // ponytail: one unfiltered scan of the bulk rows. `editor_history` holds
+  // thousands of rows and only bulk ones match the prefix; add an opKey
+  // filter if a backfill ever gets big enough to notice.
+  const seen = await db
+    .select({
+      entityType: editorHistoryTable.entityType,
+      entityId: editorHistoryTable.entityId,
+      summary: editorHistoryTable.summary,
+    })
+    .from(editorHistoryTable)
+    .where(like(editorHistoryTable.summary, `${SUMMARY_PREFIX}%`));
+
+  const pending = pendingRows(rows, seen);
+  if (pending.length > 0 && !dryRun) {
+    await db.insert(editorHistoryTable).values(pending);
+  }
+  return {
+    rows,
+    pending,
+    skipped: rows.length - pending.length,
+    written: dryRun ? 0 : pending.length,
+    dryRun,
+  };
+}


### PR DESCRIPTION
Closes #877

## Why

`editor_history` is the audit timeline, but only the app's editor write path writes to it. Corrections applied directly to the database leave no row at all — including the 2026-08-03/04 prod fixes, which are currently invisible in every affected room's history.

## What

- **`src/lib/services/bulk-history.ts`** — `recordBulkHistory(db, operations, { actor, dryRun })`. Same row shape as `recordEditorHistory` in `admin-service.ts`: entity type, entity id, before/after JSON, actor label (`maintenance-script` by default), free-text reason. Validates against the real `editor_history` column limits before any write.
  - **Idempotent** by op key: the summary is `[bulk:<opKey>] <reason>`, and a re-run skips every `(entityType, entityId, opKey)` already present. Duplicates inside one batch collapse too.
  - **Dry run by default.** Writing to a production audit log takes `dryRun: false` / `--apply`.
  - Takes an injected Drizzle instance — scripts cannot import `@lib/db`, which reads `astro:env/server`.
- **`bun run record:bulk-history -- --ops ops.json [--apply]`** — the wrapper so a future maintenance script records history without writing new plumbing. `openDb()` and the reporting are exported for reuse.
- **`scripts/backfill-bulk-history.ts`** — one-off for 2026-08-03/04: the SDS 7-room move to CHE, the 31-room building audit, the 16-group duplicate-room merge (222 rows repointed, 15 rooms deleted, spellings kept as aliases), the SDS/therio alias inserts, and proposal #28's directions patch edit. Reads the pre-operation JSON snapshots when they are still on disk (`--snapshots <dir>`, or the scratchpad default), falls back to `--ops <file>`, and records summary rows with counts when a snapshot is gone.
- **`docs/bulk-data-history.md`** — the maintainer command and the rule. AGENTS.md § Data integrity now states it: direct-database edits record history in the same run.

### Why the merge op gets one summary row, not one per room

The merge snapshot records which rooms were *candidates*, not which were kept. Per-room rows would attach "merged" history to rooms that were never touched, and to 15 room ids that no longer exist. The building audit does get per-room rows when its snapshot is present.

## QA

**Automated**

- `bun run test` — 551 pass, incl. 17 new in `src/lib/services/bulk-history.test.ts` (row shape, column-limit validation, idempotent replay against its own output, the backfill operation list, missing-snapshot tolerance)
- `bun run test:components` — 196 pass / 52 files
- `bun run build` — clean
- `bun run lint` — clean; `bun run check:readme` — passes

**Manual**

- `bun run backfill:bulk-history` dry run against the real `DATABASE_URL`: discovers `room-merge-snapshot.json`, prints all 5 operations as new, writes nothing. **No `--apply` run was performed** — that is the maintainer's step, documented in `docs/bulk-data-history.md`.

## Known gaps

- The `--apply` run against production has not been done. Until then the audit gap for 2026-08-03/04 stays open.
- `rooms-building-snapshot.json` and `rooms-map-snapshot.json` were not on disk, so the building audit records one summary row (count only) rather than 31 per-room rows. If those dumps resurface, `--snapshots <dir>` upgrades them, and the op key keeps the re-run idempotent.
- Bulk rows carry `entityId: 0` when the operation spans rows with no single id; they are audit records, not entity history, and will not appear in any room's history panel.