### PR TITLE
feat(data): Places coordinate audit script (#963)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,11 @@ PUBLIC_MAPTILER_KEY=
 # not be written into the photos table or re-hosted. See src/lib/street-view.ts.
 PUBLIC_GOOGLE_MAPS_API_KEY=
 
+# Server-side Google key for batch scripts (audit:places-coordinates). Mint a
+# separate IP-restricted key with Places API (New) enabled — the browser key
+# above is referrer-restricted and Places is billed per request (#963).
+# GOOGLE_MAPS_SERVER_API_KEY=
+
 # App environment banner: staging | production (#289).
 # Set staging on Vercel Preview (staging branch) and local dev (.env.local).
 PUBLIC_APP_ENV=staging

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "import:osa-orgs": "bun run scripts/import-osa-organizations.ts",
     "import:trail-org-about": "bun run scripts/import-trail-org-about.ts",
     "audit:campus-data": "bun run scripts/audit-campus-data.ts",
+    "audit:places-coordinates": "bun run scripts/places-coordinate-audit.ts",
     "import:campus-offices": "bun run scripts/import-campus-office-directory.ts",
     "import:amis-classes": "bun run scripts/import-amis-classes.ts",
     "import:classes-generic": "bun run scripts/import-classes-generic.ts",

--- a/scripts/lib/places-audit-core.test.ts
+++ b/scripts/lib/places-audit-core.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_FLAG_THRESHOLD_M,
+  classify,
+  namesPlausiblyMatch,
+  placesQueryText,
+} from "./places-audit-core";
+
+describe("placesQueryText", () => {
+  test("pins generic names to the campus", () => {
+    expect(placesQueryText("Main Library")).toBe(
+      "Main Library, University of the Philippines Los Baños",
+    );
+  });
+});
+
+describe("namesPlausiblyMatch", () => {
+  test("shared distinctive token matches", () => {
+    expect(
+      namesPlausiblyMatch(
+        "Physical Sciences Building",
+        "UPLB Physical Sciences Bldg",
+      ),
+    ).toBe(true);
+  });
+
+  test("structural tokens alone do not match", () => {
+    expect(
+      namesPlausiblyMatch(
+        "Graduate School Building",
+        "Administration Building",
+      ),
+    ).toBe(false);
+  });
+
+  test("acronym vs spelled-out is a miss by design", () => {
+    expect(
+      namesPlausiblyMatch(
+        "CEM Building",
+        "College of Economics and Management",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("classify", () => {
+  const hit = { name: "Graduate School Building", lat: 14.16, lon: 121.24 };
+
+  test("far confident match is flagged", () => {
+    expect(
+      classify(hit, "Graduate School Building", 190, DEFAULT_FLAG_THRESHOLD_M),
+    ).toBe("flagged");
+  });
+
+  test("near confident match is aligned", () => {
+    expect(
+      classify(hit, "Graduate School Building", 12, DEFAULT_FLAG_THRESHOLD_M),
+    ).toBe("aligned");
+  });
+
+  test("exactly at the threshold flags", () => {
+    expect(
+      classify(hit, "Graduate School Building", 50, DEFAULT_FLAG_THRESHOLD_M),
+    ).toBe("flagged");
+  });
+
+  test("wrongly named result never flags, whatever the distance", () => {
+    expect(
+      classify(
+        { ...hit, name: "Los Baños Municipal Hall" },
+        "Graduate School Building",
+        500,
+        DEFAULT_FLAG_THRESHOLD_M,
+      ),
+    ).toBe("unmatched");
+  });
+
+  test("no result is unmatched", () => {
+    expect(
+      classify(
+        null,
+        "Graduate School Building",
+        null,
+        DEFAULT_FLAG_THRESHOLD_M,
+      ),
+    ).toBe("unmatched");
+  });
+});

--- a/scripts/lib/places-audit-core.ts
+++ b/scripts/lib/places-audit-core.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure pieces of the Places coordinate audit (#963), split out so they are
+ * covered by the bun unit suite (scripts/ itself is not).
+ */
+import { STRUCTURAL_TOKENS, tokenize } from "../../src/lib/campus-audit";
+
+/**
+ * Past this, a pin and Google's location for the same name are telling two
+ * different stories. Calibrated against #886: the known-wrong Graduate School
+ * pin sits ~190m off, while GPS scatter plus "which door is the entrance"
+ * disagreements stay well under 50m on a campus where buildings are 30-80m
+ * apart.
+ */
+export const DEFAULT_FLAG_THRESHOLD_M = 50;
+
+export type PlacesHit = {
+  /** Google's displayName.text for the top result. */
+  name: string;
+  lat: number;
+  lon: number;
+};
+
+export type Bucket = "aligned" | "flagged" | "unmatched";
+
+/** Campus suffix pins generic names ("Main Library") to Los Baños results. */
+export function placesQueryText(buildingName: string): string {
+  return `${buildingName}, University of the Philippines Los Baños`;
+}
+
+/**
+ * Did Places return a plausibly-same-named place? True when the two names
+ * share a token that identifies rather than describes ("physical", not
+ * "building"). Misses acronym-vs-spelled-out pairs ("CEM Building" vs
+ * "College of Economics and Management") — those land in `unmatched` with the
+ * returned name printed, and the human reviewing the report resolves them.
+ */
+export function namesPlausiblyMatch(query: string, returned: string): boolean {
+  const distinctive = (token: string) => !STRUCTURAL_TOKENS.has(token);
+  const queryTokens = new Set(tokenize(query).filter(distinctive));
+  return tokenize(returned)
+    .filter(distinctive)
+    .some((token) => queryTokens.has(token));
+}
+
+/**
+ * A result that is missing or wrongly named proves nothing about the pin, so
+ * it is never `flagged` — only a confidently-matched, far-away result is.
+ */
+export function classify(
+  hit: PlacesHit | null,
+  queryName: string,
+  distanceM: number | null,
+  thresholdM: number,
+): Bucket {
+  if (!hit || distanceM === null || !namesPlausiblyMatch(queryName, hit.name)) {
+    return "unmatched";
+  }
+  return distanceM >= thresholdM ? "flagged" : "aligned";
+}

--- a/scripts/places-coordinate-audit.ts
+++ b/scripts/places-coordinate-audit.ts
@@ -1,0 +1,286 @@
+/**
+ * Audits building coordinates against Google Places (#963).
+ *
+ * For each building, asks Places Text Search for the building by name (biased
+ * to the campus) and reports how far Google's location sits from our stored
+ * pin. Report only: Google is not authoritative for campus interiors, so a
+ * human reviews the table and fixes pins through the editor flow, which lands
+ * the change in editor_history. Nothing here writes anywhere.
+ *
+ *   bun run audit:places-coordinates
+ *   ... --from-api https://www.uplb.tools   read /api/buildings instead of the DB
+ *   ... --threshold 50                       flag distance in metres
+ *   ... --limit 5                            first N buildings (smoke a paid run cheaply)
+ *   ... --json                               machine-readable output
+ *
+ * Cost: one Text Search request per building (~58), Essentials field mask,
+ * roughly $1-2 per full run. The Places API (New) must be enabled in the
+ * Google Cloud project — billing alone is not enough, and Google reports a
+ * disabled API with a misleading "enable Billing" message.
+ *
+ * Scripts cannot import @lib/db (it reads astro:env/server, which only exists
+ * inside Astro), so the DB path opens its own connection, the same way
+ * street-view-coverage.ts does.
+ */
+import pg from "pg";
+import { campusMap } from "../src/campus.config";
+import { distanceMeters } from "../src/lib/campus-route";
+import {
+  DEFAULT_FLAG_THRESHOLD_M,
+  classify,
+  placesQueryText,
+  type Bucket,
+  type PlacesHit,
+} from "./lib/places-audit-core";
+import { loadEnv } from "./load-env";
+
+loadEnv();
+
+// Server-side key preferred (IP-restricted, minted for scripts). The browser
+// key sometimes works from curl contexts, but relying on it means the audit
+// breaks the day its referrer restriction is enforced properly.
+const serverKey = process.env.GOOGLE_MAPS_SERVER_API_KEY;
+const browserKey = process.env.PUBLIC_GOOGLE_MAPS_API_KEY;
+const key = serverKey || browserKey;
+if (!key || key.trim().length <= 8) {
+  console.error(
+    "No Google key. Set GOOGLE_MAPS_SERVER_API_KEY (preferred: an\n" +
+      "IP-restricted server key with Places API (New) enabled) or\n" +
+      "PUBLIC_GOOGLE_MAPS_API_KEY.",
+  );
+  process.exit(1);
+}
+if (!serverKey) {
+  console.error(
+    "note: using PUBLIC_GOOGLE_MAPS_API_KEY; mint an IP-restricted\n" +
+      "GOOGLE_MAPS_SERVER_API_KEY for reliable script runs.\n",
+  );
+}
+
+const args = process.argv.slice(2);
+const asJson = args.includes("--json");
+const fromApiArg = args.indexOf("--from-api");
+const apiBase =
+  fromApiArg >= 0 ? args[fromApiArg + 1]?.replace(/\/$/, "") : undefined;
+const thresholdArg = args.indexOf("--threshold");
+const threshold =
+  thresholdArg >= 0 ? Number(args[thresholdArg + 1]) : DEFAULT_FLAG_THRESHOLD_M;
+if (!Number.isFinite(threshold) || threshold <= 0) {
+  console.error("--threshold must be a positive number of metres.");
+  process.exit(1);
+}
+const limitArg = args.indexOf("--limit");
+const limit =
+  limitArg >= 0 ? Number(args[limitArg + 1]) : Number.MAX_SAFE_INTEGER;
+if (!Number.isFinite(limit) || limit <= 0) {
+  console.error("--limit must be a positive number.");
+  process.exit(1);
+}
+
+type Row = { id: number; name: string; lat: number; lon: number };
+
+async function readBuildings(): Promise<Row[]> {
+  if (apiBase) {
+    const res = await fetch(`${apiBase}/api/buildings`);
+    if (!res.ok) {
+      console.error(`buildings API ${res.status} from ${apiBase}`);
+      process.exit(1);
+    }
+    const data = (await res.json()) as {
+      id: number;
+      buildingName: string;
+      lat: number;
+      lon: number;
+    }[];
+    return data
+      .map((b) => ({ id: b.id, name: b.buildingName, lat: b.lat, lon: b.lon }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is missing (or pass --from-api <base-url>).");
+    process.exit(1);
+  }
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  // Columns are building_name / lat / lon, NOT NULL in the schema.
+  const { rows } = await client.query<Row>(
+    `SELECT id, building_name AS name, lat, lon
+       FROM buildings
+      ORDER BY building_name`,
+  );
+  // Close before the fetch loop, not after. Holding the connection open
+  // across ~58 sequential HTTP round trips idles it out (see
+  // street-view-coverage.ts, which died that way).
+  await client.end();
+  return rows;
+}
+
+const buildings = (await readBuildings()).slice(0, limit);
+
+// Config stores [lng, lat]; Places wants latitude/longitude fields.
+const [campusLng, campusLat] = campusMap.defaultCamera.center;
+
+async function searchPlaces(name: string): Promise<PlacesHit | null> {
+  const res = await fetch(
+    "https://places.googleapis.com/v1/places:searchText",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Goog-Api-Key": key as string,
+        // Essentials-tier fields only; anything more moves the run up an SKU.
+        "X-Goog-FieldMask": "places.displayName,places.location",
+      },
+      body: JSON.stringify({
+        textQuery: placesQueryText(name),
+        locationBias: {
+          circle: {
+            center: { latitude: campusLat, longitude: campusLng },
+            radius: 2000,
+          },
+        },
+        maxResultCount: 1,
+      }),
+    },
+  );
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Places ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const data = (await res.json()) as {
+    places?: {
+      displayName?: { text?: string };
+      location?: { latitude?: number; longitude?: number };
+    }[];
+  };
+  const top = data.places?.[0];
+  if (!top?.location?.latitude || !top.location.longitude) return null;
+  return {
+    name: top.displayName?.text ?? "",
+    lat: top.location.latitude,
+    lon: top.location.longitude,
+  };
+}
+
+type Result = Row & {
+  bucket: Bucket;
+  placesName?: string;
+  placesLat?: number;
+  placesLon?: number;
+  metres?: number;
+};
+
+const results: Result[] = [];
+const errored: { name: string; reason: string }[] = [];
+
+// Sequential on purpose: a burst of parallel requests is the fastest way to
+// get a key rate limited, and this is ~58 rows once a quarter.
+for (const b of buildings) {
+  try {
+    const hit = await searchPlaces(b.name);
+    const metres = hit ? Math.round(distanceMeters(b, hit)) : null;
+    results.push({
+      ...b,
+      bucket: classify(hit, b.name, metres, threshold),
+      ...(hit
+        ? {
+            placesName: hit.name,
+            placesLat: hit.lat,
+            placesLon: hit.lon,
+            metres: metres ?? undefined,
+          }
+        : {}),
+    });
+  } catch (error) {
+    errored.push({
+      name: b.name,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+const flagged = results
+  .filter((r) => r.bucket === "flagged")
+  .sort((a, b) => (b.metres ?? 0) - (a.metres ?? 0));
+const aligned = results
+  .filter((r) => r.bucket === "aligned")
+  .sort((a, b) => (b.metres ?? 0) - (a.metres ?? 0));
+const unmatched = results.filter((r) => r.bucket === "unmatched");
+
+if (asJson) {
+  console.log(
+    JSON.stringify(
+      {
+        threshold,
+        total: buildings.length,
+        flagged,
+        aligned,
+        unmatched,
+        errored,
+      },
+      null,
+      2,
+    ),
+  );
+} else {
+  // Markdown to stdout, like audit-campus-data.ts: the report is meant to be
+  // pasted into a GitHub issue for human review.
+  const out: string[] = [];
+  const say = (line = "") => out.push(line);
+
+  say("# Places coordinate audit");
+  say();
+  say(`Threshold: ${threshold}m. Report only; fix pins via the editor flow.`);
+  say();
+  say("| Bucket | Count |");
+  say("| --- | --- |");
+  say(`| Flagged (>= ${threshold}m) | ${flagged.length} |`);
+  say(`| Aligned | ${aligned.length} |`);
+  say(`| Unmatched / low confidence | ${unmatched.length} |`);
+  say(`| Errored | ${errored.length} |`);
+  say(`| Total audited | ${buildings.length} |`);
+
+  if (flagged.length) {
+    say();
+    say("## Flagged: Places disagrees with the stored pin");
+    say();
+    say("| m | Building | Stored | Places says | Google's name |");
+    say("| --- | --- | --- | --- | --- |");
+    for (const r of flagged) {
+      say(
+        `| ${r.metres} | ${r.name} (#${r.id}) | ${r.lat.toFixed(5)}, ${r.lon.toFixed(5)} | ${r.placesLat?.toFixed(5)}, ${r.placesLon?.toFixed(5)} | ${r.placesName} |`,
+      );
+    }
+  }
+
+  if (unmatched.length) {
+    say();
+    say("## Unmatched (no result, or Google returned a different-named place)");
+    say();
+    for (const r of unmatched) {
+      say(
+        `- ${r.name} (#${r.id})${r.placesName ? ` — Google returned "${r.placesName}"${r.metres != null ? ` at ${r.metres}m` : ""}` : ""}`,
+      );
+    }
+  }
+
+  if (errored.length) {
+    say();
+    say("## Errors");
+    say();
+    for (const e of errored) say(`- ${e.name}: ${e.reason}`);
+  }
+
+  if (aligned.length) {
+    say();
+    say(`## Aligned (nearest first is furthest still under ${threshold}m)`);
+    say();
+    for (const r of aligned) {
+      say(`- ${String(r.metres).padStart(3)}m ${r.name}`);
+    }
+  }
+
+  console.log(out.join("\n"));
+}

--- a/src/lib/campus-audit.ts
+++ b/src/lib/campus-audit.ts
@@ -164,7 +164,7 @@ const GENERIC_DOC_FREQUENCY = 8;
  * reach `GENERIC_DOC_FREQUENCY`, and then "Administration Building" matches
  * "Graduate School Building" on the word "building" alone.
  */
-const STRUCTURAL_TOKENS = new Set([
+export const STRUCTURAL_TOKENS = new Set([
   "building",
   "buildings",
   "bldg",


### PR DESCRIPTION
## What

`bun run audit:places-coordinates` — the batch audit #963 asks for: one Places Text Search per building (campus-biased circle from `campusMap.defaultCamera.center`, Essentials field mask), distance vs stored pin via the shared `distanceMeters`, markdown report with headline counts + flagged table sorted by distance. Report only; no coordinate writes (fixes go through the editor so they land in `editor_history`).

Flags: `--from-api <base>` (public /api/buildings instead of DB; Supabase is not reachable from every machine), `--threshold` (default 50m), `--limit` (cheap smoke), `--json`.

Design notes:
- DB path closes the connection before the fetch loop (the street-view-coverage.ts trap).
- A missing or wrongly-named Places result is never "flagged" — it proves nothing about the pin; those rows land in "unmatched" with Google's returned name printed for human review. Name plausibility reuses `tokenize`/`STRUCTURAL_TOKENS` from `campus-audit.ts` (one-word export change).
- Acronym names ("CEM Building" vs "College of Economics and Management") intentionally land in unmatched rather than guessing.

## Premise correction for #963

The Geocoding path for "22 buildings with no pin" is dropped: `buildings.lat/lon` are NOT NULL, zero buildings lack pins. #891's 22 are organizations missing `building_id` links, already covered by `audit:campus-data`. Commented on the issue.

## Tests / verification

- `bun test scripts/lib/places-audit-core.test.ts`: 9 tests (query builder, token matching incl. structural-only and acronym misses, bucket rules incl. threshold edge and never-flag-unmatched).
- `bun run lint` / `bun run test` (817) / `bun run build` green.
- Live smoke (`--from-api https://www.uplb.tools --limit 3`): script runs end-to-end; every request 403s with the browser key ("Requests from referer <empty> are blocked"), confirming the issue's server-key requirement. **The real run is blocked on a maintainer-minted `GOOGLE_MAPS_SERVER_API_KEY`** (GCP: create key, IP-restrict, enable Places API (New)). Then: `bun run audit:places-coordinates --from-api https://www.uplb.tools` and paste the report into #963, expecting Graduate School Building flagged at ~190m (#886).