### PR TITLE
fix(contributions): rank public contributors and split the editor board

### DIFF
--- a/integration/services/contribution.integration.test.ts
+++ b/integration/services/contribution.integration.test.ts
@@ -28,6 +28,11 @@ describeIntegration("contribution ledger", () => {
       "DELETE FROM contributions WHERE user_id IN (SELECT id FROM admin_users WHERE username LIKE $1)",
       [`${PREFIX}%`],
     );
+    // Public contributors have no user_id, so they are only reachable by name.
+    await client.query(
+      "DELETE FROM contributions WHERE user_id IS NULL AND submitter_name LIKE $1",
+      [`${PREFIX}%`],
+    );
     await client.query(
       "DELETE FROM editor_history WHERE edited_by IN ('Visible Contributor', 'Hidden Contributor')",
     );
@@ -58,7 +63,19 @@ describeIntegration("contribution ledger", () => {
        VALUES
          ($1, 'Visible Contributor', 'room', 1, 'Visible room', 'proposal_approved', '2026-07-01T00:00:00Z'),
          ($1, 'Visible Contributor', 'building', 2, 'Visible building', 'proposal_approved', '2026-07-02T00:00:00Z'),
-         ($2, 'Hidden Contributor', 'room', 3, 'Hidden room', 'proposal_approved', '2026-07-03T00:00:00Z')`,
+         ($2, 'Hidden Contributor', 'room', 3, 'Hidden room', 'proposal_approved', '2026-07-03T00:00:00Z'),
+         -- Public contributor: approved submissions, never registered. The
+         -- leaderboard used to inner join admin_users, so these rows could not
+         -- rank at all and the real top contributor was invisible.
+         (NULL, '${PREFIX}-public', 'room', 4, 'Public room A', 'proposal_approved', '2026-07-04T00:00:00Z'),
+         (NULL, '${PREFIX}-public', 'room', 5, 'Public room B', 'proposal_approved', '2026-07-05T00:00:00Z'),
+         (NULL, '${PREFIX}-public', 'room', 6, 'Public room C', 'proposal_approved', '2026-07-06T00:00:00Z'),
+         -- Editor publishes belong on their own board, not ranked against
+         -- community submissions.
+         ($1, 'Visible Contributor', 'room', 7, 'Editor room', 'editor_published', '2026-07-07T00:00:00Z'),
+         -- Unattributable: no user and no name. Must not collapse into a
+         -- single row that outranks real people.
+         (NULL, NULL, 'room', 8, 'Orphan row', 'proposal_approved', '2026-07-08T00:00:00Z')`,
       [rows[0]!.id, rows[1]!.id],
     );
   });
@@ -89,13 +106,72 @@ describeIntegration("contribution ledger", () => {
     );
   });
 
+  test("ranks public contributors who never registered", async () => {
+    const { getContributorLeaderboard } = await import(
+      "@lib/services/contribution-service"
+    );
+    const leaderboard = await getContributorLeaderboard("all");
+
+    const publicContributor = leaderboard.find(
+      (row) => row.displayName === `${PREFIX}-public`,
+    );
+    expect(publicContributor).toMatchObject({ contributionCount: 3 });
+
+    // They out-contributed the registered fixture, so they must also outrank it.
+    const visible = leaderboard.find(
+      (row) => row.displayName === "Visible Contributor",
+    );
+    expect(publicContributor!.rank).toBeLessThan(visible!.rank);
+  });
+
+  test("keeps editor publishes off the community board and vice versa", async () => {
+    const { getContributorLeaderboard } = await import(
+      "@lib/services/contribution-service"
+    );
+
+    // 'Editor room' is the only editor_published fixture row, so the community
+    // board must count 2 for this contributor, not 3.
+    const community = await getContributorLeaderboard(
+      "all",
+      "proposal_approved",
+    );
+    expect(
+      community.find((row) => row.displayName === "Visible Contributor"),
+    ).toMatchObject({ contributionCount: 2 });
+    expect(community.map((row) => row.displayName)).toContain(
+      `${PREFIX}-public`,
+    );
+
+    const editors = await getContributorLeaderboard("all", "editor_published");
+    expect(
+      editors.find((row) => row.displayName === "Visible Contributor")
+        ?.contributionCount,
+    ).toBeGreaterThanOrEqual(1);
+    // Public submissions are not editor publishes.
+    expect(editors.map((row) => row.displayName)).not.toContain(
+      `${PREFIX}-public`,
+    );
+  });
+
+  test("drops rows that cannot be credited to anyone", async () => {
+    const { getContributorLeaderboard } = await import(
+      "@lib/services/contribution-service"
+    );
+    const leaderboard = await getContributorLeaderboard("all");
+    expect(leaderboard.map((row) => row.displayName)).not.toContain(
+      "Contributor",
+    );
+  });
+
   test("returns a signed-in contributor's full ledger newest first", async () => {
     const { getMyContributions } = await import(
       "@lib/services/contribution-service"
     );
+    // Personal ledger spans both sources; only the leaderboard splits them.
     await expect(getMyContributions(visibleUserId)).resolves.toMatchObject([
-      { entityLabel: "Visible building" },
-      { entityLabel: "Visible room" },
+      { entityLabel: "Editor room", source: "editor_published" },
+      { entityLabel: "Visible building", source: "proposal_approved" },
+      { entityLabel: "Visible room", source: "proposal_approved" },
     ]);
   });
 

--- a/src/components/svelte/status-bar/LeaderboardPanel.svelte
+++ b/src/components/svelte/status-bar/LeaderboardPanel.svelte
@@ -7,6 +7,7 @@
   let error = $state<string | null>(null);
   let rows = $state<LeaderboardRow[]>([]);
   let window = $state<"month" | "semester" | "all">("month");
+  let board = $state<"community" | "editors">("community");
 
   onMount(() => {
     loadLeaderboard();
@@ -16,7 +17,9 @@
     loading = true;
     error = null;
     try {
-      const res = await fetch(`/api/contributors/leaderboard?window=${window}`);
+      const res = await fetch(
+        `/api/contributors/leaderboard?window=${window}&board=${board}`,
+      );
       if (!res.ok) throw new Error("Failed to load leaderboard");
       const data = await res.json();
       rows = data.rows || [];
@@ -32,6 +35,12 @@
     loadLeaderboard();
   }
 
+  function selectBoard(next: "community" | "editors") {
+    if (board === next) return;
+    board = next;
+    loadLeaderboard();
+  }
+
   const MEDALS = ["🥇", "🥈", "🥉"];
   function initials(name: string) {
     return name
@@ -44,6 +53,28 @@
 
 <div class="leaderboard-panel">
   <header class="leaderboard-header">
+    <div class="leaderboard-boards" role="tablist" aria-label="Leaderboard">
+      <button
+        type="button"
+        role="tab"
+        class="leaderboard-board"
+        class:selected={board === "community"}
+        aria-selected={board === "community"}
+        onclick={() => selectBoard("community")}
+      >
+        Community
+      </button>
+      <button
+        type="button"
+        role="tab"
+        class="leaderboard-board"
+        class:selected={board === "editors"}
+        aria-selected={board === "editors"}
+        onclick={() => selectBoard("editors")}
+      >
+        Editors
+      </button>
+    </div>
     <select class="leaderboard-select" onchange={handleWindowChange} value={window}>
       <option value="month">This month</option>
       <option value="semester">This semester</option>
@@ -90,7 +121,33 @@
   
   .leaderboard-header {
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .leaderboard-boards {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .leaderboard-board {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid hsl(0, 0%, 82%);
+    border-radius: 0.375rem;
+    background: hsl(0, 0%, 100%);
+    color: hsl(0, 0%, 38%);
+    cursor: pointer;
+  }
+
+  .leaderboard-board.selected {
+    border-color: var(--map-ui-primary, hsl(5, 70%, 50%));
+    background: hsl(5, 60%, 96%);
+    color: var(--map-ui-primary, hsl(5, 70%, 50%));
   }
 
   .leaderboard-select {

--- a/src/lib/services/contribution-service.ts
+++ b/src/lib/services/contribution-service.ts
@@ -6,7 +6,10 @@ import type { EditProposalSummary } from "./proposal-service";
 export type ContributionSource = "proposal_approved" | "editor_published";
 
 type ContributionInput = {
-  userId: number;
+  // Null for public contributors who never registered. They are credited by
+  // submitterName instead, which the proposal flow validates and screens
+  // against reserved names.
+  userId: number | null;
   submitterName: string;
   entityType: string;
   entityId: number;
@@ -28,10 +31,12 @@ export async function recordEditorContribution(
 export async function recordProposalContribution(
   proposal: EditProposalSummary,
 ): Promise<void> {
-  if (!proposal.submitterUserId) return;
-
+  // Unregistered submitters used to be dropped here, which is why the
+  // leaderboard only ever showed staff: the rows for public contributors were
+  // never written in the first place. They are recorded with a null userId and
+  // credited by name.
   await recordContribution({
-    userId: proposal.submitterUserId,
+    userId: proposal.submitterUserId ?? null,
     submitterName: proposal.submitterName,
     entityType: proposal.entityType,
     entityId: proposal.entityId,
@@ -98,47 +103,59 @@ export type LeaderboardRow = {
   lastContributionAt: string;
 };
 
+/**
+ * Community submissions and editor publishes are separate boards. Ranking an
+ * approver's publishes against a contributor's submissions compares two
+ * different acts, and the approver always wins because approving is cheaper
+ * than surveying.
+ */
 export async function getContributorLeaderboard(
   window: LeaderboardWindow = "month",
+  source: ContributionSource = "proposal_approved",
   limit = 25,
 ): Promise<LeaderboardRow[]> {
   const start = windowStart(window);
-  const conditions = [sql`${contributionsTable.userId} IS NOT NULL`];
+
+  // Credit key: registered contributors collapse under their username, public
+  // ones under the name they submitted with. Not display_name, which is free
+  // text a user can change and would split their own history across rows.
+  const creditKey = sql`coalesce(${adminUsersTable.username}, ${contributionsTable.submitterName})`;
+
+  const conditions = [
+    eq(contributionsTable.source, source),
+    // Rows with neither a user nor a submitted name cannot be credited to
+    // anyone. Grouping them would merge unrelated people into one entry that
+    // could outrank every real contributor.
+    sql`${creditKey} IS NOT NULL`,
+    // Left join, so registered users keep their opt-out while contributors with
+    // no admin_users row (the public ones) are not filtered away by it.
+    sql`(${contributionsTable.userId} IS NULL OR (${adminUsersTable.isActive} AND ${adminUsersTable.showInCredits}))`,
+  ];
   if (start) {
     conditions.push(gte(contributionsTable.createdAt, start.toISOString()));
   }
 
   const rows = await db
     .select({
-      userId: contributionsTable.userId,
-      displayName: adminUsersTable.displayName,
-      username: adminUsersTable.username,
+      displayName: sql<
+        string | null
+      >`coalesce(max(${adminUsersTable.displayName}), max(${adminUsersTable.username}), max(${contributionsTable.submitterName}))`,
       contributionCount: count(),
       lastContributionAt: sql<string>`max(${contributionsTable.createdAt})`,
     })
     .from(contributionsTable)
-    .innerJoin(
+    .leftJoin(
       adminUsersTable,
       eq(contributionsTable.userId, adminUsersTable.id),
     )
-    .where(
-      and(
-        ...conditions,
-        eq(adminUsersTable.isActive, true),
-        eq(adminUsersTable.showInCredits, true),
-      ),
-    )
-    .groupBy(
-      contributionsTable.userId,
-      adminUsersTable.displayName,
-      adminUsersTable.username,
-    )
+    .where(and(...conditions))
+    .groupBy(creditKey)
     .orderBy(desc(count()), desc(sql`max(${contributionsTable.createdAt})`))
     .limit(limit);
 
   return rows.map((row, index) => ({
     rank: index + 1,
-    displayName: row.displayName || row.username || "Contributor",
+    displayName: row.displayName || "Contributor",
     contributionCount: Number(row.contributionCount),
     lastContributionAt: row.lastContributionAt,
   }));

--- a/src/pages/api/contributors/leaderboard.ts
+++ b/src/pages/api/contributors/leaderboard.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 import {
+  type ContributionSource,
   getContributorLeaderboard,
   type LeaderboardWindow,
 } from "@lib/services/contribution-service";
@@ -8,15 +9,25 @@ export const prerender = false;
 
 const WINDOWS = new Set<LeaderboardWindow>(["month", "semester", "all"]);
 
+// Two boards, not one ranking: "community" counts approved public submissions,
+// "editors" counts what editors published directly.
+const BOARDS: Record<string, ContributionSource> = {
+  community: "proposal_approved",
+  editors: "editor_published",
+};
+
 export const GET: APIRoute = async ({ url }) => {
   const windowParam = url.searchParams.get("window") ?? "month";
   const window = WINDOWS.has(windowParam as LeaderboardWindow)
     ? (windowParam as LeaderboardWindow)
     : "month";
 
+  const boardParam = url.searchParams.get("board") ?? "community";
+  const board = boardParam in BOARDS ? boardParam : "community";
+
   try {
-    const rows = await getContributorLeaderboard(window);
-    return json({ window, rows });
+    const rows = await getContributorLeaderboard(window, BOARDS[board]);
+    return json({ window, board, rows });
   } catch (error) {
     console.error("leaderboard query failed:", error);
     return json({ error: "Leaderboard is temporarily unavailable." }, 500);


### PR DESCRIPTION
The leaderboard structurally excluded every contributor who never registered, so it ranked approvers instead of the people doing the surveying. The real top contributor by approved submissions could not appear on it at all.

## Two causes

**1. The query could only see registered accounts.** `contribution-service.ts` filtered `user_id IS NOT NULL` and inner joined `admin_users`. Public contributors have `user_id NULL` and are identified by `submitter_name`, so every one of their rows was dropped before ranking.

Now a left join, grouped by `coalesce(username, submitter_name)`. The `is_active` / `show_in_credits` opt-out still applies to registered users (it moved into the predicate so the left join cannot resurrect someone who opted out). Rows with neither a user nor a name are excluded rather than grouped, since merging unrelated people into one entry could outrank every real contributor.

**2. Those rows were never written in the first place.** `recordProposalContribution` returned early when `submitterUserId` was null. Fixing only the query would have surfaced the existing backfill while the board silently stopped growing for every new public approval.

`contributions.user_id` is already nullable. `submitterName` is always present on a proposal, validated, and screened against reserved names, so it is safe as the credit key.

## Separate boards

Community submissions and editor publishes now rank separately, via `?board=community|editors` (default `community`). Ranking them together compares two different acts, and the approver wins every time because approving is cheaper than surveying.

`LeaderboardPanel.svelte` gets a Community/Editors tab pair, otherwise the editor board is unreachable from the UI.

## Note on grouping

Grouped by `username`, not `display_name`. `display_name` is free text a user can change, which would split one person's history across several rows.

## Tests

Added to `integration/services/contribution.integration.test.ts` (runs in CI against the e2e DB):

- a public contributor with no account ranks, and outranks a registered contributor with fewer approvals
- the community board excludes editor publishes and the editor board excludes community submissions
- uncreditable rows (no user, no name) never appear
- the existing opt-out assertion still holds under the left join

The personal ledger test was updated: it spans both sources, and only the leaderboard splits them.

## Verification

- `bunx biome ci .` exit 0
- `bun run test` 614 pass
- `bun run test:components` 237 pass
- `bun run build` clean

The integration tests need the e2e database, which is not available locally (no `.env`), so they ran in CI rather than on my machine. I have not queried production to confirm the 68 backfilled rows now rank as expected, that is worth a look once this deploys.