### PR TITLE
feat(map): satellite basemap toggle

### DIFF
--- a/e2e/browse/map-tools.spec.ts
+++ b/e2e/browse/map-tools.spec.ts
@@ -1,10 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { waitForAppBoot } from "../helpers/app";
-import {
-  openAppSidebar,
-  openHelpSettingsSection,
-  clickSidebarNav,
-} from "../helpers/map-tools";
+import { openSettingsModal } from "../helpers/map-tools";
 
 test.describe("map settings", () => {
   test.beforeEach(async ({ page }) => {
@@ -12,21 +8,12 @@ test.describe("map settings", () => {
     await waitForAppBoot(page);
   });
 
-  async function openSettings(page: import("@playwright/test").Page) {
-    const sidebar = await openAppSidebar(page);
-    await openHelpSettingsSection(sidebar);
-    await clickSidebarNav(sidebar, "Settings", { exact: true });
-    const settings = page.getByRole("dialog", { name: "Settings" });
-    await expect(settings).toBeVisible();
-    return settings;
-  }
-
   test("settings opens", async ({ page }) => {
-    await openSettings(page);
+    await openSettingsModal(page);
   });
 
   test("terrain off by default", async ({ page }) => {
-    const settings = await openSettings(page);
+    const settings = await openSettingsModal(page);
     const terrainToggle = settings.getByRole("button", {
       name: /turn terrain on/i,
     });

--- a/e2e/browse/satellite-toggle.spec.ts
+++ b/e2e/browse/satellite-toggle.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+import { waitForAppBoot } from "../helpers/app";
+import {
+  openAppSidebar,
+  openHelpSettingsSection,
+  clickSidebarNav,
+} from "../helpers/map-tools";
+
+/**
+ * The Basemap toggle only renders while MapTiler is the live provider, so the
+ * key must look healthy from this origin. The real key is domain-restricted
+ * and 403s from localhost (see maptiler-fallback.spec.ts), which would hide
+ * the toggle and turn this spec into a silent skip — stub every MapTiler
+ * endpoint instead and assert the satellite source request actually fires.
+ * Lives outside map-tools.spec.ts because the stubs must be registered
+ * before the first goto, which that file's beforeEach already performs.
+ */
+test.describe("satellite basemap toggle", () => {
+  test("switches to satellite imagery from Settings", async ({ page }) => {
+    test.skip(
+      !process.env.PUBLIC_MAPTILER_KEY,
+      "no PUBLIC_MAPTILER_KEY configured",
+    );
+
+    let satelliteTileJsonRequested = false;
+
+    await page.route("https://api.maptiler.com/**", (route) => {
+      const url = route.request().url();
+      if (url.includes("satellite-v2/tiles.json")) {
+        satelliteTileJsonRequested = true;
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            tilejson: "2.2.0",
+            tiles: ["https://api.maptiler.com/satellite-stub/{z}/{x}/{y}.jpg"],
+            minzoom: 0,
+            maxzoom: 20,
+          }),
+        });
+      }
+      if (url.includes("tiles.json")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            tilejson: "2.2.0",
+            tiles: ["https://api.maptiler.com/vector-stub/{z}/{x}/{y}.pbf"],
+            minzoom: 0,
+            maxzoom: 14,
+          }),
+        });
+      }
+      return route.fulfill({ status: 204, body: "" });
+    });
+
+    await page.goto("/");
+    await waitForAppBoot(page);
+
+    const sidebar = await openAppSidebar(page);
+    await openHelpSettingsSection(sidebar);
+    await clickSidebarNav(sidebar, "Settings", { exact: true });
+    const settings = page.getByRole("dialog", { name: "Settings" });
+    await expect(settings).toBeVisible();
+
+    const toggle = settings.getByRole("button", {
+      name: /switch to satellite imagery/i,
+    });
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+    await toggle.click();
+
+    // The accessible name flips with the state (WCAG 2.5.3), so re-query.
+    await expect(
+      settings.getByRole("button", { name: /switch to the standard map/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    // The imagery source is added lazily on first toggle; its TileJSON fetch
+    // is the proof the layer actually reached MapLibre.
+    await expect.poll(() => satelliteTileJsonRequested).toBe(true);
+  });
+});

--- a/e2e/browse/satellite-toggle.spec.ts
+++ b/e2e/browse/satellite-toggle.spec.ts
@@ -1,10 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { waitForAppBoot } from "../helpers/app";
-import {
-  openAppSidebar,
-  openHelpSettingsSection,
-  clickSidebarNav,
-} from "../helpers/map-tools";
+import { openSettingsModal } from "../helpers/map-tools";
 
 /**
  * The Basemap toggle only renders while MapTiler is the live provider, so the
@@ -57,11 +53,7 @@ test.describe("satellite basemap toggle", () => {
     await page.goto("/");
     await waitForAppBoot(page);
 
-    const sidebar = await openAppSidebar(page);
-    await openHelpSettingsSection(sidebar);
-    await clickSidebarNav(sidebar, "Settings", { exact: true });
-    const settings = page.getByRole("dialog", { name: "Settings" });
-    await expect(settings).toBeVisible();
+    const settings = await openSettingsModal(page);
 
     const toggle = settings.getByRole("button", {
       name: /switch to satellite imagery/i,

--- a/e2e/helpers/map-tools.ts
+++ b/e2e/helpers/map-tools.ts
@@ -38,6 +38,24 @@ export async function openHelpSettingsSection(sidebar: Locator) {
   return sidebar;
 }
 
+/**
+ * Open the Settings modal through its live entry points: the desktop top bar
+ * Settings button, or the App menu on mobile. The old path (rail Sidebar >
+ * Help & settings > Settings) targets a component that stopped rendering
+ * (#930), so specs that used it timed out without touching the feature they
+ * covered.
+ */
+export async function openSettingsModal(page: Page) {
+  const appMenu = page.getByRole("button", { name: /app menu/i });
+  if (await appMenu.isVisible().catch(() => false)) {
+    await appMenu.click();
+  }
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const settings = page.getByRole("dialog", { name: "Settings" });
+  await expect(settings).toBeVisible();
+  return settings;
+}
+
 export async function openMapTools(page: Page) {
   const mapMenu = page.getByRole("button", { name: /map menu/i });
   const mapToolsFab = page.getByRole("button", { name: /^Map tools$/i });

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -118,6 +118,7 @@
   } from "@lib/travel-graph/engine";
   import { loadTravelGraph } from "@lib/travel-graph/load";
   import { applyBasemapPalette } from "@lib/map-basemap-palette";
+  import { syncSatelliteLayer } from "@lib/map-satellite";
   import { loadCampusMapStyle } from "@lib/maptiler-key";
   import { isMap2DPitch } from "@constants/map-dimension";
   import { syncBuildingLayersForDimension } from "@lib/map-dimension-layers";
@@ -1856,6 +1857,25 @@
       applyPalette();
     } else {
       map.once("load", applyPalette);
+    }
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    const satellite = mapViewStore.satellite;
+    if (!map) return;
+
+    let cancelled = false;
+    const applySatellite = () => {
+      if (!cancelled) syncSatelliteLayer(map, satellite);
+    };
+    if (map.isStyleLoaded()) {
+      applySatellite();
+    } else {
+      map.once("load", applySatellite);
     }
     return () => {
       cancelled = true;

--- a/src/components/svelte/MapViewControls.svelte
+++ b/src/components/svelte/MapViewControls.svelte
@@ -8,6 +8,7 @@
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
   import GraduationCap from "@lucide/svelte/icons/graduation-cap";
   import MapIcon from "@lucide/svelte/icons/map";
+  import Satellite from "@lucide/svelte/icons/satellite";
   import {
     mapStore,
     mapViewStore,
@@ -15,6 +16,10 @@
     terrainStore,
   } from "@lib/store.svelte";
   import { onMount } from "svelte";
+  import {
+    getBasemapProvider,
+    onBasemapProviderChange,
+  } from "@lib/basemap-provider";
   import { THREE_D_PITCH, isMap2DPitch } from "@constants/map-dimension";
   import {
     enterFlatMapDimension,
@@ -68,6 +73,17 @@
     is2D
       ? "Camera is flat 2D. Switch to tilted 3D."
       : "Camera is tilted 3D. Switch to flat 2D.",
+  );
+  // Satellite tiles need a working MapTiler key. Gate on the provider that
+  // actually served the basemap: a configured-but-rejected key (#863) falls
+  // back to a keyless basemap, and satellite would 403 the same way.
+  let basemapProvider = $state(getBasemapProvider());
+  onMount(() => onBasemapProviderChange((next) => (basemapProvider = next)));
+  const satelliteAvailable = $derived(basemapProvider === "maptiler");
+  const satelliteTitle = $derived(
+    mapViewStore.satellite
+      ? "Showing satellite imagery. Switch to the standard map."
+      : "Showing the standard map. Switch to satellite imagery.",
   );
   function syncCamera() {
     const map = mapStore.mapInstance;
@@ -207,6 +223,31 @@
         <span class="control-value">{is2D ? "2D flat" : "3D tilted"}</span>
       </span>
     </button>
+
+    {#if satelliteAvailable}
+      <div class="divider"></div>
+
+      <button
+        class="control mode-toggle satellite-toggle"
+        class:active={mapViewStore.satellite}
+        onclick={mapViewStore.toggleSatellite}
+        title={satelliteTitle}
+        aria-label={satelliteTitle}
+        aria-pressed={mapViewStore.satellite}
+      >
+        {#if mapViewStore.satellite}
+          <Satellite size={18} aria-hidden="true" />
+        {:else}
+          <MapIcon size={18} aria-hidden="true" />
+        {/if}
+        <span class="control-copy">
+          <span class="control-kicker">Basemap</span>
+          <span class="control-value">
+            {mapViewStore.satellite ? "Satellite" : "Standard"}
+          </span>
+        </span>
+      </button>
+    {/if}
   {/if}
 
   {#if showCameraNav}
@@ -478,12 +519,14 @@
     line-height: 1.3;
   }
 
-  .camera-toggle {
+  .camera-toggle,
+  .satellite-toggle {
     border-color: hsl(5, 34%, 78%);
     background-color: hsl(0, 100%, 99%);
   }
 
-  .camera-toggle:hover {
+  .camera-toggle:hover,
+  .satellite-toggle:hover {
     border-color: hsl(5, 34%, 68%);
     background-color: hsl(0, 78%, 97%);
   }

--- a/src/components/svelte/map-chrome/DesktopTopBar.svelte
+++ b/src/components/svelte/map-chrome/DesktopTopBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { adminAuthStore, sidebarStore } from "@lib/store.svelte";
+  import SettingsIcon from "@lucide/svelte/icons/settings";
+  import { adminAuthStore, modalStore, sidebarStore } from "@lib/store.svelte";
 
   type NavId = "map" | "planner" | "finals";
 
@@ -59,6 +60,19 @@
       </button>
     {/each}
     <a href="/wiki" class="desktop-top-bar__link">Wiki</a>
+    <!-- Settings lost its only entry point when the rail Sidebar stopped
+         rendering (#930) and the desktop Menu was removed (#960); the modal
+         (map display, terrain, cache) was unreachable on desktop. -->
+    <button
+      type="button"
+      class="desktop-top-bar__link desktop-top-bar__settings"
+      aria-label="Settings"
+      title="Settings"
+      onclick={() => modalStore.openModal("settings")}
+    >
+      <SettingsIcon size={16} aria-hidden="true" />
+      <span>Settings</span>
+    </button>
     <button
       type="button"
       class="desktop-top-bar__signin"
@@ -119,6 +133,12 @@
     justify-content: flex-end;
     gap: 4px;
     min-width: 0;
+  }
+
+  .desktop-top-bar__settings {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
   }
 
   .desktop-top-bar__link {

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Menu from "@lucide/svelte/icons/menu";
+  import SettingsIcon from "@lucide/svelte/icons/settings";
   import Keyboard from "@lucide/svelte/icons/keyboard";
   import ChartColumn from "@lucide/svelte/icons/chart-column";
   import FileText from "@lucide/svelte/icons/file-text";
@@ -190,6 +191,11 @@
     modalStore.openModal("changelog");
   }
 
+  function handleSettings() {
+    closePanel();
+    modalStore.openModal("settings");
+  }
+
   function handleCoverage() {
     closePanel();
     modalStore.openModal("coverage");
@@ -285,6 +291,20 @@
         >
           <CalendarDays size={14} aria-hidden="true" />
           <span>Academic calendar</span>
+        </button>
+      </section>
+
+      <!-- Settings lost its only entry point when the rail Sidebar stopped
+           rendering (#930); the modal (map display, terrain, cache) was
+           unreachable. Same fix as Today/calendar above. -->
+      <section class="app-menu__section" aria-label="Settings">
+        <button
+          type="button"
+          class="app-menu__action map-chrome-chip"
+          onclick={handleSettings}
+        >
+          <SettingsIcon size={14} aria-hidden="true" />
+          <span>Settings</span>
         </button>
       </section>
 

--- a/src/lib/map-satellite.test.ts
+++ b/src/lib/map-satellite.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type maplibregl from "maplibre-gl";
+import {
+  SATELLITE_LAYER_ID,
+  SATELLITE_SOURCE_ID,
+  syncSatelliteLayer,
+} from "@lib/map-satellite";
+
+const realKey = process.env.PUBLIC_MAPTILER_KEY;
+
+type FakeLayer = { id: string; type: string; visibility?: string };
+
+/** The slice of maplibregl.Map the sync function touches, ordered like a style. */
+function fakeMap(layers: FakeLayer[]) {
+  const sources = new Map<string, unknown>();
+  return {
+    layers,
+    sources,
+    getLayer: (id: string) => layers.find((layer) => layer.id === id),
+    getSource: (id: string) => sources.get(id),
+    addSource: (id: string, source: unknown) => sources.set(id, source),
+    addLayer: (layer: FakeLayer, beforeId?: string) => {
+      const at = beforeId
+        ? layers.findIndex((existing) => existing.id === beforeId)
+        : layers.length;
+      layers.splice(at === -1 ? layers.length : at, 0, layer);
+    },
+    getStyle: () => ({ layers }),
+    setLayoutProperty: (id: string, _prop: string, value: string) => {
+      const layer = layers.find((existing) => existing.id === id);
+      if (layer) layer.visibility = value;
+    },
+  };
+}
+
+type MapStub = ReturnType<typeof fakeMap>;
+const asMap = (map: MapStub) => map as unknown as maplibregl.Map;
+
+const baseLayers = (): FakeLayer[] => [
+  { id: "background", type: "background" },
+  { id: "water", type: "fill" },
+  { id: "road-label", type: "symbol" },
+  { id: "place-label", type: "symbol" },
+];
+
+describe("syncSatelliteLayer", () => {
+  beforeEach(() => {
+    process.env.PUBLIC_MAPTILER_KEY = "test-key-123";
+  });
+
+  afterEach(() => {
+    process.env.PUBLIC_MAPTILER_KEY = realKey;
+  });
+
+  test("never adds the source while satellite stays off", () => {
+    const map = fakeMap(baseLayers());
+    syncSatelliteLayer(asMap(map), false);
+    expect(map.sources.size).toBe(0);
+    expect(map.getLayer(SATELLITE_LAYER_ID)).toBeUndefined();
+  });
+
+  test("inserts the raster layer before the first symbol layer", () => {
+    const map = fakeMap(baseLayers());
+    syncSatelliteLayer(asMap(map), true);
+    const ids = map.layers.map((layer) => layer.id);
+    expect(ids).toEqual([
+      "background",
+      "water",
+      SATELLITE_LAYER_ID,
+      "road-label",
+      "place-label",
+    ]);
+    const source = JSON.stringify(map.sources.get(SATELLITE_SOURCE_ID));
+    expect(source).toContain("key=test-key-123");
+    expect(source).not.toContain("__MAPTILER_KEY__");
+  });
+
+  test("appends on top when the style has no symbol layers", () => {
+    const map = fakeMap([{ id: "background", type: "background" }]);
+    syncSatelliteLayer(asMap(map), true);
+    expect(map.layers.at(-1)?.id).toBe(SATELLITE_LAYER_ID);
+  });
+
+  test("toggles visibility without duplicating the layer", () => {
+    const map = fakeMap(baseLayers());
+    syncSatelliteLayer(asMap(map), true);
+    syncSatelliteLayer(asMap(map), false);
+    syncSatelliteLayer(asMap(map), true);
+    const satelliteLayers = map.layers.filter(
+      (layer) => layer.id === SATELLITE_LAYER_ID,
+    );
+    expect(satelliteLayers).toHaveLength(1);
+    expect(satelliteLayers[0]?.visibility).toBe("visible");
+  });
+});

--- a/src/lib/map-satellite.ts
+++ b/src/lib/map-satellite.ts
@@ -1,0 +1,49 @@
+import type maplibregl from "maplibre-gl";
+import { withMaptilerKey } from "./maptiler-key";
+
+export const SATELLITE_SOURCE_ID = "satellite-basemap";
+export const SATELLITE_LAYER_ID = "satellite-basemap";
+
+/**
+ * MapTiler satellite TileJSON — same source their own hybrid style uses.
+ * The placeholder is swapped for PUBLIC_MAPTILER_KEY at runtime, matching
+ * every other keyed URL in the app.
+ */
+const SATELLITE_TILEJSON_URL =
+  "https://api.maptiler.com/tiles/satellite-v2/tiles.json?key=__MAPTILER_KEY__";
+
+/**
+ * Show or hide satellite imagery under the app's own layers.
+ *
+ * The raster layer is inserted before the style's first symbol layer, so
+ * road/place labels keep rendering on top (hybrid look) while fills and
+ * land polygons are covered. App layers (pins, routes) are added after the
+ * style and always sit above it. The source is added lazily on first use so
+ * users who never toggle satellite never fetch imagery tiles. Idempotent.
+ */
+export function syncSatelliteLayer(
+  map: maplibregl.Map,
+  visible: boolean,
+): void {
+  if (!map.getLayer(SATELLITE_LAYER_ID)) {
+    if (!visible) return;
+    if (!map.getSource(SATELLITE_SOURCE_ID)) {
+      map.addSource(SATELLITE_SOURCE_ID, {
+        type: "raster",
+        url: withMaptilerKey(SATELLITE_TILEJSON_URL),
+      });
+    }
+    const firstSymbolId = map
+      .getStyle()
+      .layers.find((layer) => layer.type === "symbol")?.id;
+    map.addLayer(
+      { id: SATELLITE_LAYER_ID, type: "raster", source: SATELLITE_SOURCE_ID },
+      firstSymbolId,
+    );
+  }
+  map.setLayoutProperty(
+    SATELLITE_LAYER_ID,
+    "visibility",
+    visible ? "visible" : "none",
+  );
+}

--- a/src/lib/maptiler-key.ts
+++ b/src/lib/maptiler-key.ts
@@ -55,7 +55,7 @@ const OFFLINE_FALLBACK_MAP_STYLE = {
 const TILE_PROBE_TIMEOUT_MS = 6_000;
 
 /** A key is configured. Says nothing about whether MapTiler will accept it. */
-function hasConfiguredMaptilerKey(): boolean {
+export function hasConfiguredMaptilerKey(): boolean {
   const key = import.meta.env.PUBLIC_MAPTILER_KEY?.trim();
   return Boolean(key && key.length > 8);
 }

--- a/src/lib/stores/map-stores.svelte.ts
+++ b/src/lib/stores/map-stores.svelte.ts
@@ -22,9 +22,15 @@ export class MapViewStore {
   /** Org/place pins are also zoom-gated in Map.svelte. The legend reads this
    * so its toggles cannot claim "Shown" while the gate is hiding them. */
   poiPinsZoomVisible: boolean = $state(true);
+  /** Satellite imagery under the basemap labels (MapTiler raster). */
+  satellite: boolean = $state(false);
 
   toggleEventsOnly = () => {
     this.eventsOnly = !this.eventsOnly;
+  };
+
+  toggleSatellite = () => {
+    this.satellite = !this.satellite;
   };
 
   toggleOrgs = () => {


### PR DESCRIPTION
## What

1. **Basemap: Standard / Satellite toggle** in the map display controls (Settings modal, same block as the 2D/3D and pin toggles).
   - MapTiler `satellite-v2` raster source, added lazily on first toggle (users who never touch it fetch zero imagery tiles).
   - Layer inserted before the style's first symbol layer: labels stay readable on top (hybrid look), pins/routes stay above.
   - Toggle only renders while MapTiler is the live basemap provider; with a missing/rejected key (#863 fallback) satellite would 403 identically, so it hides.
   - Satellite tiles ride the existing `api.maptiler.com` CacheFirst SW rule.
2. **Settings reachability fix (prerequisite)**: the Settings modal had NO live opener on desktop or mobile — its only `openModal("settings")` caller was the rail Sidebar, which stopped rendering in #930, and the desktop Menu was removed in #960. Desktop now has a top-bar Settings button; mobile has a Settings entry in the App menu (same pattern as the Today/calendar restore). Without this, the satellite toggle (and terrain, cache controls) shipped dead. Suite-wide e2e fallout of the dead sidebar is filed as #971.

## Tests

- Unit (`map-satellite.test.ts`): insertion before first symbol layer, no-symbol fallback, lazy source add, idempotent re-toggle, key injection.
- E2E: `satellite-toggle.spec.ts` stubs MapTiler as healthy (real key is domain-restricted from localhost, per `maptiler-fallback.spec.ts` precedent), opens Settings via the NEW `openSettingsModal()` helper, toggles, asserts the `satellite-v2/tiles.json` request fires. `map-tools.spec.ts` ported to the same helper (its old sidebar path targeted UI that never renders, so it timed out; #971).
- `bun run lint` / `test` (780) / `test:components` (292) / `build` green locally. Local Playwright is environmentally red (Supabase e2e DB unreachable from this machine); note that blocking e2e has been red on ALL branches since 2026-08-05 for the #971 reasons, independent of this PR.

## Verification

Preview deploy: Settings reachable on desktop (top bar) and mobile (App menu); satellite toggle renders and swaps imagery (preview domain key works). Screenshots in PR comments.