### PR TITLE
docs(readme): add the logo and fix the live-app badge escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 <div align="center">
 
+<img src="public/logo.png" alt="Room TBA" width="120" height="120">
+
 # Room TBA
 
 **Saan sa UPLB ang \___?**
 
-[![Live app](https://img.shields.io/badge/open-room, tba.uplb.tools-maroon?style=for-the-badge)](https://room-tba.uplb.tools)
+[![Live app](https://img.shields.io/badge/open-room--tba.uplb.tools-maroon?style=for-the-badge)](https://room-tba.uplb.tools)
 [![MIT](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)](LICENSE)
 [![Bun](https://img.shields.io/badge/bun-1.3+-black?style=flat-square&logo=bun)](https://bun.sh)
 [![Astro](https://img.shields.io/badge/Astro-7-BC52EE?style=flat-square&logo=astro)](https://astro.build)


### PR DESCRIPTION
Closes #907.

Adds `public/logo.png` at 120px above the title, inside the existing centred block, with an `alt` so screen readers and images-blocked views still get the name. Repo-relative path so it survives forks and mirrors.

Also fixes the live-app badge, which currently renders as **"room, tba.uplb.tools"**. shields.io treats a dash as a field separator and wants a literal dash escaped as `--`; a comma had been substituted instead, so the comma was showing in the rendered badge.

## One thing I deliberately did not do

No dark-mode variant. I sampled the asset: the mark is maroon-heavy on a transparent background, 44% of sampled opaque pixels below 110 luminance, which is roughly **1.4:1** against GitHub's dark canvas (#0d1117). It will be hard to see on the dark theme.

Fixing that means either a light-background lockup or a light-ink variant, which is a brand decision, not a mechanical one. Left to the designer. Once a variant exists it wires up with `<picture>` and `media="(prefers-color-scheme: dark)"`.

`bunx biome ci .` exit 0. Docs only, no code paths touched.