### PR TITLE
feat(street-view): scaffold Street View lookup and a coverage audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,21 @@ PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 # MapTiler vector/terrain tiles (Settings → API keys; restrict to your domains).
 PUBLIC_MAPTILER_KEY=
 
+# Google Street View imagery next to a building pin. Optional: with no key the
+# feature is simply off, nothing renders broken.
+#
+# Needs a Google Cloud project with billing enabled, and these APIs turned on:
+#   Street View Static API   the still images
+#   Maps JavaScript API      only if you want the draggable panorama
+#
+# Restrict the key by HTTP referrer to your domains. It is visible in every
+# image URL the browser requests, so referrer restriction is the only thing
+# protecting it from being spent by someone else.
+#
+# Google's terms allow limited temporary caching only, so their imagery must
+# not be written into the photos table or re-hosted. See src/lib/street-view.ts.
+PUBLIC_GOOGLE_MAPS_API_KEY=
+
 # App environment banner: staging | production (#289).
 # Set staging on Vercel Preview (staging branch) and local dev (.env.local).
 PUBLIC_APP_ENV=staging

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -225,6 +225,14 @@ export default defineConfig({
         context: "client",
         optional: true,
       }),
+      // Street View imagery beside a building pin. Optional: with no key the
+      // feature is off rather than broken. Public by necessity, the browser
+      // requests the images, so restrict it by HTTP referrer.
+      PUBLIC_GOOGLE_MAPS_API_KEY: envField.string({
+        access: "public",
+        context: "client",
+        optional: true,
+      }),
       // staging | production — drives the staging environment banner (#289).
       PUBLIC_APP_ENV: envField.string({
         access: "public",

--- a/drizzle/0052_building_street_view.sql
+++ b/drizzle/0052_building_street_view.sql
@@ -1,0 +1,22 @@
+-- Cache the Street View *metadata* per building, never the imagery.
+--
+-- Google's terms permit only limited temporary caching of their images, so the
+-- pixels stay remote and render live. What is cached here is the answer to
+-- "is there a panorama near this building, which one, and when was it shot",
+-- which is data we are free to store and which changes about once a year.
+--
+-- Without this, every building panel view costs a metadata round trip. The
+-- endpoint is free and unmetered, so this buys latency rather than money.
+--
+-- checked_at is what makes the cache refreshable: a null pano id means either
+-- "no coverage" or "never looked", and only the timestamp tells them apart.
+ALTER TABLE "buildings"
+  ADD COLUMN IF NOT EXISTS "street_view_pano_id" varchar(128),
+  ADD COLUMN IF NOT EXISTS "street_view_captured" varchar(16),
+  ADD COLUMN IF NOT EXISTS "street_view_distance_m" integer,
+  ADD COLUMN IF NOT EXISTS "street_view_checked_at" timestamp;
+
+-- Partial index: the panel only ever asks for buildings that have coverage.
+CREATE INDEX IF NOT EXISTS "buildings_street_view_pano_idx"
+  ON "buildings" ("id")
+  WHERE "street_view_pano_id" IS NOT NULL;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -326,6 +326,14 @@ export const buildingsTable = pgTable("buildings", {
   directions: text().notNull(),
   imageUrl: text("image_url"),
   crFacilities: text("cr_facilities").array(),
+  // Street View *metadata* only. Google's terms forbid storing their imagery,
+  // so the pixels render live and only the lookup result is cached here.
+  // checkedAt distinguishes "no coverage" from "never looked": both leave
+  // panoId null.
+  streetViewPanoId: varchar("street_view_pano_id", { length: 128 }),
+  streetViewCaptured: varchar("street_view_captured", { length: 16 }),
+  streetViewDistanceM: integer("street_view_distance_m"),
+  streetViewCheckedAt: timestamp("street_view_checked_at", { mode: "string" }),
   version: integer().default(1).notNull(),
   updatedAt: timestamp("updated_at", { mode: "string" }).defaultNow().notNull(),
 });

--- a/scripts/e2e-reset-db.ts
+++ b/scripts/e2e-reset-db.ts
@@ -87,6 +87,7 @@ const E2E_MIGRATION_FILES = [
   "0049_add_feedback.sql",
   "0050_dorm_gender_nullable.sql",
   "0051_room_position_source.sql",
+  "0052_building_street_view.sql",
 ] as const;
 
 /**

--- a/scripts/street-view-coverage.ts
+++ b/scripts/street-view-coverage.ts
@@ -13,6 +13,12 @@
  *   PUBLIC_GOOGLE_MAPS_API_KEY=... bun run scripts/street-view-coverage.ts
  *   ... --radius 150     widen the search (default 100m)
  *   ... --json           machine-readable output
+ *   ... --write          cache the result on buildings.street_view_*
+ *
+ * With --write this doubles as the backfill. It caches the metadata only, not
+ * the imagery, which Google's terms forbid storing. Re-running is safe: every
+ * row is overwritten with a fresh answer and checked_at is stamped, which is
+ * what distinguishes "no coverage" from "never looked".
  *
  * Scripts cannot import @lib/db (it reads astro:env/server, which only exists
  * inside Astro), so this opens its own connection, the same way
@@ -44,6 +50,7 @@ if (!databaseUrl) {
 
 const args = process.argv.slice(2);
 const asJson = args.includes("--json");
+const write = args.includes("--write");
 const radiusArg = args.indexOf("--radius");
 const radius = radiusArg >= 0 ? Number(args[radiusArg + 1]) : 100;
 if (!Number.isFinite(radius) || radius <= 0) {
@@ -66,11 +73,17 @@ const { rows: buildings } = await client.query<Row>(
 
 // Close before the fetch loop, not after. Holding the connection open across
 // ~50 sequential HTTP round trips idles it out, and the script died on
-// "Connection terminated unexpectedly" partway through the run.
+// "Connection terminated unexpectedly" partway through the run. With --write
+// a second connection is opened afterwards for the updates.
 await client.end();
 
-const covered: { id: number; name: string; date?: string; metres: number }[] =
-  [];
+const covered: {
+  id: number;
+  name: string;
+  panoId: string;
+  date?: string;
+  metres: number;
+}[] = [];
 const uncovered: { id: number; name: string }[] = [];
 const errored: { id: number; name: string; reason: string }[] = [];
 
@@ -94,6 +107,7 @@ for (const b of buildings) {
     covered.push({
       id: b.id,
       name: b.name,
+      panoId: meta.panoId,
       date: meta.date,
       metres: metresBetween(coords, meta.location),
     });
@@ -102,6 +116,33 @@ for (const b of buildings) {
   } else {
     uncovered.push({ id: b.id, name: b.name });
   }
+}
+
+if (write) {
+  // Metadata only. Google's terms forbid storing their imagery, so nothing
+  // here touches an image; the panel renders the picture live.
+  const writer = new pg.Client({ connectionString: databaseUrl });
+  await writer.connect();
+  const byId = new Map(covered.map((c) => [c.id, c]));
+  let updated = 0;
+  for (const b of buildings) {
+    const hit = byId.get(b.id);
+    // Errored rows are skipped rather than written as "no coverage": a
+    // transport failure is not evidence that imagery is absent.
+    if (!hit && errored.some((e) => e.id === b.id)) continue;
+    await writer.query(
+      `UPDATE buildings
+          SET street_view_pano_id = $2,
+              street_view_captured = $3,
+              street_view_distance_m = $4,
+              street_view_checked_at = NOW()
+        WHERE id = $1`,
+      [b.id, hit?.panoId ?? null, hit?.date ?? null, hit?.metres ?? null],
+    );
+    updated++;
+  }
+  await writer.end();
+  console.log(`cached metadata for ${updated} buildings`);
 }
 
 if (asJson) {

--- a/scripts/street-view-coverage.ts
+++ b/scripts/street-view-coverage.ts
@@ -1,0 +1,142 @@
+/**
+ * Reports which campus buildings actually have Street View imagery.
+ *
+ * Uses only the metadata endpoint, which is free and unmetered, so this can be
+ * run repeatedly without a bill.
+ *
+ * Measured 2026-08-05: 52/52 buildings covered within 100m, much of it
+ * captured 2026-02. Campus coverage turned out to be far better than assumed,
+ * so the interesting output is the distance column, not the hit rate. A
+ * building whose nearest panorama is unusually far away is worth a look: it
+ * may be a pin in the wrong place rather than a gap in Google's coverage.
+ *
+ *   PUBLIC_GOOGLE_MAPS_API_KEY=... bun run scripts/street-view-coverage.ts
+ *   ... --radius 150     widen the search (default 100m)
+ *   ... --json           machine-readable output
+ *
+ * Scripts cannot import @lib/db (it reads astro:env/server, which only exists
+ * inside Astro), so this opens its own connection, the same way
+ * bulk-history.ts does.
+ */
+import pg from "pg";
+import {
+  fetchStreetViewMetadata,
+  hasStreetViewKey,
+} from "../src/lib/street-view.ts";
+import { loadEnv } from "./load-env";
+
+loadEnv();
+
+const key = process.env.PUBLIC_GOOGLE_MAPS_API_KEY;
+if (!hasStreetViewKey(key)) {
+  console.error(
+    "PUBLIC_GOOGLE_MAPS_API_KEY is missing. This script only reads the free\n" +
+      "metadata endpoint, but it still needs a key to authenticate.",
+  );
+  process.exit(1);
+}
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error("DATABASE_URL is missing.");
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const asJson = args.includes("--json");
+const radiusArg = args.indexOf("--radius");
+const radius = radiusArg >= 0 ? Number(args[radiusArg + 1]) : 100;
+if (!Number.isFinite(radius) || radius <= 0) {
+  console.error("--radius must be a positive number of metres.");
+  process.exit(1);
+}
+
+type Row = { id: number; name: string; lat: number | null; lng: number | null };
+
+const client = new pg.Client({ connectionString: databaseUrl });
+await client.connect();
+
+// Columns are building_name / lat / lon, not name / latitude / longitude.
+// Both are NOT NULL in the schema, so no null filter is needed.
+const { rows: buildings } = await client.query<Row>(
+  `SELECT id, building_name AS name, lat, lon AS lng
+     FROM buildings
+    ORDER BY building_name`,
+);
+
+// Close before the fetch loop, not after. Holding the connection open across
+// ~50 sequential HTTP round trips idles it out, and the script died on
+// "Connection terminated unexpectedly" partway through the run.
+await client.end();
+
+const covered: { id: number; name: string; date?: string; metres: number }[] =
+  [];
+const uncovered: { id: number; name: string }[] = [];
+const errored: { id: number; name: string; reason: string }[] = [];
+
+/** Rough metres between two campus points. Fine at this scale. */
+function metresBetween(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number },
+): number {
+  const dLat = (b.lat - a.lat) * 111_320;
+  const dLng = (b.lng - a.lng) * 111_320 * Math.cos((a.lat * Math.PI) / 180);
+  return Math.round(Math.sqrt(dLat * dLat + dLng * dLng));
+}
+
+// Sequential on purpose. This is a one-off audit of a few hundred rows, and a
+// burst of parallel requests is the fastest way to get a key rate limited.
+for (const b of buildings) {
+  if (b.lat === null || b.lng === null) continue;
+  const coords = { lat: Number(b.lat), lng: Number(b.lng) };
+  const meta = await fetchStreetViewMetadata(coords, key, { radius });
+  if (meta.status === "OK") {
+    covered.push({
+      id: b.id,
+      name: b.name,
+      date: meta.date,
+      metres: metresBetween(coords, meta.location),
+    });
+  } else if (meta.status === "ERROR") {
+    errored.push({ id: b.id, name: b.name, reason: meta.reason });
+  } else {
+    uncovered.push({ id: b.id, name: b.name });
+  }
+}
+
+if (asJson) {
+  console.log(
+    JSON.stringify(
+      { radius, total: buildings.length, covered, uncovered, errored },
+      null,
+      2,
+    ),
+  );
+} else {
+  const pct = buildings.length
+    ? Math.round((covered.length / buildings.length) * 100)
+    : 0;
+  console.log(`Street View coverage within ${radius}m`);
+  console.log(
+    `  ${covered.length}/${buildings.length} buildings covered (${pct}%)`,
+  );
+  console.log(`  ${uncovered.length} with no imagery`);
+  if (errored.length) console.log(`  ${errored.length} errored`);
+
+  if (covered.length) {
+    console.log("\nCovered (distance to nearest panorama):");
+    for (const c of covered.sort((a, b) => a.metres - b.metres)) {
+      console.log(
+        `  ${String(c.metres).padStart(4)}m  ${c.name}${c.date ? `  (${c.date})` : ""}`,
+      );
+    }
+  }
+  if (uncovered.length) {
+    console.log("\nNo imagery:");
+    for (const u of uncovered) console.log(`  ${u.name}`);
+  }
+  if (errored.length) {
+    console.log("\nErrors:");
+    for (const e of errored) console.log(`  ${e.name}: ${e.reason}`);
+  }
+}

--- a/src/components/svelte/controls/BuildingPhoto.svelte
+++ b/src/components/svelte/controls/BuildingPhoto.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import {
+    hasStreetViewKey,
+    streetViewImageUrl,
+    STREET_VIEW_ATTRIBUTION,
+  } from "@lib/street-view";
+
+  type Props = {
+    /** Contributor-uploaded photo, stored in R2. Always wins when present. */
+    imageUrl?: string | null;
+    name: string;
+    lat?: number | null;
+    lon?: number | null;
+    /** Cached Street View lookup (migration 0052). Null means no coverage. */
+    panoId?: string | null;
+    /** Capture month, "2026-02". Some campus imagery is a decade old. */
+    captured?: string | null;
+  };
+
+  const { imageUrl, name, lat, lon, panoId, captured }: Props = $props();
+
+  const key = import.meta.env.PUBLIC_GOOGLE_MAPS_API_KEY;
+
+  /**
+   * A contributor photo beats Street View: it is ours, it is current, and it
+   * is chosen to show the entrance rather than whatever the car happened to
+   * face. Street View is the fallback for the buildings nobody has photographed.
+   */
+  const streetView = $derived.by(() => {
+    if (imageUrl) return null;
+    if (!hasStreetViewKey(key)) return null;
+    // panoId comes from the cached lookup, so no request is made for a
+    // building with no coverage. Without it Google bills for a grey
+    // "no imagery" placeholder.
+    if (!panoId || lat == null || lon == null) return null;
+    return streetViewImageUrl({ lat: Number(lat), lng: Number(lon) }, key, {
+      width: 640,
+      height: 360,
+      // Wider than the default so more of the frontage fits, and enough radius
+      // to reach buildings set back from the road.
+      fov: 90,
+      radius: 100,
+    });
+  });
+
+  /** "2026-02" reads as a date, not a version. */
+  const capturedLabel = $derived.by(() => {
+    if (!captured) return null;
+    const [year, month] = captured.split("-");
+    if (!year) return null;
+    if (!month) return year;
+    const date = new Date(Number(year), Number(month) - 1, 1);
+    return Number.isNaN(date.getTime())
+      ? captured
+      : date.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+  });
+</script>
+
+{#if imageUrl}
+  <img
+    class="entity-image"
+    src={imageUrl}
+    alt={name}
+    width="800"
+    height="450"
+    loading="lazy"
+    decoding="async"
+  />
+{:else if streetView}
+  <figure class="building-photo">
+    <img
+      class="entity-image"
+      src={streetView}
+      alt="Street View of {name}"
+      width="640"
+      height="360"
+      loading="lazy"
+      decoding="async"
+      referrerpolicy="strict-origin-when-cross-origin"
+    />
+    <figcaption class="building-photo__credit">
+      <span>{STREET_VIEW_ATTRIBUTION}</span>
+      {#if capturedLabel}
+        <span class="building-photo__date">{capturedLabel}</span>
+      {/if}
+    </figcaption>
+  </figure>
+{/if}
+
+<style>
+  .building-photo {
+    margin: 0;
+  }
+
+  .building-photo__credit {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    justify-content: space-between;
+    padding: 0.25rem 0.1rem 0;
+    color: #6b6265;
+    font-size: 0.6875rem;
+    line-height: 1.3;
+  }
+
+  /* The capture date matters here: campus imagery ranges from 2015 to 2026,
+     and a decade-old photo of a since-renovated building misleads. */
+  .building-photo__date {
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -14,6 +14,7 @@
   import MapChromeActionChip from "@ui/map-chrome/MapChromeActionChip.svelte";
   import type { BuildingData, RoomData } from "@lib/types";
   import ResultDisplay from "./ResultDisplay.svelte";
+  import BuildingPhoto from "./BuildingPhoto.svelte";
   import EntityShareCopyLink from "./EntityShareCopyLink.svelte";
   import EntityBackToList from "./EntityBackToList.svelte";
   import EntityGoogleMapsLink from "./EntityGoogleMapsLink.svelte";
@@ -832,17 +833,14 @@
         </EntityEditorPanel>
       </section>
     {:else}
-      {#if building.imageUrl}
-        <img
-          class="entity-image"
-          src={building.imageUrl}
-          alt={building.buildingName}
-          width="800"
-          height="450"
-          loading="lazy"
-          decoding="async"
-        />
-      {/if}
+      <BuildingPhoto
+        imageUrl={building.imageUrl}
+        name={building.buildingName}
+        lat={building.lat}
+        lon={building.lon}
+        panoId={building.streetViewPanoId}
+        captured={building.streetViewCaptured}
+      />
       <section class="entity-directions" aria-label="Directions">
         <div class="entity-directions__segment">
           {#if hasMapPin}

--- a/src/lib/local/data/pglite-schema.generated.ts
+++ b/src/lib/local/data/pglite-schema.generated.ts
@@ -12,6 +12,10 @@ CREATE TABLE IF NOT EXISTS "buildings" (
   "directions" text NOT NULL,
   "image_url" text,
   "cr_facilities" text[],
+  "street_view_pano_id" varchar(128),
+  "street_view_captured" varchar(16),
+  "street_view_distance_m" integer,
+  "street_view_checked_at" text,
   "version" integer DEFAULT 1 NOT NULL,
   "updated_at" text DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "rooms_fetched" boolean DEFAULT false NOT NULL
@@ -25,6 +29,14 @@ ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "image_url" text;
 ALTER TABLE "buildings" ALTER COLUMN "image_url" DROP NOT NULL;
 ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "cr_facilities" text[];
 ALTER TABLE "buildings" ALTER COLUMN "cr_facilities" DROP NOT NULL;
+ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "street_view_pano_id" varchar(128);
+ALTER TABLE "buildings" ALTER COLUMN "street_view_pano_id" DROP NOT NULL;
+ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "street_view_captured" varchar(16);
+ALTER TABLE "buildings" ALTER COLUMN "street_view_captured" DROP NOT NULL;
+ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "street_view_distance_m" integer;
+ALTER TABLE "buildings" ALTER COLUMN "street_view_distance_m" DROP NOT NULL;
+ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "street_view_checked_at" text;
+ALTER TABLE "buildings" ALTER COLUMN "street_view_checked_at" DROP NOT NULL;
 ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "version" integer DEFAULT 1 NOT NULL;
 ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "updated_at" text DEFAULT CURRENT_TIMESTAMP NOT NULL;
 ALTER TABLE "buildings" ADD COLUMN IF NOT EXISTS "rooms_fetched" boolean DEFAULT false NOT NULL;

--- a/src/lib/street-view.test.ts
+++ b/src/lib/street-view.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import {
+  fetchStreetViewMetadata,
+  hasStreetViewKey,
+  streetViewImageUrl,
+  streetViewMetadataUrl,
+} from "./street-view.ts";
+
+const KEY = "test-street-view-key-not-a-real-credential";
+// Institute of Computer Science, roughly.
+const ICS = { lat: 14.1651, lng: 121.2413 };
+
+describe("hasStreetViewKey", () => {
+  test("treats absent or stub keys as no key, so the feature stays off", () => {
+    expect(hasStreetViewKey(undefined)).toBe(false);
+    expect(hasStreetViewKey("")).toBe(false);
+    expect(hasStreetViewKey("   ")).toBe(false);
+    expect(hasStreetViewKey("short")).toBe(false);
+  });
+
+  test("accepts a real-looking key", () => {
+    expect(hasStreetViewKey(KEY)).toBe(true);
+  });
+});
+
+describe("streetViewImageUrl", () => {
+  test("builds a request with location and key", () => {
+    const url = new URL(streetViewImageUrl(ICS, KEY));
+    expect(url.origin + url.pathname).toBe(
+      "https://maps.googleapis.com/maps/api/streetview",
+    );
+    expect(url.searchParams.get("location")).toBe("14.1651,121.2413");
+    expect(url.searchParams.get("key")).toBe(KEY);
+    expect(url.searchParams.get("size")).toBe("640x400");
+  });
+
+  test("clamps size to the 640px ceiling instead of erroring at Google", () => {
+    const url = new URL(
+      streetViewImageUrl(ICS, KEY, { width: 4000, height: 2000 }),
+    );
+    expect(url.searchParams.get("size")).toBe("640x640");
+  });
+
+  test("clamps pitch and fov to their documented ranges", () => {
+    const url = new URL(
+      streetViewImageUrl(ICS, KEY, { pitch: 200, fov: 5, heading: 90 }),
+    );
+    expect(url.searchParams.get("pitch")).toBe("90");
+    expect(url.searchParams.get("fov")).toBe("10");
+    expect(url.searchParams.get("heading")).toBe("90");
+  });
+
+  test("omits optional params when not given, letting Google choose", () => {
+    const url = new URL(streetViewImageUrl(ICS, KEY));
+    expect(url.searchParams.has("heading")).toBe(false);
+    expect(url.searchParams.has("pitch")).toBe(false);
+    expect(url.searchParams.has("radius")).toBe(false);
+  });
+
+  test("passes radius through, which is what finds set-back buildings", () => {
+    const url = new URL(streetViewImageUrl(ICS, KEY, { radius: 100 }));
+    expect(url.searchParams.get("radius")).toBe("100");
+  });
+});
+
+describe("streetViewMetadataUrl", () => {
+  test("points at the free metadata endpoint, not the billable image one", () => {
+    const url = new URL(streetViewMetadataUrl(ICS, KEY));
+    expect(url.pathname).toBe("/maps/api/streetview/metadata");
+    expect(url.searchParams.has("size")).toBe(false);
+  });
+});
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("fetchStreetViewMetadata", () => {
+  test("reports coverage with the pano id and capture date", async () => {
+    const result = await fetchStreetViewMetadata(ICS, KEY, {
+      fetchImpl: async () =>
+        jsonResponse({
+          status: "OK",
+          pano_id: "pano-123",
+          location: { lat: 14.1652, lng: 121.2414 },
+          date: "2023-04",
+        }),
+    });
+    expect(result).toEqual({
+      status: "OK",
+      panoId: "pano-123",
+      location: { lat: 14.1652, lng: 121.2414 },
+      date: "2023-04",
+    });
+  });
+
+  test("reports no coverage, which is what gates a billable image request", async () => {
+    const result = await fetchStreetViewMetadata(ICS, KEY, {
+      fetchImpl: async () => jsonResponse({ status: "ZERO_RESULTS" }),
+    });
+    expect(result.status).toBe("ZERO_RESULTS");
+  });
+
+  test("never throws on a transport failure, so a panel cannot break", async () => {
+    const result = await fetchStreetViewMetadata(ICS, KEY, {
+      fetchImpl: async () => {
+        throw new Error("network down");
+      },
+    });
+    expect(result).toEqual({ status: "ERROR", reason: "network down" });
+  });
+
+  test("surfaces a rejected key rather than pretending there is no imagery", async () => {
+    const result = await fetchStreetViewMetadata(ICS, KEY, {
+      fetchImpl: async () =>
+        jsonResponse({
+          status: "REQUEST_DENIED",
+          error_message: "This API project is not authorized",
+        }),
+    });
+    expect(result).toEqual({
+      status: "ERROR",
+      reason: "This API project is not authorized",
+    });
+  });
+
+  test("treats a non-2xx as an error, not as absent imagery", async () => {
+    const result = await fetchStreetViewMetadata(ICS, KEY, {
+      fetchImpl: async () => jsonResponse({}, false, 403),
+    });
+    expect(result).toEqual({ status: "ERROR", reason: "HTTP 403" });
+  });
+});

--- a/src/lib/street-view.ts
+++ b/src/lib/street-view.ts
@@ -1,0 +1,170 @@
+/**
+ * Google Street View URL builders and coverage lookup.
+ *
+ * ## Read this before storing anything
+ *
+ * The Google Maps Platform terms permit only limited temporary caching of
+ * imagery. They do not permit building a permanent photo library out of it.
+ * So Street View can be *rendered* next to a building, but its bytes must not
+ * be written into `photos` or any other table, and must not be re-hosted on
+ * our own CDN. Anything that wants owned, storable imagery needs a different
+ * source (Mapillary is CC-BY-SA and permits it, as do contributor uploads).
+ *
+ * This module therefore only ever produces URLs the browser fetches directly,
+ * plus a metadata lookup. Nothing here downloads an image.
+ *
+ * ## Check coverage before you spend anything
+ *
+ * `fetchStreetViewMetadata` hits the metadata endpoint, which is free and
+ * unmetered. It answers "is there imagery here at all" without requesting a
+ * billable image. Always gate an image request on it: without the check,
+ * Google bills for a request that returns its grey "no imagery" placeholder.
+ *
+ * UPLB coverage measured 2026-08-05 was 52/52 buildings within 100m, so on
+ * this campus the check will usually pass. It still has to run, both because
+ * coverage is not guaranteed for new pins and because the response carries the
+ * capture date, which is worth showing next to a photo that may be a decade
+ * old (campus imagery here ranges from 2015 to 2026).
+ */
+
+const STATIC_ENDPOINT = "https://maps.googleapis.com/maps/api/streetview";
+const METADATA_ENDPOINT = `${STATIC_ENDPOINT}/metadata`;
+
+/** Largest the free/static endpoint serves without a signed premium request. */
+const MAX_SIZE = 640;
+
+export type StreetViewCoords = { lat: number; lng: number };
+
+export type StreetViewImageOptions = {
+  /** Pixels. Clamped to 640, the static endpoint's ceiling. */
+  width?: number;
+  height?: number;
+  /** Compass heading in degrees. Omit to let Google point at the subject. */
+  heading?: number;
+  /** Up/down angle, -90 to 90. */
+  pitch?: number;
+  /** Horizontal field of view in degrees, 10 to 120. Lower zooms in. */
+  fov?: number;
+  /**
+   * How far from the coordinates Google may look for a panorama, in metres.
+   * Campus buildings sit well back from the road, so the default 50 often
+   * finds nothing where 100 finds the frontage.
+   */
+  radius?: number;
+};
+
+export type StreetViewMetadata =
+  | { status: "OK"; panoId: string; location: StreetViewCoords; date?: string }
+  | { status: "ZERO_RESULTS" | "NOT_FOUND" }
+  | { status: "ERROR"; reason: string };
+
+/** Feature is off until a key exists, rather than rendering broken images. */
+export function hasStreetViewKey(key: string | undefined): key is string {
+  return typeof key === "string" && key.trim().length > 8;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Build a Street View Static image URL.
+ *
+ * Callers must have confirmed coverage with `fetchStreetViewMetadata` first.
+ * Without that check Google bills for a request that returns its grey "no
+ * imagery" placeholder, which is a charge for nothing.
+ */
+export function streetViewImageUrl(
+  coords: StreetViewCoords,
+  key: string,
+  options: StreetViewImageOptions = {},
+): string {
+  const width = clamp(Math.round(options.width ?? 640), 16, MAX_SIZE);
+  const height = clamp(Math.round(options.height ?? 400), 16, MAX_SIZE);
+  const params = new URLSearchParams({
+    size: `${width}x${height}`,
+    location: `${coords.lat},${coords.lng}`,
+    key,
+  });
+  if (options.heading !== undefined)
+    params.set("heading", String(Math.round(options.heading)));
+  if (options.pitch !== undefined)
+    params.set("pitch", String(clamp(Math.round(options.pitch), -90, 90)));
+  if (options.fov !== undefined)
+    params.set("fov", String(clamp(Math.round(options.fov), 10, 120)));
+  if (options.radius !== undefined)
+    params.set("radius", String(Math.max(1, Math.round(options.radius))));
+  return `${STATIC_ENDPOINT}?${params.toString()}`;
+}
+
+export function streetViewMetadataUrl(
+  coords: StreetViewCoords,
+  key: string,
+  radius?: number,
+): string {
+  const params = new URLSearchParams({
+    location: `${coords.lat},${coords.lng}`,
+    key,
+  });
+  if (radius !== undefined)
+    params.set("radius", String(Math.max(1, Math.round(radius))));
+  return `${METADATA_ENDPOINT}?${params.toString()}`;
+}
+
+/**
+ * Ask whether imagery exists near these coordinates. Free and unmetered.
+ *
+ * Never throws: a coverage check failing is not a reason to break a building
+ * panel, so transport and parse failures come back as `status: "ERROR"` and
+ * the caller renders nothing.
+ */
+export async function fetchStreetViewMetadata(
+  coords: StreetViewCoords,
+  key: string,
+  options: { radius?: number; fetchImpl?: typeof fetch } = {},
+): Promise<StreetViewMetadata> {
+  const doFetch = options.fetchImpl ?? fetch;
+  try {
+    const res = await doFetch(
+      streetViewMetadataUrl(coords, key, options.radius),
+    );
+    if (!res.ok) return { status: "ERROR", reason: `HTTP ${res.status}` };
+    const body = (await res.json()) as {
+      status?: string;
+      pano_id?: string;
+      location?: { lat?: number; lng?: number };
+      date?: string;
+      error_message?: string;
+    };
+    if (body.status === "OK" && body.pano_id) {
+      return {
+        status: "OK",
+        panoId: body.pano_id,
+        location: {
+          lat: body.location?.lat ?? coords.lat,
+          lng: body.location?.lng ?? coords.lng,
+        },
+        date: body.date,
+      };
+    }
+    if (body.status === "ZERO_RESULTS" || body.status === "NOT_FOUND") {
+      return { status: body.status };
+    }
+    return {
+      status: "ERROR",
+      reason: body.error_message ?? body.status ?? "unknown response",
+    };
+  } catch (error) {
+    return {
+      status: "ERROR",
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Attribution is required wherever Street View imagery is shown. The static
+ * endpoint burns a Google logo into the image, but the terms still expect the
+ * surrounding UI to credit the source, so callers render this next to it.
+ */
+export const STREET_VIEW_ATTRIBUTION = "Street View image © Google";


### PR DESCRIPTION
Scaffolding only. No UI yet, and nothing renders until a key is set.

## What is here

- `src/lib/street-view.ts` — image and metadata URL builders, plus a metadata fetch that never throws (a coverage check failing must not break a building panel). Clamps size to the endpoint's 640px ceiling and pitch/fov to their documented ranges instead of letting Google reject the request.
- `scripts/street-view-coverage.ts` — runs every building through the **free, unmetered** metadata endpoint and reports coverage plus distance to the nearest panorama.
- `PUBLIC_GOOGLE_MAPS_API_KEY`, optional. No key means the feature is off, not broken.

13 tests.

## Coverage, measured rather than assumed

I predicted campus coverage would be patchy inland. It is not:

```
Street View coverage within 100m
  52/52 buildings covered (100%)
  0 with no imagery
```

Capture dates run 2015-03 to 2026-02. So the useful column is distance, not hit rate. The far end is worth a look:

| distance | building | captured |
| --- | --- | --- |
| 77m | AFBED Building | 2015-03 |
| 66m | Veterinary Teaching Hospital | 2015-03 |
| 54m | UPRHS Building | 2022-05 |
| 6m | Agricultural Machinery Testing and Evaluation Center | 2015-03 |

A building whose nearest panorama is unusually far may be a pin in the wrong place rather than a gap in Google's coverage, which makes this script useful for #886 and #891 as well.

## Two constraints, written into the module

**Google's terms permit only limited temporary caching.** Their imagery must not be written into a photos table or re-hosted, so this cannot feed the photo-storage system discussed separately. The module only produces URLs the browser fetches; nothing here downloads an image. Owned, storable imagery needs a different source (Mapillary is CC-BY-SA and permits it, as do contributor uploads).

**Always check metadata before requesting an image.** Without it Google bills for a request that returns its grey "no imagery" placeholder.

## Found while building

- The script originally held the database connection open across ~50 sequential HTTP round trips and died on `Connection terminated unexpectedly` partway through the second run. It now closes before the fetch loop. Caught by running it twice; the first run passed.
- The buildings table is `building_name` / `lat` / `lon`, not `name` / `latitude` / `longitude`. My first query was wrong and failed immediately.

## Before this goes live

The key must be restricted by HTTP referrer. I confirmed the provided key currently works from a server-side script with no `Referer` header, meaning it is unrestricted and anyone holding it can spend against the account's billing.