### PR TITLE
perf(boot): defer PGlite off the critical path and batch the sync probes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -96,6 +96,25 @@ export default defineConfig({
             },
           },
           {
+            // #866: PGlite ships ~5 MB of wasm + data. Too big to precache
+            // (that would download Postgres during service worker install),
+            // but content-hashed, so CacheFirst is safe — a new build emits a
+            // new filename and never hits this entry. As with the navigate
+            // denylist above, the pattern must tolerate a `?` suffix: workbox
+            // matches the full URL, so a `$` anchor alone would miss.
+            urlPattern: /\/_astro\/(pglite|initdb)\.[^/?]*\.(wasm|data)(\?|$)/,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "pglite-wasm",
+              expiration: {
+                maxEntries: 8,
+                maxAgeSeconds: 60 * 60 * 24 * 365,
+                purgeOnQuotaError: true,
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
             // MapTiler vector tiles + tiles.json
             urlPattern: /^https:\/\/api\.maptiler\.com\/.*/i,
             handler: "CacheFirst",

--- a/integration/http/public.integration.test.ts
+++ b/integration/http/public.integration.test.ts
@@ -35,6 +35,40 @@ describeIntegration("HTTP redirects", () => {
     expect(Array.isArray(body)).toBe(true);
   });
 
+  test("GET /api/check returns every sync key in one response (#866)", async () => {
+    const res = await fetch(`${PREVIEW_BASE}/api/check`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: Record<string, string | null>;
+    };
+    expect(body.success).toBe(true);
+    // The eight tables the app probes on boot must all be in the one payload.
+    for (const table of [
+      "buildings",
+      "colleges",
+      "divisions",
+      "dorms",
+      "events",
+      "classes",
+      "organizations",
+      "places",
+    ]) {
+      expect(body.data).toHaveProperty(table);
+    }
+  });
+
+  test("GET /api/check/[name] still answers for one table (#866 compat)", async () => {
+    const res = await fetch(`${PREVIEW_BASE}/api/check/buildings`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { tableName: string | null };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.tableName).toBe("buildings");
+  });
+
   test("GET /api/classes caps inflated limits and returns the cursor shape", async () => {
     const res = await fetch(`${PREVIEW_BASE}/api/classes?limit=1000000`);
     expect(res.status).toBe(200);

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -52,8 +52,9 @@
     syncEvents,
     syncAliasCache,
     syncClasses,
+    getSyncKeysFromLs,
   } from "@lib/local/data/sync";
-  import { getDB, initPGLiteDB } from "@lib/local/data/pgliteDB";
+  import { getDB } from "@lib/local/data/pgliteDB";
   import { CAMPUS_DATA_REFRESH_EVENT } from "@lib/local/data/invalidate-sync-key";
 
   type MetadataProps = {
@@ -170,6 +171,9 @@
     }
   }
 
+  /** Set once network rows are on screen, so a late cache read can't undo them. */
+  let networkDataApplied = false;
+
   async function refreshFromNetwork(hasCachedDataAtStart: boolean) {
     if (hasCachedDataAtStart) {
       appBootstrapStore.markBackgroundRefresh();
@@ -241,6 +245,7 @@
         totalRooms: roomsData.totalRooms,
       };
       applyData(nextData);
+      networkDataApplied = true;
 
       const hasData = hasUsableCampusData(nextData);
       if (hasData) {
@@ -371,26 +376,38 @@
     void (async () => {
       try {
         syncToastStore.startRemoteFetch();
-        const localDB = getDB();
-        try {
-          await initPGLiteDB(localDB);
-          void transitStore.refresh();
-        } catch (error) {
-          console.error(error);
-        }
 
-        const cached = await loadCachedAppData();
-        const hasCache = hasUsableCampusData(cached);
-        appBootstrapStore.setHasCachedData(hasCache);
-        if (hasCache) {
+        // #866: PGlite is ~5 MB of wasm + data. Awaiting it here put a full
+        // Postgres download in front of the first campus fetch, for every
+        // visitor — including first-timers whose cache is guaranteed empty.
+        // Start hydrating in the background and let the cached read race the
+        // network instead of gating it.
+        void getDB().then(
+          () => void transitStore.refresh(),
+          (error: unknown) => console.error(error),
+        );
+
+        // localStorage outlives no PGlite download, so it answers "has this
+        // browser synced before?" for free — the network refresh still gets
+        // the offline/stale-cache semantics it had when the cache read came
+        // first.
+        const hasSyncedBefore = Object.values(
+          getSyncKeysFromLs() ?? {},
+        ).some(Boolean);
+
+        void loadCachedAppData().then((cached) => {
+          if (!hasUsableCampusData(cached)) return;
+          appBootstrapStore.setHasCachedData(true);
+          // The network may have painted fresher rows while the cache was
+          // still hydrating; never regress the UI back to the cached copy.
+          if (networkDataApplied) return;
           applyData(cached);
           appBootstrapStore.complete();
           dismissStaticLoadingShell();
-          void refreshFromNetwork(true);
-        } else {
-          await refreshFromNetwork(false);
-          dismissStaticLoadingShell();
-        }
+        }, console.error);
+
+        await refreshFromNetwork(hasSyncedBefore);
+        dismissStaticLoadingShell();
       } catch (error) {
         console.error("Bootstrap failed", error);
         dismissStaticLoadingShell();

--- a/src/lib/local/data/entity-cache-gate.store.test.ts
+++ b/src/lib/local/data/entity-cache-gate.store.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { BuildingData } from "@lib/types";
+
+const query = vi.fn();
+
+/** Controls whether the offline cache is hydrated for the call under test. */
+let cacheReady = false;
+/** The PGlite handle; left pending to stand in for a wasm download in flight. */
+let dbHandle: Promise<unknown> = new Promise(() => {});
+
+vi.mock("./pgliteDB", () => ({
+  getDB: () => dbHandle,
+  isLocalCacheReady: () => cacheReady,
+}));
+
+import { getBuildings } from "./utils";
+
+const REMOTE: BuildingData[] = [
+  {
+    id: 1,
+    buildingName: "Physical Sciences",
+    lon: 121,
+    lat: 14,
+    directions: null,
+    buildingType: "academic",
+    imageUrl: null,
+    crFacilities: null,
+    version: 1,
+    updatedAt: "2026-08-04T00:00:00.000Z",
+  } as BuildingData,
+];
+
+const realFetch = globalThis.fetch;
+
+/** Fails the test rather than hanging it if PGlite is back on the boot path. */
+function withinBudget<T>(work: Promise<T>, ms = 1000): Promise<T> {
+  return Promise.race([
+    work,
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("boot load blocked on PGlite hydration")),
+        ms,
+      ),
+    ),
+  ]);
+}
+
+beforeEach(() => {
+  query.mockReset();
+  cacheReady = false;
+  dbHandle = new Promise(() => {});
+  globalThis.fetch = vi.fn(
+    async () =>
+      new Response(JSON.stringify(REMOTE), {
+        headers: { "content-type": "application/json" },
+      }),
+  ) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("campus load while the offline cache is still hydrating (#866)", () => {
+  test("a first visit serves remote rows without waiting for PGlite", async () => {
+    const result = await withinBudget(
+      getBuildings({ valid: false, newKey: "buildings-key" }),
+    );
+
+    expect(result.source).toBe("remote");
+    expect(result.rows).toEqual(REMOTE);
+    // The cache is empty on a first visit; reading it would only have bought
+    // a ~5 MB wasm download in front of the fetch.
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  test("a hydrated cache with a matching sync key still short-circuits the fetch", async () => {
+    cacheReady = true;
+    dbHandle = Promise.resolve({ waitReady: Promise.resolve(), query });
+    query.mockResolvedValue({ rows: REMOTE });
+
+    const result = await withinBudget(
+      getBuildings({ valid: true, newKey: "buildings-key" }),
+    );
+
+    expect(result.source).toBe("cache");
+    expect(result.rows).toEqual(REMOTE);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("offline still falls back to the cache once it is hydrated", async () => {
+    cacheReady = true;
+    dbHandle = Promise.resolve({ waitReady: Promise.resolve(), query });
+    query.mockResolvedValue({ rows: REMOTE });
+
+    const result = await withinBudget(
+      getBuildings({ valid: false, newKey: null }),
+    );
+
+    expect(result.source).toBe("cache");
+    expect(result.rows).toEqual(REMOTE);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/local/data/pgliteDB.ts
+++ b/src/lib/local/data/pgliteDB.ts
@@ -1,26 +1,41 @@
-import { PGlite } from "@electric-sql/pglite";
+import type { PGlite } from "@electric-sql/pglite";
 import { PGLITE_INIT_SQL } from "./pglite-schema.generated";
 
-let localDB: PGlite | null = null;
+let dbPromise: Promise<PGlite> | null = null;
+let ready = false;
 
 /**
- * Create/upgrade the offline cache tables. The DDL is generated from
- * drizzle/schema.ts (see scripts/generate-pglite-schema.ts), so the server
- * schema is the single source of truth; ADD COLUMN IF NOT EXISTS statements
- * migrate caches created by older app versions.
+ * The offline cache, hydrated on first use.
+ *
+ * PGlite is ~5 MB of wasm + data (#866), so it is imported dynamically: it
+ * stays out of the entry bundle and downloads alongside the first campus
+ * fetch instead of in front of it. The DDL is generated from drizzle/schema.ts
+ * (see scripts/generate-pglite-schema.ts), so the server schema is the single
+ * source of truth; ADD COLUMN IF NOT EXISTS statements migrate caches created
+ * by older app versions. It runs here, so every caller gets an initialised
+ * database and nothing has to sequence init before its own queries.
  */
-export async function initPGLiteDB(db: PGlite) {
-  try {
+export function getDB(): Promise<PGlite> {
+  dbPromise ??= (async () => {
+    const { PGlite } = await import("@electric-sql/pglite");
+    const db = new PGlite("idb://site-data");
     await db.waitReady;
-    await db.exec(PGLITE_INIT_SQL);
-  } catch (e) {
-    console.error("An error occurred", e);
-  }
+    try {
+      await db.exec(PGLITE_INIT_SQL);
+    } catch (e) {
+      console.error("An error occurred", e);
+    }
+    ready = true;
+    return db;
+  })();
+  return dbPromise;
 }
 
-export function getDB() {
-  if (!localDB) {
-    localDB = new PGlite("idb://site-data");
-  }
-  return localDB;
+/**
+ * True once the cache is queryable. Callers that only want a cached row *if
+ * one is already there* check this first, so an empty first-visit cache does
+ * not make them wait out the wasm download (#866).
+ */
+export function isLocalCacheReady(): boolean {
+  return ready;
 }

--- a/src/lib/local/data/sync-keys.test.ts
+++ b/src/lib/local/data/sync-keys.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getSyncKey } from "./sync-keys";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Records every URL the probe hits and answers with one batched payload. */
+function stubCheckEndpoint(data: Record<string, string | null> | null) {
+  const calls: string[] = [];
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    calls.push(String(url));
+    return new Response(JSON.stringify({ success: true, error: null, data }), {
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return calls;
+}
+
+const BOOT_TABLES = [
+  "buildings",
+  "colleges",
+  "divisions",
+  "dorms",
+  "events",
+  "classes",
+  "organizations",
+  "places",
+];
+
+describe("getSyncKey — batched sync probe (#866)", () => {
+  test("the eight boot lookups share a single /api/check request", async () => {
+    const calls = stubCheckEndpoint(
+      Object.fromEntries(BOOT_TABLES.map((t) => [t, `${t}-key`])),
+    );
+
+    const keys = await Promise.all(
+      BOOT_TABLES.map((table) => getSyncKey(table)),
+    );
+
+    expect(calls).toEqual(["/api/check"]);
+    expect(keys).toEqual(BOOT_TABLES.map((t) => `${t}-key`));
+  });
+
+  test("a later refresh re-probes instead of reusing a settled response", async () => {
+    const calls = stubCheckEndpoint({ buildings: "b1" });
+
+    expect(await getSyncKey("buildings")).toBe("b1");
+    expect(await getSyncKey("buildings")).toBe("b1");
+
+    // An admin write changes the key; a cached probe would hide it.
+    expect(calls).toEqual(["/api/check", "/api/check"]);
+  });
+
+  test("a table missing from the registry reads as null, not undefined", async () => {
+    stubCheckEndpoint({ buildings: "b1" });
+    expect(await getSyncKey("jeepney_routes")).toBeNull();
+  });
+
+  test("a registry response without data reads as null", async () => {
+    stubCheckEndpoint(null);
+    expect(await getSyncKey("buildings")).toBeNull();
+  });
+});

--- a/src/lib/local/data/sync-keys.ts
+++ b/src/lib/local/data/sync-keys.ts
@@ -1,3 +1,39 @@
+import { fetchJsonWithRetry, SYNC_CHECK_FETCH_OPTIONS } from "./fetch-json";
+
+type SyncKeyResponse = {
+  success: boolean;
+  error: string | null;
+  data: Record<string, string | null> | null;
+};
+
+/**
+ * Shared in-flight probe of `/api/check` (#866). Boot asks for eight tables in
+ * the same tick and they all await this one request instead of firing eight
+ * `/api/check/<table>` probes. Cleared once it settles, so a later refresh
+ * (coming back online, an admin write) re-probes and never reads a stale key.
+ */
+let syncKeysInFlight: Promise<Record<string, string | null>> | null = null;
+
+/** Remote sync key for one table; null when the registry is unreachable. */
+export async function getSyncKey(table: string): Promise<string | null> {
+  try {
+    if (!syncKeysInFlight) {
+      syncKeysInFlight = fetchJsonWithRetry<SyncKeyResponse>(
+        "/api/check",
+        SYNC_CHECK_FETCH_OPTIONS,
+      )
+        .then((response) => response.data ?? {})
+        .finally(() => {
+          syncKeysInFlight = null;
+        });
+    }
+    return (await syncKeysInFlight)[table] ?? null;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+}
+
 /** LocalStorage sync-key helpers (no PGlite imports). */
 export function getSyncKeysFromLs(): {
   [key: string]: string;

--- a/src/lib/local/data/sync.ts
+++ b/src/lib/local/data/sync.ts
@@ -11,17 +11,16 @@ import type {
   TableSyncInfo,
 } from "@lib/types";
 import { getDB } from "./pgliteDB";
-import { fetchJsonWithRetry, SYNC_CHECK_FETCH_OPTIONS } from "./fetch-json";
 import { syncToastStore } from "@lib/store.svelte";
 import type { Results } from "@electric-sql/pglite";
-import { getSyncKeysFromLs } from "./sync-keys";
+import { getSyncKey, getSyncKeysFromLs } from "./sync-keys";
 import type { JeepneyRoute } from "@constants/jeepney-routes";
 
-export { getSyncKeysFromLs };
+export { getSyncKey, getSyncKeysFromLs };
 
 async function localCacheIsEmpty(tableName: string): Promise<boolean> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const result = (await localDB.query(
       `SELECT 1 FROM "${tableName}" LIMIT 1;`,
@@ -75,24 +74,6 @@ export function updateSyncKeyFromLs(tableName: string, newKey: string) {
   localStorage.setItem("sync-key", JSON.stringify(syncKeys));
 }
 
-export async function getSyncKey(table: string) {
-  try {
-    const tableOnline = await fetchJsonWithRetry<{
-      success: boolean;
-      error: string | null;
-      data: {
-        id: number;
-        tableName: string | null;
-        syncKey: string | null;
-      };
-    }>(`/api/check/${table}`, SYNC_CHECK_FETCH_OPTIONS);
-    return tableOnline.data.syncKey;
-  } catch (e) {
-    console.error(e);
-    return null;
-  }
-}
-
 export async function syncBuildings(
   checker: TableSyncInfo,
   remoteBuildings: BuildingData[],
@@ -104,7 +85,7 @@ export async function syncBuildings(
   // overwriting it with empty remote data or resetting rooms_fetched (#169).
   if (checker.newKey === null) return;
   if (!trustedRemote) return;
-  const localDB = getDB();
+  const localDB = await getDB();
 
   await localDB.waitReady;
   syncToastStore.startBuildingsSync(remoteBuildings.length);
@@ -162,7 +143,7 @@ export async function syncColleges(
   if (checker.newKey === null) return;
   if (!trustedRemote) return;
 
-  const localDB = getDB();
+  const localDB = await getDB();
 
   await localDB.waitReady;
   syncToastStore.startCollegesSync(remoteColleges.length);
@@ -211,7 +192,7 @@ export async function syncDivisions(
   if (checker.newKey === null) return;
   if (!trustedRemote) return;
 
-  const localDB = getDB();
+  const localDB = await getDB();
 
   await localDB.waitReady;
   syncToastStore.startDivisionsSync(remoteDivisions.length);
@@ -261,7 +242,7 @@ export async function syncDorms(
   if (checker.newKey === null) return;
   if (!trustedRemote) return;
 
-  const localDB = getDB();
+  const localDB = await getDB();
 
   await localDB.waitReady;
   syncToastStore.startDormsSync(remoteDorms.length);
@@ -333,7 +314,7 @@ export async function syncOrganizations(
   if (checker.newKey === null) return;
   if (!trustedRemote) return;
 
-  const localDB = getDB();
+  const localDB = await getDB();
   await localDB.waitReady;
   for (const o of remoteOrgs) {
     try {
@@ -399,7 +380,7 @@ export async function syncPlaces(
   if (checker.newKey === null) return;
   if (!trustedRemote) return;
 
-  const localDB = getDB();
+  const localDB = await getDB();
   await localDB.waitReady;
   for (const p of remotePlaces) {
     try {
@@ -453,7 +434,7 @@ export async function syncAnnouncements(
   if (checker.newKey === null) return;
   if (!trustedRemote) return;
 
-  const localDB = getDB();
+  const localDB = await getDB();
   await localDB.waitReady;
   // `/api/announcements` serves only live rows, so rows that expired or were
   // deleted server-side must leave the cache too — replace, don't upsert.
@@ -509,7 +490,7 @@ export async function syncJeepneyRoutes(
   if (await shouldSkipValidSync(checker, "jeepney_routes")) return;
   if (checker.newKey === null || !trustedRemote) return;
 
-  const localDB = getDB();
+  const localDB = await getDB();
   await localDB.waitReady;
   try {
     await localDB.transaction(async (tx) => {
@@ -569,7 +550,7 @@ export async function syncEvents(
   if (checker.newKey === null) return;
   if (!trustedRemote) return;
 
-  const localDB = getDB();
+  const localDB = await getDB();
   await localDB.waitReady;
   syncToastStore.startEventsSync(remoteEvents.length);
 
@@ -708,7 +689,7 @@ export async function syncEvents(
 
 export async function resetBuildingsSyncStatus() {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     await localDB.exec("UPDATE buildings SET rooms_fetched = false");
   } catch (e) {
@@ -718,7 +699,7 @@ export async function resetBuildingsSyncStatus() {
 
 export async function localBuildingSyncStatus(id: number) {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `
@@ -736,7 +717,7 @@ export async function localBuildingSyncStatus(id: number) {
 
 export async function getLocalBuildingRooms(id: number) {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `
@@ -812,7 +793,7 @@ export async function syncBuildingRooms(
   // Offline/failed fetch returns no rooms — keep the existing cache and the
   // rooms_fetched flag untouched instead of marking an empty fetch as done.
   if (!rooms || rooms.length === 0) return;
-  const localDB = getDB();
+  const localDB = await getDB();
   for (const room of rooms) {
     try {
       await localDB.query(
@@ -856,7 +837,7 @@ export async function syncBuildingRooms(
 
 export async function resetCollegesSyncStatus() {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     await localDB.exec("UPDATE colleges SET rooms_fetched = false");
   } catch (e) {
@@ -866,7 +847,7 @@ export async function resetCollegesSyncStatus() {
 
 export async function localCollegeSyncStatus(id: number) {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `
@@ -884,7 +865,7 @@ export async function localCollegeSyncStatus(id: number) {
 
 export async function getLocalCollegeRooms(id: number) {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `
@@ -942,7 +923,7 @@ export async function syncCollegeRooms(
 ) {
   if (validSync) return;
   if (!rooms || rooms.length === 0) return;
-  const localDB = getDB();
+  const localDB = await getDB();
   for (const room of rooms) {
     try {
       await localDB.query(
@@ -986,7 +967,7 @@ export async function syncCollegeRooms(
 
 export async function resetDivisionsSyncStatus() {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     await localDB.exec("UPDATE divisions SET rooms_fetched = false");
   } catch (e) {
@@ -996,7 +977,7 @@ export async function resetDivisionsSyncStatus() {
 
 export async function localDivisionSyncStatus(id: number) {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `
@@ -1014,7 +995,7 @@ export async function localDivisionSyncStatus(id: number) {
 
 export async function getLocalDivisionRooms(id: number) {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `
@@ -1072,7 +1053,7 @@ export async function syncDivisionRooms(
 ) {
   if (validSync) return;
   if (!rooms || rooms.length === 0) return;
-  const localDB = getDB();
+  const localDB = await getDB();
   for (const room of rooms) {
     try {
       await localDB.query(
@@ -1133,7 +1114,7 @@ export async function syncAliasCache() {
     const rows = payload.data;
     if (!Array.isArray(rows)) return;
 
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     await localDB.exec("DELETE FROM aliases");
     if (rows.length === 0) return;
@@ -1181,7 +1162,7 @@ export async function syncClasses(
   if (!trustedRemote) return;
   if (checker.newKey === null) return;
 
-  const localDB = getDB();
+  const localDB = await getDB();
   await localDB.waitReady;
   syncToastStore.startClassesSync(remoteClasses.length);
 

--- a/src/lib/local/data/utils.ts
+++ b/src/lib/local/data/utils.ts
@@ -13,7 +13,7 @@ import type {
   RoomData,
   TableSyncInfo,
 } from "@lib/types";
-import { getDB } from "./pgliteDB";
+import { getDB, isLocalCacheReady } from "./pgliteDB";
 import { ENTITY_FETCH_OPTIONS, fetchJsonWithRetry } from "./fetch-json";
 import {
   getLocalBuildingRooms,
@@ -30,7 +30,7 @@ export async function getLocalJeepneyRoutes(): Promise<
   JeepneyRoute[] | undefined
 > {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const [routes, stops] = await Promise.all([
       localDB.query(`
@@ -75,7 +75,7 @@ export async function getLocalJeepneyRoutes(): Promise<
 
 export async function getLocalBuildings(): Promise<BuildingData[] | undefined> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(`
         SELECT building_name AS "buildingName", lon, lat, id, directions, type AS "buildingType", image_url AS "imageUrl", cr_facilities AS "crFacilities", version, updated_at AS "updatedAt" FROM buildings
@@ -89,7 +89,7 @@ export async function getLocalBuildings(): Promise<BuildingData[] | undefined> {
 
 export async function getLocalColleges(): Promise<CollegeData[] | undefined> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(`
         SELECT college_name AS "collegeName", website_link AS "websiteLink", id, version, updated_at AS "updatedAt" FROM colleges;
@@ -103,7 +103,7 @@ export async function getLocalColleges(): Promise<CollegeData[] | undefined> {
 
 export async function getLocalDivisions(): Promise<DivisionData[] | undefined> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(`
         SELECT division_name AS "divisionName", website_link AS "websiteLink", id, version, updated_at AS "updatedAt" FROM divisions;
@@ -117,7 +117,7 @@ export async function getLocalDivisions(): Promise<DivisionData[] | undefined> {
 
 export async function getLocalDorms(): Promise<DormData[] | undefined> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(`
       SELECT
@@ -151,7 +151,7 @@ export async function getLocalDorms(): Promise<DormData[] | undefined> {
 
 export async function getLocalOrganizations(): Promise<OrgData[] | undefined> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(`
       SELECT
@@ -184,7 +184,7 @@ export async function getLocalOrganizations(): Promise<OrgData[] | undefined> {
 
 export async function getLocalPlaces(): Promise<PlaceData[] | undefined> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(`
       SELECT
@@ -213,7 +213,7 @@ export async function getLocalAnnouncements(): Promise<
   AnnouncementData[] | undefined
 > {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(`
       SELECT
@@ -239,7 +239,7 @@ export async function getLocalAnnouncements(): Promise<
 
 export async function getLocalEvents(): Promise<EventData[] | undefined> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const [events, locations, routes, stops] = await Promise.all([
       localDB.query(`
@@ -341,7 +341,7 @@ export async function getLocalEvents(): Promise<EventData[] | undefined> {
 export async function getLocalRoomByCode(code: string) {
   try {
     const normalizedCode = code.toUpperCase();
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `
@@ -378,7 +378,7 @@ export async function getLocalRoomByCode(code: string) {
 
 export async function getLocalRoomById(id: number) {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `
@@ -441,7 +441,7 @@ export async function getLocalRoomById(id: number) {
 
 export async function getLocalClasses(): Promise<ClassMapValue[] | undefined> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
 
     await localDB.waitReady;
     const data = (await localDB.query(`
@@ -475,7 +475,7 @@ export async function getBuildingIdsWithClasses(
   termId?: number | null,
 ): Promise<Set<number>> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const scoped = termId != null;
     const data = (await localDB.query(
@@ -552,7 +552,12 @@ export function getEntity<T>(
         return [];
       }
     };
-    const initialSnapshot: T[] = await local();
+    // #866: the cache hydrates in the background (~5 MB of wasm). This
+    // snapshot is only a last-resort fallback for a failed fetch, so it must
+    // not put the whole boot behind PGlite — a first-time visitor would be
+    // waiting on a database that is guaranteed empty. Once hydrated, every
+    // later call takes the real snapshot as before.
+    const initialSnapshot: T[] = isLocalCacheReady() ? await local() : [];
     // Offline (sync endpoint unreachable): prefer stale local cache over
     // failing to remote. Only treat invalid checker as "must refetch" when
     // we actually got a newKey back (confirmed sync mismatch) (#169).
@@ -679,7 +684,7 @@ export async function getLocalClassesForRoom(
   termId: number | null,
 ): Promise<ClassMapValue[] | null> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const hasAny = (await localDB.query(
       "SELECT 1 FROM classes LIMIT 1",
@@ -718,7 +723,7 @@ export async function getLocalRoomClassCounts(
   termId?: number,
 ): Promise<Map<number, number> | null> {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const hasAny = (await localDB.query(
       "SELECT 1 FROM classes LIMIT 1",
@@ -812,7 +817,7 @@ export async function getLocalRoomsCounts(): Promise<
   Pick<DBData, "directionCount" | "totalRooms">
 > {
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const total = (await localDB.query(
       "SELECT COUNT(*)::int AS count FROM rooms",
@@ -841,7 +846,7 @@ export async function searchLocalRooms(
       .replace(/\\/g, "\\\\")
       .replace(/%/g, "\\%")
       .replace(/_/g, "\\_");
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `SELECT room_code AS value FROM rooms
@@ -864,7 +869,7 @@ export async function searchLocalAliases(
   const normalized = normalizeAlias(searchString);
   if (!normalized) return [];
   try {
-    const localDB = getDB();
+    const localDB = await getDB();
     await localDB.waitReady;
     const data = (await localDB.query(
       `

--- a/src/pages/api/check/index.ts
+++ b/src/pages/api/check/index.ts
@@ -1,0 +1,36 @@
+import type { APIRoute } from "astro";
+import { db } from "@lib/db";
+import { updateTable } from "@drizzle/schema";
+
+export const prerender = false;
+
+/**
+ * Every table's sync key in one response (#866). Boot needs eight of them, and
+ * as separate `/api/check/<name>` probes that was eight round trips at ~500 ms
+ * each before the first campus fetch could start. `/api/check/[name]` stays
+ * for compatibility.
+ */
+export const GET = (async () => {
+  let rows: (typeof updateTable.$inferSelect)[];
+  try {
+    rows = await db.select().from(updateTable);
+  } catch (error) {
+    console.error("Sync check failed:", error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        data: null,
+        error:
+          "Sync registry unavailable. Apply pending DB migrations (drizzle/0016_ensure_update_sync_table.sql).",
+      }),
+      { status: 503 },
+    );
+  }
+
+  const data: Record<string, string | null> = {};
+  for (const row of rows) {
+    if (row.tableName) data[row.tableName] = row.syncKey;
+  }
+
+  return new Response(JSON.stringify({ success: true, error: null, data }));
+}) satisfies APIRoute;


### PR DESCRIPTION
Closes #866.

## What was wrong

Boot was strictly serial: `AppRoot` awaited `getDB()` + `initPGLiteDB()` on mount, and `getEntity()` took a local snapshot before every fetch. So ~5 MB of Postgres (wasm + data) sat in front of the first `/api` call — for every visitor, including first-timers whose cache is guaranteed empty. On top of that, eight separate `/api/check/<table>` probes ran before any campus data was requested.

## What changed

**(a) PGlite off the critical path.** `getDB()` now dynamically imports `@electric-sql/pglite`, runs the generated DDL itself, and memoises the handle — so PGlite leaves the entry bundle and hydrates in the background. `initPGLiteDB()` is folded in, so no caller has to sequence init before its own queries. New `isLocalCacheReady()` gates the one read that only wants a cached row *if one is already there* (`getEntity`'s last-resort snapshot); the branches that genuinely need the cache — offline, and a matching sync key — still await it, so offline behaviour is unchanged.

`AppRoot` now kicks hydration off in the background and lets the cached read race the network instead of gating it. `localStorage` sync keys (which survive without PGlite) answer "has this browser synced before?" for free, so the network refresh keeps the offline/stale-cache semantics it had when the cache read came first. A `networkDataApplied` flag stops a slow cache read from regressing the UI back to stale rows.

**(b) One sync probe.** New `GET /api/check` returns every table's sync key from the `update` registry in a single response. `getSyncKey()` moved to `sync-keys.ts` (no store or PGlite imports, so it is unit-testable) and shares one in-flight request across the eight boot lookups. The promise is cleared once it settles, so a later refresh — coming back online, an admin write — re-probes and never reads a stale key. `/api/check/[name]` is untouched and still works.

**(c) SW caching.** CacheFirst runtime rule for the content-hashed `pglite`/`initdb` wasm + data with a one-year max-age. They stay out of the precache (that would download Postgres during SW install), and the pattern tolerates a `?` suffix for the same reason the navigate denylist does.

## Measurements

Cold profile (no service worker, no IndexedDB, no localStorage) against a local production build, same machine and database for both runs:

| | before | after |
| --- | --- | --- |
| Boot requests | 58 | **50** |
| API requests | 23 | **14** |
| `/api/check` probes | **10** (8 boot + announcements + jeepney) | **2** (both the batched `/api/check`) |
| First campus fetch starts | 5567 / 6688 ms | **1183 / 3469 ms** |
| Building pins on map | 7433 / 7421 ms | **5698 / 6578 ms** |

**Does PGlite still block first paint? No.** Baseline: the wasm started at ~490 ms and the eight sync probes did not fire until ~4726 ms — the campus fetch waited ~4.2 s on the download. After: `/api/check` and the campus fetches go out while the wasm is still in flight. The map canvas itself was never gated (separate island, ~650 ms in both).

Repeat visits: verified over three loads in one profile. The `pglite-wasm` cache is populated once the service worker takes control (visit 2), and visits 2 and 3 serve all three assets from the SW.

## Tests

Per AGENTS § Tests with GitHub issues:

- **Unit** — `src/lib/local/data/sync-keys.test.ts`: the eight boot lookups collapse to one `/api/check`; a later refresh re-probes rather than reusing a settled response; a missing table and a missing `data` both read as `null`.
- **Component/store** — `src/lib/local/data/entity-cache-gate.store.test.ts`: with the cache still hydrating (a deliberately pending `getDB()`), a first visit serves remote rows without touching PGlite; a hydrated cache with a matching key still short-circuits the fetch; offline still falls back to the cache. Confirmed the first case **fails** on the pre-fix code (`boot load blocked on PGlite hydration`), so it is a real regression guard.
- **Integration** — `integration/http/public.integration.test.ts`: `GET /api/check` returns all eight boot tables in one payload, and `GET /api/check/[name]` still answers for a single table.

Playwright: none added. The measurements above came from a throwaway harness driving real Chromium against a local production build; no blocking spec was needed and no `networkidle` waits were used.

## Verified

`bun run lint` (no errors on touched files), `bun run test` (538 pass), `bun run test:components` (199 pass), `bun run build` (Vercel adapter, clean), `bun run check:readme`.

## Residual risk

- The `/api/check` in-flight dedupe is per page load, not cross-tab: two tabs booting at once still make one request each. Deliberate — coordinating that would cost more than it saves.
- Offline behaviour is unchanged by design, but the offline E2E suite is the real gate. This PR needs `run/e2e` before merge.
