### PR TITLE
style(map-chrome): format the bottom sheet intent union

### DIFF
--- a/src/lib/bottom-sheet-snap.ts
+++ b/src/lib/bottom-sheet-snap.ts
@@ -1,11 +1,7 @@
 /** Snap points for the mobile entity bottom sheet (GMaps-style). */
 export type BottomSheetSnap = "peek" | "expanded";
 
-export type BottomSheetReleaseIntent =
-  | "expand"
-  | "peek"
-  | "dismiss"
-  | "none";
+export type BottomSheetReleaseIntent = "expand" | "peek" | "dismiss" | "none";
 
 /** Decide snap after a drag release. Pure for unit tests. */
 export function resolveBottomSheetRelease({


### PR DESCRIPTION
`src/lib/bottom-sheet-snap.ts` fails `bunx biome ci .`:

```
src/lib/bottom-sheet-snap.ts format × File content differs from formatting output
```

It arrived with the bottom sheet in #909. staging's own CI has been red on it since, and since every PR is tested merged with its base, it reds **#879, #888, #892, #894 and #837** at the same verify step for a reason none of them caused.

Formatting only (biome collapses the four-member union onto one line), no behaviour change. `bunx biome ci .` exits 0 with it applied.

Merging this to staging lets those five PRs go green on their next sync.