### PR TITLE
fix(settings): restructure the settings modal into scannable rows

### DIFF
--- a/src/components/svelte/ScheduleImportPanel.svelte
+++ b/src/components/svelte/ScheduleImportPanel.svelte
@@ -69,12 +69,6 @@
   class="schedule-import-panel"
   class:schedule-import-panel--embedded={embedded}
 >
-  <p class="schedule-import-panel__note">
-    Class stops come from your Planner plan for the current term. Everything
-    stays on this device.
-  </p>
-  <p class="schedule-import-panel__scope">{scheduleRouteStore.scopeNote}</p>
-
   {#if scheduleRouteStore.importError}
     <p class="schedule-import-panel__error" role="alert">
       {scheduleRouteStore.importError}
@@ -82,15 +76,22 @@
   {/if}
 
   {#if scheduleRouteStore.hasImport}
-    <p class="schedule-import-panel__plan">
-      Plan {plannerStore.activePlan?.label ?? ""} ·
-      {scheduleRouteStore.importedRows.length} section{scheduleRouteStore
-        .importedRows.length === 1
-        ? ""
-        : "s"}
-      <a class="schedule-import-panel__planner-link" href="/planner"
-        >Edit in Planner</a
-      >
+    <div class="map-chrome-row">
+      <span class="map-chrome-row__label">
+        Plan {plannerStore.activePlan?.label ?? ""}
+      </span>
+      <span class="map-chrome-row__value">
+        {scheduleRouteStore.importedRows.length} section{scheduleRouteStore
+          .importedRows.length === 1
+          ? ""
+          : "s"}
+      </span>
+      <div class="map-chrome-row__control">
+        <a class="map-chrome-action-chip" href="/planner">Edit in Planner</a>
+      </div>
+    </div>
+    <p class="map-chrome-row-hint">
+      Stops come from your Planner, on this device.
     </p>
   {:else if !scheduleRouteStore.matching}
     <p class="schedule-import-panel__empty">
@@ -176,7 +177,7 @@
             {#each scheduleRouteStore.unresolved as item (item.row.courseCode + item.row.section + item.row.type)}
               <li>
                 {item.row.courseCode}
-                {item.row.section} ({item.row.type}) —
+                {item.row.section} ({item.row.type}):
                 {item.unresolvedReason}
               </li>
             {/each}
@@ -212,6 +213,13 @@
       </div>
     {/if}
   {/if}
+
+  <!-- Which section types have a room at all. Real, but it is a footnote, not
+       the first thing you read in a settings panel. -->
+  <details class="schedule-import-panel__scope">
+    <summary>Why a class may be missing</summary>
+    <p>{scheduleRouteStore.scopeNote}</p>
+  </details>
 </div>
 
 <style>
@@ -224,24 +232,10 @@
     box-sizing: border-box;
   }
 
-  .schedule-import-panel__note,
-  .schedule-import-panel__scope {
-    margin: 0;
-    font-size: 0.8125rem;
-    line-height: 1.35;
-    color: hsl(0, 0%, 22%);
-  }
-
   .schedule-import-panel__error {
     margin: 0;
     font-size: 0.8125rem;
     color: hsl(0, 65%, 40%);
-  }
-
-  .schedule-import-panel__plan {
-    margin: 0;
-    font-size: 0.8125rem;
-    color: hsl(5, 53%, 22%);
   }
 
   .schedule-import-panel__planner-link {
@@ -430,7 +424,8 @@
     color: hsl(0, 0%, 40%);
   }
 
-  .schedule-import-panel__unresolved {
+  .schedule-import-panel__unresolved,
+  .schedule-import-panel__scope {
     font-size: 0.75rem;
     color: hsl(0, 0%, 35%);
   }
@@ -438,6 +433,21 @@
   .schedule-import-panel__unresolved ul {
     margin: 0.375rem 0 0;
     padding-left: 1rem;
+  }
+
+  /* 44px tap target on the disclosure row. */
+  .schedule-import-panel__scope summary,
+  .schedule-import-panel__unresolved summary {
+    display: list-item;
+    padding: 0.375rem 0;
+    min-height: 2.75rem;
+    align-content: center;
+    cursor: pointer;
+  }
+
+  .schedule-import-panel__scope p {
+    margin: 0.25rem 0 0;
+    line-height: 1.4;
   }
 
   .schedule-import-panel__route-actions {

--- a/src/components/svelte/TerrainControl.svelte
+++ b/src/components/svelte/TerrainControl.svelte
@@ -9,6 +9,7 @@
     TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE,
   } from "@constants/map-terrain";
   import { floatingControlPanelStore, terrainStore } from "@lib/store.svelte";
+  import "./map-chrome/map-chrome.css";
 
   type Props = {
     embedded?: boolean;
@@ -27,22 +28,32 @@
   const menuOpen = $derived(floatingControlPanelStore.openPanel === panelId);
   const showPanel = $derived(embedded || menuOpen);
 
+  // Only says something when the state is not the plain "off and fine" one.
+  // The what-is-this copy lives on the toggle's title instead of a paragraph.
   const statusText = $derived.by(() => {
     if (!isOnline) return TERRAIN_UNAVAILABLE_OFFLINE_MESSAGE;
-    if (terrainStore.status === "loading") {
-      return "Loading hosted elevation tiles...";
-    }
+    if (terrainStore.status === "loading") return "Loading elevation tiles...";
     if (terrainStore.status === "active") {
-      return "Terrain is contextual, not survey-grade elevation data.";
+      return "Contextual relief, not survey-grade elevation.";
     }
     if (terrainStore.status === "unavailable") {
       return terrainStore.message ?? "Terrain is unavailable right now.";
     }
-    if (lowDataConnection) {
-      return "Terrain uses online elevation tiles. Keep it off on low-data connections.";
-    }
-    return "Terrain loads hosted elevation tiles only when enabled.";
+    if (lowDataConnection) return "Uses online tiles. Keep it off on low data.";
+    return "";
   });
+
+  const statusWarns = $derived(
+    !isOnline || lowDataConnection || terrainStore.status === "unavailable",
+  );
+
+  // Visible label is "Off"/"On", so the accessible name has to contain it
+  // (WCAG 2.5.3) while still naming the action.
+  const toggleLabel = $derived(
+    terrainStore.enabled
+      ? "Terrain is on. Turn terrain off."
+      : "Terrain is off. Turn terrain on.",
+  );
 
   function getConnection(): NetworkInformation | undefined {
     return (navigator as Navigator & { connection?: NetworkInformation })
@@ -92,7 +103,7 @@
 
 <div class="terrain-control" class:embedded>
   {#if showPanel}
-    <div class="terrain-panel" class:embedded role="menu">
+    <div class="terrain-panel" class:embedded>
       {#if !embedded}
         <div class="terrain-panel-header">
           <span>Makiling Terrain</span>
@@ -107,29 +118,39 @@
         </div>
       {/if}
 
-      <p class="terrain-copy">
-        Explore Mt. Makiling in 3D context. This layer is online-only for now
-        and stays off until you enable it.
-      </p>
+      <div class="map-chrome-row">
+        <span class="map-chrome-row__label">Makiling terrain</span>
+        <div class="map-chrome-row__control">
+          <button
+            type="button"
+            class="map-chrome-chip"
+            class:map-chrome-chip--toggle-active={terrainStore.enabled}
+            onclick={handleToggle}
+            aria-pressed={terrainStore.enabled}
+            aria-label={toggleLabel}
+            title="Mt. Makiling in 3D. Loads elevation tiles over the network."
+          >
+            {terrainStore.enabled ? "On" : "Off"}
+          </button>
+        </div>
+      </div>
 
-      <button
-        type="button"
-        class="terrain-toggle"
-        class:active={terrainStore.enabled}
-        onclick={handleToggle}
-        aria-pressed={terrainStore.enabled}
-      >
-        {terrainStore.enabled ? "Turn terrain off" : "Turn terrain on"}
-      </button>
-
-      <div class="terrain-options" aria-label="Terrain exaggeration">
-        <span>Exaggeration</span>
-        <div class="terrain-option-buttons">
+      <div class="map-chrome-row">
+        <span class="map-chrome-row__label" id="terrain-exaggeration-label">
+          Exaggeration
+        </span>
+        <div
+          class="map-chrome-row__control"
+          role="group"
+          aria-labelledby="terrain-exaggeration-label"
+        >
           {#each TERRAIN_EXAGGERATION_OPTIONS as option (option)}
             <button
               type="button"
-              class="terrain-option"
-              class:active={terrainStore.exaggeration === option}
+              class="map-chrome-chip"
+              class:map-chrome-chip--toggle-active={terrainStore.exaggeration ===
+                option}
+              aria-pressed={terrainStore.exaggeration === option}
               onclick={() => terrainStore.setExaggeration(option)}
             >
               {option}x
@@ -138,32 +159,36 @@
         </div>
       </div>
 
-      <button
-        type="button"
-        class="reset-btn"
-        disabled={!terrainStore.enabled}
-        onclick={() => terrainStore.requestReset()}
-      >
-        <RotateCcw size="14" />
-        Reset Makiling view
-      </button>
+      <div class="map-chrome-row">
+        <span class="map-chrome-row__label">Camera</span>
+        <div class="map-chrome-row__control">
+          <button
+            type="button"
+            class="map-chrome-action-chip"
+            disabled={!terrainStore.enabled}
+            onclick={() => terrainStore.requestReset()}
+            title="Point the camera back at Mt. Makiling."
+          >
+            <RotateCcw size="14" aria-hidden="true" />
+            Reset view
+          </button>
+        </div>
+      </div>
 
-      <p
-        class="terrain-status"
-        class:warning={!isOnline ||
-          lowDataConnection ||
-          terrainStore.status === "unavailable"}
-        aria-live="polite"
-      >
-        {statusText}
-      </p>
+      <div class="terrain-status" aria-live="polite">
+        {#if statusText}
+          <p class="map-chrome-row-hint" class:map-chrome-row-hint--warn={statusWarns}>
+            {statusText}
+          </p>
+        {/if}
+      </div>
 
-      <p class="terrain-attribution">
-        Elevation tiles by
-        <a href="https://www.maptiler.com/" target="_blank" rel="noreferrer">
-          MapTiler
-        </a>
-        .
+      <p class="map-chrome-row-note">
+        Elevation tiles by <a
+          href="https://www.maptiler.com/"
+          target="_blank"
+          rel="noreferrer">MapTiler</a
+        >.
       </p>
     </div>
   {/if}
@@ -190,7 +215,9 @@
   .terrain-panel.embedded {
     width: 100%;
     max-width: 100%;
-    padding: 0;
+    /* 1px so overflow-x does not shave the left stem off the attribution's
+       "E" — same clip the settings scroll body already pads around. */
+    padding: 0 0 0 1px;
     box-shadow: none;
     overflow-x: hidden;
   }
@@ -233,7 +260,7 @@
     width: 18rem;
     max-width: calc(100vw - 1rem);
     flex-direction: column;
-    gap: 0.625rem;
+    gap: 0.25rem;
     border-radius: 0.875rem;
     background-color: white;
     padding: 0.75rem;
@@ -250,97 +277,16 @@
     font-weight: 600;
   }
 
-  .terrain-copy,
-  .terrain-status,
-  .terrain-attribution {
-    margin: 0;
-    color: hsl(0, 0%, 38%);
-    font-size: 0.75rem;
-    line-height: 1.35;
+  /* Live region, so it stays mounted; :empty keeps it out of the panel's gap
+     while the state is the plain "off and fine" one. */
+  .terrain-status:empty {
+    display: none;
   }
 
-  .terrain-toggle,
-  .reset-btn {
-    /* inline-flex, not flex: a block-level flex container stretched these to
-       the full panel width for a two-word label. */
-    display: inline-flex;
-    align-self: flex-start;
-    align-items: center;
-    justify-content: center;
-    gap: 0.375rem;
-    border: 1px solid hsl(0, 0%, 88%);
-    border-radius: 0.625rem;
-    background-color: white;
-    color: hsl(5, 53%, 32%);
-    cursor: pointer;
-    font: inherit;
-    font-size: 0.8125rem;
-    font-weight: 700;
-    padding: 0.55rem 0.625rem;
-  }
-
-  .terrain-toggle:hover,
-  .reset-btn:hover:not(:disabled) {
-    background-color: hsl(5, 53%, 98%);
-  }
-
-  .terrain-toggle.active {
-    border-color: hsl(160, 84%, 26%);
-    background-color: hsl(160, 84%, 26%);
-    color: white;
-  }
-
-  .terrain-options {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    min-width: 0;
-    color: hsl(0, 0%, 30%);
-    font-size: 0.75rem;
-    font-weight: 600;
-  }
-
-  .terrain-option-buttons {
-    display: flex;
-    gap: 0.25rem;
-  }
-
-  .terrain-option {
-    border: 1px solid hsl(0, 0%, 88%);
-    border-radius: 999px;
-    background-color: white;
-    color: hsl(0, 0%, 30%);
-    cursor: pointer;
-    font: inherit;
-    font-size: 0.75rem;
-    font-weight: 700;
-    padding: 0.25rem 0.5rem;
-  }
-
-  .terrain-option:hover {
-    background-color: hsl(5, 53%, 98%);
-  }
-
-  .terrain-option.active {
-    border-color: hsl(5, 53%, 32%);
-    background-color: hsl(5, 53%, 96%);
-    color: hsl(5, 53%, 32%);
-  }
-
-  .reset-btn:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
-
-  .terrain-status.warning {
-    color: hsl(25, 80%, 35%);
-    font-weight: 600;
-  }
-
-  .terrain-attribution a {
-    color: hsl(5, 53%, 32%);
-    font-weight: 700;
+  /* Attribution is required by the basemap terms. Small print, with enough air
+     that it does not read as another setting row. */
+  .map-chrome-row-note {
+    margin-top: 0.25rem;
+    padding-left: 3px;
   }
 </style>

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -378,6 +378,102 @@ button.map-chrome-chip:disabled {
   color: currentColor;
 }
 
+/* Settings rows: label on the left, current value or control on the right.
+   One short hint line under a row is the ceiling — longer copy belongs in a
+   title, a <details>, or nowhere. */
+.map-chrome-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.25rem 0.5rem;
+  min-width: 0;
+}
+
+.map-chrome-row__label {
+  flex: 0 1 auto;
+  min-width: 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: hsl(0, 0%, 22%);
+}
+
+.map-chrome-row__value {
+  flex: 0 1 auto;
+  min-width: 0;
+  font-size: 0.8125rem;
+  line-height: 1.25;
+  color: hsl(0, 0%, 30%);
+}
+
+.map-chrome-row__control,
+.map-chrome-row-actions {
+  display: flex;
+  flex: 0 1 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.map-chrome-row__control {
+  justify-content: flex-end;
+}
+
+/* Row controls carry a 44px touch target; the bare chips are band-sized. The
+   squarer radius is not cosmetic: a 999px pill at 44px tall with a two-glyph
+   label ("1x", "On") comes out a circle. */
+.map-chrome-row .map-chrome-chip,
+.map-chrome-row .map-chrome-action-chip,
+.map-chrome-row-actions .map-chrome-action-chip {
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+  height: auto;
+  gap: 0.375rem;
+  border-radius: 0.625rem;
+  padding: 0.375rem 0.75rem;
+}
+
+/* Nothing here is busy while disabled (Reset view is off until terrain is on),
+   so the action chip's progress cursor would lie. */
+.map-chrome-row .map-chrome-action-chip:disabled {
+  cursor: default;
+}
+
+.map-chrome-row-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: hsl(0, 0%, 38%);
+}
+
+.map-chrome-row-hint--warn {
+  color: hsl(25, 85%, 28%);
+  font-weight: 600;
+}
+
+.map-chrome-row-hint--ok {
+  color: hsl(150, 45%, 25%);
+  font-weight: 600;
+}
+
+/* Small print that has to be there: attribution, licence credits. */
+.map-chrome-row-note {
+  margin: 0;
+  font-size: 0.6875rem;
+  line-height: 1.35;
+  color: hsl(0, 0%, 40%);
+}
+
+/* No invisible ::after tap target here on purpose: #905 removed exactly that
+   pattern from this file after it swallowed the map attribution's own links.
+   The attribution stays a plain inline link until that is redone properly. */
+.map-chrome-row-note a {
+  color: hsl(5, 53%, 32%);
+  font-weight: 700;
+}
+
 .map-chrome-fab-trigger {
   display: flex;
   flex-shrink: 0;

--- a/src/components/svelte/modal/SettingsModal.component.test.ts
+++ b/src/components/svelte/modal/SettingsModal.component.test.ts
@@ -26,8 +26,8 @@ const reload = vi.fn();
 const clearButton = () =>
   screen.getByRole("button", { name: "Clear cached data and reload" });
 
-const resyncButton = () =>
-  screen.getByRole("button", { name: "Resync campus data" });
+// The row label carries "campus data" now, so the button is just the verb.
+const resyncButton = () => screen.getByRole("button", { name: "Resync" });
 
 describe("SettingsModal", () => {
   test("renders every section at 320px without horizontal overflow", () => {
@@ -228,5 +228,17 @@ describe("SettingsModal resync campus data", () => {
       screen.getByText(/downloaded offline maps are kept/i),
     ).toBeInTheDocument();
     expect(clearButton()).toBeInTheDocument();
+  });
+
+  test("keeps the row label and ties the kept-maps promise to the button", () => {
+    render(SettingsModalHost);
+
+    expect(screen.getByText("Campus data")).toBeInTheDocument();
+    const described = document.getElementById(
+      resyncButton().getAttribute("aria-describedby") ?? "",
+    );
+    expect(described?.textContent?.replace(/\s+/g, " ")).toMatch(
+      /downloaded offline maps are kept/i,
+    );
   });
 });

--- a/src/components/svelte/modal/SettingsModal.svelte
+++ b/src/components/svelte/modal/SettingsModal.svelte
@@ -75,25 +75,29 @@
       <h3>Storage</h3>
 
       <div class="settings-modal__task">
-        <p class="settings-modal__hint">
-          Rooms or classes look stale or wrong? Fetch campus data again from
-          the server. Your downloaded offline maps are kept.
-        </p>
-        <div class="settings-modal__actions">
-          <button
-            type="button"
-            class="settings-modal__btn"
-            disabled={resyncing}
-            onclick={resync}
-          >
-            {resyncing ? "Resyncing…" : "Resync campus data"}
-          </button>
+        <div class="map-chrome-row">
+          <span class="map-chrome-row__label">Campus data</span>
+          <div class="map-chrome-row__control">
+            <button
+              type="button"
+              class="map-chrome-action-chip"
+              aria-describedby="settings-resync-hint"
+              disabled={resyncing}
+              onclick={resync}
+            >
+              {resyncing ? "Resyncing…" : "Resync"}
+            </button>
+          </div>
         </div>
+        <p id="settings-resync-hint" class="map-chrome-row-hint">
+          Fetches rooms and classes again. Your downloaded offline maps are
+          kept.
+        </p>
         {#if resyncResult}
           <p
-            class="settings-modal__hint"
-            class:settings-modal__hint--warn={resyncResult !== "synced"}
-            class:settings-modal__hint--ok={resyncResult === "synced"}
+            class="map-chrome-row-hint"
+            class:map-chrome-row-hint--warn={resyncResult !== "synced"}
+            class:map-chrome-row-hint--ok={resyncResult === "synced"}
             role="status"
           >
             {RESYNC_MESSAGE[resyncResult]}
@@ -101,23 +105,37 @@
         {/if}
       </div>
 
-      <p class="settings-modal__hint">
-        Still broken? This is the heavier fix: it clears the cached app, saved
-        campus data, and downloaded offline maps, then reloads. Your saved
-        class plans stay.
+      <div class="map-chrome-row">
+        <span class="map-chrome-row__label">Cached app data</span>
+        {#if !confirming}
+          <div class="map-chrome-row__control">
+            <button
+              type="button"
+              class="map-chrome-action-chip settings-modal__danger"
+              aria-describedby="settings-storage-hint"
+              onclick={() => (confirming = true)}
+            >
+              Clear cached data and reload
+            </button>
+          </div>
+        {/if}
+      </div>
+      <p id="settings-storage-hint" class="map-chrome-row-hint">
+        Clears the cached app, saved campus data, and downloaded offline maps,
+        then reloads. Your saved class plans stay.
       </p>
       {#if confirming}
         <p
           id="settings-storage-warning"
-          class="settings-modal__hint settings-modal__hint--warn"
+          class="map-chrome-row-hint map-chrome-row-hint--warn"
         >
-          Downloaded offline maps go too — you will need to download them again
-          on a connection.
+          Downloaded offline maps go too. You will need a connection to
+          download them again.
         </p>
-        <div class="settings-modal__actions">
+        <div class="map-chrome-row-actions">
           <button
             type="button"
-            class="settings-modal__btn settings-modal__btn--danger"
+            class="map-chrome-action-chip settings-modal__danger settings-modal__danger--solid"
             aria-describedby="settings-storage-warning"
             disabled={clearing}
             bind:this={confirmButton}
@@ -127,21 +145,11 @@
           </button>
           <button
             type="button"
-            class="settings-modal__btn"
+            class="map-chrome-action-chip"
             disabled={clearing}
             onclick={() => (confirming = false)}
           >
             Cancel
-          </button>
-        </div>
-      {:else}
-        <div class="settings-modal__actions">
-          <button
-            type="button"
-            class="settings-modal__btn"
-            onclick={() => (confirming = true)}
-          >
-            Clear cached data and reload
           </button>
         </div>
       {/if}
@@ -194,21 +202,6 @@
     color: hsl(0, 0%, 40%);
   }
 
-  .settings-modal__hint {
-    margin: 0;
-    font-size: 0.8125rem;
-    line-height: 1.35;
-    color: hsl(0, 0%, 40%);
-  }
-
-  .settings-modal__hint--warn {
-    color: hsl(5, 53%, 32%);
-  }
-
-  .settings-modal__hint--ok {
-    color: hsl(150, 40%, 28%);
-  }
-
   /* Groups the light fix with its own result line, so the heavier
      clear-and-reload below reads as the separate, bigger hammer. */
   .settings-modal__task {
@@ -219,53 +212,29 @@
     border-bottom: 1px solid hsl(0, 0%, 90%);
   }
 
-  .settings-modal__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.375rem;
-    margin-top: 0.125rem;
+  /* The chrome chip is maroon like the rest of the app, so destructive gets a
+     true red: outlined to arm, filled to confirm. Never the same as Resync. */
+  .settings-modal__danger {
+    border-color: hsl(0, 55%, 70%);
+    color: hsl(0, 70%, 34%);
   }
 
-  .settings-modal__btn {
-    box-sizing: border-box;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    /* 44px touch target. */
-    min-height: 2.75rem;
-    border: 1px solid hsl(0, 0%, 82%);
-    border-radius: 0.5rem;
-    padding: 0.4375rem 0.75rem;
-    background-color: white;
-    color: hsl(0, 0%, 20%);
-    font: inherit;
-    font-size: 0.8125rem;
-    font-weight: 600;
-    line-height: 1.2;
-    cursor: pointer;
+  .settings-modal__danger:hover:not(:disabled),
+  .settings-modal__danger:focus-visible {
+    border-color: hsl(0, 60%, 52%);
+    background: hsl(0, 75%, 98%);
   }
 
-  .settings-modal__btn:hover:not(:disabled) {
-    background-color: hsl(0, 0%, 96%);
-  }
-
-  .settings-modal__btn:focus-visible {
-    outline: 2px solid hsl(5, 53%, 32%);
-    outline-offset: 2px;
-  }
-
-  .settings-modal__btn:disabled {
-    opacity: 0.6;
-    cursor: default;
-  }
-
-  .settings-modal__btn--danger {
-    border-color: hsl(5, 53%, 32%);
-    background-color: hsl(5, 53%, 32%);
+  .settings-modal__danger--solid,
+  .settings-modal__danger--solid:hover:not(:disabled),
+  .settings-modal__danger--solid:focus-visible {
+    border-color: hsl(0, 70%, 32%);
+    background: hsl(0, 70%, 32%);
     color: white;
   }
 
-  .settings-modal__btn--danger:hover:not(:disabled) {
-    background-color: hsl(5, 53%, 27%);
+  .settings-modal__danger--solid:hover:not(:disabled) {
+    background: hsl(0, 70%, 27%);
+    border-color: hsl(0, 70%, 27%);
   }
 </style>


### PR DESCRIPTION
## Before

Every setting below the View section was buried under prose. Terrain carried three separate paragraphs, Schedule carried three with no control in them at all, and Storage explained itself twice before you reached either button. The copy set the modal's width and its height, so the panel scrolled past text to get to two buttons.

## After

One row pattern for every setting, matching the compact label-and-value shape the View section already used: label on the left, current value or control on the right, at most one short hint line under it.

| Section | Before | After |
| --- | --- | --- |
| Terrain | 3 paragraphs, a loose toggle, a label-and-chips line, a loose button | 3 rows (Makiling terrain / Exaggeration / Camera) plus one conditional status line and small-print attribution |
| Schedule | 3 paragraphs before any control | 1 plan row, 1 hint line, 1 disclosure |
| Storage | 2 paragraphs and 2 loose buttons | 2 rows, each with its own hint |

The row parts live in `map-chrome.css` (`.map-chrome-row`, `__label`, `__value`, `__control`, `-hint`, `-note`) so the settings modal and the Map tools flyout render the same panels the same way, and the controls themselves are the existing `.map-chrome-chip` and `.map-chrome-action-chip`. `SettingsModal` deleted its private button vocabulary; `TerrainControl` deleted ~90 lines of one-off CSS.

## Copy cut, and why

**Terrain, three paragraphs to zero.**
- "Explore Mt. Makiling in 3D context. This layer is online-only for now and stays off until you enable it." and "Terrain loads hosted elevation tiles only when enabled." said the same thing twice, in the state where the user needs it least. Both collapse into the toggle's `title`.
- The status line now returns an empty string when terrain is off and nothing is wrong. It still speaks up for offline, low-data, loading, active and unavailable, which are the states where a sentence changes what you do.
- "Elevation tiles by MapTiler" stays. The basemap terms require attribution. It is now 11px small print instead of a paragraph.

**Schedule, three paragraphs to one line plus a disclosure.**
- "Class stops come from your Planner plan for the current term. Everything stays on this device." becomes "Stops come from your Planner, on this device." and only renders when there is a plan, since the empty state already names the Planner.
- The thesis and dissertation scope note keeps every word of `ROOM_SCHEDULE_SCOPE_NOTE`, moved behind "Why a class may be missing" and placed next to the stops list it explains rather than above the controls.

**Storage, rhetorical openers only.**
- "Rooms or classes look stale or wrong?" and "Still broken? This is the heavier fix:" are gone. Both were throat-clearing.

## Kept deliberately

The destructive path is the one place a sentence earns its space, so nothing there was compressed into ambiguity:

- "Clears the cached app, saved campus data, and downloaded offline maps, then reloads. Your saved class plans stay." stays in full.
- "Downloaded offline maps go too. You will need a connection to download them again." stays on the confirm step, still wired through `aria-describedby`.
- "Your downloaded offline maps are kept" stays on Resync, now tied to the button by `aria-describedby` instead of floating above it.
- The two are no longer the same button. Resync is a plain chip; the clear trigger is red-outlined and its confirm is filled red. The app's neutral chrome is maroon, so the destructive treatment is a true red plus a fill change, not hue alone.

No control or setting was removed.

## Incidental fixes found on the way

- The exaggeration options conveyed selection by colour alone. They now carry `aria-pressed`, and the group is labelled by the row's own label.
- The terrain panel had `role="menu"` with no menu items. Removed.
- An em dash in the confirm warning, replaced with two sentences.
- `overflow-x: hidden` on the embedded terrain panel was shaving the left stem off the attribution's "E", the same clip the settings scroll body already pads around. Screenshot-confirmed before and after.
- Reused chips would have shown a busy cursor on `Reset view` while it is merely disabled. Row-scoped back to `default`.
- No invisible `::after` tap targets: #905 removed exactly that pattern from this file for swallowing the attribution's links, so the small-print link stays a plain inline link rather than reviving it.

## Accessibility

- Every control in the panel measures at least 44px in both dimensions, checked in a real browser at 320px. The only remaining smaller hits are the modal close button and the View toggles, both pre-existing and outside this change.
- The terrain toggle's visible label is "Off" / "On" and its accessible name is "Terrain is off. Turn terrain on.", so the visible text is contained in the accessible name (2.5.3) while the existing e2e that looks for `/turn terrain on/i` keeps passing.
- The status line stays mounted as the `aria-live` region and empties rather than unmounting, so announcements still fire.
- Focus still moves to the confirm button when the destructive action is armed; verified in-browser, not just in jsdom.

## Verification

- `bunx biome ci .` exit 0
- `bun run test` 614 pass
- `bun run test:components` 238 pass, including the 320px no-horizontal-overflow assertion
- `bun run build` clean
- `e2e/browse/map-tools.spec.ts` on desktop-chrome, 2 passed
- Screenshotted at 320px and 1100px, in the settings modal and in the Map tools flyout, in the default, terrain-on and confirm states

`SettingsModal.component.test.ts` changed in two places: the resync button's name is now "Resync" because the row label carries "Campus data", and a new test asserts that row label plus the fact that the kept-maps promise is still tied to the button through `aria-describedby`. Nothing it checked was dropped.
