### PR TITLE
test(pglite): give the schema idempotency test a real timeout

### DIFF
--- a/src/lib/local/data/pglite-schema.test.ts
+++ b/src/lib/local/data/pglite-schema.test.ts
@@ -14,6 +14,11 @@ describe("pglite offline schema", () => {
     expect(committed).toBe(buildGeneratedModule());
   });
 
+  // Timeout is 30s, not bun's 5s default: booting a WASM Postgres and running
+  // the whole schema twice sits right on that default, so this failed
+  // intermittently on a loaded machine and passed on the retry. The work is not
+  // slow enough to be worth splitting, it just needs a bound that is not a coin
+  // flip.
   test("init SQL runs on a fresh PGlite and is idempotent", async () => {
     const db = new PGlite();
     await db.exec(PGLITE_INIT_SQL);
@@ -24,7 +29,7 @@ describe("pglite offline schema", () => {
     );
     expect(rows[0]?.count).toBe(0);
     await db.close();
-  });
+  }, 30_000);
 
   test("covers every column sync.ts writes", () => {
     // Spot-check the columns that drifted historically.


### PR DESCRIPTION
`pglite offline schema > init SQL runs on a fresh PGlite and is idempotent` fails intermittently. Same input, back to back:

```
1 pass  1 fail (run 1)
2 pass  0 fail (run 2)
```

It boots a WASM Postgres and runs the full schema twice, measured at 9.3s in the failing run, against bun's 5s default timeout. Not a logic bug, just a bound set by accident.

Raised to 30s. Four consecutive runs pass afterwards.

Found while widening the test glob in #956. Kept separate since it is unrelated to that change.