### PR TITLE
ci: stop a Discord delivery failure from turning main red

### DIFF
--- a/.github/workflows/discord-test-inventory.yml
+++ b/.github/workflows/discord-test-inventory.yml
@@ -44,4 +44,8 @@ jobs:
             echo "::warning::NOTIFICATION_GATEWAY_URL or NOTIFICATION_INGRESS_SECRET not set — Discord test inventory skipped"
             exit 0
           fi
-          bun run scripts/post-test-inventory-discord.ts
+          # Delivery is best effort, same as the unconfigured case above. The
+          # gateway returning 500 says nothing about the commit, so it should
+          # not turn main red and send people hunting for a build break.
+          bun run scripts/post-test-inventory-discord.ts ||
+            echo "::warning::Discord test inventory delivery failed, see the log above"


### PR DESCRIPTION
Main went red after #950 on `Discord test inventory`, not on anything in the commit:

```
error: Discord notify failed (500): {"error":"Delivery failed"}
```

The gateway returned a 500. The step already exits 0 with a warning when `NOTIFICATION_GATEWAY_URL` or `NOTIFICATION_INGRESS_SECRET` is unset, so delivery was always best effort. A delivery failure should behave the same way rather than reporting a broken build.

Now emits `::warning::` and continues. The error still appears in the log and the warning shows in the run summary, so a persistently down gateway stays visible without a red main sending people hunting for a build break.

Verified the step body parses (`bash -n`) and the workflow is valid YAML.