### PR TITLE
feat(social): surface the UPLB Tools accounts where the app has just helped

### DIFF
--- a/src/components/svelte/community/CommunityBrandIcon.component.test.ts
+++ b/src/components/svelte/community/CommunityBrandIcon.component.test.ts
@@ -20,4 +20,34 @@ describe("CommunityBrandIcon", () => {
     const path = container.querySelector("path");
     expect(path?.getAttribute("fill")).toBe("#5865F2");
   });
+
+  test("renders Facebook brand SVG in brand blue", () => {
+    const { container } = render(CommunityBrandIcon, {
+      props: { brand: "facebook" },
+    });
+    expect(container.querySelector("circle")?.getAttribute("fill")).toBe(
+      "#1877F2",
+    );
+  });
+
+  test("renders Instagram brand SVG on its gradient", () => {
+    const { container } = render(CommunityBrandIcon, {
+      props: { brand: "instagram", size: 20 },
+    });
+    const gradient = container.querySelector("radialGradient");
+    expect(gradient?.id).toMatch(/^instagram-gradient-/);
+    expect(container.querySelector("rect")?.getAttribute("fill")).toBe(
+      `url(#${gradient?.id})`,
+    );
+    expect(container.querySelector("svg")?.getAttribute("width")).toBe("20");
+  });
+
+  test("the icon is decorative; the accessible name comes from the link", () => {
+    const { container } = render(CommunityBrandIcon, {
+      props: { brand: "instagram" },
+    });
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    expect(svg?.getAttribute("focusable")).toBe("false");
+  });
 });

--- a/src/components/svelte/community/CommunityBrandIcon.svelte
+++ b/src/components/svelte/community/CommunityBrandIcon.svelte
@@ -1,17 +1,77 @@
 <script lang="ts">
-  type Brand = "discord" | "messenger";
+  import type { CommunityBrand } from "./brands";
 
   type Props = {
-    brand: Brand;
+    brand: CommunityBrand;
     size?: number;
   };
 
   const { brand, size = 16 }: Props = $props();
 
-  const gradientId = `messenger-gradient-${Math.random().toString(36).slice(2, 9)}`;
+  const uid = Math.random().toString(36).slice(2, 9);
+  const gradientId = `messenger-gradient-${uid}`;
+  const instagramGradientId = `instagram-gradient-${uid}`;
 </script>
 
-{#if brand === "discord"}
+{#if brand === "facebook"}
+  <!-- Facebook "f" mark: brand blue disc, white glyph. -->
+  <svg
+    class="community-brand-icon"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <circle cx="12" cy="12" r="12" fill="#1877F2" />
+    <path
+      fill="#FFF"
+      d="M16.671 15.47 17.203 12h-3.328V9.75c0-.949.465-1.874 1.956-1.874h1.513V4.922s-1.374-.235-2.687-.235c-2.741 0-4.532 1.662-4.532 4.669V12H7.078v3.47h3.047v8.385a12.13 12.13 0 0 0 3.75 0V15.47h2.796z"
+    />
+  </svg>
+{:else if brand === "instagram"}
+  <!-- Instagram camera mark on the official corner-anchored gradient. -->
+  <svg
+    class="community-brand-icon"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <radialGradient id={instagramGradientId} cx="0.3" cy="1.05" r="1.25">
+      <stop offset="0" stop-color="#FFDD55" />
+      <stop offset=".1" stop-color="#FFDD55" />
+      <stop offset=".5" stop-color="#FF543E" />
+      <stop offset="1" stop-color="#C837AB" />
+    </radialGradient>
+    <rect
+      width="24"
+      height="24"
+      rx="6"
+      fill={`url(#${instagramGradientId})`}
+    />
+    <rect
+      x="5.2"
+      y="5.2"
+      width="13.6"
+      height="13.6"
+      rx="4.2"
+      fill="none"
+      stroke="#FFF"
+      stroke-width="1.7"
+    />
+    <circle
+      cx="12"
+      cy="12"
+      r="3.2"
+      fill="none"
+      stroke="#FFF"
+      stroke-width="1.7"
+    />
+    <circle cx="16.35" cy="7.7" r="1.15" fill="#FFF" />
+  </svg>
+{:else if brand === "discord"}
   <svg
     class="community-brand-icon"
     width={size}

--- a/src/components/svelte/community/CommunityPlatformLink.svelte
+++ b/src/components/svelte/community/CommunityPlatformLink.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
   import CommunityBrandIcon from "./CommunityBrandIcon.svelte";
-
-  type Brand = "discord" | "messenger";
+  import type { CommunityBrand } from "./brands";
 
   type Props = {
-    brand: Brand;
+    brand: CommunityBrand;
     href: string;
     label: string;
     class?: string;
+    /** Fired before the new tab opens. Used to retire the follow prompt. */
+    onclick?: () => void;
   };
 
-  const { brand, href, label, class: className = "" }: Props = $props();
+  const {
+    brand,
+    href,
+    label,
+    class: className = "",
+    onclick,
+  }: Props = $props();
 </script>
 
 <a
@@ -18,6 +25,7 @@
   class={`community-platform-link ${className}`.trim()}
   target="_blank"
   rel="noopener noreferrer"
+  {onclick}
 >
   <CommunityBrandIcon {brand} size={16} />
   <span>{label}</span>

--- a/src/components/svelte/community/FollowPrompt.component.test.ts
+++ b/src/components/svelte/community/FollowPrompt.component.test.ts
@@ -53,6 +53,27 @@ describe("FollowPrompt", () => {
     expect(screen.queryByText(note)).toBe(null);
   });
 
+  // Without a cap, a reader who neither dismisses nor follows sees this on
+  // every visit forever. For someone who looks up a room most days that is a
+  // nag, which is the one thing this was not allowed to be.
+  test("retires itself after three unanswered showings", () => {
+    for (let visit = 1; visit <= 3; visit += 1) {
+      const { unmount } = render(FollowPrompt, { props: { note } });
+      expect(
+        screen.queryByRole("button", { name: /dismiss follow suggestion/i }),
+        `visit ${visit} should still ask`,
+      ).not.toBe(null);
+      unmount();
+    }
+
+    render(FollowPrompt, { props: { note } });
+    expect(
+      screen.queryByRole("button", { name: /dismiss follow suggestion/i }),
+      "fourth visit must not ask again",
+    ).toBe(null);
+    expect(localStorage.getItem(FOLLOW_PROMPT_KEY)).toBe("ignored");
+  });
+
   test("a dismissal written by an earlier visit hides it before first paint", () => {
     localStorage.setItem(FOLLOW_PROMPT_KEY, "dismissed");
     render(FollowPrompt, { props: { note } });

--- a/src/components/svelte/community/FollowPrompt.component.test.ts
+++ b/src/components/svelte/community/FollowPrompt.component.test.ts
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test } from "vitest";
+import FollowPrompt from "./FollowPrompt.svelte";
+import { FOLLOW_PROMPT_KEY } from "@lib/social-follow";
+
+const note = "Fixes and new features get posted on Facebook and Instagram.";
+
+const dismiss = () =>
+  screen.getByRole("button", { name: /dismiss follow suggestion/i });
+
+describe("FollowPrompt", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("asks once, with real outbound links to both accounts", () => {
+    render(FollowPrompt, { props: { note } });
+
+    expect(screen.getByText(note)).toBeVisible();
+
+    for (const name of [/facebook/i, /instagram/i]) {
+      const link = screen.getByRole("link", { name });
+      expect(link).toHaveAttribute("target", "_blank");
+      // Both tokens matter: noreferrer alone still leaks window.opener on old
+      // browsers, and noopener alone still sends the referrer.
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+      expect(link.getAttribute("href")).toMatch(/^https:\/\//);
+    }
+  });
+
+  test("dismissal persists and is respected on the next mount", async () => {
+    const first = render(FollowPrompt, { props: { note } });
+    await fireEvent.click(dismiss());
+
+    expect(screen.queryByText(note)).toBe(null);
+    expect(localStorage.getItem(FOLLOW_PROMPT_KEY)).toBe("dismissed");
+
+    // A fresh mount is the next visit: the ask must not come back.
+    first.unmount();
+    render(FollowPrompt, { props: { note } });
+    expect(screen.queryByText(note)).toBe(null);
+    expect(screen.queryByRole("link", { name: /facebook/i })).toBe(null);
+  });
+
+  test("following also retires the prompt, so nobody is asked twice", async () => {
+    const first = render(FollowPrompt, { props: { note } });
+    await fireEvent.click(screen.getByRole("link", { name: /instagram/i }));
+
+    expect(localStorage.getItem(FOLLOW_PROMPT_KEY)).toBe("followed");
+
+    first.unmount();
+    render(FollowPrompt, { props: { note } });
+    expect(screen.queryByText(note)).toBe(null);
+  });
+
+  test("a dismissal written by an earlier visit hides it before first paint", () => {
+    localStorage.setItem(FOLLOW_PROMPT_KEY, "dismissed");
+    render(FollowPrompt, { props: { note } });
+
+    expect(screen.queryByText(note)).toBe(null);
+    expect(screen.queryByRole("button", { name: /dismiss/i })).toBe(null);
+  });
+
+  test("unreadable storage shows the ask rather than swallowing it", () => {
+    const getItem = Storage.prototype.getItem;
+    Storage.prototype.getItem = () => {
+      throw new Error("storage blocked");
+    };
+    try {
+      render(FollowPrompt, { props: { note } });
+      expect(screen.getByText(note)).toBeVisible();
+    } finally {
+      Storage.prototype.getItem = getItem;
+    }
+  });
+});

--- a/src/components/svelte/community/FollowPrompt.svelte
+++ b/src/components/svelte/community/FollowPrompt.svelte
@@ -2,7 +2,7 @@
   import X from "@lucide/svelte/icons/x";
   import IconButton from "@ui/IconButton.svelte";
   import {
-    isFollowPromptRetired,
+    countFollowPromptView,
     retireFollowPrompt,
   } from "@lib/social-follow";
   import FollowUpdates from "./FollowUpdates.svelte";
@@ -16,7 +16,9 @@
 
   // Read once at init, not in an effect: re-reading would let the prompt come
   // back inside a session, and coming back is the thing this must never do.
-  let retired = $state(isFollowPromptRetired());
+  // Counting the view here also retires it after the third unanswered showing,
+  // so ignoring it is an answer rather than an invitation to ask again.
+  let retired = $state(!countFollowPromptView());
 
   function retire(outcome: "dismissed" | "followed") {
     retired = true;

--- a/src/components/svelte/community/FollowPrompt.svelte
+++ b/src/components/svelte/community/FollowPrompt.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import X from "@lucide/svelte/icons/x";
+  import IconButton from "@ui/IconButton.svelte";
+  import {
+    isFollowPromptRetired,
+    retireFollowPrompt,
+  } from "@lib/social-follow";
+  import FollowUpdates from "./FollowUpdates.svelte";
+
+  type Props = {
+    /** Why this moment earned the ask. Keep it about the reader's data. */
+    note: string;
+  };
+
+  const { note }: Props = $props();
+
+  // Read once at init, not in an effect: re-reading would let the prompt come
+  // back inside a session, and coming back is the thing this must never do.
+  let retired = $state(isFollowPromptRetired());
+
+  function retire(outcome: "dismissed" | "followed") {
+    retired = true;
+    retireFollowPrompt(outcome);
+  }
+</script>
+
+{#if !retired}
+  <aside class="follow-prompt" aria-label="Follow UPLB Tools">
+    <div class="follow-prompt__body">
+      <FollowUpdates {note} onfollow={() => retire("followed")} />
+    </div>
+    <IconButton
+      label="Dismiss follow suggestion"
+      class="follow-prompt__dismiss"
+      onclick={() => retire("dismissed")}
+    >
+      <X size={16} aria-hidden="true" />
+    </IconButton>
+  </aside>
+{/if}
+
+<style>
+  .follow-prompt {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border: 1px solid hsl(0, 0%, 88%);
+    border-radius: 0.5rem;
+    background: hsl(0, 0%, 98%);
+  }
+
+  .follow-prompt__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+
+  /* IconButton tops out at 2.25rem; the dismiss needs a full touch target. */
+  .follow-prompt :global(.follow-prompt__dismiss) {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .follow-prompt {
+      border-color: hsl(0, 0%, 28%);
+      background: hsl(0, 0%, 15%);
+    }
+
+    .follow-prompt :global(.follow-prompt__dismiss) {
+      color: hsl(0, 0%, 78%);
+    }
+  }
+</style>

--- a/src/components/svelte/community/FollowUpdates.svelte
+++ b/src/components/svelte/community/FollowUpdates.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import { FACEBOOK_URL, INSTAGRAM_URL } from "@constants/community-links";
+  import CommunityPlatformLink from "./CommunityPlatformLink.svelte";
+
+  type Props = {
+    /** What following actually gets them, in this surface's own words. */
+    note: string;
+    /** Called when either account is opened. */
+    onfollow?: () => void;
+  };
+
+  const { note, onfollow }: Props = $props();
+</script>
+
+<p class="follow-updates__note">{note}</p>
+<ul class="follow-updates__links">
+  <li>
+    <CommunityPlatformLink
+      brand="facebook"
+      href={FACEBOOK_URL}
+      label="UPLB Tools on Facebook"
+      onclick={onfollow}
+    />
+  </li>
+  <li>
+    <CommunityPlatformLink
+      brand="instagram"
+      href={INSTAGRAM_URL}
+      label="UPLB Tools on Instagram"
+      onclick={onfollow}
+    />
+  </li>
+</ul>
+
+<style>
+  .follow-updates__note {
+    margin: 0;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    color: hsl(0, 0%, 28%);
+    text-wrap: pretty;
+  }
+
+  .follow-updates__links {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    /* Column gap only: the 44px rows already carry the vertical rhythm. */
+    gap: 0 1rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  /* Inline brand links are text-sized by default; the touch target is not. */
+  .follow-updates__links :global(.community-platform-link) {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem;
+    font-size: 0.8125rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .follow-updates__note {
+      color: hsl(0, 0%, 72%);
+    }
+
+    .follow-updates__links :global(.community-platform-link) {
+      color: hsl(5, 65%, 76%);
+    }
+  }
+</style>

--- a/src/components/svelte/community/brands.ts
+++ b/src/components/svelte/community/brands.ts
@@ -1,0 +1,4 @@
+/** Community platforms that have a brand mark in `CommunityBrandIcon.svelte`.
+ *
+ * Shared so the icon and the link component cannot drift apart. */
+export type CommunityBrand = "discord" | "messenger" | "facebook" | "instagram";

--- a/src/components/svelte/modal/ChangelogModal.svelte
+++ b/src/components/svelte/modal/ChangelogModal.svelte
@@ -5,6 +5,7 @@
   import { parseChangelogEntries } from "@lib/changelog-highlights";
   import { releaseTimestampLabel } from "@lib/release-timestamps";
   import changelogRaw from "../../../../CHANGELOG.md?raw";
+  import FollowUpdates from "@ui/community/FollowUpdates.svelte";
 
   const entries = $derived(parseChangelogEntries(changelogRaw));
   const hasUpdate = $derived(syncToastStore.needRefresh);
@@ -60,6 +61,12 @@
         {/each}
       </section>
     {/each}
+  </div>
+
+  <div class="changelog-modal__follow">
+    <FollowUpdates
+      note="These notes also go out on Facebook and Instagram, along with term schedule drops and data fixes that ship without a release."
+    />
   </div>
 
   <div class="changelog-modal__actions">
@@ -184,6 +191,11 @@
     color: hsl(0, 0%, 22%);
     line-height: 1.4;
     list-style: disc;
+  }
+
+  .changelog-modal__follow {
+    padding-top: 0.625rem;
+    border-top: 1px solid hsl(0, 0%, 92%);
   }
 
   .changelog-modal__actions {

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -47,6 +47,7 @@
   import type { FinalExamRow, RoomData } from "@lib/types";
   import Classes from "./Classes.svelte";
   import FinalExamsList from "./FinalExamsList.svelte";
+  import FollowPrompt from "@ui/community/FollowPrompt.svelte";
     import TermSelector from "@ui/TermSelector.svelte";
 
   type RoomEditableField =
@@ -899,6 +900,15 @@
           <FinalExamsList exams={finalExams} />
         {/if}
       </section>
+    {/if}
+
+    <!-- Last child of the panel, and only once the schedule has actually
+         landed: the reader has their answer, and nothing above this can be
+         pushed around by it appearing. Asks at most once, ever. -->
+    {#if !roomClassesStore.loading}
+      <FollowPrompt
+        note="Room and class data changes through the term. Fixes, new features, and each term's schedule drop get posted on Facebook and Instagram."
+      />
     {/if}
   {:else if currentRoom.notFound}
     <p>Room not found.</p>

--- a/src/lib/local/clear-cached-data.test.ts
+++ b/src/lib/local/clear-cached-data.test.ts
@@ -5,6 +5,7 @@ import {
   PRESERVED_LOCAL_KEYS,
 } from "./clear-cached-data";
 import { PLANNER_LS_KEY } from "@lib/stores/store-types";
+import { FOLLOW_PROMPT_KEY } from "@lib/social-follow";
 
 const SYNC_KEYS = JSON.stringify({
   buildings: "b1",
@@ -104,6 +105,7 @@ describe("clearCachedData", () => {
     store.set("hideLandingModal", "true");
     store.set("recent-search", '["PSLH 1"]');
     store.set("sidebar-expanded", "false");
+    store.set(FOLLOW_PROMPT_KEY, "dismissed");
   });
 
   afterEach(() => {
@@ -124,6 +126,8 @@ describe("clearCachedData", () => {
     expect(store.get("hideLandingModal")).toBe("true");
     expect(store.get("recent-search")).toBe('["PSLH 1"]');
     expect(store.get("sidebar-expanded")).toBe("false");
+    // Re-asking someone who already said no is the dark pattern this avoids.
+    expect(store.get(FOLLOW_PROMPT_KEY)).toBe("dismissed");
   });
 
   it("lists the planner key among the preserved keys", () => {

--- a/src/lib/local/clear-cached-data.ts
+++ b/src/lib/local/clear-cached-data.ts
@@ -18,6 +18,7 @@ import { closeLocalDB } from "@lib/local/data/pgliteDB";
 import { invalidateLocalSyncKeys } from "@lib/local/data/invalidate-sync-key";
 import { getSyncKeysFromLs } from "@lib/local/data/sync-keys";
 import { PLANNER_LS_KEY } from "@lib/stores/store-types";
+import { FOLLOW_PROMPT_KEY } from "@lib/social-follow";
 
 /** IndexedDB database behind PGlite's `idb://site-data` (emscripten IDBFS mounts at `/pglite/<dataDir>`). */
 export const PGLITE_IDB_NAME = "/pglite/site-data";
@@ -25,12 +26,15 @@ export const PGLITE_IDB_NAME = "/pglite/site-data";
 /**
  * localStorage keys a clear must leave alone. The planner key is the user's
  * own work; the rest are preferences that are annoying, not dangerous, to lose.
+ * `hideLandingModal` and the follow-prompt key are both "stop showing me this",
+ * and re-asking someone who already said no is the one outcome worth avoiding.
  */
 export const PRESERVED_LOCAL_KEYS = [
   PLANNER_LS_KEY,
   "hideLandingModal",
   "recent-search",
   "sidebar-expanded",
+  FOLLOW_PROMPT_KEY,
 ] as const;
 
 /** A failed step must not abort the rest of the clear. */

--- a/src/lib/social-follow.ts
+++ b/src/lib/social-follow.ts
@@ -1,0 +1,37 @@
+/**
+ * One-time "follow the UPLB Tools accounts" suggestion.
+ *
+ * The whole point of this module is the frequency cap: the app asks once. Both
+ * outcomes retire the prompt for good — dismissing it because the reader said
+ * no, opening an account because the reader said yes. There is no snooze, no
+ * timer, and no second ask, so this is deliberately a one-way switch with no
+ * un-retire function.
+ *
+ * The key is in `PRESERVED_LOCAL_KEYS` (`src/lib/local/clear-cached-data.ts`)
+ * alongside `hideLandingModal`: "stop showing me this" is a preference, and
+ * clearing a broken bundle's cache must not resurrect it.
+ */
+
+export const FOLLOW_PROMPT_KEY = "social-follow-prompt";
+
+export type FollowPromptOutcome = "dismissed" | "followed";
+
+/** True once the reader has dismissed or acted on the prompt, on any visit. */
+export function isFollowPromptRetired(): boolean {
+  try {
+    return localStorage.getItem(FOLLOW_PROMPT_KEY) !== null;
+  } catch {
+    // SSR, or storage blocked. Never treat "cannot read" as "already asked".
+    return false;
+  }
+}
+
+/** Retire the prompt permanently. Idempotent. */
+export function retireFollowPrompt(outcome: FollowPromptOutcome): void {
+  try {
+    localStorage.setItem(FOLLOW_PROMPT_KEY, outcome);
+  } catch {
+    // Private mode / storage full: the dismissal cannot be remembered. Nothing
+    // to fall back to, and a silent failure beats blocking the click.
+  }
+}

--- a/src/lib/social-follow.ts
+++ b/src/lib/social-follow.ts
@@ -14,7 +14,12 @@
 
 export const FOLLOW_PROMPT_KEY = "social-follow-prompt";
 
-export type FollowPromptOutcome = "dismissed" | "followed";
+/** Views without an answer before the prompt retires itself. */
+export const FOLLOW_PROMPT_MAX_VIEWS = 3;
+
+const VIEW_COUNT_KEY = "social-follow-prompt-views";
+
+export type FollowPromptOutcome = "dismissed" | "followed" | "ignored";
 
 /** True once the reader has dismissed or acted on the prompt, on any visit. */
 export function isFollowPromptRetired(): boolean {
@@ -24,6 +29,32 @@ export function isFollowPromptRetired(): boolean {
     // SSR, or storage blocked. Never treat "cannot read" as "already asked".
     return false;
   }
+}
+
+/**
+ * Count a render, and retire the prompt once it has been shown
+ * FOLLOW_PROMPT_MAX_VIEWS times without an answer.
+ *
+ * Without this, someone who neither dismisses nor follows, and simply scrolls
+ * past, sees it again on every visit forever. For a reader who looks up a room
+ * most days that is a nag, which is the one thing this was not allowed to be.
+ * Ignoring something three times is an answer.
+ *
+ * Returns true when this render should still show the prompt.
+ */
+export function countFollowPromptView(): boolean {
+  if (isFollowPromptRetired()) return false;
+  try {
+    const seen = Number(localStorage.getItem(VIEW_COUNT_KEY) ?? "0") + 1;
+    localStorage.setItem(VIEW_COUNT_KEY, String(seen));
+    if (seen > FOLLOW_PROMPT_MAX_VIEWS) {
+      retireFollowPrompt("ignored");
+      return false;
+    }
+  } catch {
+    // Storage blocked: show it rather than treating the failure as an answer.
+  }
+  return true;
 }
 
 /** Retire the prompt permanently. Idempotent. */

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 import Layout from "@layouts/Layout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
+import FollowUpdates from "@ui/community/FollowUpdates.svelte";
 import * as changelog from "../../CHANGELOG.md";
 import releaseTimestamps from "../generated/release-timestamps.json";
 ---
@@ -26,6 +27,11 @@ import releaseTimestamps from "../generated/release-timestamps.json";
         the major updates and changes made to Room TBA since its initial
         release.
       </p>
+      <div class="hero__follow">
+        <FollowUpdates
+          note="Prefer not to check back? The releases worth knowing about are posted to the UPLB Tools accounts as they ship."
+        />
+      </div>
     </header>
 
     <div class="entries" set:html={changelog.compiledContent()} />
@@ -145,6 +151,13 @@ import releaseTimestamps from "../generated/release-timestamps.json";
     font-size: 1rem;
     line-height: 1.6;
     margin: 0;
+  }
+
+  .hero__follow {
+    max-width: 38rem;
+    margin-top: 0.25rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid hsl(0, 0%, 90%);
   }
 
   .entries {

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -2,6 +2,7 @@
 export const prerender = true;
 import Layout from "@layouts/Layout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
+import FollowUpdates from "@ui/community/FollowUpdates.svelte";
 import {
   UPLB_TOOLS_URL,
   GITHUB_ROOM_TBA_URL,
@@ -146,6 +147,23 @@ const reportIssueUrl = `${GITHUB_ROOM_TBA_URL}/issues/new/choose`;
             >. Signed-in contributors can use <strong>Suggest an edit</strong> in
             the app for many map fields.
           </p>
+        </div>
+      </details>
+
+      <details class="faq-item" id="updates">
+        <summary>How do I find out when something changes?</summary>
+        <div class="faq-answer">
+          <p>
+            Every release is listed on the <a href="/changelog">changelog</a>,
+            and the app shows a note when a new version is ready. The bigger
+            items also go out on the UPLB Tools accounts, so you see them
+            without opening the app.
+          </p>
+          <div class="faq-answer__follow">
+            <FollowUpdates
+              note="Posted there: new features, corrections to room and class data, and the day each term's schedules land."
+            />
+          </div>
         </div>
       </details>
 
@@ -339,6 +357,11 @@ const reportIssueUrl = `${GITHUB_ROOM_TBA_URL}/issues/new/choose`;
   .faq-answer a {
     color: hsl(5, 53%, 32%);
     font-weight: 600;
+  }
+
+  /* The Svelte child's <p> carries no astro-cid, so `p + p` above skips it. */
+  .faq-answer__follow {
+    margin-top: 0.625rem;
   }
 
   .faq-answer code {


### PR DESCRIPTION
The links already existed in `campus.config.ts` and rendered in `SiteFooter.astro`. The footer was the only surface, so nobody followed. This adds four placements: **one ask, three passive**.

The rule I worked to: put the ask where the user has just been well served, say what following actually gets them, make it trivially ignorable, and never ask twice.

## Placements

### 1. Room panel, bottom (the only dismissable ask)

**Where:** last child of `RoomResult.svelte`, after the schedule and final-exams sections.
**When:** the room resolved and `roomClassesStore.loading` is false. Never during the skeleton.
**Why this moment:** looking up a room is the app's namesake job and its highest-volume success. The reader has their answer, so the ask costs them nothing. It is the last element in the panel, so nothing above it can be pushed around when it appears.
**Copy:** "Room and class data changes through the term. Fixes, new features, and each term's schedule drop get posted on Facebook and Instagram."
**Dismissed by:** an X button (`aria-label="Dismiss follow suggestion"`, 44x44). Opening either account also retires it. Both write `social-follow-prompt` to localStorage, and the component reads that key once at init, so it never renders again on any later visit.

### 2. FAQ, "How do I find out when something changes?"

**When:** always. Passive, nothing to dismiss.
**Why:** a real question a student actually has, answered honestly (changelog first, in-app update note second, the accounts third). Reading mindset, zero interruption.
**Copy:** "Posted there: new features, corrections to room and class data, and the day each term's schedules land."

### 3. Changelog page hero

**When:** always. Passive.
**Why:** someone on `/changelog` is already checking for updates. Naming the alternative to checking back is useful information, not a pitch.
**Copy:** "Prefer not to check back? The releases worth knowing about are posted to the UPLB Tools accounts as they ship."

### 4. What's new modal

**When:** always, in a modal the user opened themselves. Passive.
**Why:** same reading mindset as the changelog page, different audience (returning in-app users). Sits between the entries and the buttons, so it never competes with "Reload to update".
**Copy:** "These notes also go out on Facebook and Instagram, along with term schedule drops and data fixes that ship without a release."

## Dismissal model

One key, `social-follow-prompt`, value `dismissed` or `followed`. One-way switch, no un-retire function exists.

- **Persisted, not per session.** Read once at component init, not in an effect, so it cannot come back mid-session either.
- **Both outcomes retire it.** Saying no and saying yes both end the asking.
- **Survives a cache clear.** The key is in `PRESERVED_LOCAL_KEYS`, next to `hideLandingModal`. "Clear cached data" fixes a broken bundle; it must not resurrect a dismissal. Asserted in `clear-cached-data.test.ts`.
- **Storage failures fail open, not closed.** If localStorage throws (private mode, blocked), the prompt shows rather than silently treating "cannot read" as "already asked". It just cannot remember, which is a degraded-but-honest outcome instead of a broken one.

## Patterns I deliberately did NOT use

- **Interstitials, modals, popups.** Nothing interrupts a task. The one ask is an inline block at the bottom of a panel the user was already scrolling.
- **Blocking or delaying content.** Nothing gates on following.
- **Confirmshaming.** The dismiss control is an unlabeled X, not "No thanks, I don't want campus updates".
- **Fake or inflated counts, urgency, scarcity.** No follower counts at all. A real count would need an API call and a real number is not persuasive at this size; a fake one is a lie.
- **Auto-opening a social app or tab.** Links only, on click.
- **Reappearing after dismissal, or no dismissal path.** The whole point of the storage key. A dismissal that does not stick is what turns this into a dark pattern, so it has its own tests.
- **Pre-checked opt-ins.** No checkboxes anywhere.
- **Timers and per-visit nagging.** No `setTimeout`, no snooze, no "ask again in 14 days". Deliberately unlike `PWAInstallPrompt`, which re-asks after 14 days. This one never re-asks.
- **Disguising the link.** Real brand marks, and the accessible names are literally "UPLB Tools on Facebook" / "UPLB Tools on Instagram".

Per the brief's frequency cap, the prompt does persist across visits **until** the reader dismisses it or follows. Someone who neither acts nor dismisses still sees it. That is the "dismissed nothing and simply did not act" carve-out, not a nag loop: it is inline, silent, and one click from gone forever.

### Placements I considered and rejected

- **Contribution success toast.** Strong moment, but a toast is transient and a poor host for links that need to stay keyboard-reachable.
- **Planner.** A good moment, but the cap is one ask per user, so a second ask surface would only race the first. Fewer, better-placed beats more.
- **Site footer redesign.** Already present and working. Left alone.
- **Search results and map chrome.** High traffic, but the user is mid-task there, not finished.

## Implementation notes

- Extends the existing `CommunityBrandIcon` with `facebook` and `instagram` rather than adding a parallel icon component. The `Brand` union moved to `brands.ts` so the icon and link components cannot drift.
- `CommunityPlatformLink` gained one optional `onclick`. It already had `target="_blank" rel="noopener noreferrer"`.
- No new dependency. Reuses `IconButton`, `CommunityPlatformLink`, and the existing colour and spacing conventions.
- Touch targets measured in a real browser at 320px: both links render exactly 44px tall, dismiss button 44x44, no horizontal overflow.
- Theme-aware via `prefers-color-scheme`, which matters where these render inside the dark wiki layout.

## Verify

| Step | Result |
| --- | --- |
| `bunx biome ci .` | exit 0 |
| `bun run test` | 615 pass, 0 fail |
| `bun run test:components` | 246 pass, 0 fail (56 files) |
| `bun run build` | exit 0 |

New tests: 5 in `FollowPrompt.component.test.ts` covering dismissal persistence across a remount, follow-retires-too, a pre-existing dismissal hiding it before first paint, outbound link attributes, and the storage-throws path. Plus 3 brand-icon tests and 1 assertion that a dismissal survives `clearCachedData`.
