### PR TITLE
feat(settings): add a Storage section with Resync campus data and Clear cached data

### DIFF
--- a/e2e/advisory/clear-cached-data.spec.ts
+++ b/e2e/advisory/clear-cached-data.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import { waitForAppBoot } from "../helpers/app";
+import {
+  openAppSidebar,
+  openHelpSettingsSection,
+  clickSidebarNav,
+} from "../helpers/map-tools";
+
+const PLANNER_LS_KEY = "room-tba-planner";
+const PLAN = JSON.stringify({
+  v: 1,
+  plans: [{ id: "e2e-plan", label: "E2E plan", termId: 1252, sections: [] }],
+  activePlanIdByTerm: { "1252": "e2e-plan" },
+});
+
+/**
+ * #865 — clearing cached data must not take the user's plans with it.
+ *
+ * The plan is seeded *after* boot, on purpose: an `addInitScript` seed would
+ * be re-applied by the reload and would hide exactly the bug this guards.
+ */
+test.describe("Settings → Storage: clear cached data", () => {
+  test("clears and reboots without losing the saved plan", async ({ page }) => {
+    await page.goto("/");
+    await waitForAppBoot(page);
+
+    await page.evaluate(
+      ([key, value]) => {
+        localStorage.setItem(key, value);
+        localStorage.setItem("hideLandingModal", "true");
+        (window as unknown as { __preReload?: boolean }).__preReload = true;
+      },
+      [PLANNER_LS_KEY, PLAN],
+    );
+
+    const sidebar = await openAppSidebar(page);
+    await openHelpSettingsSection(sidebar);
+    await clickSidebarNav(sidebar, "Settings", { exact: true });
+    const settings = page.getByRole("dialog", { name: "Settings" });
+    await expect(settings).toBeVisible();
+
+    await settings
+      .getByRole("button", { name: "Clear cached data and reload" })
+      .click();
+    await expect(
+      settings.getByText(/Downloaded offline maps go too/),
+    ).toBeVisible();
+    await settings.getByRole("button", { name: "Clear and reload" }).click();
+
+    // The reload is the success signal — wait for the marker to disappear.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __preReload?: boolean }).__preReload ===
+              undefined,
+          ),
+        { timeout: 60_000 },
+      )
+      .toBe(true);
+
+    await waitForAppBoot(page);
+
+    expect(
+      await page.evaluate((key) => localStorage.getItem(key), PLANNER_LS_KEY),
+    ).toBe(PLAN);
+    expect(
+      await page.evaluate(() => localStorage.getItem("hideLandingModal")),
+    ).toBe("true");
+  });
+});

--- a/src/components/svelte/modal/SettingsModal.component.test.ts
+++ b/src/components/svelte/modal/SettingsModal.component.test.ts
@@ -60,6 +60,19 @@ describe("SettingsModal storage section (#865)", () => {
     ).toBeInTheDocument();
   });
 
+  test("moves focus to the confirm so keyboard users are not dropped on <body>", async () => {
+    render(SettingsModalHost);
+
+    clearButton().click();
+    const confirm = await screen.findByRole("button", {
+      name: "Clear and reload",
+    });
+    await vi.waitFor(() => expect(document.activeElement).toBe(confirm));
+    expect(confirm.getAttribute("aria-describedby")).toBe(
+      "settings-storage-warning",
+    );
+  });
+
   test("cancel backs out without clearing", async () => {
     render(SettingsModalHost);
 

--- a/src/components/svelte/modal/SettingsModal.component.test.ts
+++ b/src/components/svelte/modal/SettingsModal.component.test.ts
@@ -5,14 +5,29 @@ import {
   expectNoHorizontalOverflow,
   mountAtWidth,
 } from "@test/layout-assertions";
+import { SYNC_TABLE_NAMES } from "@lib/local/data/sync-keys";
+import { syncToastStore } from "@lib/store.svelte";
 
 const clearCachedData = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock("@lib/local/clear-cached-data", () => ({ clearCachedData }));
+
+// Only the sync-key module is stubbed, so the real `resyncCampusData()` runs
+// and the table list it passes is actually asserted.
+const invalidateLocalSyncKeys = vi.hoisted(() => vi.fn());
+const requestCampusDataRefresh = vi.hoisted(() => vi.fn());
+vi.mock("@lib/local/data/invalidate-sync-key", () => ({
+  invalidateLocalSyncKeys,
+  requestCampusDataRefresh,
+  CAMPUS_DATA_REFRESH_EVENT: "room-tba:campus-data-refresh",
+}));
 
 const reload = vi.fn();
 
 const clearButton = () =>
   screen.getByRole("button", { name: "Clear cached data and reload" });
+
+const resyncButton = () =>
+  screen.getByRole("button", { name: "Resync campus data" });
 
 describe("SettingsModal", () => {
   test("renders every section at 320px without horizontal overflow", () => {
@@ -122,5 +137,96 @@ describe("SettingsModal storage section (#865)", () => {
 
     finish();
     await vi.waitFor(() => expect(reload).toHaveBeenCalled());
+  });
+});
+
+describe("SettingsModal resync campus data", () => {
+  beforeEach(() => {
+    invalidateLocalSyncKeys.mockClear();
+    requestCampusDataRefresh.mockClear();
+    // Mid-sync state: `startRemoteFetch()` clears both when a refresh starts.
+    syncToastStore.allSynced = false;
+    syncToastStore.syncError = null;
+  });
+
+  test("invalidates every tracked table, not a subset", async () => {
+    render(SettingsModalHost);
+
+    resyncButton().click();
+    await Promise.resolve();
+
+    expect(invalidateLocalSyncKeys).toHaveBeenCalledWith([...SYNC_TABLE_NAMES]);
+    expect(requestCampusDataRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows a busy state and ignores a second click", async () => {
+    render(SettingsModalHost);
+
+    resyncButton().click();
+
+    const busy = await screen.findByRole("button", { name: "Resyncing…" });
+    expect((busy as HTMLButtonElement).disabled).toBe(true);
+
+    busy.click();
+    expect(requestCampusDataRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports success once the sync store settles", async () => {
+    render(SettingsModalHost);
+
+    resyncButton().click();
+    await screen.findByRole("button", { name: "Resyncing…" });
+    syncToastStore.allSynced = true;
+
+    expect(
+      await screen.findByText(
+        "Campus data is up to date.",
+        {},
+        { timeout: 3000 },
+      ),
+    ).toBeInTheDocument();
+    await vi.waitFor(() => expect(resyncButton()).toBeInTheDocument());
+  });
+
+  test("surfaces a failure instead of silently doing nothing", async () => {
+    render(SettingsModalHost);
+
+    syncToastStore.syncError = "Network request failed";
+    resyncButton().click();
+
+    expect(
+      await screen.findByText(
+        "Resync failed. Check your connection and try again.",
+        {},
+        { timeout: 3000 },
+      ),
+    ).toBeInTheDocument();
+    // Not left stuck in the busy state.
+    await vi.waitFor(() => expect(resyncButton()).toBeInTheDocument());
+  });
+
+  test("does not claim success when nothing handled the refresh", async () => {
+    render(SettingsModalHost);
+
+    // No listener ran, so `allSynced` still carries the previous sync's true.
+    syncToastStore.allSynced = true;
+    resyncButton().click();
+
+    expect(
+      await screen.findByText(
+        "Resync failed. Check your connection and try again.",
+        {},
+        { timeout: 3000 },
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("leaves the offline map caches and the clear button alone", () => {
+    render(SettingsModalHost);
+
+    expect(
+      screen.getByText(/downloaded offline maps are kept/i),
+    ).toBeInTheDocument();
+    expect(clearButton()).toBeInTheDocument();
   });
 });

--- a/src/components/svelte/modal/SettingsModal.component.test.ts
+++ b/src/components/svelte/modal/SettingsModal.component.test.ts
@@ -1,10 +1,18 @@
 import { render, screen } from "@testing-library/svelte";
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import SettingsModalHost from "@test/components/SettingsModalHost.svelte";
 import {
   expectNoHorizontalOverflow,
   mountAtWidth,
 } from "@test/layout-assertions";
+
+const clearCachedData = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("@lib/local/clear-cached-data", () => ({ clearCachedData }));
+
+const reload = vi.fn();
+
+const clearButton = () =>
+  screen.getByRole("button", { name: "Clear cached data and reload" });
 
 describe("SettingsModal", () => {
   test("renders every section at 320px without horizontal overflow", () => {
@@ -13,11 +21,93 @@ describe("SettingsModal", () => {
 
     expect(screen.getByRole("heading", { name: "Settings" })).toBeVisible();
     // Transit moved to the sidebar's Jeepney routes browse panel.
-    for (const section of ["View", "Terrain", "Schedule"]) {
+    for (const section of ["View", "Terrain", "Schedule", "Storage"]) {
       expect(
         screen.getByRole("heading", { name: section }),
       ).toBeInTheDocument();
     }
     expectNoHorizontalOverflow(container);
+  });
+});
+
+describe("SettingsModal storage section (#865)", () => {
+  beforeEach(() => {
+    clearCachedData.mockReset();
+    clearCachedData.mockImplementation(async () => {});
+    reload.mockClear();
+    vi.spyOn(window.location, "reload").mockImplementation(reload);
+  });
+
+  test("promises the user's plans survive", () => {
+    render(SettingsModalHost);
+
+    expect(screen.getByText(/Your saved class plans stay/)).toBeInTheDocument();
+    expect(clearButton()).toBeInTheDocument();
+  });
+
+  test("the first click only asks; it clears nothing", async () => {
+    render(SettingsModalHost);
+
+    clearButton().click();
+    await Promise.resolve();
+
+    expect(clearCachedData).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/Downloaded offline maps go too/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Clear and reload" }),
+    ).toBeInTheDocument();
+  });
+
+  test("cancel backs out without clearing", async () => {
+    render(SettingsModalHost);
+
+    clearButton().click();
+    await Promise.resolve();
+    screen.getByRole("button", { name: "Cancel" }).click();
+    await Promise.resolve();
+
+    expect(clearCachedData).not.toHaveBeenCalled();
+    expect(clearButton()).toBeInTheDocument();
+  });
+
+  test("confirming clears and reloads", async () => {
+    render(SettingsModalHost);
+
+    clearButton().click();
+    await Promise.resolve();
+    screen.getByRole("button", { name: "Clear and reload" }).click();
+
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(clearCachedData).toHaveBeenCalledTimes(1);
+  });
+
+  test("disables the buttons while clearing and ignores a second click", async () => {
+    let finish = () => {};
+    clearCachedData.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    render(SettingsModalHost);
+
+    clearButton().click();
+    await Promise.resolve();
+    screen.getByRole("button", { name: "Clear and reload" }).click();
+
+    const busy = await screen.findByRole("button", { name: "Clearing…" });
+    expect((busy as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    busy.click();
+    expect(clearCachedData).toHaveBeenCalledTimes(1);
+
+    finish();
+    await vi.waitFor(() => expect(reload).toHaveBeenCalled());
   });
 });

--- a/src/components/svelte/modal/SettingsModal.svelte
+++ b/src/components/svelte/modal/SettingsModal.svelte
@@ -3,7 +3,20 @@
   import TerrainControl from "@ui/TerrainControl.svelte";
   import ScheduleImportPanel from "@ui/ScheduleImportPanel.svelte";
   import { TERRAIN_ENABLED } from "@constants/map-terrain";
+  import { clearCachedData } from "@lib/local/clear-cached-data";
   import "../map-chrome/map-chrome.css";
+
+  let confirming = $state(false);
+  let clearing = $state(false);
+
+  // The reload is the success signal, so there is no toast: either the page
+  // comes back clean or the button is still sitting there.
+  async function clearAndReload() {
+    if (clearing) return;
+    clearing = true;
+    await clearCachedData();
+    location.reload();
+  }
 </script>
 
 <div class="settings-modal">
@@ -22,6 +35,48 @@
     <section class="settings-modal__section">
       <h3>Schedule</h3>
       <ScheduleImportPanel embedded />
+    </section>
+    <section class="settings-modal__section">
+      <h3>Storage</h3>
+      <p class="settings-modal__hint">
+        Fixes a stuck app after a bad update: clears the cached app, saved
+        campus data, and downloaded offline maps, then reloads. Your saved
+        class plans stay.
+      </p>
+      {#if confirming}
+        <p class="settings-modal__hint settings-modal__hint--warn">
+          Downloaded offline maps go too — you will need to download them again
+          on a connection.
+        </p>
+        <div class="settings-modal__actions">
+          <button
+            type="button"
+            class="settings-modal__btn settings-modal__btn--danger"
+            disabled={clearing}
+            onclick={clearAndReload}
+          >
+            {clearing ? "Clearing…" : "Clear and reload"}
+          </button>
+          <button
+            type="button"
+            class="settings-modal__btn"
+            disabled={clearing}
+            onclick={() => (confirming = false)}
+          >
+            Cancel
+          </button>
+        </div>
+      {:else}
+        <div class="settings-modal__actions">
+          <button
+            type="button"
+            class="settings-modal__btn"
+            onclick={() => (confirming = true)}
+          >
+            Clear cached data and reload
+          </button>
+        </div>
+      {/if}
     </section>
   </div>
 </div>
@@ -69,5 +124,66 @@
     letter-spacing: 0.02em;
     text-transform: uppercase;
     color: hsl(0, 0%, 40%);
+  }
+
+  .settings-modal__hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    line-height: 1.35;
+    color: hsl(0, 0%, 40%);
+  }
+
+  .settings-modal__hint--warn {
+    color: hsl(5, 53%, 32%);
+  }
+
+  .settings-modal__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    margin-top: 0.125rem;
+  }
+
+  .settings-modal__btn {
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* 44px touch target. */
+    min-height: 2.75rem;
+    border: 1px solid hsl(0, 0%, 82%);
+    border-radius: 0.5rem;
+    padding: 0.4375rem 0.75rem;
+    background-color: white;
+    color: hsl(0, 0%, 20%);
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.2;
+    cursor: pointer;
+  }
+
+  .settings-modal__btn:hover:not(:disabled) {
+    background-color: hsl(0, 0%, 96%);
+  }
+
+  .settings-modal__btn:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 2px;
+  }
+
+  .settings-modal__btn:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .settings-modal__btn--danger {
+    border-color: hsl(5, 53%, 32%);
+    background-color: hsl(5, 53%, 32%);
+    color: white;
+  }
+
+  .settings-modal__btn--danger:hover:not(:disabled) {
+    background-color: hsl(5, 53%, 27%);
   }
 </style>

--- a/src/components/svelte/modal/SettingsModal.svelte
+++ b/src/components/svelte/modal/SettingsModal.svelte
@@ -4,11 +4,39 @@
   import ScheduleImportPanel from "@ui/ScheduleImportPanel.svelte";
   import { TERRAIN_ENABLED } from "@constants/map-terrain";
   import { clearCachedData } from "@lib/local/clear-cached-data";
+  import {
+    resyncCampusData,
+    type ResyncOutcome,
+  } from "@lib/local/resync-campus-data";
+  import { syncToastStore } from "@lib/store.svelte";
   import "../map-chrome/map-chrome.css";
 
   let confirming = $state(false);
   let clearing = $state(false);
   let confirmButton = $state<HTMLButtonElement | null>(null);
+  let resyncing = $state(false);
+  let resyncResult = $state<ResyncOutcome | null>(null);
+
+  const RESYNC_MESSAGE: Record<ResyncOutcome, string> = {
+    synced: "Campus data is up to date.",
+    failed: "Resync failed. Check your connection and try again.",
+    timeout: "Still syncing in the background. Check again in a moment.",
+  };
+
+  // No reload to signal success here, so the result has to be said out loud.
+  async function resync() {
+    if (resyncing) return;
+    resyncing = true;
+    resyncResult = null;
+    try {
+      resyncResult = await resyncCampusData(() => ({
+        allSynced: syncToastStore.allSynced,
+        syncError: syncToastStore.syncError,
+      }));
+    } finally {
+      resyncing = false;
+    }
+  }
 
   // Opening the confirm swaps the button out from under the pointer, which
   // would drop keyboard focus to <body>. Move it to the confirm instead.
@@ -45,8 +73,36 @@
     </section>
     <section class="settings-modal__section">
       <h3>Storage</h3>
+
+      <div class="settings-modal__task">
+        <p class="settings-modal__hint">
+          Rooms or classes look stale or wrong? Fetch campus data again from
+          the server. Your downloaded offline maps are kept.
+        </p>
+        <div class="settings-modal__actions">
+          <button
+            type="button"
+            class="settings-modal__btn"
+            disabled={resyncing}
+            onclick={resync}
+          >
+            {resyncing ? "Resyncing…" : "Resync campus data"}
+          </button>
+        </div>
+        {#if resyncResult}
+          <p
+            class="settings-modal__hint"
+            class:settings-modal__hint--warn={resyncResult !== "synced"}
+            class:settings-modal__hint--ok={resyncResult === "synced"}
+            role="status"
+          >
+            {RESYNC_MESSAGE[resyncResult]}
+          </p>
+        {/if}
+      </div>
+
       <p class="settings-modal__hint">
-        Fixes a stuck app after a bad update: clears the cached app, saved
+        Still broken? This is the heavier fix: it clears the cached app, saved
         campus data, and downloaded offline maps, then reloads. Your saved
         class plans stay.
       </p>
@@ -147,6 +203,20 @@
 
   .settings-modal__hint--warn {
     color: hsl(5, 53%, 32%);
+  }
+
+  .settings-modal__hint--ok {
+    color: hsl(150, 40%, 28%);
+  }
+
+  /* Groups the light fix with its own result line, so the heavier
+     clear-and-reload below reads as the separate, bigger hammer. */
+  .settings-modal__task {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding-bottom: 0.625rem;
+    border-bottom: 1px solid hsl(0, 0%, 90%);
   }
 
   .settings-modal__actions {

--- a/src/components/svelte/modal/SettingsModal.svelte
+++ b/src/components/svelte/modal/SettingsModal.svelte
@@ -8,6 +8,13 @@
 
   let confirming = $state(false);
   let clearing = $state(false);
+  let confirmButton = $state<HTMLButtonElement | null>(null);
+
+  // Opening the confirm swaps the button out from under the pointer, which
+  // would drop keyboard focus to <body>. Move it to the confirm instead.
+  $effect(() => {
+    if (confirming) confirmButton?.focus();
+  });
 
   // The reload is the success signal, so there is no toast: either the page
   // comes back clean or the button is still sitting there.
@@ -44,7 +51,10 @@
         class plans stay.
       </p>
       {#if confirming}
-        <p class="settings-modal__hint settings-modal__hint--warn">
+        <p
+          id="settings-storage-warning"
+          class="settings-modal__hint settings-modal__hint--warn"
+        >
           Downloaded offline maps go too — you will need to download them again
           on a connection.
         </p>
@@ -52,7 +62,9 @@
           <button
             type="button"
             class="settings-modal__btn settings-modal__btn--danger"
+            aria-describedby="settings-storage-warning"
             disabled={clearing}
+            bind:this={confirmButton}
             onclick={clearAndReload}
           >
             {clearing ? "Clearing…" : "Clear and reload"}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -226,6 +226,14 @@ const shareTitle = ogTitle ?? title;
           return !island || island.children.length > 0;
         }
 
+            // Last-resort teardown when the app never hydrates. Deliberately
+            // duplicates part of `clearCachedData()` in
+            // src/lib/local/clear-cached-data.ts (the Settings → Storage
+            // button): this script is `is:inline` so it can still run when the
+            // bundle itself is broken, which means it cannot import that
+            // module. Keep the two in step by hand. Like the shared version,
+            // it must never call localStorage.clear() — planner plans live
+            // there.
             function resetAppData() {
               var jobs = [];
               try {

--- a/src/lib/local/clear-cached-data.test.ts
+++ b/src/lib/local/clear-cached-data.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  clearCachedData,
+  PGLITE_IDB_NAME,
+  PRESERVED_LOCAL_KEYS,
+} from "./clear-cached-data";
+import { PLANNER_LS_KEY } from "@lib/stores/store-types";
+
+const SYNC_KEYS = JSON.stringify({
+  buildings: "b1",
+  rooms: "r1",
+  classes: "c1",
+});
+
+const PLANNER_STATE = JSON.stringify({
+  v: 1,
+  plans: [{ id: "p1", label: "My plan", termId: 1252, sections: [] }],
+  activePlanIdByTerm: { "1252": "p1" },
+});
+
+type Harness = {
+  unregistered: number;
+  cacheKeys: string[];
+  deletedCaches: string[];
+  deletedDatabases: string[];
+};
+
+let harness: Harness;
+const originals = new Map<string, PropertyDescriptor | undefined>();
+
+function define(name: string, value: unknown) {
+  if (!originals.has(name)) {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+  }
+  Object.defineProperty(globalThis, name, { value, configurable: true });
+}
+
+/** Bun has no DOM; stand up only the globals the clear routine touches. */
+function setupBrowserGlobals(overrides: { cachesFails?: boolean } = {}) {
+  harness = {
+    unregistered: 0,
+    cacheKeys: ["workbox-precache-v2", "map-tiles", "map-assets"],
+    deletedCaches: [],
+    deletedDatabases: [],
+  };
+
+  const store = new Map<string, string>();
+  define("localStorage", {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+  });
+
+  const caches = {
+    keys: async () => [...harness.cacheKeys],
+    delete: async (key: string) => {
+      if (overrides.cachesFails) throw new Error("cache storage unavailable");
+      harness.deletedCaches.push(key);
+      harness.cacheKeys = harness.cacheKeys.filter((k) => k !== key);
+      return true;
+    },
+  };
+  define("caches", caches);
+  define("window", { caches });
+
+  define("navigator", {
+    serviceWorker: {
+      getRegistrations: async () => [
+        {
+          unregister: async () => {
+            harness.unregistered += 1;
+            return true;
+          },
+        },
+      ],
+    },
+  });
+
+  define("indexedDB", {
+    deleteDatabase: (name: string) => {
+      const request: Record<string, unknown> = {};
+      queueMicrotask(() => {
+        harness.deletedDatabases.push(name);
+        (request.onsuccess as (() => void) | undefined)?.();
+      });
+      return request;
+    },
+  });
+
+  return store;
+}
+
+describe("clearCachedData", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = setupBrowserGlobals();
+    store.set("sync-key", SYNC_KEYS);
+    store.set(PLANNER_LS_KEY, PLANNER_STATE);
+    store.set("hideLandingModal", "true");
+    store.set("recent-search", '["PSLH 1"]');
+    store.set("sidebar-expanded", "false");
+  });
+
+  afterEach(() => {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else Reflect.deleteProperty(globalThis, name);
+    }
+    originals.clear();
+  });
+
+  it("keeps the user's planner plans — the whole point of not calling localStorage.clear()", async () => {
+    await clearCachedData();
+    expect(store.get(PLANNER_LS_KEY)).toBe(PLANNER_STATE);
+  });
+
+  it("keeps the preference keys", async () => {
+    await clearCachedData();
+    expect(store.get("hideLandingModal")).toBe("true");
+    expect(store.get("recent-search")).toBe('["PSLH 1"]');
+    expect(store.get("sidebar-expanded")).toBe("false");
+  });
+
+  it("lists the planner key among the preserved keys", () => {
+    expect(PRESERVED_LOCAL_KEYS).toContain(PLANNER_LS_KEY);
+  });
+
+  it("unregisters service workers", async () => {
+    await clearCachedData();
+    expect(harness.unregistered).toBe(1);
+  });
+
+  it("deletes every cache, including the offline map caches", async () => {
+    await clearCachedData();
+    expect(harness.deletedCaches).toContain("workbox-precache-v2");
+    expect(harness.deletedCaches).toContain("map-tiles");
+    expect(harness.deletedCaches).toContain("map-assets");
+    expect(harness.cacheKeys).toEqual([]);
+  });
+
+  it("drops the PGlite campus cache", async () => {
+    await clearCachedData();
+    expect(harness.deletedDatabases).toEqual([PGLITE_IDB_NAME]);
+  });
+
+  it("empties the sync keys so campus data re-syncs", async () => {
+    await clearCachedData();
+    expect(JSON.parse(store.get("sync-key") ?? "null")).toEqual({});
+  });
+
+  it("finishes the remaining steps when one fails", async () => {
+    store = setupBrowserGlobals({ cachesFails: true });
+    store.set("sync-key", SYNC_KEYS);
+    store.set(PLANNER_LS_KEY, PLANNER_STATE);
+
+    await clearCachedData();
+
+    expect(harness.deletedDatabases).toEqual([PGLITE_IDB_NAME]);
+    expect(JSON.parse(store.get("sync-key") ?? "null")).toEqual({});
+    expect(store.get(PLANNER_LS_KEY)).toBe(PLANNER_STATE);
+  });
+});

--- a/src/lib/local/clear-cached-data.ts
+++ b/src/lib/local/clear-cached-data.ts
@@ -1,0 +1,98 @@
+/**
+ * Wipe this device's app cache so a returning visitor can recover from a bad
+ * bundle or a stuck service worker without devtools (#865).
+ *
+ * **The user's own work survives.** Planner plans, and the small preference
+ * keys below, are never touched — which is why this never calls
+ * `localStorage.clear()`. Anything added here that touches localStorage must
+ * remove named keys only.
+ *
+ * `src/layouts/Layout.astro` has a smaller copy of the service-worker + Cache
+ * Storage teardown inside its boot watchdog. It is `is:inline` (it must run
+ * before any module loads, precisely for the case where the bundle is broken),
+ * so it cannot import this file. Keep the two in step by hand.
+ */
+
+import { clearMapCaches } from "@lib/local/offline-maps";
+import { closeLocalDB } from "@lib/local/data/pgliteDB";
+import { invalidateLocalSyncKeys } from "@lib/local/data/invalidate-sync-key";
+import { getSyncKeysFromLs } from "@lib/local/data/sync-keys";
+import { PLANNER_LS_KEY } from "@lib/stores/store-types";
+
+/** IndexedDB database behind PGlite's `idb://site-data` (emscripten IDBFS mounts at `/pglite/<dataDir>`). */
+export const PGLITE_IDB_NAME = "/pglite/site-data";
+
+/**
+ * localStorage keys a clear must leave alone. The planner key is the user's
+ * own work; the rest are preferences that are annoying, not dangerous, to lose.
+ */
+export const PRESERVED_LOCAL_KEYS = [
+  PLANNER_LS_KEY,
+  "hideLandingModal",
+  "recent-search",
+  "sidebar-expanded",
+] as const;
+
+/** A failed step must not abort the rest of the clear. */
+async function step(label: string, run: () => Promise<void> | void) {
+  try {
+    await run();
+  } catch (error) {
+    console.error(`Clear cached data: ${label} failed`, error);
+  }
+}
+
+async function unregisterServiceWorkers(): Promise<void> {
+  if (!navigator.serviceWorker) return;
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  await Promise.all(registrations.map((reg) => reg.unregister()));
+}
+
+/** App shell, workbox precache, `map-tiles`, `map-assets` — everything on this origin. */
+async function deleteCacheStorage(): Promise<void> {
+  if (!("caches" in window)) return;
+  // Named drop of the downloaded offline maps first, so the intent survives
+  // even if the sweep below is ever narrowed to a prefix.
+  await clearMapCaches();
+  const keys = await caches.keys();
+  await Promise.all(keys.map((key) => caches.delete(key)));
+}
+
+/**
+ * Drop the PGlite campus cache so campus data re-syncs from the server.
+ *
+ * ponytail: resolve on `blocked` instead of waiting it out. A blocked delete
+ * stays queued and completes when the last connection closes, which the reload
+ * does anyway; hanging here would strand the user on a spinner.
+ */
+async function deletePgliteDatabase(): Promise<void> {
+  if (typeof indexedDB === "undefined") return;
+  await closeLocalDB();
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase(PGLITE_IDB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+/** Forget every cached sync key so the next fetch pulls fresh server rows. */
+function clearSyncKeys(): void {
+  if (typeof localStorage === "undefined") return;
+  const syncKeys = getSyncKeysFromLs();
+  if (syncKeys) invalidateLocalSyncKeys(Object.keys(syncKeys));
+}
+
+/**
+ * Clear caches, the offline campus database, and sync keys. Resolves even when
+ * individual steps fail — the caller reloads either way, and a reload on a
+ * partial clear still beats leaving the user stuck.
+ *
+ * Does **not** reload; the caller owns that.
+ */
+export async function clearCachedData(): Promise<void> {
+  await step("service worker unregister", unregisterServiceWorkers);
+  await step("cache storage", deleteCacheStorage);
+  await step("campus database", deletePgliteDatabase);
+  await step("sync keys", clearSyncKeys);
+}

--- a/src/lib/local/data/pgliteDB.ts
+++ b/src/lib/local/data/pgliteDB.ts
@@ -24,3 +24,15 @@ export function getDB() {
   }
   return localDB;
 }
+
+/**
+ * Close the offline cache so its IndexedDB database can be deleted (#865).
+ * No-op when nothing opened it — deliberately does not call `getDB()`, which
+ * would boot the WASM engine just to shut it down again.
+ */
+export async function closeLocalDB(): Promise<void> {
+  if (!localDB) return;
+  const db = localDB;
+  localDB = null;
+  await db.close();
+}

--- a/src/lib/local/data/sync-keys.ts
+++ b/src/lib/local/data/sync-keys.ts
@@ -1,26 +1,38 @@
 /** LocalStorage sync-key helpers (no PGlite imports). */
+
+/**
+ * Every table tracked by a sync key. Single source of truth: the stored
+ * default is built from this, and callers that invalidate "everything"
+ * (Settings → Resync campus data) read it instead of hardcoding a subset that
+ * silently rots when a table is added.
+ */
+export const SYNC_TABLE_NAMES = [
+  "buildings",
+  "colleges",
+  "divisions",
+  "rooms",
+  "dorms",
+  "classes",
+  "final_exams",
+  "events",
+  "organizations",
+  "places",
+  "announcements",
+] as const;
+
+function emptySyncKeys(): string {
+  return JSON.stringify(
+    Object.fromEntries(SYNC_TABLE_NAMES.map((table) => [table, ""])),
+  );
+}
+
 export function getSyncKeysFromLs(): {
   [key: string]: string;
 } | null {
   const lsStore = localStorage.getItem("sync-key");
 
   if (lsStore === null) {
-    localStorage.setItem(
-      "sync-key",
-      `{
-      "buildings": "",
-      "colleges": "",
-      "divisions": "",
-      "rooms": "",
-      "dorms": "",
-      "classes": "",
-      "final_exams": "",
-      "events": "",
-      "organizations": "",
-      "places": "",
-      "announcements": ""
-    }`,
-    );
+    localStorage.setItem("sync-key", emptySyncKeys());
     return null;
   }
 
@@ -35,22 +47,7 @@ export function getSyncKeysFromLs(): {
     }
   } catch {
     console.error("Error: the sync keys in the localStorage was corrupted");
-    localStorage.setItem(
-      "sync-key",
-      `{
-      "buildings": "",
-      "colleges": "",
-      "divisions": "",
-      "rooms": "",
-      "dorms": "",
-      "classes": "",
-      "final_exams": "",
-      "events": "",
-      "organizations": "",
-      "places": "",
-      "announcements": ""
-    }`,
-    );
+    localStorage.setItem("sync-key", emptySyncKeys());
     return null;
   }
 }

--- a/src/lib/local/resync-campus-data.test.ts
+++ b/src/lib/local/resync-campus-data.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resyncCampusData, type SyncStatus } from "./resync-campus-data";
+import { SYNC_TABLE_NAMES } from "./data/sync-keys";
+
+const originals = new Map<string, PropertyDescriptor | undefined>();
+
+function define(name: string, value: unknown) {
+  if (!originals.has(name)) {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+  }
+  Object.defineProperty(globalThis, name, { value, configurable: true });
+}
+
+/** Sync keys start populated so the invalidation has something to strip. */
+function seedSyncKeys(store: Map<string, string>) {
+  store.set(
+    "sync-key",
+    JSON.stringify(
+      Object.fromEntries(SYNC_TABLE_NAMES.map((table) => [table, "stale"])),
+    ),
+  );
+}
+
+let dispatched: string[];
+
+function setup() {
+  const store = new Map<string, string>();
+  define("localStorage", {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+  });
+  dispatched = [];
+  define("window", {
+    dispatchEvent: (event: Event) => {
+      dispatched.push(event.type);
+      return true;
+    },
+  });
+  seedSyncKeys(store);
+  return store;
+}
+
+/** Status that flips to a terminal state after `afterCalls` reads. */
+function statusAfter(afterCalls: number, terminal: SyncStatus) {
+  let calls = 0;
+  return () => {
+    calls += 1;
+    return calls > afterCalls
+      ? terminal
+      : { allSynced: false, syncError: null };
+  };
+}
+
+describe("resyncCampusData", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = setup();
+  });
+
+  afterEach(() => {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else Reflect.deleteProperty(globalThis, name);
+    }
+    originals.clear();
+  });
+
+  it("invalidates every sync key, not a subset", async () => {
+    await resyncCampusData(
+      statusAfter(1, { allSynced: true, syncError: null }),
+    );
+
+    expect(JSON.parse(store.get("sync-key") ?? "null")).toEqual({});
+  });
+
+  it("asks the app to refetch", async () => {
+    await resyncCampusData(
+      statusAfter(1, { allSynced: true, syncError: null }),
+    );
+
+    expect(dispatched).toEqual(["room-tba:campus-data-refresh"]);
+  });
+
+  it("reports success once the sync store settles", async () => {
+    const outcome = await resyncCampusData(
+      statusAfter(1, { allSynced: true, syncError: null }),
+      { pollMs: 1 },
+    );
+
+    expect(outcome).toBe("synced");
+  });
+
+  it("reports a failure when the sync errors", async () => {
+    const outcome = await resyncCampusData(
+      statusAfter(2, { allSynced: false, syncError: "Network request failed" }),
+      { pollMs: 1 },
+    );
+
+    expect(outcome).toBe("failed");
+  });
+
+  it("fails fast when nothing handled the refresh request", async () => {
+    // `startRemoteFetch()` would have cleared `allSynced` synchronously, so a
+    // still-true flag means no listener ran — a silent no-op otherwise.
+    const outcome = await resyncCampusData(() => ({
+      allSynced: true,
+      syncError: null,
+    }));
+
+    expect(outcome).toBe("failed");
+  });
+
+  it("times out instead of hanging in a busy state forever", async () => {
+    const outcome = await resyncCampusData(
+      () => ({ allSynced: false, syncError: null }),
+      { pollMs: 1, timeoutMs: 20 },
+    );
+
+    expect(outcome).toBe("timeout");
+  });
+
+  it("covers every table the sync keys track", () => {
+    expect([...SYNC_TABLE_NAMES]).toEqual(
+      expect.arrayContaining([
+        "buildings",
+        "colleges",
+        "divisions",
+        "rooms",
+        "dorms",
+        "classes",
+        "final_exams",
+        "events",
+        "organizations",
+        "places",
+        "announcements",
+      ]),
+    );
+  });
+});

--- a/src/lib/local/resync-campus-data.ts
+++ b/src/lib/local/resync-campus-data.ts
@@ -1,0 +1,70 @@
+/**
+ * Manual "Resync campus data" (Settings → Storage): drop the cached sync keys
+ * and ask the app to refetch buildings/rooms/classes/… from the server.
+ *
+ * The light counterpart to `clearCachedData()` — downloaded offline map tiles
+ * and the service worker are left alone. This is for data that looks stale or
+ * wrong, not for a broken install.
+ *
+ * `requestCampusDataRefresh()` only dispatches an event; the listener in
+ * `AppRoot.svelte` calls `refreshFromNetwork()` fire-and-forget, so there is
+ * no promise to await. The outcome is read off the sync store instead, which
+ * the caller injects so this stays free of Svelte runes and unit-testable.
+ */
+
+import {
+  invalidateLocalSyncKeys,
+  requestCampusDataRefresh,
+} from "@lib/local/data/invalidate-sync-key";
+import { SYNC_TABLE_NAMES } from "@lib/local/data/sync-keys";
+
+/** The two terminal fields of `SyncToastStore`: `endSync()` sets `allSynced`, `setSyncError()` sets `syncError`. */
+export type SyncStatus = {
+  allSynced: boolean;
+  syncError: string | null;
+};
+
+export type ResyncOutcome = "synced" | "failed" | "timeout";
+
+// ponytail: 250ms polling rather than an $effect subscription — this runs
+// outside a component root, and a campus sync takes seconds, so the
+// granularity is irrelevant. Swap to a store subscription if it ever needs to
+// drive a progress bar.
+const POLL_MS = 250;
+const TIMEOUT_MS = 60_000;
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Invalidate every sync key, request a refresh, and resolve once the sync
+ * store reports a terminal state.
+ *
+ * Never rejects and never hangs: an unheard request resolves `"failed"`
+ * immediately, and a sync that never finishes resolves `"timeout"`.
+ */
+export async function resyncCampusData(
+  readStatus: () => SyncStatus,
+  options: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<ResyncOutcome> {
+  const timeoutMs = options.timeoutMs ?? TIMEOUT_MS;
+  const pollMs = options.pollMs ?? POLL_MS;
+
+  invalidateLocalSyncKeys([...SYNC_TABLE_NAMES]);
+  requestCampusDataRefresh();
+
+  // `refreshFromNetwork()` calls `startRemoteFetch()` synchronously, which
+  // clears `allSynced`, and `dispatchEvent` runs listeners synchronously. So a
+  // still-true `allSynced` here means nothing handled the request — report it
+  // rather than reporting the previous sync's success.
+  if (readStatus().allSynced) return "failed";
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const status = readStatus();
+    if (status.syncError !== null) return "failed";
+    if (status.allSynced) return "synced";
+    await sleep(pollMs);
+  }
+  return "timeout";
+}


### PR DESCRIPTION
Closes #865

## What

A **Storage** section in `SettingsModal.svelte` with two paired recovery actions — the light one first, the heavy one below it.

### 1. Resync campus data (light)

For data that looks stale or wrong. Invalidates every sync key and asks the app to refetch buildings/rooms/classes/etc. **Downloaded offline map tiles and the service worker are left alone.**

- Reuses `invalidateLocalSyncKeys()` + `requestCampusDataRefresh()`.
- The table list moved out of the two duplicated JSON literals in `sync-keys.ts` into an exported `SYNC_TABLE_NAMES`, and the stored default is now built from it. "Invalidate everything" therefore cannot silently miss a table added later — the component test asserts the call receives the full list.
- No confirm step (non-destructive), busy state, and an explicit result line.

### 2. Clear cached data and reload (heavy)

The bigger hammer, behind a confirm because it drops downloaded offline maps too. Unregisters service workers, deletes Cache Storage (`clearMapCaches()` then a sweep), drops the PGlite campus cache, empties the sync keys, reloads. Each step is individually fault-tolerant.

## On `requestCampusDataRefresh()` — it is wired, but fire-and-forget

The listener is live: `AppRoot.svelte:365` handles `CAMPUS_DATA_REFRESH_EVENT` and calls `refreshFromNetwork(...)` + `transitStore.refresh()`. But both are `void`-ed, so **the event yields no completion signal** — a naive implementation would flash "synced" instantly and lie.

So the outcome is read off `syncToastStore` instead, which the component injects into the helper (keeping `resync-campus-data.ts` free of Svelte runes and unit-testable under `bun test`):

- success — `endSync()` sets `allSynced = true`
- failure — `setSyncError()` sets `syncError`

Two failure modes the naive version would get wrong, both covered by tests:

- **Nothing listening.** `refreshFromNetwork()` calls `startRemoteFetch()` synchronously (clearing `allSynced`), and `dispatchEvent` runs listeners synchronously — so if `allSynced` is *still* true immediately after the dispatch, no handler ran. That returns `failed` at once instead of reporting the previous sync's success.
- **Never resolves.** A 60s timeout returns `timeout` ("Still syncing in the background") rather than leaving the button spinning forever.

## Safety: the user's plans survive

**No `localStorage.clear()` anywhere.** Only the `sync-key` entry is touched, via `invalidateLocalSyncKeys()`.

Preserved: the planner key (`room-tba-planner`, `PLANNER_LS_KEY`), `hideLandingModal`, `recent-search`, `sidebar-expanded`, and the sessionStorage schedule weekday (`room-tba-schedule-import` — sessionStorage is never touched). `PRESERVED_LOCAL_KEYS` imports the real `PLANNER_LS_KEY` rather than duplicating the string.

Also worth a reviewer's eye: **the PGlite IndexedDB name is `/pglite/site-data`, not `site-data`** — emscripten's IDBFS keys by mount point and PGlite mounts `idb://<dir>` at `/pglite/<dir>`. Deleting `site-data` would have silently no-opped. `closeLocalDB()` closes the instance first so the delete is not blocked, and deliberately does not call `getDB()` (which would boot the WASM engine just to shut it down).

## UX

44px minimum targets and `:focus-visible` on both buttons. The clear button keeps its confirm step, moves focus to the confirm (it swaps the button out of the DOM, which otherwise dropped keyboard focus to `<body>`), and points at the warning with `aria-describedby`. The resync result is a `role="status"` live region since there is no reload to signal success.

## Layout.astro

The boot watchdog's inline `resetAppData()` is left alone: it is `is:inline` so it can still run when the bundle itself is broken, which is exactly when it is needed. Added a comment pointing at the shared module.

## QA

**Automated**

- `bun run test` — 549 pass, incl. 8 in `clear-cached-data.test.ts` and 7 in `resync-campus-data.test.ts` (full table list invalidated, refresh requested, success/failure/timeout outcomes, fail-fast when unheard)
- `bun run test:components` — 208 pass; 13 in `SettingsModal.component.test.ts` covering both buttons, and the existing 320px no-overflow test now includes the Storage section
- `bun run build`, `bun run lint` — clean

**Real browser** (advisory `e2e/advisory/clear-cached-data.spec.ts`, local node-adapter preview)

- desktop-chrome and mobile-chrome pass, re-run after the section was restructured: seeds a plan, clicks through the confirm, waits for the real reload, asserts the app boots and the plan survived.
- The plan is seeded *after* boot on purpose — an `addInitScript` seed would be re-applied by the reload and would hide the exact bug this guards.
- webkit is not installed on this machine; CI covers it.

## Known gaps

- The resync's 60s timeout is a guess tuned to be longer than a normal campus sync; a slow connection on a big term could hit it and show "still syncing in the background" while the sync is in fact still progressing. It is a message, not a cancellation.
- Not exercised: an iOS PWA where a service worker holds the IDB open across the reload. The delete resolves on `blocked` and stays queued, so campus data re-syncs one reload later at worst.
- The watchdog copy in `Layout.astro` stays duplicated by design; a future teardown change has to touch both.