### PR TITLE
fix(proposals): make the approver queue usable at 59 pending

### DIFF
--- a/drizzle/0045_add_proposal_submitter_note.sql
+++ b/drizzle/0045_add_proposal_submitter_note.sql
@@ -1,0 +1,9 @@
+-- #873: contributors had no way to talk to a reviewer, so one used the room
+-- `directions` content field to send admins a message ("You may opt to remove
+-- this room from the app"). Approving that would have published the message as
+-- user-facing directions. submitter_note is a reviewer-visible free-text field
+-- that is never part of the published patch.
+--
+-- Distinct from admin_note, which travels the other way (reviewer to
+-- contributor on reject / request changes).
+ALTER TABLE "edit_proposals" ADD COLUMN IF NOT EXISTS "submitter_note" text;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -506,6 +506,8 @@ export const editProposalsTable = pgTable("edit_proposals", {
     () => adminUsersTable.id,
   ),
   adminNote: text("admin_note"),
+  /** Contributor's message to the reviewer. Never published (#873). */
+  submitterNote: text("submitter_note"),
   reviewedBy: varchar("reviewed_by", { length: 100 }),
   reviewedAt: timestamp("reviewed_at", { mode: "string" }),
   createdAt: timestamp("created_at", { mode: "string" }).defaultNow().notNull(),

--- a/e2e/admin/proposals.spec.ts
+++ b/e2e/admin/proposals.spec.ts
@@ -42,6 +42,14 @@ test.describe("contributor proposals", () => {
     const queue = page.getByRole("region", {
       name: "Edit proposals review queue",
     });
+    // Rows start collapsed (#873) and keep their diff body out of the DOM, so
+    // the marker is unmatchable until every row is opened.
+    const summaries = queue.locator("li.entity-review-item summary");
+    await expect(summaries.first()).toBeVisible({ timeout: 15_000 });
+    for (let i = 0; i < (await summaries.count()); i += 1) {
+      await summaries.nth(i).click();
+    }
+
     const proposal = queue.locator("li.entity-review-item", {
       hasText: marker,
     });

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -80,6 +80,7 @@ const E2E_MIGRATION_FILES = [
   "0040_pre_drizzle_schema_backfill.sql",
   "0041_add_announcements.sql",
   "0042_add_class_acad_org.sql",
+  "0045_add_proposal_submitter_note.sql",
 ] as const;
 
 /**

--- a/src/components/svelte/ProposalReviewPanel.component.test.ts
+++ b/src/components/svelte/ProposalReviewPanel.component.test.ts
@@ -21,6 +21,14 @@ function baseProposal() {
   };
 }
 
+/** Rows start collapsed (#873), so open one before asserting on its body. */
+async function expandFirstRow() {
+  const summaries = document.querySelectorAll("summary");
+  const first = summaries[0];
+  if (!first) throw new Error("no proposal row rendered");
+  await fireEvent.click(first);
+}
+
 describe("ProposalReviewPanel diffs", () => {
   beforeEach(() => {
     adminAuthStore.isLoggedIn = true;
@@ -29,25 +37,36 @@ describe("ProposalReviewPanel diffs", () => {
     proposalsStore.pendingCount = 1;
   });
 
-  test("renders before and after for a changed field at 320px", () => {
+  test("renders before and after for a changed field at 320px", async () => {
     mountAtWidth(320);
     proposalsStore.proposals = [baseProposal()];
     render(ProposalReviewPanelHost);
+    await expandFirstRow();
     expect(screen.getByText("Directions")).toBeVisible();
     expect(screen.getByText("Enter from the west gate")).toBeVisible();
     expect(screen.getByText("Enter from the east gate")).toBeVisible();
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
-  test("shows stale banner when published version moved past baseVersion", () => {
+  test("collapsed rows keep the diff body out of the DOM", () => {
+    proposalsStore.proposals = [baseProposal()];
+    render(ProposalReviewPanelHost);
+    // The row is listed, but its diffs and buttons are not mounted yet.
+    expect(screen.getByText("Old Hall")).toBeVisible();
+    expect(screen.queryByText("Enter from the east gate")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+  });
+
+  test("shows stale banner when published version moved past baseVersion", async () => {
     proposalsStore.proposals = [{ ...baseProposal(), currentVersion: 5 }];
     render(ProposalReviewPanelHost);
+    await expandFirstRow();
     expect(screen.getByRole("alert").textContent).toMatch(
       /published data changed/i,
     );
   });
 
-  test("create proposals show New entry as the before value", () => {
+  test("create proposals show New entry as the before value", async () => {
     proposalsStore.proposals = [
       {
         ...baseProposal(),
@@ -60,12 +79,106 @@ describe("ProposalReviewPanel diffs", () => {
       },
     ];
     render(ProposalReviewPanelHost);
+    await expandFirstRow();
     expect(screen.getByText("New entry")).toBeVisible();
     expect(screen.getByText("CEM 203")).toBeVisible();
   });
 });
 
-describe("ProposalReviewPanel batch approve", () => {
+describe("ProposalReviewPanel foreign keys (#873)", () => {
+  beforeEach(() => {
+    adminAuthStore.isLoggedIn = true;
+    adminAuthStore.canReview = true;
+    proposalsStore.loading = false;
+    proposalsStore.pendingCount = 1;
+  });
+
+  test("a building reassignment shows names, not raw row ids", async () => {
+    // loadedAppContext() seeds building id 1 as "Class Hall".
+    proposalsStore.proposals = [
+      {
+        ...baseProposal(),
+        entityType: "room",
+        proposedPatch: { buildingId: 1 },
+        currentValues: { buildingId: 99 },
+      },
+    ];
+    render(ProposalReviewPanelHost);
+    await expandFirstRow();
+
+    expect(screen.getByText("Building")).toBeVisible();
+    expect(screen.getByText("Class Hall")).toBeVisible();
+    // The id stays available as secondary text next to the name.
+    expect(screen.getByText("#1")).toBeVisible();
+    // Unresolvable ids still fall back to the raw number rather than vanishing.
+    expect(screen.getByText("99")).toBeVisible();
+  });
+});
+
+describe("ProposalReviewPanel note flow (#873)", () => {
+  beforeEach(() => {
+    adminAuthStore.isLoggedIn = true;
+    adminAuthStore.canReview = true;
+    proposalsStore.loading = false;
+    proposalsStore.pendingCount = 1;
+    proposalsStore.proposals = [baseProposal()];
+  });
+
+  test("the note field appears only after choosing reject", async () => {
+    render(ProposalReviewPanelHost);
+    await expandFirstRow();
+
+    expect(screen.queryByLabelText(/note to yeyel/i)).toBeNull();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+
+    const note = screen.getByLabelText(/note to yeyel/i);
+    expect(note).toBeVisible();
+    // The rule lives in visible hint text, not a placeholder that vanishes.
+    expect(
+      screen.getByText(/optional\. the contributor sees this/i),
+    ).toBeVisible();
+  });
+
+  test("request changes keeps confirm disabled until a note is written", async () => {
+    render(ProposalReviewPanelHost);
+    await expandFirstRow();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Request changes" }),
+    );
+    expect(
+      screen.getByText(/required\. say what needs to change/i),
+    ).toBeVisible();
+
+    const confirm = screen.getByRole("button", {
+      name: /confirm request changes/i,
+    });
+    expect(confirm).toBeDisabled();
+
+    await fireEvent.input(screen.getByLabelText(/note to yeyel/i), {
+      target: { value: "Please cite a source." },
+    });
+    expect(confirm).toBeEnabled();
+  });
+
+  test("shows the contributor's note to the reviewer", async () => {
+    proposalsStore.proposals = [
+      {
+        ...baseProposal(),
+        submitterNote: "You may opt to remove this room from the app.",
+      },
+    ];
+    render(ProposalReviewPanelHost);
+    await expandFirstRow();
+
+    expect(
+      screen.getByText(/you may opt to remove this room from the app/i),
+    ).toBeVisible();
+  });
+});
+
+describe("ProposalReviewPanel bulk actions", () => {
   beforeEach(() => {
     adminAuthStore.isLoggedIn = true;
     adminAuthStore.canReview = true;
@@ -92,18 +205,16 @@ describe("ProposalReviewPanel batch approve", () => {
     render(ProposalReviewPanelHost);
 
     const approveBtn = screen.getByRole("button", {
-      name: /approve 0 selected/i,
+      name: /approve selected/i,
     });
+    // The disabled default reads as an action, not "Approve 0 selected".
     expect(approveBtn).toBeDisabled();
 
-    await fireEvent.click(screen.getByLabelText(/select all/i));
-    expect(
-      screen.getByRole("button", { name: /approve 2 selected/i }),
-    ).toBeEnabled();
+    await fireEvent.click(screen.getByLabelText(/^select all$/i));
+    expect(approveBtn).toBeEnabled();
+    expect(screen.getByText(/2 selected/)).toBeVisible();
 
-    await fireEvent.click(
-      screen.getByRole("button", { name: /approve 2 selected/i }),
-    );
+    await fireEvent.click(approveBtn);
 
     await waitFor(() => {
       const urls = fetchMock.mock.calls.map((c) => String(c[0]));
@@ -112,5 +223,50 @@ describe("ProposalReviewPanel batch approve", () => {
     });
 
     vi.unstubAllGlobals();
+  });
+
+  test("bulk reject posts a reject with the shared note", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(ProposalReviewPanelHost);
+    await fireEvent.click(screen.getByLabelText(/^select all$/i));
+    await fireEvent.click(
+      screen.getByRole("button", { name: /reject selected/i }),
+    );
+
+    await fireEvent.input(screen.getByLabelText(/note for 2 selected/i), {
+      target: { value: "Duplicate of an existing entry." },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /^reject 2$/i }));
+
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls).toContain("/api/admin/proposals/7/reject");
+      expect(urls).toContain("/api/admin/proposals/8/reject");
+    });
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.note).toBe("Duplicate of an existing entry.");
+
+    vi.unstubAllGlobals();
+  });
+
+  test("groups a submitter's suggestions and selects them as a set", async () => {
+    proposalsStore.proposals = [
+      { ...baseProposal(), id: 7, submitterName: "Yeyel" },
+      { ...baseProposal(), id: 8, submitterName: "Yeyel" },
+      { ...baseProposal(), id: 9, submitterName: "Ana" },
+    ];
+    render(ProposalReviewPanelHost);
+
+    await fireEvent.click(
+      screen.getByLabelText(/select all 2 suggestions from yeyel/i),
+    );
+    expect(screen.getByText(/2 selected/)).toBeVisible();
   });
 });

--- a/src/components/svelte/ProposalReviewPanel.svelte
+++ b/src/components/svelte/ProposalReviewPanel.svelte
@@ -7,6 +7,7 @@
     toastStore,
   } from "@lib/store.svelte";
   import { buildFieldDiffs } from "@lib/proposals/diff";
+  import { appEntityNameResolver } from "@lib/proposals/entity-names";
   import { afterProposalPublished } from "@lib/proposals/apply-published-entity";
   import { syncOpenEntityQueryAfterPublish } from "@lib/proposals/sync-open-entity-query";
   import { getAppActions, getAppData } from "@lib/context";
@@ -19,6 +20,24 @@
   const appActions = getAppActions();
   const appData = getAppData();
 
+  /** Turns buildingId/collegeId/divisionId into names for the diff (#873). */
+  const resolveEntityName = $derived(appEntityNameResolver(appData()));
+
+  type ReviewAction = "approve" | "reject" | "request-changes";
+  /** Reject may carry a note; request-changes requires one. */
+  type NoteAction = Exclude<ReviewAction, "approve">;
+
+  const ACTION_LABELS: Record<NoteAction, string> = {
+    reject: "Reject",
+    "request-changes": "Request changes",
+  };
+
+  const NOTE_HINTS: Record<NoteAction, string> = {
+    reject: "Optional. The contributor sees this on their suggestion.",
+    "request-changes":
+      "Required. Say what needs to change so the contributor can revise.",
+  };
+
   function bundledRoomsSummary(
     entityType: ProposalEntityType,
     patch: Record<string, unknown>,
@@ -29,14 +48,67 @@
     return `Will create building + ${rooms.length} room${rooms.length === 1 ? "" : "s"}: ${rooms.map((r) => r.roomCode).join(", ")}`;
   }
 
+  function diffsFor(proposal: {
+    currentValues?: Record<string, unknown> | null;
+    proposedPatch: Record<string, unknown>;
+  }) {
+    return buildFieldDiffs(
+      proposal.currentValues ?? null,
+      proposal.proposedPatch,
+      resolveEntityName,
+    );
+  }
+
+  function isStale(proposal: {
+    currentVersion?: number | null;
+    baseVersion: number;
+  }) {
+    return (
+      proposal.currentVersion != null &&
+      proposal.currentVersion !== proposal.baseVersion
+    );
+  }
+
+  function submittedOn(createdAt: string | Date | null | undefined) {
+    if (!createdAt) return "";
+    const date = new Date(createdAt);
+    return Number.isNaN(date.getTime())
+      ? ""
+      : date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+
   let noteById = $state<Record<number, string>>({});
   let actingId = $state<number | null>(null);
   const selectedIds = new SvelteSet<number>();
   let batchRunning = $state(false);
+  // Rows render collapsed. The body is kept out of the DOM until opened so a
+  // 59-item queue does not mount 59 diff lists and textareas (#873).
+  let openById = $state<Record<number, boolean>>({});
+  // Which per-row action is awaiting a note + confirmation, if any.
+  let pendingActionById = $state<Record<number, NoteAction | null>>({});
+  let bulkAction = $state<NoteAction | null>(null);
+  let bulkNote = $state("");
+
+  // Same submitter's suggestions review as a set: one contributor filing many
+  // near-identical room edits is the common shape of this queue (#873).
+  const groups = $derived.by(() => {
+    const bySubmitter = new Map<string, typeof proposalsStore.proposals>();
+    for (const proposal of proposalsStore.proposals) {
+      const list = bySubmitter.get(proposal.submitterName) ?? [];
+      list.push(proposal);
+      bySubmitter.set(proposal.submitterName, list);
+    }
+    return [...bySubmitter].map(([submitterName, proposals]) => ({
+      submitterName,
+      proposals,
+    }));
+  });
 
   // Approve a single proposal: POST + apply the published entity to local
   // state. No toast/refresh — callers (single action, batch) decide those.
-  async function approveOne(id: number): Promise<{ ok: boolean; error?: string }> {
+  async function approveOne(
+    id: number,
+  ): Promise<{ ok: boolean; error?: string }> {
     const res = await fetch(`/api/admin/proposals/${id}/approve`, {
       method: "POST",
       credentials: "same-origin",
@@ -67,10 +139,26 @@
     return { ok: true };
   }
 
-  async function runAction(
+  /** Reject / request-changes for one proposal. Note comes from `note`. */
+  async function reviewOne(
     id: number,
-    action: "approve" | "reject" | "request-changes",
-  ) {
+    action: NoteAction,
+    note: string,
+  ): Promise<{ ok: boolean; error?: string }> {
+    const res = await fetch(`/api/admin/proposals/${id}/${action}`, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ note }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: (data as { error?: string }).error };
+    }
+    return { ok: true };
+  }
+
+  async function runAction(id: number, action: ReviewAction) {
     actingId = id;
     try {
       if (action === "approve") {
@@ -88,22 +176,16 @@
         return;
       }
 
-      const res = await fetch(`/api/admin/proposals/${id}/${action}`, {
-        method: "POST",
-        credentials: "same-origin",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ note: noteById[id] ?? "" }),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) {
+      const result = await reviewOne(id, action, noteById[id] ?? "");
+      if (!result.ok) {
         toastStore.show(
-          (data as { error?: string }).error ??
-            `Could not ${action} proposal #${id}.`,
+          result.error ?? `Could not ${action} proposal #${id}.`,
           "error",
         );
         return;
       }
       selectedIds.delete(id);
+      pendingActionById[id] = null;
       toastStore.show(
         action === "reject"
           ? "Proposal rejected."
@@ -135,20 +217,39 @@
     }
   }
 
-  // Approve every selected proposal in turn. Each approve can conflict (409)
-  // independently, so aggregate outcomes and report a summary rather than
-  // failing the whole batch on the first error.
-  async function runBatchApprove() {
+  function groupSelected(proposals: { id: number }[]) {
+    return proposals.length > 0 && proposals.every((p) => selectedIds.has(p.id));
+  }
+
+  function toggleGroup(proposals: { id: number }[]) {
+    if (groupSelected(proposals)) {
+      for (const p of proposals) selectedIds.delete(p.id);
+    } else {
+      for (const p of proposals) selectedIds.add(p.id);
+    }
+  }
+
+  // Run one action across every selected proposal. Each request can fail
+  // independently (approve conflicts on 409), so aggregate outcomes and report
+  // a summary rather than failing the whole batch on the first error.
+  async function runBatch(action: ReviewAction) {
     const ids = [...selectedIds];
     if (ids.length === 0 || batchRunning) return;
+    if (action === "request-changes" && bulkNote.trim() === "") {
+      toastStore.show("A note is required to request changes.", "error");
+      return;
+    }
     batchRunning = true;
-    let approved = 0;
+    let done = 0;
     let failed = 0;
     try {
       for (const id of ids) {
-        const result = await approveOne(id);
+        const result =
+          action === "approve"
+            ? await approveOne(id)
+            : await reviewOne(id, action, bulkNote);
         if (result.ok) {
-          approved += 1;
+          done += 1;
           selectedIds.delete(id);
         } else {
           failed += 1;
@@ -156,16 +257,29 @@
       }
     } finally {
       batchRunning = false;
+      bulkAction = null;
+      bulkNote = "";
       await proposalsStore.refresh();
     }
+    const verb =
+      action === "approve"
+        ? "Approved"
+        : action === "reject"
+          ? "Rejected"
+          : "Sent back";
     toastStore.show(
       failed === 0
-        ? `Approved ${approved} proposal${approved === 1 ? "" : "s"}.`
-        : `Approved ${approved}, ${failed} failed (likely conflicts) — review the rest.`,
+        ? `${verb} ${done} proposal${done === 1 ? "" : "s"}.`
+        : `${verb} ${done}, ${failed} failed (likely conflicts) — review the rest.`,
       failed === 0 ? "success" : "error",
     );
   }
 </script>
+
+{#snippet diffValue(text: string | null, id: number | undefined)}
+  {text ?? "—"}{#if id != null}<small class="entity-review-diff-id">#{id}</small
+    >{/if}
+{/snippet}
 
 {#if adminAuthStore.canReview}
   <section class="entity-review-panel" aria-label="Edit proposals review queue">
@@ -191,100 +305,256 @@
             type="checkbox"
             checked={allSelected}
             onchange={toggleSelectAll}
+            aria-label="Select all"
           />
           Select all
+          <span class="entity-review-selected-count">
+            {selectedIds.size} selected
+          </span>
         </label>
-        <button
-          type="button"
-          class="entity-review-batch-approve"
-          disabled={selectedIds.size === 0 || batchRunning}
-          onclick={runBatchApprove}
-        >
-          {batchRunning
-            ? "Approving…"
-            : `Approve ${selectedIds.size} selected`}
-        </button>
+        <div class="entity-review-batch-actions">
+          <button
+            type="button"
+            class="entity-review-batch-approve"
+            disabled={selectedIds.size === 0 || batchRunning}
+            onclick={() => runBatch("approve")}
+          >
+            {batchRunning && bulkAction === null
+              ? "Approving…"
+              : "Approve selected"}
+          </button>
+          <button
+            type="button"
+            disabled={selectedIds.size === 0 || batchRunning}
+            onclick={() => (bulkAction = "request-changes")}
+          >
+            Request changes on selected
+          </button>
+          <button
+            type="button"
+            class="entity-review-batch-reject"
+            disabled={selectedIds.size === 0 || batchRunning}
+            onclick={() => (bulkAction = "reject")}
+          >
+            Reject selected
+          </button>
+        </div>
       </div>
+
+      {#if bulkAction}
+        <div class="entity-review-bulk-note">
+          <EntityEditorFormField
+            label={`Note for ${selectedIds.size} selected`}
+            inputId="proposal-bulk-note"
+            hint={NOTE_HINTS[bulkAction]}
+          >
+            {#snippet control()}
+              <textarea
+                id="proposal-bulk-note"
+                rows="2"
+                bind:value={bulkNote}
+                aria-describedby="proposal-bulk-note-hint"
+              ></textarea>
+            {/snippet}
+          </EntityEditorFormField>
+          <div class="entity-review-actions">
+            <button
+              type="button"
+              class={bulkAction === "reject" ? "reject" : ""}
+              disabled={batchRunning ||
+                (bulkAction === "request-changes" && bulkNote.trim() === "")}
+              onclick={() => bulkAction && runBatch(bulkAction)}
+            >
+              {batchRunning
+                ? "Working…"
+                : `${ACTION_LABELS[bulkAction]} ${selectedIds.size}`}
+            </button>
+            <button
+              type="button"
+              disabled={batchRunning}
+              onclick={() => {
+                bulkAction = null;
+                bulkNote = "";
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      {/if}
+
       <ul class="entity-review-list">
-        {#each proposalsStore.proposals as proposal (proposal.id)}
-          <li class="entity-review-item">
-            <div class="entity-review-meta">
-              <label class="entity-review-select">
+        {#each groups as group (group.submitterName)}
+          <li class="entity-review-group">
+            <div class="entity-review-group-head">
+              <label class="entity-review-select-all">
                 <input
                   type="checkbox"
-                  checked={selectedIds.has(proposal.id)}
-                  onchange={() => toggleSelected(proposal.id)}
-                  aria-label={`Select ${proposal.entityLabel} for batch approve`}
+                  checked={groupSelected(group.proposals)}
+                  onchange={() => toggleGroup(group.proposals)}
+                  aria-label={`Select all ${group.proposals.length} suggestions from ${group.submitterName}`}
                 />
+                <Avatar name={group.submitterName} size={20} />
+                {group.submitterName}
               </label>
-              <span class="entity-review-entity">
-                {proposal.entityLabel}
-                <small>({proposal.entityType})</small>
-              </span>
-              <span class="entity-review-submitter">
-                <Avatar name={proposal.submitterName} size={20} />
-                {proposal.submitterName}
+              <span class="entity-review-count">
+                {group.proposals.length} suggestion{group.proposals.length === 1
+                  ? ""
+                  : "s"}
               </span>
             </div>
-            {#if proposal.currentVersion != null && proposal.currentVersion !== proposal.baseVersion}
-              <p class="entity-review-stale" role="alert">
-                Published data changed since this was submitted. Compare
-                carefully — approving may conflict.
-              </p>
-            {/if}
-            <ul class="entity-review-changes">
-              {#each buildFieldDiffs(proposal.currentValues ?? null, proposal.proposedPatch) as diff (diff.field)}
-                <li class="entity-review-diff">
-                  <span class="entity-review-diff-label">{diff.label}</span>
-                  <span class="entity-review-diff-values">
-                    <span
-                      class="entity-review-diff-old"
-                      class:entity-review-diff-before={diff.before != null}
-                      >{proposal.currentValues == null &&
-                      proposal.entityType.startsWith("create_")
-                        ? "New entry"
-                        : (diff.before ?? "—")}</span
-                    >
-                    <span aria-hidden="true">→</span>
-                    <span class="entity-review-diff-after"
-                      >{diff.after ?? "—"}</span
-                    >
-                  </span>
+
+            <ul class="entity-review-list entity-review-sublist">
+              {#each group.proposals as proposal (proposal.id)}
+                {@const diffs = diffsFor(proposal)}
+                {@const stale = isStale(proposal)}
+                <li class="entity-review-item">
+                  <div class="entity-review-row">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(proposal.id)}
+                      onchange={() => toggleSelected(proposal.id)}
+                      aria-label={`Select ${proposal.entityLabel} for batch review`}
+                    />
+                    <details bind:open={openById[proposal.id]}>
+                      <summary>
+                        <span class="entity-review-entity">
+                          {proposal.entityLabel}
+                        </span>
+                        <span class="entity-review-summary-meta">
+                          {proposal.entityType} · {diffs.length} field{diffs.length ===
+                          1
+                            ? ""
+                            : "s"}
+                          {#if submittedOn(proposal.createdAt)}
+                            · {submittedOn(proposal.createdAt)}
+                          {/if}
+                        </span>
+                        {#if proposal.status === "needs_changes"}
+                          <span class="entity-review-badge">needs changes</span>
+                        {/if}
+                        {#if stale}
+                          <span class="entity-review-badge stale">stale</span>
+                        {/if}
+                      </summary>
+
+                      {#if openById[proposal.id]}
+                        {#if stale}
+                          <p class="entity-review-stale" role="alert">
+                            Published data changed since this was submitted.
+                            Compare carefully — approving may conflict.
+                          </p>
+                        {/if}
+
+                        <ul class="entity-review-changes">
+                          {#each diffs as diff (diff.field)}
+                            <li class="entity-review-diff">
+                              <span class="entity-review-diff-label"
+                                >{diff.label}</span
+                              >
+                              <span class="entity-review-diff-values">
+                                <span
+                                  class="entity-review-diff-old"
+                                  class:entity-review-diff-before={diff.before !=
+                                    null}
+                                >
+                                  {#if proposal.currentValues == null && proposal.entityType.startsWith("create_")}
+                                    New entry
+                                  {:else}
+                                    {@render diffValue(
+                                      diff.before,
+                                      diff.beforeId,
+                                    )}
+                                  {/if}
+                                </span>
+                                <span aria-hidden="true">→</span>
+                                <span class="entity-review-diff-after">
+                                  {@render diffValue(diff.after, diff.afterId)}
+                                </span>
+                              </span>
+                            </li>
+                          {/each}
+                        </ul>
+
+                        {#if bundledRoomsSummary(proposal.entityType as ProposalEntityType, proposal.proposedPatch as Record<string, unknown>)}
+                          <p class="entity-review-bundled">
+                            {bundledRoomsSummary(
+                              proposal.entityType as ProposalEntityType,
+                              proposal.proposedPatch as Record<string, unknown>,
+                            )}
+                          </p>
+                        {/if}
+
+                        {#if proposal.submitterNote}
+                          <p class="entity-review-submitter-note">
+                            <strong>Note from {proposal.submitterName}:</strong>
+                            {proposal.submitterNote}
+                          </p>
+                        {/if}
+
+                        {#if proposal.status === "needs_changes" && proposal.adminNote}
+                          <p class="entity-review-note">
+                            Previous note: {proposal.adminNote}
+                          </p>
+                        {/if}
+
+                        {#if pendingActionById[proposal.id]}
+                          {@const action = pendingActionById[
+                            proposal.id
+                          ] as NoteAction}
+                          <EntityEditorFormField
+                            label={`Note to ${proposal.submitterName}`}
+                            inputId="proposal-note-{proposal.id}"
+                            hint={NOTE_HINTS[action]}
+                          >
+                            {#snippet control()}
+                              <textarea
+                                id="proposal-note-{proposal.id}"
+                                rows="2"
+                                bind:value={noteById[proposal.id]}
+                                aria-describedby="proposal-note-{proposal.id}-hint"
+                              ></textarea>
+                            {/snippet}
+                          </EntityEditorFormField>
+                          <div class="entity-review-actions">
+                            <button
+                              type="button"
+                              class={action === "reject" ? "reject" : ""}
+                              disabled={actingId === proposal.id ||
+                                (action === "request-changes" &&
+                                  (noteById[proposal.id] ?? "").trim() === "")}
+                              onclick={() => runAction(proposal.id, action)}
+                            >
+                              {actingId === proposal.id
+                                ? "Working…"
+                                : `Confirm ${ACTION_LABELS[action].toLowerCase()}`}
+                            </button>
+                            <button
+                              type="button"
+                              disabled={actingId === proposal.id}
+                              onclick={() =>
+                                (pendingActionById[proposal.id] = null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        {:else}
+                          <EntityReviewActions
+                            disabled={actingId === proposal.id}
+                            onapprove={() => runAction(proposal.id, "approve")}
+                            onrequestChanges={() =>
+                              (pendingActionById[proposal.id] =
+                                "request-changes")}
+                            onreject={() =>
+                              (pendingActionById[proposal.id] = "reject")}
+                          />
+                        {/if}
+                      {/if}
+                    </details>
+                  </div>
                 </li>
               {/each}
             </ul>
-            {#if bundledRoomsSummary(proposal.entityType as ProposalEntityType, proposal.proposedPatch as Record<string, unknown>)}
-              <p class="entity-review-bundled">
-                {bundledRoomsSummary(
-                  proposal.entityType as ProposalEntityType,
-                  proposal.proposedPatch as Record<string, unknown>,
-                )}
-              </p>
-            {/if}
-            {#if proposal.status === "needs_changes" && proposal.adminNote}
-              <p class="entity-review-note">
-                Previous note: {proposal.adminNote}
-              </p>
-            {/if}
-            <EntityEditorFormField
-              label="Note to contributor"
-              inputId="proposal-note-{proposal.id}"
-            >
-              {#snippet control()}
-                <textarea
-                  id="proposal-note-{proposal.id}"
-                  rows="2"
-                  bind:value={noteById[proposal.id]}
-                  placeholder="Optional for reject; required to request changes."
-                ></textarea>
-              {/snippet}
-            </EntityEditorFormField>
-            <EntityReviewActions
-              disabled={actingId === proposal.id}
-              onapprove={() => runAction(proposal.id, "approve")}
-              onrequestChanges={() => runAction(proposal.id, "request-changes")}
-              onreject={() => runAction(proposal.id, "reject")}
-            />
           </li>
         {/each}
       </ul>
@@ -300,12 +570,51 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.5rem;
+    flex-wrap: wrap;
+    gap: 0.375rem;
     margin-bottom: 0.5rem;
     padding: 0.375rem 0.5rem;
     border: 1px solid hsl(0, 0%, 88%);
     border-radius: 8px;
     background: hsl(0, 0%, 98%);
+  }
+
+  .entity-review-batch-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .entity-review-batch-actions button {
+    padding: 0.3rem 0.6rem;
+    border: 1px solid hsl(0, 0%, 78%);
+    border-radius: 999px;
+    background: white;
+    color: hsl(0, 0%, 16%);
+    font: inherit;
+    font-size: 0.8rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .entity-review-batch-actions button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .entity-review-batch-actions .entity-review-batch-approve {
+    border-color: hsl(140, 45%, 38%);
+    background: hsl(140, 45%, 38%);
+    color: white;
+  }
+
+  .entity-review-batch-actions .entity-review-batch-approve:hover:not(:disabled) {
+    background: hsl(140, 45%, 44%);
+  }
+
+  .entity-review-batch-actions .entity-review-batch-reject {
+    border-color: hsl(0, 70%, 78%);
+    color: hsl(0, 70%, 32%);
   }
 
   .entity-review-select-all {
@@ -316,39 +625,107 @@
     font-weight: 600;
     color: hsl(0, 0%, 30%);
     cursor: pointer;
+    min-width: 0;
   }
 
-  .entity-review-batch-approve {
-    padding: 0.3rem 0.75rem;
-    border: 1px solid hsl(140, 45%, 38%);
-    border-radius: 999px;
-    background: hsl(140, 45%, 38%);
-    color: white;
-    font-size: 0.8rem;
-    font-weight: 700;
-    cursor: pointer;
+  .entity-review-selected-count {
+    font-weight: 500;
+    color: hsl(0, 0%, 42%);
   }
 
-  .entity-review-batch-approve:hover:not(:disabled) {
-    border-color: hsl(140, 45%, 44%);
-    background: hsl(140, 45%, 44%);
+  .entity-review-bulk-note {
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 8px;
   }
 
-  .entity-review-batch-approve:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+  .entity-review-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
   }
 
-  .entity-review-select {
-    display: inline-flex;
+  .entity-review-group-head {
+    display: flex;
     align-items: center;
-    margin-right: 0.375rem;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding: 0.125rem 0.125rem 0;
   }
 
-  .entity-review-submitter {
-    display: inline-flex;
-    align-items: center;
+  .entity-review-sublist {
+    max-height: none;
+    overflow: visible;
+  }
+
+  .entity-review-list {
+    max-height: 22rem;
+  }
+
+  .entity-review-row {
+    display: flex;
+    align-items: flex-start;
     gap: 0.375rem;
+    min-width: 0;
+  }
+
+  .entity-review-row > input {
+    margin-top: 0.3rem;
+    flex-shrink: 0;
+  }
+
+  .entity-review-row > details {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .entity-review-row summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.25rem 0.375rem;
+    cursor: pointer;
+    padding: 0.125rem 0;
+    border-radius: 0.375rem;
+  }
+
+  .entity-review-row summary:focus-visible {
+    outline: 2px solid hsl(5, 53%, 40%);
+    outline-offset: 2px;
+  }
+
+  .entity-review-summary-meta {
+    font-size: 0.75rem;
+    color: hsl(0, 0%, 40%);
+  }
+
+  .entity-review-badge {
+    padding: 0 0.3125rem;
+    border-radius: 999px;
+    background: hsl(0, 0%, 92%);
+    color: hsl(0, 0%, 25%);
+    font-size: 0.6875rem;
+    font-weight: 700;
+  }
+
+  .entity-review-badge.stale {
+    background: hsl(40, 90%, 88%);
+    color: hsl(30, 60%, 25%);
+  }
+
+  /* Matches .entity-review-stale's shape so the two reviewer callouts read as
+     one family. */
+  .entity-review-submitter-note {
+    margin: 0.375rem 0 0;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid hsl(210, 45%, 82%);
+    border-radius: 6px;
+    background: hsl(210, 60%, 97%);
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    color: hsl(210, 40%, 22%);
   }
 
   .entity-review-bundled {
@@ -400,5 +777,12 @@
   .entity-review-diff-after {
     font-weight: 600;
     overflow-wrap: anywhere;
+  }
+
+  .entity-review-diff-id {
+    margin-left: 0.25rem;
+    font-weight: 400;
+    font-size: 0.6875rem;
+    color: hsl(0, 0%, 50%);
   }
 </style>

--- a/src/components/svelte/SuggestAdditionPanel.svelte
+++ b/src/components/svelte/SuggestAdditionPanel.svelte
@@ -14,7 +14,10 @@
     fetchPublicProposalSummary,
     type ProposalCreateType,
   } from "@lib/proposals/client";
-  import { validateSubmitterName } from "@constants/proposals";
+  import {
+    MAX_SUBMITTER_NOTE_LENGTH,
+    validateSubmitterName,
+  } from "@constants/proposals";
   import { instantToCampusWallString } from "@lib/event-time";
   import { slugifySegment } from "@lib/site";
   import {
@@ -90,6 +93,7 @@
 
   let kind = $state<ProposalCreateType>("create_building");
   let submitterName = $state("");
+  let submitterNote = $state("");
   let buildingName = $state("");
   let buildingDirections = $state("");
   let buildingType = $state<"admin" | "non-admin">("non-admin");
@@ -589,6 +593,7 @@
         entityType: kind,
         patch,
         submitterName: name,
+        submitterNote,
         proposalId:
           pendingCreate?.status === "needs_changes" ? pendingCreate.id : null,
       });
@@ -1070,6 +1075,24 @@
       disabled={submitting}
       onclick={pickOnMap}
     />
+  {/if}
+
+  {#if !isPublish}
+    <EntityEditorFormField
+      label="Note to reviewer (optional)"
+      inputId="suggest-addition-note"
+      hint="Goes to the editor who reviews this, and is never shown on the map. Use it for context, sources, or anything that is not part of the entry itself."
+    >
+      {#snippet control()}
+        <textarea
+          id="suggest-addition-note"
+          rows="2"
+          maxlength={MAX_SUBMITTER_NOTE_LENGTH}
+          bind:value={submitterNote}
+          aria-describedby="suggest-addition-note-hint"
+        ></textarea>
+      {/snippet}
+    </EntityEditorFormField>
   {/if}
 
   {#if error}

--- a/src/components/svelte/editor/EntityEditorPanel.svelte
+++ b/src/components/svelte/editor/EntityEditorPanel.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import SubmitterNameField from "@ui/SubmitterNameField.svelte";
+  import { MAX_SUBMITTER_NOTE_LENGTH } from "@constants/proposals";
+  import EntityEditorFormField from "./EntityEditorFormField.svelte";
   import EntityEditorMessage from "./EntityEditorMessage.svelte";
   import EntityEditorSubmitButton from "./EntityEditorSubmitButton.svelte";
   import EntityHistoryPanel from "./EntityHistoryPanel.svelte";
@@ -18,6 +20,12 @@
     showSubmitterName?: boolean;
     submitterNameId: string;
     submitterName?: string;
+    /**
+     * Opt in to the "Note to reviewer" box (#873). Callers must forward the
+     * bound value to persistEntityChange, so it stays off until wired.
+     */
+    showSubmitterNote?: boolean;
+    submitterNote?: string;
     proposalStatus?: string | null;
     activeProposalId?: number | null;
     onWithdrawn?: () => void;
@@ -40,6 +48,8 @@
     showSubmitterName = false,
     submitterNameId,
     submitterName = $bindable(""),
+    showSubmitterNote = false,
+    submitterNote = $bindable(""),
     proposalStatus = null,
     activeProposalId = null,
     onWithdrawn,
@@ -105,6 +115,24 @@
   {/if}
 
   {@render children?.()}
+
+  {#if !canPublish && showSubmitterNote}
+    <EntityEditorFormField
+      label="Note to reviewer (optional)"
+      inputId="{submitterNameId}-note"
+      hint="Goes to the editor who reviews this, and is never shown on the map. Use it for context, sources, or anything that is not part of the entry itself."
+    >
+      {#snippet control()}
+        <textarea
+          id="{submitterNameId}-note"
+          rows="2"
+          maxlength={MAX_SUBMITTER_NOTE_LENGTH}
+          bind:value={submitterNote}
+          aria-describedby="{submitterNameId}-note-hint"
+        ></textarea>
+      {/snippet}
+    </EntityEditorFormField>
+  {/if}
 
   {#if !canPublish && onsubmit}
     <div class="entity-editor-form-actions">

--- a/src/components/svelte/editor/EntityHistoryPanel.svelte
+++ b/src/components/svelte/editor/EntityHistoryPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import LoadingIndicator from "@ui/LoadingIndicator.svelte";
   import { buildFieldDiffs } from "@lib/proposals/diff";
+  import { appEntityNameResolver } from "@lib/proposals/entity-names";
   import { afterProposalPublished } from "@lib/proposals/apply-published-entity";
   import { syncOpenEntityQueryAfterPublish } from "@lib/proposals/sync-open-entity-query";
   import type { ProposalEntityType } from "@lib/services/proposal-service";
@@ -30,6 +31,7 @@
 
   const appActions = getAppActions();
   const appData = getAppData();
+  const resolveEntityName = $derived(appEntityNameResolver(appData()));
 
   let open = $state(false);
   let loading = $state(false);
@@ -115,7 +117,13 @@
   }
 
   function entryDiffs(entry: HistoryEntry) {
-    return buildFieldDiffs(entry.before ?? null, entry.after ?? {});
+    // Same foreign-key resolution as the review queue: history entries showed
+    // raw row ids for buildingId/collegeId/divisionId too (#873).
+    return buildFieldDiffs(
+      entry.before ?? null,
+      entry.after ?? {},
+      resolveEntityName,
+    );
   }
 
   function formatWhen(iso: string) {

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -88,6 +88,7 @@
   let fieldError = $state<string | null>(null);
   let editing = $state(false);
   let submitterNameDraft = $state("");
+  let submitterNoteDraft = $state("");
   let proposalStatus = $state<string | null>(null);
   let activeProposalId = $state<number | null>(null);
   let mergePrompt = $state<{
@@ -271,6 +272,7 @@
           adminAuthStore.displayName ??
           adminAuthStore.username ??
           submitterNameDraft,
+        submitterNote: submitterNoteDraft,
         proposalId: activeProposalId,
       });
 
@@ -455,6 +457,7 @@
           adminAuthStore.displayName ??
           adminAuthStore.username ??
           submitterNameDraft,
+        submitterNote: submitterNoteDraft,
         proposalId: activeProposalId,
       });
 
@@ -569,6 +572,8 @@
           submitterNameId="room-submitter-name"
           historyEntity={currentRoom.value ? { entityType: "room", entityId: currentRoom.value.id, version: currentRoom.value.version } : null}
           bind:submitterName={submitterNameDraft}
+          showSubmitterNote={!canPublish}
+          bind:submitterNote={submitterNoteDraft}
           {proposalStatus}
           activeProposalId={activeProposalId}
           onWithdrawn={() => {

--- a/src/constants/proposals.test.ts
+++ b/src/constants/proposals.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
   MAX_SUBMITTER_NAME_LENGTH,
+  MAX_SUBMITTER_NOTE_LENGTH,
   MIN_SUBMITTER_NAME_LENGTH,
   validateSubmitterName,
+  validateSubmitterNote,
 } from "./proposals";
 
 describe("validateSubmitterName", () => {
@@ -38,5 +40,27 @@ describe("validateSubmitterName", () => {
   test("accepts max length", () => {
     const result = validateSubmitterName("x".repeat(MAX_SUBMITTER_NAME_LENGTH));
     expect(result.ok).toBe(true);
+  });
+});
+
+describe("validateSubmitterNote (#873)", () => {
+  test("treats blank as no note rather than an error", () => {
+    const result = validateSubmitterNote("   ");
+    expect(result).toEqual({ ok: true, note: null });
+  });
+
+  test("trims an actual note", () => {
+    const result = validateSubmitterNote("  Please remove this room.  ");
+    expect(result).toEqual({ ok: true, note: "Please remove this room." });
+  });
+
+  test("rejects a note past the cap", () => {
+    const result = validateSubmitterNote(
+      "x".repeat(MAX_SUBMITTER_NOTE_LENGTH + 1),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(String(MAX_SUBMITTER_NOTE_LENGTH));
+    }
   });
 });

--- a/src/constants/proposals.ts
+++ b/src/constants/proposals.ts
@@ -2,6 +2,23 @@ export const MIN_SUBMITTER_NAME_LENGTH = 2;
 /** Keep contributor credits short — fits status bar and review queue. */
 export const MAX_SUBMITTER_NAME_LENGTH = 32;
 
+/** Contributor's note to the reviewer: a sentence or two, never published. */
+export const MAX_SUBMITTER_NOTE_LENGTH = 500;
+
+export function validateSubmitterNote(
+  note: string,
+): { ok: true; note: string | null } | { ok: false; error: string } {
+  const trimmed = note.trim();
+  if (trimmed.length === 0) return { ok: true, note: null };
+  if (trimmed.length > MAX_SUBMITTER_NOTE_LENGTH) {
+    return {
+      ok: false,
+      error: `Keep the note under ${MAX_SUBMITTER_NOTE_LENGTH} characters.`,
+    };
+  }
+  return { ok: true, note: trimmed };
+}
+
 export function validateSubmitterName(
   name: string,
 ): { ok: true; name: string } | { ok: false; error: string } {

--- a/src/lib/proposals/client.ts
+++ b/src/lib/proposals/client.ts
@@ -3,7 +3,10 @@ import type {
   ProposalEntityType,
 } from "@lib/services/proposal-service";
 import { FIELD_LABELS } from "./diff";
-import { validateSubmitterName } from "@constants/proposals";
+import {
+  validateSubmitterName,
+  validateSubmitterNote,
+} from "@constants/proposals";
 import type { RoomData } from "@lib/types";
 import {
   isOpenProposalStatus,
@@ -193,6 +196,8 @@ type PersistEntityChangeInput = {
   entityLabel: string;
   canPublish: boolean;
   submitterName?: string;
+  /** Contributor's message to the reviewer. Ignored when publishing directly. */
+  submitterNote?: string;
   proposalId?: number | null;
 };
 
@@ -232,6 +237,7 @@ export async function persistEntityChange(
     baseVersion: input.baseVersion,
     patch: input.patch,
     submitterName: input.submitterName,
+    submitterNote: input.submitterNote,
     proposalId: input.proposalId,
   });
 
@@ -501,6 +507,7 @@ export async function submitCreateProposal(input: {
   entityType: ProposalCreateType;
   patch: Record<string, unknown>;
   submitterName?: string;
+  submitterNote?: string;
   proposalId?: number | null;
 }): Promise<{ ok: boolean; error?: string; proposal?: StoredProposalRef }> {
   return submitEntityProposal({
@@ -509,6 +516,7 @@ export async function submitCreateProposal(input: {
     baseVersion: 0,
     patch: input.patch,
     submitterName: input.submitterName,
+    submitterNote: input.submitterNote,
     proposalId: input.proposalId,
   });
 }
@@ -519,12 +527,19 @@ export async function submitEntityProposal(input: {
   baseVersion: number;
   patch: Record<string, unknown>;
   submitterName?: string;
+  submitterNote?: string;
   proposalId?: number | null;
 }): Promise<{ ok: boolean; error?: string; proposal?: StoredProposalRef }> {
   if (input.submitterName !== undefined) {
     const validation = validateSubmitterName(input.submitterName);
     if (!validation.ok) {
       return { ok: false, error: validation.error };
+    }
+  }
+  if (input.submitterNote !== undefined) {
+    const noteCheck = validateSubmitterNote(input.submitterNote);
+    if (!noteCheck.ok) {
+      return { ok: false, error: noteCheck.error };
     }
   }
 

--- a/src/lib/proposals/diff.test.ts
+++ b/src/lib/proposals/diff.test.ts
@@ -97,3 +97,92 @@ describe("buildFieldDiffs", () => {
     });
   });
 });
+
+describe("buildFieldDiffs foreign key resolution (#873)", () => {
+  const resolveName = (field: string, id: number) => {
+    if (field === "buildingId") {
+      return (
+        (
+          { 3: "Physical Sciences", 24: "CHE Building" } as Record<
+            number,
+            string
+          >
+        )[id] ?? null
+      );
+    }
+    if (field === "collegeId") {
+      return ({ 5: "CAS" } as Record<number, string>)[id] ?? null;
+    }
+    return null;
+  };
+
+  test("renders entity names and keeps the ids as secondary values", () => {
+    const diffs = buildFieldDiffs(
+      { buildingId: 3 },
+      { buildingId: 24 },
+      resolveName,
+    );
+    expect(diffs).toEqual([
+      {
+        field: "buildingId",
+        label: "Building",
+        before: "Physical Sciences",
+        after: "CHE Building",
+        beforeId: 3,
+        afterId: 24,
+      },
+    ]);
+  });
+
+  test("falls back to the raw id when the resolver has no name", () => {
+    const diffs = buildFieldDiffs(
+      { buildingId: 3 },
+      { buildingId: 99 },
+      resolveName,
+    );
+    expect(diffs[0]?.after).toBe("99");
+    expect(diffs[0]?.afterId).toBeUndefined();
+  });
+
+  test("labels divisionId instead of leaking the field name", () => {
+    const diffs = buildFieldDiffs({ divisionId: 1 }, { divisionId: 2 });
+    expect(diffs[0]?.label).toBe("Division");
+  });
+
+  test("resolves a create proposal's foreign key with a null before", () => {
+    const diffs = buildFieldDiffs(null, { buildingId: 24 }, resolveName);
+    expect(diffs[0]).toEqual({
+      field: "buildingId",
+      label: "Building",
+      before: null,
+      after: "CHE Building",
+      afterId: 24,
+    });
+  });
+
+  test("still detects a change when two ids share a display name", () => {
+    const sameName = () => "Twin Hall";
+    const diffs = buildFieldDiffs(
+      { buildingId: 3 },
+      { buildingId: 24 },
+      sameName,
+    );
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]?.beforeId).toBe(3);
+    expect(diffs[0]?.afterId).toBe(24);
+  });
+
+  test("leaves non-id fields untouched", () => {
+    const diffs = buildFieldDiffs(
+      { capacity: 10 },
+      { capacity: 12 },
+      resolveName,
+    );
+    expect(diffs[0]).toEqual({
+      field: "capacity",
+      label: "Capacity",
+      before: "10",
+      after: "12",
+    });
+  });
+});

--- a/src/lib/proposals/diff.ts
+++ b/src/lib/proposals/diff.ts
@@ -12,6 +12,7 @@ export const FIELD_LABELS: Record<string, string> = {
   roomCode: "Room code",
   collegeName: "College name",
   collegeId: "Parent college",
+  divisionId: "Division",
   divisionName: "Division name",
   description: "Description",
   managingOffice: "Managing office",
@@ -37,7 +38,21 @@ export type FieldDiff = {
   /** null = empty / not set (render as em dash) */
   before: string | null;
   after: string | null;
+  /**
+   * Raw row ids, set only when `before`/`after` above were replaced by a
+   * resolved entity name. Reviewers see the name; the id stays available as
+   * secondary text (#873).
+   */
+  beforeId?: number;
+  afterId?: number;
 };
+
+/**
+ * Maps a foreign-key field and row id to that entity's display name, or null
+ * when it cannot be resolved. Without one, `*Id` fields render as raw row ids
+ * and an approver cannot judge the edit (#873).
+ */
+export type EntityNameResolver = (field: string, id: number) => string | null;
 
 // Keys with their own review summary (create_building bundled rooms).
 const SKIPPED_KEYS = new Set(["rooms"]);
@@ -79,24 +94,50 @@ function formatValue(value: unknown): string | null {
  * Before/after rows for a proposal patch against the currently published
  * entity. `current` is null for create_* proposals (before renders as new).
  * Unchanged fields are omitted so reviewers only see real differences.
+ *
+ * Pass `resolveName` to turn foreign keys into entity names. Change detection
+ * always runs on the raw ids, so two buildings that happen to share a name
+ * still register as a change.
  */
 export function buildFieldDiffs(
   current: Record<string, unknown> | null,
   patch: Record<string, unknown>,
+  resolveName?: EntityNameResolver,
 ): FieldDiff[] {
   const diffs: FieldDiff[] = [];
   for (const [field, proposed] of Object.entries(patch)) {
     if (SKIPPED_KEYS.has(field)) continue;
     const format = field === "locations" ? formatLocations : formatValue;
-    const before = current ? format(current[field]) : null;
+    const beforeRaw = current ? current[field] : null;
+    const before = current ? format(beforeRaw) : null;
     const after = format(proposed);
     if (current && before === after) continue;
-    diffs.push({
+
+    const diff: FieldDiff = {
       field,
       label: FIELD_LABELS[field] ?? field,
       before,
       after,
-    });
+    };
+
+    if (resolveName && field.endsWith("Id")) {
+      if (typeof beforeRaw === "number") {
+        const name = resolveName(field, beforeRaw);
+        if (name) {
+          diff.before = name;
+          diff.beforeId = beforeRaw;
+        }
+      }
+      if (typeof proposed === "number") {
+        const name = resolveName(field, proposed);
+        if (name) {
+          diff.after = name;
+          diff.afterId = proposed;
+        }
+      }
+    }
+
+    diffs.push(diff);
   }
   return diffs;
 }

--- a/src/lib/proposals/entity-names.test.ts
+++ b/src/lib/proposals/entity-names.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import type { AppContextData } from "@lib/context";
+import { appEntityNameResolver } from "./entity-names";
+
+const loaded = {
+  loaded: true,
+  buildings: [{ id: 3, buildingName: "Physical Sciences" }],
+  colleges: [{ id: 5, collegeName: "CAS" }],
+  divisions: [{ id: 8, divisionName: "Physical Sciences Division" }],
+  dorms: [],
+  events: [],
+  organizations: [],
+  places: [],
+  totalRooms: 0,
+  directionCount: 0,
+} as unknown as AppContextData;
+
+describe("appEntityNameResolver", () => {
+  test("resolves the foreign keys that appear in proposals", () => {
+    const resolve = appEntityNameResolver(loaded);
+    expect(resolve("buildingId", 3)).toBe("Physical Sciences");
+    expect(resolve("collegeId", 5)).toBe("CAS");
+    expect(resolve("divisionId", 8)).toBe("Physical Sciences Division");
+  });
+
+  test("returns null for unknown ids and unhandled fields", () => {
+    const resolve = appEntityNameResolver(loaded);
+    expect(resolve("buildingId", 999)).toBeNull();
+    expect(resolve("roomId", 3)).toBeNull();
+  });
+
+  test("returns null for everything before app data loads", () => {
+    const resolve = appEntityNameResolver({
+      loaded: false,
+    } as unknown as AppContextData);
+    expect(resolve("buildingId", 3)).toBeNull();
+  });
+});

--- a/src/lib/proposals/entity-names.ts
+++ b/src/lib/proposals/entity-names.ts
@@ -1,0 +1,27 @@
+import type { AppContextData } from "@lib/context";
+import type { EntityNameResolver } from "./diff";
+
+/**
+ * Resolve the foreign keys that appear in edit proposals against the entity
+ * lists the app already holds in context, so a reviewer reads
+ * "Building  Physical Sciences → CHE Building" instead of "Building 3 → 24"
+ * (#873). Returns null for anything it does not know, which leaves the raw id
+ * on screen rather than inventing a name.
+ */
+export function appEntityNameResolver(app: AppContextData): EntityNameResolver {
+  if (!app.loaded) return () => null;
+  // ponytail: linear scan. Campus entity lists are in the hundreds and the
+  // queue renders once; build id→name Maps if a review ever feels slow.
+  return (field, id) => {
+    switch (field) {
+      case "buildingId":
+        return app.buildings.find((b) => b.id === id)?.buildingName ?? null;
+      case "collegeId":
+        return app.colleges.find((c) => c.id === id)?.collegeName ?? null;
+      case "divisionId":
+        return app.divisions.find((d) => d.id === id)?.divisionName ?? null;
+      default:
+        return null;
+    }
+  };
+}

--- a/src/lib/services/proposal-service.ts
+++ b/src/lib/services/proposal-service.ts
@@ -16,7 +16,10 @@ import {
 import { normalizeAlias } from "@lib/site";
 import type { SessionUser } from "@lib/admin/auth";
 import { db } from "@lib/db";
-import { validateSubmitterName } from "@constants/proposals";
+import {
+  validateSubmitterName,
+  validateSubmitterNote,
+} from "@constants/proposals";
 import { recordProposalContribution } from "./contribution-service";
 import { parseImageUrl } from "@lib/r2-upload";
 import { R2_PUBLIC_URL } from "astro:env/server";
@@ -586,6 +589,8 @@ type SubmitProposalInput = {
   submitterName: string;
   submitterUserId?: number | null;
   proposalId?: number | null;
+  /** Contributor's message to the reviewer. Never merged into the patch. */
+  submitterNote?: string | null;
 };
 
 /** Anonymous submitters cannot borrow a registered contributor's identity:
@@ -640,6 +645,11 @@ export async function submitProposal(
     throw new ProposalValidationError(validation.error);
   }
   const name = validation.name;
+  const noteValidation = validateSubmitterNote(input.submitterNote ?? "");
+  if (!noteValidation.ok) {
+    throw new ProposalValidationError(noteValidation.error);
+  }
+  const submitterNote = noteValidation.note;
   if (!input.submitterUserId && (await isReservedContributorName(name))) {
     throw new ProposalValidationError(
       "That name belongs to a registered contributor. Sign in to use it, or pick a different name.",
@@ -726,6 +736,8 @@ export async function submitProposal(
         baseVersion: input.baseVersion,
         status: "pending",
         adminNote: null,
+        // A revise with no new note keeps the one already on the proposal.
+        submitterNote: submitterNote ?? existing.submitterNote,
         reviewedBy: null,
         reviewedAt: null,
         updatedAt: sql`now()`,
@@ -745,6 +757,7 @@ export async function submitProposal(
       baseVersion: input.baseVersion,
       submitterName: name,
       submitterUserId: input.submitterUserId ?? null,
+      submitterNote,
       status: "pending",
     })
     .returning();

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -702,6 +702,8 @@ class ProposalsStore {
       submitterName: string;
       proposedPatch: Record<string, unknown>;
       adminNote?: string | null;
+      /** Contributor's message to the reviewer, never published (#873). */
+      submitterNote?: string | null;
       createdAt: string;
       baseVersion: number;
       currentValues?: Record<string, unknown> | null;

--- a/src/pages/api/proposals/index.ts
+++ b/src/pages/api/proposals/index.ts
@@ -23,6 +23,7 @@ type ProposalBody = {
   baseVersion?: number;
   patch?: Record<string, unknown>;
   submitterName?: string;
+  submitterNote?: string;
   proposalId?: number;
   _hp?: string;
 };
@@ -65,6 +66,8 @@ export const POST: APIRoute = async ({ cookies, request }) => {
       baseVersion: Number(body.baseVersion),
       patch: body.patch ?? {},
       submitterName,
+      submitterNote:
+        typeof body.submitterNote === "string" ? body.submitterNote : null,
       submitterUserId: session?.id && session.id > 0 ? session.id : null,
       proposalId: Number.isInteger(body.proposalId) ? body.proposalId : null,
     });


### PR DESCRIPTION
Closes #873.

## 1. Blocking: approvers were shown raw database ids

`buildFieldDiffs()` ran every value through `formatValue()`, which stringifies a number as-is, so a room's building reassignment rendered as **"Building 3 → 24"** while `FIELD_LABELS` made the label look human. The approver could not judge the edit without querying the database. That is the whole feature failing.

Every `*Id` now resolves to its entity name:

> **Building** ~~Physical Sciences~~ `#3` → **CHE Building** `#24`

- `buildFieldDiffs(current, patch, resolveName?)` takes an optional resolver. `FieldDiff` gains `beforeId` / `afterId`, set only when a name replaced the number, so the panel can render the id as small muted secondary text.
- `appEntityNameResolver()` (`src/lib/proposals/entity-names.ts`) resolves `buildingId`, `collegeId`, `divisionId` against the entity lists the app **already holds in context**. No API, service, or query change.
- Unresolvable ids fall back to the raw number rather than vanishing.
- **Change detection still runs on the raw ids**, so two buildings that happen to share a name still register as a change.
- `divisionId` had no `FIELD_LABELS` entry and rendered as the literal string `divisionId`. Added.
- `EntityHistoryPanel` is the other `buildFieldDiffs()` caller and had the same bug. Fixed there too rather than only on the path the issue named.

## 2. Density

Every proposal used to render fully expanded, all 59 mounted at once, roughly 1.5 items per screen.

- Each proposal is now a dense one-line summary: entity label, type, field count, submission date, and `needs changes` / `stale` badges.
- Rows use a native `<details>`, so expand/collapse is keyboard and screen-reader correct for free, and the summary is focusable and toggles on Enter or Space. That is the keyboard flow for a long queue.
- The body is behind `{#if open}`, so a collapsed row keeps its diff list, textarea, and buttons **out of the DOM**. 59 pending no longer mounts 59 diff lists. There is a component test for this.
- The note field appears only after Reject or Request changes is chosen, then Confirm / Cancel.

## 3. Polish

- **"Approve 0 selected"** is gone. The disabled default reads "Approve selected"; the count sits next to the checkbox as "N selected".
- **Bulk reject and bulk request-changes** added next to bulk approve, with one shared note box. Request-changes keeps Confirm disabled until a note exists. Batches still aggregate per-item failures (409 conflicts) into one summary instead of dying on the first error.
- **Validation rules moved out of placeholder text** into the persistent `hint` slot `EntityEditorFormField` already supports, wired with `aria-describedby`. "Required. Say what needs to change…" no longer vanishes on the first keystroke.
- **Grouping by submitter**, with a per-group checkbox to select the whole set. The screenshot's one contributor filing many near-identical room edits is now reviewable as a set.

Not done, deliberately: map preview for building reassignments, undo after approve, and single-key `j`/`k`/`a`/`r` shortcuts. The native `<details>` flow covers keyboard navigation; global single-key handlers would fight the note textareas. Happy to file follow-ups.

## Also: contributors had no note-to-reviewer field

Found while triaging. A contributor used the room **`directions` content field** to send admins a message:

> "You may opt to remove this room from the app"

Approving that would have published it as user-facing directions on the map. There was no other channel: `admin_note` travels the other way, reviewer to contributor.

`edit_proposals.submitter_note` is a proper contributor note:

- Never part of `proposed_patch`, so it can never publish. It is a column, not a patch key.
- Never leaves through `toPublicProposalView` / `toSubmitterProposalView` (both pick fields explicitly), so it reaches reviewers only.
- Surfaced in the review queue as "Note from `<contributor>`".
- Capped at 500 chars, validated client and server side, blank normalizes to null.
- Wired into the shared `EntityEditorPanel` behind `showSubmitterNote`, enabled for `RoomResult` (the entity from the incident) and `SuggestAdditionPanel` (new entries). The remaining entity panels are one prop each; the flag is explicit so a caller cannot collect a note and silently drop it.

## Migration number

**This branch takes `0045`.** `0044` is taken by #879 (room `full_name`), and `0043` is claimed twice already, by #795 and #874. `0045` collides with nothing today. The two migrations are independent, so this can merge with or without #879.

**Maintainer step:** preview and production share one Supabase project and `apply:migrations:prod` only runs on push to `main`, so apply `0045` before this reaches a deploy. It is additive and idempotent.

## Tests

- **Unit** `src/lib/proposals/diff.test.ts` (+6): names with ids as secondary text, fallback to the raw id, `divisionId` label, create-proposal resolution, the shared-display-name case that must still count as a change, and non-id fields left alone.
- **Unit** `src/lib/proposals/entity-names.test.ts` (new, 3): resolves the three FK fields, returns null for unknown ids and unhandled fields, returns null before app data loads.
- **Unit** `src/constants/proposals.test.ts` (+3): note trimming, blank-is-null, length cap.
- **Component** `src/components/svelte/ProposalReviewPanel.component.test.ts` (11 total): names not row ids, collapsed rows keep the body out of the DOM, note appears only on reject, request-changes gates Confirm on a note, the contributor note renders, bulk approve, bulk reject sends the shared note, and submitter grouping.

## Verified

- `bun run lint` clean on every touched file (the 2 remaining repo warnings are pre-existing, in files this PR does not touch).
- `bun run test` 546 pass, 0 fail.
- `bun run test:components` 52 files, 203 pass, 0 fail.
- `bun run build` completes.
- `bun run test:integration` 53 pass / 8 fail, and **the same 8 fail on clean `origin/staging`** (they need a running preview server and admin credentials not configured locally). No regression from this branch. I applied the additive `submitter_note` column to the **E2E** database (`yhzinxlakcewqjaqbbaj`) to run it; production was never written to.

## E2E migration list

Also registers `0045` in `scripts/e2e-reset-db.ts`. That script replays an explicit list when resetting the shared `public` schema on the E2E project, and the list stopped at `0042`, so without this the CI E2E database never gets `submitter_note` and every proposal insert fails with `42703` (exactly how it failed locally before I applied the column by hand).
