### PR TITLE
feat(directions): multi-modal directions with GMaps-style follow mode

### DIFF
--- a/docs/map-ui-mode-matrix.md
+++ b/docs/map-ui-mode-matrix.md
@@ -12,6 +12,9 @@ Source of truth for which map chrome is visible in each mode.
 | Transit active                | yes             | yes          | yes          | legend available  | sidebar     | hidden                | status bar | bottom band     |
 | Travel time active (#847)     | yes             | yes          | yes          | closed default    | sidebar     | hidden                | status bar | bottom band     |
 | Measure route active (#848)   | yes             | yes          | yes          | closed default    | sidebar     | hidden                | status bar | bottom band     |
+| Directions active             | yes (+ Add stop on pill / result rows; stop list under search) | yes | yes | closed default | hidden while active | hidden | status bar | bottom band |
+
+Directions opens the mobile sheet at **peek**. Stop sequence (origin / waypoints / destination) lives under the search bar; the sheet only shows route options + Show on map / Start.
 
 Implementation: `getMapChromeVisibility()` in `src/lib/map-chrome.ts`.
 

--- a/src/components/svelte/BottomSheet.component.test.ts
+++ b/src/components/svelte/BottomSheet.component.test.ts
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, test, vi } from "vitest";
+import BottomSheetHost from "../../test/components/BottomSheetHost.svelte";
+
+/**
+ * Regression cover for #966: the sheet used to lay a full-bleed "Close
+ * details" button across the whole root, so every tap, pan and pinch on the
+ * map strip above the sheet hit that button instead of the map. Details were
+ * readable but the map underneath was inert.
+ */
+describe("bottom sheet does not capture the map", () => {
+  test("renders no full-bleed dismiss overlay over the map strip", () => {
+    render(BottomSheetHost, { open: true });
+
+    expect(screen.queryByRole("button", { name: "Close details" })).toBeNull();
+    expect(document.querySelector(".bottom-sheet__scrim")).toBeNull();
+  });
+
+  test("the root lets pointer events through; only the sheet takes them", () => {
+    const { container } = render(BottomSheetHost, { open: true });
+
+    const root = container.querySelector(".bottom-sheet-root");
+    const sheet = container.querySelector(".bottom-sheet");
+    expect(root).not.toBeNull();
+    expect(sheet).not.toBeNull();
+
+    // Scoped <style> is not applied by happy-dom, so assert on the contract
+    // that matters instead: nothing between the root and the sheet claims the
+    // area above the sheet.
+    const interactiveChildren = Array.from(root?.children ?? []).filter(
+      (child) => !child.classList.contains("bottom-sheet"),
+    );
+    expect(interactiveChildren).toEqual([]);
+  });
+
+  test("dismissal is still reachable from the drag handle", () => {
+    render(BottomSheetHost, { open: true });
+
+    expect(
+      screen.getByRole("button", { name: /Expand details|Collapse details/ }),
+    ).toBeVisible();
+  });
+
+  test("renders nothing at all when closed", () => {
+    const { container } = render(BottomSheetHost, { open: false });
+    expect(container.querySelector(".bottom-sheet-root")).toBeNull();
+  });
+
+  test("a drag down past the dismiss threshold still dismisses", async () => {
+    const onDismiss = vi.fn();
+    const { container } = render(BottomSheetHost, { open: true, onDismiss });
+
+    const sheet = container.querySelector(".bottom-sheet") as HTMLElement;
+    const handle = container.querySelector(
+      ".bottom-sheet__handle",
+    ) as HTMLElement;
+
+    handle.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        clientY: 100,
+        bubbles: true,
+        pointerId: 1,
+      }),
+    );
+    sheet.dispatchEvent(
+      new PointerEvent("pointermove", {
+        clientY: 400,
+        bubbles: true,
+        pointerId: 1,
+      }),
+    );
+    sheet.dispatchEvent(
+      new PointerEvent("pointerup", {
+        clientY: 400,
+        bubbles: true,
+        pointerId: 1,
+      }),
+    );
+
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/src/components/svelte/BottomSheet.svelte
+++ b/src/components/svelte/BottomSheet.svelte
@@ -182,11 +182,6 @@
     snap = snap === "peek" ? "expanded" : "peek";
   }
 
-  function onScrimClick() {
-    // Tap map strip outside the sheet → dismiss (same as drag-down past peek).
-    onDismiss?.();
-  }
-
   const transitionMs = $derived(reducedMotion.current ? 0 : 320);
 </script>
 
@@ -198,13 +193,10 @@
     style:--bs-bottom={bottomInset}
     style:--bs-duration="{transitionMs}ms"
   >
-    <!-- Map strip above the sheet: tap dismisses back to map/search. -->
-    <button
-      type="button"
-      class="bottom-sheet__scrim"
-      aria-label="Close details"
-      onclick={onScrimClick}
-    ></button>
+    <!-- No scrim: the map strip above the sheet stays live, so panning,
+         pinching and tapping pins keep working while details are open (GMaps).
+         Dismissal is the drag-down past peek plus the search bar's
+         "Close details" button. -->
 
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
@@ -250,20 +242,6 @@
     /* Above map-tools + bottom nav so locate/3D/zoom never paint over it. */
     z-index: var(--z-mobile-sheet, 16);
     pointer-events: none;
-  }
-
-  .bottom-sheet__scrim {
-    /* Fills the root under the sheet; sheet sits on top so only the map
-       strip above the visible sheet receives these taps → dismiss. */
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-    margin: 0;
-    padding: 0;
-    border: none;
-    background: transparent;
-    pointer-events: auto;
-    cursor: pointer;
   }
 
   .bottom-sheet {

--- a/src/components/svelte/EditorAdditionModal.svelte
+++ b/src/components/svelte/EditorAdditionModal.svelte
@@ -4,7 +4,6 @@
   import X from "@lucide/svelte/icons/x";
   import IconButton from "@ui/IconButton.svelte";
   import { adminAuthStore, editorChromeStore } from "@lib/store.svelte";
-  import { trapFocus } from "@lib/focus-trap";
   import {
     modalContentDismiss,
     modalContentReveal,
@@ -25,20 +24,25 @@
     if (e.key === "Escape") close();
   }
 
-  $effect(() => {
-    if (!editorChromeStore.additionModalOpen || !dialogEl) return;
-    return trapFocus(dialogEl, { onEscape: close });
-  });
+  // No focus trap: this panel is non-modal now (#966). Trapping focus would
+  // lock keyboard users out of the very map they are placing a pin on.
+  // Escape still closes, via handleKeydown.
 
   // Same click-outside pattern as AppMenu / TermSelector / OfflineMaps /
   // KeyboardShortcutsPopup: a window-level pointerdown that bails when the
   // event lands inside the dialog. Keeps the dismiss affordance off the
   // static overlay div, which would need its own keyboard handler (a11y).
+  //
+  // #966 exempts the map surface. Adding a place means looking around and
+  // dropping a pin, so a pan or a marker tap is the user working *with* this
+  // panel — dismissing there would make the panel unusable. Clicks on other
+  // chrome still dismiss, which is what #836 asked for.
   function handleDocumentPointerDown(event: PointerEvent) {
     if (!editorChromeStore.additionModalOpen) return;
     const target = event.target;
     if (!(target instanceof Node)) return;
     if (dialogEl?.contains(target)) return;
+    if (target instanceof Element && target.closest(".map")) return;
     close();
   }
 </script>
@@ -57,7 +61,6 @@
       bind:this={dialogEl}
       class="editor-addition-frame"
       role="dialog"
-      aria-modal="true"
       aria-labelledby="editor-addition-title"
       in:fly={modalContentReveal(reducedMotion.current)}
       out:fly={modalContentDismiss(reducedMotion.current)}
@@ -93,16 +96,30 @@
     inset: 0;
     z-index: 200;
     display: flex;
-    align-items: center;
+    /* Docked, not centred: placing a pin needs the map visible and live, so
+       the panel sits at the bottom and the overlay itself catches nothing
+       (#966). No backdrop for the same reason. */
+    align-items: flex-end;
     justify-content: center;
     padding: 1rem;
-    background-color: rgba(8, 12, 22, 0.55);
+    pointer-events: none;
+  }
+
+  @media (min-width: 48rem) {
+    .editor-addition-overlay {
+      align-items: center;
+      justify-content: flex-end;
+      padding: 1.5rem;
+    }
   }
 
   .editor-addition-frame {
     display: flex;
+    /* The overlay is inert; the panel itself is the only live surface. */
+    pointer-events: auto;
     width: min(28rem, 100%);
-    max-height: min(85dvh, 40rem);
+    /* Leave a map strip above the docked panel to pan and drop a pin in. */
+    max-height: min(60dvh, 40rem);
     flex-direction: column;
     overflow: hidden;
     border-radius: 0.75rem;

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -49,6 +49,7 @@
   import { fade } from "svelte/transition";
   import { metersToLngLatCircle } from "@lib/geolocation";
   import { sumRouteLegs } from "@lib/campus-route";
+  import { isNearRoute } from "@lib/travel-graph/route-proximity";
   import MapLibreGlDirections from "@maplibre/maplibre-gl-directions";
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
   import X from "@lucide/svelte/icons/x";
@@ -276,7 +277,24 @@
     return isLandmarkPlaceCategory(place.category);
   }
 
+  function tryAddDirectionsStop(
+    lat: number,
+    lon: number,
+    label: string,
+  ): boolean {
+    if (!directionsStore.addingStop) return false;
+    void directionsStore.addWaypoint({ lat, lng: lon, label });
+    return true;
+  }
+
   function handlePlaceMarkerClick(place: PlaceData) {
+    if (
+      place.lat != null &&
+      place.lon != null &&
+      tryAddDirectionsStop(place.lat, place.lon, place.name)
+    ) {
+      return;
+    }
     if (
       queryStore.category === "place" &&
       queryStore.inputValue === place.name
@@ -2962,9 +2980,20 @@
     });
   });
 
-  function handleBuildingMarkerClick(buildingName: string) {
+  function handleBuildingMarkerClick(
+    buildingName: string,
+    lat: number | null,
+    lon: number | null,
+  ) {
     if (eventPlacementStore.active) return;
     if (isMapEditEnabled() && selectedEditKey !== null) return;
+    if (
+      lat != null &&
+      lon != null &&
+      tryAddDirectionsStop(lat, lon, buildingName)
+    ) {
+      return;
+    }
     if (buildingName === queryStore.inputValue) return;
     queryStore.updateQuery({
       category: "building",
@@ -2978,9 +3007,20 @@
     });
   }
 
-  function handleDormMarkerClick(dormName: string) {
+  function handleDormMarkerClick(
+    dormName: string,
+    lat: number | null,
+    lon: number | null,
+  ) {
     if (eventPlacementStore.active) return;
     if (isMapEditEnabled() && selectedEditKey !== null) return;
+    if (
+      lat != null &&
+      lon != null &&
+      tryAddDirectionsStop(lat, lon, dormName)
+    ) {
+      return;
+    }
     if (dormName === queryStore.inputValue) return;
     queryStore.updateQuery({
       category: "dorm",
@@ -2994,9 +3034,16 @@
     });
   }
 
-  function handleOrgMarkerClick(name: string) {
+  function handleOrgMarkerClick(
+    name: string,
+    lat: number | null,
+    lon: number | null,
+  ) {
     if (eventPlacementStore.active) return;
     if (isMapEditEnabled() && selectedEditKey !== null) return;
+    if (lat != null && lon != null && tryAddDirectionsStop(lat, lon, name)) {
+      return;
+    }
     if (
       queryStore.category === "organization" &&
       name === queryStore.inputValue
@@ -3366,6 +3413,44 @@
     return classHighlightActive && !plannerBuildingsStore.buildingIds.has(buildingId);
   }
 
+  /**
+   * While Get Directions is open, fade pins that are not the destination,
+   * a waypoint, or within ~25 m of the drawn route (#966 route UI).
+   */
+  function isExemptFromDirectionsDim(lat: number, lon: number): boolean {
+    const dest = directionsStore.destination;
+    if (
+      dest &&
+      Math.abs(dest.lat - lat) < 1e-5 &&
+      Math.abs(dest.lng - lon) < 1e-5
+    ) {
+      return true;
+    }
+    for (const stop of directionsStore.waypoints) {
+      if (
+        Math.abs(stop.lat - lat) < 1e-5 &&
+        Math.abs(stop.lng - lon) < 1e-5
+      ) {
+        return true;
+      }
+    }
+    const line = directionsStore.selectedRouteCoords;
+    if (line.length >= 2 && isNearRoute({ lat, lon }, line)) return true;
+    return false;
+  }
+
+  function isDimmedForDirections(lat: number | null, lon: number | null): boolean {
+    if (
+      !directionsStore.active ||
+      !directionsStore.selected ||
+      lat == null ||
+      lon == null
+    ) {
+      return false;
+    }
+    return !isExemptFromDirectionsDim(lat, lon);
+  }
+
   let linkedActiveEventBuildingIds = $derived.by(() => {
     if (!loaded) return new Set<number>();
     return new Set(
@@ -3455,6 +3540,20 @@
               <div class="user-location-pin"></div>
             {/if}
           </Marker>
+        {/if}
+        {#if directionsStore.active}
+          {#each directionsStore.waypoints as stop, i (`dir-wp-${i}-${stop.lat}-${stop.lng}`)}
+            <Marker lngLat={[stop.lng, stop.lat]}>
+              <button
+                type="button"
+                class="directions-waypoint"
+                aria-label={`Stop ${i + 1}: ${stop.label}. Remove stop.`}
+                onclick={() => void directionsStore.removeWaypoint(i)}
+              >
+                {i + 1}
+              </button>
+            </Marker>
+          {/each}
         {/if}
         {#if measureRouteStore.active}
           {#each measureRouteStore.waypoints as waypoint, i (i)}
@@ -3759,7 +3858,12 @@
                 <Marker
                   lngLat={[position.lon, position.lat]}
                   draggable={canDragPin(editKey)}
-                  onclick={() => handleBuildingMarkerClick(building.buildingName)}
+                  onclick={() =>
+                    handleBuildingMarkerClick(
+                      building.buildingName,
+                      position.lat,
+                      position.lon,
+                    )}
                   ondragstart={() => beginMarkerDrag(editKey)}
                   ondragend={(e) =>
                     handleBuildingDragEnd(
@@ -3775,7 +3879,8 @@
                     editable={canDragPin(editKey)}
                     editing={selectedEditKey === editKey}
                     dimmed={isBuildingDimmedForEventFocus(building.id) ||
-                      isBuildingDimmedForClassHighlight(building.id)}
+                      isBuildingDimmedForClassHighlight(building.id) ||
+                      isDimmedForDirections(position.lat, position.lon)}
                     eventLinked={isBuildingEventLinked(building.id)}
                     hovered={hoveredEditKey === editKey}
                     saveState={savingEditKey === editKey
@@ -3785,9 +3890,13 @@
                         : failedEditKey === editKey
                           ? "failed"
                           : "idle"}
-                    labelVisible={zoomLevel >= 17 ||
-                      activeBuildingName === building.buildingName ||
-                      isMyClassBuilding(building.id)}
+                    labelVisible={!isDimmedForDirections(
+                      position.lat,
+                      position.lon,
+                    ) &&
+                      (zoomLevel >= 17 ||
+                        activeBuildingName === building.buildingName ||
+                        isMyClassBuilding(building.id))}
                     useCentralHoverPreview={centralHoverPreview}
                     {previewSuppressed}
                     onpointerenter={(event) =>
@@ -3848,7 +3957,12 @@
                 <Marker
                   lngLat={[position.lon, position.lat]}
                   draggable={canDragPin(editKey)}
-                  onclick={() => handleDormMarkerClick(dorm.dormName)}
+                  onclick={() =>
+                    handleDormMarkerClick(
+                      dorm.dormName,
+                      position.lat,
+                      position.lon,
+                    )}
                   ondragstart={() => beginMarkerDrag(editKey)}
                   ondragend={(e) =>
                     handleDormDragEnd(e, dorm.id, dorm.dormName, position)}
@@ -3858,7 +3972,8 @@
                     tone={dorm.isUpManaged ? "dorm" : "privateDorm"}
                     active={activeDormName === dorm.dormName}
                     dimmed={isDormDimmedForEventFocus(dorm.id) ||
-                      classHighlightActive}
+                      classHighlightActive ||
+                      isDimmedForDirections(position.lat, position.lon)}
                     eventLinked={isDormEventLinked(dorm.id)}
                     editable={canDragPin(editKey)}
                     editing={selectedEditKey === editKey}
@@ -3870,8 +3985,11 @@
                         : failedEditKey === editKey
                           ? "failed"
                           : "idle"}
-                    labelVisible={zoomLevel >= 17 ||
-                      activeDormName === dorm.dormName}
+                    labelVisible={!isDimmedForDirections(
+                      position.lat,
+                      position.lon,
+                    ) &&
+                      (zoomLevel >= 17 || activeDormName === dorm.dormName)}
                     useCentralHoverPreview={centralHoverPreview}
                     {previewSuppressed}
                     onpointerenter={(event) =>
@@ -3898,10 +4016,13 @@
                   tone={isLandmarkPlace(place) ? "landmark" : "establishment"}
                   active={queryStore.category === "place" &&
                     queryStore.inputValue === place.name}
-                  dimmed={classHighlightActive && pinSponsorId === undefined}
-                  labelVisible={zoomLevel >= 17 ||
-                    (queryStore.category === "place" &&
-                      queryStore.inputValue === place.name)}
+                  dimmed={(classHighlightActive &&
+                    pinSponsorId === undefined) ||
+                    isDimmedForDirections(place.lat, place.lon)}
+                  labelVisible={!isDimmedForDirections(place.lat, place.lon) &&
+                    (zoomLevel >= 17 ||
+                      (queryStore.category === "place" &&
+                        queryStore.inputValue === place.name))}
                   sponsored={pinSponsorId !== undefined}
                   useCentralHoverPreview={centralHoverPreview}
                   {previewSuppressed}
@@ -3938,11 +4059,13 @@
                   ? "organization"
                   : "office"}
                 active={activeOrgName === org.name}
-                dimmed={classHighlightActive}
-                labelVisible={zoomLevel >= 17 || activeOrgName === org.name}
+                dimmed={classHighlightActive ||
+                  isDimmedForDirections(lat, lon)}
+                labelVisible={!isDimmedForDirections(lat, lon) &&
+                  (zoomLevel >= 17 || activeOrgName === org.name)}
                 useCentralHoverPreview={centralHoverPreview}
                 {previewSuppressed}
-                onclick={() => handleOrgMarkerClick(org.name)}
+                onclick={() => handleOrgMarkerClick(org.name, lat, lon)}
                 onpointerenter={(event) =>
                   handleOrganizationPinPointerEnter(org, event)}
                 onpointerleave={handleDetailPinPointerLeave}
@@ -4542,6 +4665,30 @@
   }
 
   .measure-waypoint:focus-visible {
+    outline: 2px solid white;
+    outline-offset: 1px;
+  }
+
+  /* Numbered intermediate stops while Get Directions is open (#966). */
+  .directions-waypoint {
+    display: flex;
+    width: 1.5rem;
+    height: 1.5rem;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid white;
+    border-radius: 50%;
+    background-color: var(--color-brand, #8d1437);
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 700;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.28);
+    cursor: pointer;
+    position: relative;
+    z-index: 72;
+  }
+
+  .directions-waypoint:focus-visible {
     outline: 2px solid white;
     outline-offset: 1px;
   }

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -567,12 +567,44 @@
 
   const JOURNEY_SOURCE_ID = "directions-journey";
   const JOURNEY_WALK_LAYER_ID = "directions-journey-walk";
+  const JOURNEY_WALK_CASING_ID = "directions-journey-walk-casing";
   const JOURNEY_RIDE_LAYER_ID = "directions-journey-ride";
+  const JOURNEY_RIDE_CASING_ID = "directions-journey-ride-casing";
+  /** Stock MapLibreGlDirections foot routeline (`layers.ts` routelineFoot). */
+  const JOURNEY_WALK_COLOR = "#3665ff";
+  /**
+   * Zoom-scaled widths from maplibre-gl-directions `layersFactory` — the fat
+   * translucent casing + thinner core is what made the old OSRM path look
+   * like a glow, not a flat stroke.
+   */
+  const JOURNEY_LINE_WIDTH: mapGl.ExpressionSpecification = [
+    "interpolate",
+    ["exponential", 1.5],
+    ["zoom"],
+    0,
+    3,
+    5,
+    3,
+    18,
+    10,
+  ];
+  const JOURNEY_CASING_WIDTH: mapGl.ExpressionSpecification = [
+    "interpolate",
+    ["exponential", 1.5],
+    ["zoom"],
+    0,
+    7,
+    5,
+    7,
+    18,
+    23,
+  ];
 
   /**
-   * The planned journey (#966): ride legs solid in the route's own colour,
-   * walk legs dotted, so a rider can see at a glance where they are on foot
-   * and where they are on a jeep.
+   * Journey polyline while Get directions is open (#966). Paint matches the
+   * stock MapLibreGlDirections foot routeline (casing @ 0.55 under core @
+   * 0.85) so walk looks like the pre–multi-modal OSRM path; ride legs use
+   * the jeepney route colour with the same widths.
    */
   function ensureJourneyLayers(map: mapGl.MapLibreMap) {
     if (!map.getSource(JOURNEY_SOURCE_ID)) {
@@ -582,17 +614,47 @@
       });
     }
 
+    if (!map.getLayer(JOURNEY_RIDE_CASING_ID)) {
+      map.addLayer({
+        id: JOURNEY_RIDE_CASING_ID,
+        type: "line",
+        source: JOURNEY_SOURCE_ID,
+        filter: ["==", ["get", "kind"], "ride"],
+        layout: { "line-cap": "butt", "line-join": "round" },
+        paint: {
+          "line-color": ["get", "color"],
+          "line-width": JOURNEY_CASING_WIDTH,
+          "line-opacity": 0.55,
+        },
+      });
+    }
+
     if (!map.getLayer(JOURNEY_RIDE_LAYER_ID)) {
       map.addLayer({
         id: JOURNEY_RIDE_LAYER_ID,
         type: "line",
         source: JOURNEY_SOURCE_ID,
         filter: ["==", ["get", "kind"], "ride"],
-        layout: { "line-cap": "round", "line-join": "round" },
+        layout: { "line-cap": "butt", "line-join": "round" },
         paint: {
           "line-color": ["get", "color"],
-          "line-width": 6,
-          "line-opacity": 0.9,
+          "line-width": JOURNEY_LINE_WIDTH,
+          "line-opacity": 0.85,
+        },
+      });
+    }
+
+    if (!map.getLayer(JOURNEY_WALK_CASING_ID)) {
+      map.addLayer({
+        id: JOURNEY_WALK_CASING_ID,
+        type: "line",
+        source: JOURNEY_SOURCE_ID,
+        filter: ["==", ["get", "kind"], "walk"],
+        layout: { "line-cap": "butt", "line-join": "round" },
+        paint: {
+          "line-color": JOURNEY_WALK_COLOR,
+          "line-width": JOURNEY_CASING_WIDTH,
+          "line-opacity": 0.55,
         },
       });
     }
@@ -603,26 +665,51 @@
         type: "line",
         source: JOURNEY_SOURCE_ID,
         filter: ["==", ["get", "kind"], "walk"],
-        layout: { "line-cap": "round", "line-join": "round" },
+        layout: { "line-cap": "butt", "line-join": "round" },
         paint: {
-          "line-color": "#1d4ed8",
-          "line-width": 5,
+          "line-color": JOURNEY_WALK_COLOR,
+          "line-width": JOURNEY_LINE_WIDTH,
           "line-opacity": 0.85,
-          "line-dasharray": [0.1, 1.8],
         },
       });
     }
   }
 
-  function clearJourneyLayers(map: mapGl.MapLibreMap) {
+  /** Re-assert OSRM-matching paint when layers already exist from an older build. */
+  function applyJourneyPaint(map: mapGl.MapLibreMap) {
+    for (const id of [JOURNEY_WALK_CASING_ID, JOURNEY_RIDE_CASING_ID]) {
+      if (!map.getLayer(id)) continue;
+      map.setPaintProperty(id, "line-dasharray", null);
+      map.setPaintProperty(id, "line-opacity", 0.55);
+      map.setPaintProperty(id, "line-width", JOURNEY_CASING_WIDTH);
+      map.setLayoutProperty(id, "line-cap", "butt");
+    }
     for (const id of [JOURNEY_WALK_LAYER_ID, JOURNEY_RIDE_LAYER_ID]) {
+      if (!map.getLayer(id)) continue;
+      map.setPaintProperty(id, "line-dasharray", null);
+      map.setPaintProperty(id, "line-opacity", 0.85);
+      map.setPaintProperty(id, "line-width", JOURNEY_LINE_WIDTH);
+      map.setLayoutProperty(id, "line-cap", "butt");
+    }
+    if (map.getLayer(JOURNEY_WALK_CASING_ID)) {
+      map.setPaintProperty(JOURNEY_WALK_CASING_ID, "line-color", JOURNEY_WALK_COLOR);
+    }
+    if (map.getLayer(JOURNEY_WALK_LAYER_ID)) {
+      map.setPaintProperty(JOURNEY_WALK_LAYER_ID, "line-color", JOURNEY_WALK_COLOR);
+    }
+  }  function clearJourneyLayers(map: mapGl.MapLibreMap) {
+    for (const id of [
+      JOURNEY_WALK_LAYER_ID,
+      JOURNEY_WALK_CASING_ID,
+      JOURNEY_RIDE_LAYER_ID,
+      JOURNEY_RIDE_CASING_ID,
+    ]) {
       if (map.getLayer(id)) map.removeLayer(id);
     }
     if (map.getSource(JOURNEY_SOURCE_ID)) {
       map.removeSource(JOURNEY_SOURCE_ID);
     }
   }
-
   function ensureEventRouteLayers(map: mapGl.MapLibreMap) {
     if (!map.getSource(EVENT_ROUTE_SOURCE_ID)) {
       map.addSource(EVENT_ROUTE_SOURCE_ID, {
@@ -2085,6 +2172,8 @@
    */
   const NAV_PITCH = 60;
   const NAV_ZOOM = 18;
+  /** Plain let: edge detector for nav exit; must not be $state or it loops. */
+  let wasNavigating = false;
 
   $effect(() => {
     const map = mapStore.mapInstance;
@@ -2117,67 +2206,121 @@
       return;
     }
 
-    map.easeTo({
-      center: coords,
-      zoom: NAV_ZOOM,
-      pitch: NAV_PITCH,
-      // Hold the current bearing when the device gives no heading, rather
-      // than snapping north-up mid-walk.
-      bearing: locationStore.bearing ?? map.getBearing(),
-      duration: 900,
-      essential: true,
+    // rAF: easeTo fires zoom/move handlers sync; keep those state writes out
+    // of this reactive flush (same guard as jeepney stop flyTo).
+    const bearing = locationStore.bearing ?? map.getBearing();
+    const frame = requestAnimationFrame(() => {
+      map.easeTo({
+        center: coords,
+        zoom: NAV_ZOOM,
+        pitch: NAV_PITCH,
+        // Hold the current bearing when the device gives no heading, rather
+        // than snapping north-up mid-walk.
+        bearing,
+        duration: 900,
+        essential: true,
+      });
     });
+    return () => cancelAnimationFrame(frame);
   });
 
-  /** Restore a plain north-up view when navigation ends. */
+  /**
+   * After follow-mode ends, flatten north-up. Must NOT run on every boot:
+   * campus defaultCamera is pitched (pitch 60), and calling easeTo from this
+   * effect while !navigating re-entered via zoom handlers →
+   * effect_update_depth_exceeded (blank crash card).
+   */
   $effect(() => {
     const map = mapStore.mapInstance;
-    if (!map || directionsStore.navigating) return;
-    if (map.getPitch() === 0 && map.getBearing() === 0) return;
-    if (terrainStore.enabled) return; // terrain owns the camera
-    map.easeTo({ pitch: 0, bearing: 0, duration: 600 });
+    const navigating = directionsStore.navigating;
+    const leavingNav = wasNavigating && !navigating;
+    wasNavigating = navigating;
+
+    if (!map || !leavingNav) return;
+    if (untrack(() => terrainStore.enabled)) return; // terrain owns the camera
+
+    const frame = requestAnimationFrame(() => {
+      map.easeTo({ pitch: 0, bearing: 0, duration: 600 });
+    });
+    return () => cancelAnimationFrame(frame);
   });
 
-  /** Draw the selected multi-modal journey (#966). */
+  /**
+   * Draw the selected multi-modal journey (#966) while the directions modal
+   * (or follow mode) is open. Same readiness gate as jeepney routes:
+   * isStyleLoaded() is false during repaints and "load" fires once, so those
+   * gates deadlock and the polyline never appears.
+   */
   $effect(() => {
     const map = mapStore.mapInstance;
     if (!map) return;
 
+    // Track the fields the selected getter reads so replan/select re-draws.
+    void directionsStore.journeys;
+    void directionsStore.selectedId;
     const journey = directionsStore.selected;
-    if (!journey) {
-      if (map.isStyleLoaded()) clearJourneyLayers(map);
+
+    if (!journey || !directionsStore.active) {
+      // Clear immediately — never queue clears on styledata (wipes a later draw).
+      try {
+        clearJourneyLayers(map);
+      } catch {
+        // Style not ready; nothing drawn yet.
+      }
       return;
     }
 
     const draw = () => {
       ensureJourneyLayers(map);
-      const source = map.getSource(JOURNEY_SOURCE_ID);
-      if (!source || !("setData" in source)) return;
-      source.setData({
+      applyJourneyPaint(map);
+      const source = map.getSource(JOURNEY_SOURCE_ID) as
+        | mapGl.GeoJSONSource
+        | undefined;
+      source?.setData({
         type: "FeatureCollection",
-        features: journey.legs.map((leg) => ({
-          type: "Feature" as const,
-          geometry: {
-            type: "LineString" as const,
-            coordinates: leg.coordinates,
-          },
-          properties: {
-            kind: leg.kind,
-            color: leg.kind === "ride" ? leg.color : "#1d4ed8",
-          },
-        })),
+        features: journey.legs
+          .filter((leg) => leg.coordinates.length >= 2)
+          .map((leg) => ({
+            type: "Feature" as const,
+            geometry: {
+              type: "LineString" as const,
+              coordinates: leg.coordinates,
+            },
+            properties: {
+              kind: leg.kind,
+              color: leg.kind === "ride" ? leg.color : JOURNEY_WALK_COLOR,
+            },
+          })),
       });
     };
 
-    if (map.isStyleLoaded()) draw();
-    else map.once("load", draw);
+    const tryDraw = () => {
+      try {
+        draw();
+        return true;
+      } catch (error) {
+        console.warn("journey draw failed; retrying on styledata", error);
+        return false;
+      }
+    };
+
+    if (tryDraw()) return;
+    const onStyleData = () => {
+      if (tryDraw()) map.off("styledata", onStyleData);
+    };
+    map.on("styledata", onStyleData);
+    return () => {
+      map.off("styledata", onStyleData);
+    };
   });
 
   $effect(() => {
     if (!directions) return;
 
-    // The multi-modal planner owns the drawn route while it is open; letting
-    // the OSRM polyline render too would put two different lines on the map.
+    // Multi-modal Get directions owns the drawn journey; keep OSRM clear while
+    // that session is open. Schedule-day routes still use routeWaypoints.
+    // Do not revive OSRM from locationStore.destination — that leftover used
+    // to redraw the foot polyline after the directions modal closed (#966).
     if (directionsStore.active) {
       directions.clear();
       return;
@@ -2195,22 +2338,6 @@
         map.fitBounds(bounds, {
           padding: { top: 80, bottom: 80, left: 80, right: 80 },
           duration: 1200,
-          maxZoom: 18,
-        });
-      }
-    } else if (locationStore.routeOrigin && locationStore.destination) {
-      directions.setWaypoints([
-        locationStore.routeOrigin,
-        locationStore.destination,
-      ]);
-      const map = mapStore.mapInstance;
-      if (map) {
-        const bounds = new mapGl.LngLatBounds();
-        bounds.extend(locationStore.routeOrigin);
-        bounds.extend(locationStore.destination);
-        map.fitBounds(bounds, {
-          padding: { top: 80, bottom: 120, left: 80, right: 80 },
-          duration: 1000,
           maxZoom: 18,
         });
       }

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -37,6 +37,7 @@
     plannerStore,
     plannerBuildingsStore,
     plannerRoomCodes,
+    directionsStore,
   } from "@lib/store.svelte";
   import { untrack } from "svelte";
   import { onMount } from "svelte";
@@ -561,6 +562,64 @@
     }
     if (map.getSource(MEASURE_ROUTE_SOURCE_ID)) {
       map.removeSource(MEASURE_ROUTE_SOURCE_ID);
+    }
+  }
+
+  const JOURNEY_SOURCE_ID = "directions-journey";
+  const JOURNEY_WALK_LAYER_ID = "directions-journey-walk";
+  const JOURNEY_RIDE_LAYER_ID = "directions-journey-ride";
+
+  /**
+   * The planned journey (#966): ride legs solid in the route's own colour,
+   * walk legs dotted, so a rider can see at a glance where they are on foot
+   * and where they are on a jeep.
+   */
+  function ensureJourneyLayers(map: mapGl.MapLibreMap) {
+    if (!map.getSource(JOURNEY_SOURCE_ID)) {
+      map.addSource(JOURNEY_SOURCE_ID, {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      });
+    }
+
+    if (!map.getLayer(JOURNEY_RIDE_LAYER_ID)) {
+      map.addLayer({
+        id: JOURNEY_RIDE_LAYER_ID,
+        type: "line",
+        source: JOURNEY_SOURCE_ID,
+        filter: ["==", ["get", "kind"], "ride"],
+        layout: { "line-cap": "round", "line-join": "round" },
+        paint: {
+          "line-color": ["get", "color"],
+          "line-width": 6,
+          "line-opacity": 0.9,
+        },
+      });
+    }
+
+    if (!map.getLayer(JOURNEY_WALK_LAYER_ID)) {
+      map.addLayer({
+        id: JOURNEY_WALK_LAYER_ID,
+        type: "line",
+        source: JOURNEY_SOURCE_ID,
+        filter: ["==", ["get", "kind"], "walk"],
+        layout: { "line-cap": "round", "line-join": "round" },
+        paint: {
+          "line-color": "#1d4ed8",
+          "line-width": 5,
+          "line-opacity": 0.85,
+          "line-dasharray": [0.1, 1.8],
+        },
+      });
+    }
+  }
+
+  function clearJourneyLayers(map: mapGl.MapLibreMap) {
+    for (const id of [JOURNEY_WALK_LAYER_ID, JOURNEY_RIDE_LAYER_ID]) {
+      if (map.getLayer(id)) map.removeLayer(id);
+    }
+    if (map.getSource(JOURNEY_SOURCE_ID)) {
+      map.removeSource(JOURNEY_SOURCE_ID);
     }
   }
 
@@ -2018,8 +2077,111 @@
     }
   });
 
+  /**
+   * Follow camera for navigation (#966): a tilted, heading-up view locked to
+   * the rider, like GMaps navigation. A manual pan releases the lock rather
+   * than fighting the user for the camera; the bar's re-centre button takes
+   * it back.
+   */
+  const NAV_PITCH = 60;
+  const NAV_ZOOM = 18;
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    if (!map || !directionsStore.navigating) return;
+
+    const onUserPan = (event: { originalEvent?: unknown }) => {
+      // Only a real gesture releases the lock; our own easeTo has no
+      // originalEvent, so the camera does not fight itself.
+      if (event.originalEvent) directionsStore.releaseCamera();
+    };
+    map.on("dragstart", onUserPan);
+    map.on("rotatestart", onUserPan);
+    map.on("zoomstart", onUserPan);
+    return () => {
+      map.off("dragstart", onUserPan);
+      map.off("rotatestart", onUserPan);
+      map.off("zoomstart", onUserPan);
+    };
+  });
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    const coords = locationStore.coords;
+    if (
+      !map ||
+      !directionsStore.navigating ||
+      !directionsStore.cameraFollowing ||
+      !coords
+    ) {
+      return;
+    }
+
+    map.easeTo({
+      center: coords,
+      zoom: NAV_ZOOM,
+      pitch: NAV_PITCH,
+      // Hold the current bearing when the device gives no heading, rather
+      // than snapping north-up mid-walk.
+      bearing: locationStore.bearing ?? map.getBearing(),
+      duration: 900,
+      essential: true,
+    });
+  });
+
+  /** Restore a plain north-up view when navigation ends. */
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    if (!map || directionsStore.navigating) return;
+    if (map.getPitch() === 0 && map.getBearing() === 0) return;
+    if (terrainStore.enabled) return; // terrain owns the camera
+    map.easeTo({ pitch: 0, bearing: 0, duration: 600 });
+  });
+
+  /** Draw the selected multi-modal journey (#966). */
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+
+    const journey = directionsStore.selected;
+    if (!journey) {
+      if (map.isStyleLoaded()) clearJourneyLayers(map);
+      return;
+    }
+
+    const draw = () => {
+      ensureJourneyLayers(map);
+      const source = map.getSource(JOURNEY_SOURCE_ID);
+      if (!source || !("setData" in source)) return;
+      source.setData({
+        type: "FeatureCollection",
+        features: journey.legs.map((leg) => ({
+          type: "Feature" as const,
+          geometry: {
+            type: "LineString" as const,
+            coordinates: leg.coordinates,
+          },
+          properties: {
+            kind: leg.kind,
+            color: leg.kind === "ride" ? leg.color : "#1d4ed8",
+          },
+        })),
+      });
+    };
+
+    if (map.isStyleLoaded()) draw();
+    else map.once("load", draw);
+  });
+
   $effect(() => {
     if (!directions) return;
+
+    // The multi-modal planner owns the drawn route while it is open; letting
+    // the OSRM polyline render too would put two different lines on the map.
+    if (directionsStore.active) {
+      directions.clear();
+      return;
+    }
 
     const waypoints = locationStore.routeWaypoints;
     if (waypoints && waypoints.length >= 2) {
@@ -3153,7 +3315,18 @@
       >
         {#if locationStore.coords}
           <Marker lngLat={locationStore.coords}>
-            <div class="user-location-pin"></div>
+            {#if directionsStore.navigating}
+              <!-- Heading arrow while navigating (#966); falls back to the
+                   plain dot when the device reports no heading. -->
+              <div
+                class="user-location-puck"
+                class:user-location-puck--heading={locationStore.bearing !==
+                  null}
+                style:--puck-rotation="{locationStore.bearing ?? 0}deg"
+              ></div>
+            {:else}
+              <div class="user-location-pin"></div>
+            {/if}
           </Marker>
         {/if}
         {#if measureRouteStore.active}
@@ -4178,6 +4351,49 @@
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
     position: relative;
     z-index: 70;
+  }
+
+  /* Navigation puck (#966): a white disc with a heading arrow, GMaps-style.
+     Without a heading the arrow is hidden and only the disc shows, so the
+     puck never points somewhere the device did not actually report. */
+  .user-location-puck {
+    position: relative;
+    z-index: 70;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 6px rgb(0 0 0 / 0.35);
+  }
+
+  .user-location-puck::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 50%;
+    background: #4285f4;
+  }
+
+  .user-location-puck--heading::before {
+    /* Arrowhead pointing along the reported bearing. */
+    width: 0;
+    height: 0;
+    border-right: 0.4375rem solid transparent;
+    border-bottom: 0.75rem solid #4285f4;
+    border-left: 0.4375rem solid transparent;
+    border-radius: 0;
+    background: none;
+    rotate: var(--puck-rotation, 0deg);
+    transition: rotate 300ms linear;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .user-location-puck--heading::before {
+      transition: none;
+    }
   }
 
   .measure-waypoint {

--- a/src/components/svelte/controls/EntityDirectionsChip.svelte
+++ b/src/components/svelte/controls/EntityDirectionsChip.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import CornerRightUp from "@lucide/svelte/icons/corner-right-up";
   import MapChromeActionChip from "@ui/map-chrome/MapChromeActionChip.svelte";
-  import { locationStore } from "@lib/store.svelte";
+  import { directionsStore, locationStore } from "@lib/store.svelte";
 
   type Props = {
     lat: number;
@@ -28,6 +28,18 @@
   function openDirections() {
     locationStore.requestLocation();
     locationStore.setDestination([lon, lat]);
+    // Opens with whatever fix we already have; DirectionsSession replans as
+    // soon as the watch delivers one (or a better one).
+    void directionsStore.open(
+      { lat, lng: lon, label: destinationLabel ?? "Destination" },
+      locationStore.coords
+        ? {
+            lat: locationStore.coords[1],
+            lng: locationStore.coords[0],
+            label: "Your location",
+          }
+        : null,
+    );
   }
 </script>
 

--- a/src/components/svelte/controls/EntityDirectionsChip.svelte
+++ b/src/components/svelte/controls/EntityDirectionsChip.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CornerRightUp from "@lucide/svelte/icons/corner-right-up";
+  import Plus from "@lucide/svelte/icons/plus";
   import MapChromeActionChip from "@ui/map-chrome/MapChromeActionChip.svelte";
   import { directionsStore, locationStore } from "@lib/store.svelte";
 
@@ -19,19 +20,38 @@
     toolbar = true,
   }: Props = $props();
 
-  const ariaLabel = $derived(
-    destinationLabel
-      ? `Get directions to ${destinationLabel}`
-      : "Get directions",
+  const addingStop = $derived(
+    directionsStore.active && directionsStore.addingStop,
   );
 
-  function openDirections() {
+  const ariaLabel = $derived(
+    addingStop
+      ? `Add ${destinationLabel ?? "this place"} as a stop`
+      : destinationLabel
+        ? `Get directions to ${destinationLabel}`
+        : "Get directions",
+  );
+
+  const chipLabel = $derived(addingStop ? "Add stop" : label);
+
+  function onChipClick() {
+    const endpoint = {
+      lat,
+      lng: lon,
+      label: destinationLabel ?? "Destination",
+    };
+
+    if (directionsStore.active && directionsStore.addingStop) {
+      void directionsStore.addWaypoint(endpoint);
+      return;
+    }
+
     locationStore.requestLocation();
     // Multi-modal directionsStore owns the session. Do not also set
     // locationStore.destination — that feeds the legacy OSRM polyline, which
     // would redraw after close once directionsStore.active flips false.
     void directionsStore.open(
-      { lat, lng: lon, label: destinationLabel ?? "Destination" },
+      endpoint,
       locationStore.coords
         ? {
             lat: locationStore.coords[1],
@@ -43,7 +63,11 @@
   }
 </script>
 
-<MapChromeActionChip {toolbar} {ariaLabel} onclick={openDirections}>
-  <CornerRightUp size={14} aria-hidden="true" />
-  {label}
+<MapChromeActionChip {toolbar} {ariaLabel} onclick={onChipClick}>
+  {#if addingStop}
+    <Plus size={14} aria-hidden="true" />
+  {:else}
+    <CornerRightUp size={14} aria-hidden="true" />
+  {/if}
+  {chipLabel}
 </MapChromeActionChip>

--- a/src/components/svelte/controls/EntityDirectionsChip.svelte
+++ b/src/components/svelte/controls/EntityDirectionsChip.svelte
@@ -27,9 +27,9 @@
 
   function openDirections() {
     locationStore.requestLocation();
-    locationStore.setDestination([lon, lat]);
-    // Opens with whatever fix we already have; DirectionsSession replans as
-    // soon as the watch delivers one (or a better one).
+    // Multi-modal directionsStore owns the session. Do not also set
+    // locationStore.destination — that feeds the legacy OSRM polyline, which
+    // would redraw after close once directionsStore.active flips false.
     void directionsStore.open(
       { lat, lng: lon, label: destinationLabel ?? "Destination" },
       locationStore.coords

--- a/src/components/svelte/controls/SidePanel.svelte
+++ b/src/components/svelte/controls/SidePanel.svelte
@@ -41,11 +41,32 @@
 
   /** Navigation is a map-first view: the bar takes a strip, the map the rest. */
   const navPeek = $derived(directionsStore.navigating);
+  /** Planning mode: thin summary strip so map + top search stay in view. */
+  const directionsPeek = $derived(
+    directionsStore.active && !directionsStore.navigating,
+  );
+  // Directions peek must clear the first option + Show on map / Start;
+  // 0.3 only showed the Walk card.
+  const sheetPeekRatio = $derived(
+    navPeek ? 0.22 : directionsPeek ? 0.44 : 0.48,
+  );
 
   // Entering follow mode from an expanded sheet would otherwise leave the map
   // hidden behind the very panel that is meant to be guiding it.
   $effect(() => {
     if (directionsStore.navigating) mobileSnap = "peek";
+  });
+
+  // Opening Get Directions starts at peek so the map + search stay usable;
+  // users expand via the sheet handle for the full option list.
+  let directionsWasActive = false;
+  $effect(() => {
+    const active = directionsStore.active;
+    if (active && !directionsWasActive) {
+      mobileSnap = "peek";
+      if (mobile.current) sidePanelStore.collapse();
+    }
+    directionsWasActive = active;
   });
 
   const panelIdentity = $derived(
@@ -141,7 +162,7 @@
   <BottomSheet
     open={panelOpen}
     bind:snap={mobileSnap}
-    peekRatio={navPeek ? 0.22 : 0.48}
+    peekRatio={sheetPeekRatio}
     topInset="var(--mobile-detail-sheet-top-inset, 0px)"
     bottomInset="0px"
     onDismiss={dismissMobileSheet}

--- a/src/components/svelte/controls/SidePanel.svelte
+++ b/src/components/svelte/controls/SidePanel.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import BottomSheet from "@ui/BottomSheet.svelte";
-  import { queryStore, sidePanelStore, jeepneyStore } from "@lib/store.svelte";
+  import DirectionsPanel from "@ui/directions/DirectionsPanel.svelte";
+  import {
+    queryStore,
+    sidePanelStore,
+    jeepneyStore,
+    directionsStore,
+  } from "@lib/store.svelte";
   import JeepneyStopPanel from "./JeepneyStopPanel.svelte";
   import JeepneyRouteModal from "@ui/modal/JeepneyRouteModal.svelte";
   import SponsorBanner from "@ui/SponsorBanner.svelte";
@@ -25,11 +31,22 @@
   const showSponsorBanner = $derived(
     queryStore.category !== null &&
       SPONSOR_CATEGORIES.has(queryStore.category) &&
-      jeepneyStore.selectedStopIndex === null,
+      jeepneyStore.selectedStopIndex === null &&
+      // Directions is a task view, not an entity detail view (docs/ad-policy.md).
+      !directionsStore.active,
   );
   let lastPanelIdentity = $state<string | null>(null);
   /** Mobile sheet snap, independent of sidePanelStore.collapsed (Map.expand race). */
   let mobileSnap = $state<BottomSheetSnap>("peek");
+
+  /** Navigation is a map-first view: the bar takes a strip, the map the rest. */
+  const navPeek = $derived(directionsStore.navigating);
+
+  // Entering follow mode from an expanded sheet would otherwise leave the map
+  // hidden behind the very panel that is meant to be guiding it.
+  $effect(() => {
+    if (directionsStore.navigating) mobileSnap = "peek";
+  });
 
   const panelIdentity = $derived(
     queryStore.category === null && jeepneyStore.selectedStopIndex === null
@@ -51,7 +68,9 @@
   );
 
   const panelOpen = $derived(
-    PanelContent !== null || jeepneyStore.selectedStopIndex !== null,
+    PanelContent !== null ||
+      jeepneyStore.selectedStopIndex !== null ||
+      directionsStore.active,
   );
 
   const toggleLabel = $derived(
@@ -91,6 +110,7 @@
   }
 
   function dismissMobileSheet() {
+    directionsStore.close();
     jeepneyStore.closeStop();
     queryStore.clearQuery();
     sidePanelStore.closePanel();
@@ -100,7 +120,9 @@
 </script>
 
 {#snippet panelBody()}
-  {#if jeepneyStore.selectedStopIndex !== null}
+  {#if directionsStore.active}
+    <DirectionsPanel />
+  {:else if jeepneyStore.selectedStopIndex !== null}
     <JeepneyStopPanel />
   {:else if jeepneyStore.selectedRouteId !== null && queryStore.category === "browse" && queryStore.queryValue === "jeepney"}
     <JeepneyRouteModal
@@ -119,7 +141,7 @@
   <BottomSheet
     open={panelOpen}
     bind:snap={mobileSnap}
-    peekRatio={0.48}
+    peekRatio={navPeek ? 0.22 : 0.48}
     topInset="var(--mobile-detail-sheet-top-inset, 0px)"
     bottomInset="0px"
     onDismiss={dismissMobileSheet}

--- a/src/components/svelte/directions/DirectionsPanel.component.test.ts
+++ b/src/components/svelte/directions/DirectionsPanel.component.test.ts
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test } from "vitest";
+import { directionsStore } from "@lib/store.svelte";
+import {
+  expectNoHorizontalOverflow,
+  mountAtWidth,
+} from "@test/layout-assertions";
+import type { Journey } from "@lib/travel-graph/journey";
+import DirectionsPanel from "./DirectionsPanel.svelte";
+
+const walkJourney: Journey = {
+  id: "walk",
+  kind: "walk",
+  seconds: 12 * 60,
+  meters: 910,
+  walkMeters: 910,
+  legs: [
+    {
+      kind: "walk",
+      seconds: 12 * 60,
+      meters: 910,
+      coordinates: [
+        [121.24, 14.16],
+        [121.241, 14.161],
+      ],
+    },
+  ],
+  fare: null,
+  geometrySource: "walk-graph",
+};
+
+function seedReadyDirections() {
+  directionsStore.close();
+  directionsStore.phase = "ready";
+  directionsStore.origin = {
+    lat: 14.16,
+    lng: 121.24,
+    label: "Your location",
+  };
+  directionsStore.destination = {
+    lat: 14.161,
+    lng: 121.241,
+    label: "CDC Building",
+  };
+  directionsStore.journeys = [walkJourney];
+  directionsStore.selectedId = walkJourney.id;
+  directionsStore.navigating = false;
+}
+
+describe("DirectionsPanel", () => {
+  beforeEach(() => {
+    directionsStore.close();
+  });
+
+  test.each([320, 768])(
+    "option card and actions fit without horizontal overflow at %ipx",
+    (width) => {
+      mountAtWidth(width);
+      seedReadyDirections();
+      const { container } = render(DirectionsPanel);
+
+      expect(screen.getByText("12 min")).toBeInTheDocument();
+      expect(screen.getByText("Walk")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Show on map" }),
+      ).toBeVisible();
+      expect(screen.getByRole("button", { name: "Start" })).toBeVisible();
+      expect(
+        container.querySelector(".option--selected"),
+      ).toBeTruthy();
+
+      expectNoHorizontalOverflow(container as HTMLElement);
+      const panel = container.querySelector(".directions");
+      expect(panel).toBeTruthy();
+      expectNoHorizontalOverflow(panel as HTMLElement);
+    },
+  );
+
+  test("does not list stops or Add stop in the sheet", () => {
+    mountAtWidth(320);
+    seedReadyDirections();
+    directionsStore.waypoints = [
+      { lat: 14.1605, lng: 121.2405, label: "Main Library" },
+    ];
+    render(DirectionsPanel);
+    expect(screen.queryByText("Main Library")).toBeNull();
+    expect(screen.queryByText("Your location")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Add stop" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Close directions" }),
+    ).toBeNull();
+  });
+});

--- a/src/components/svelte/directions/DirectionsPanel.svelte
+++ b/src/components/svelte/directions/DirectionsPanel.svelte
@@ -1,0 +1,427 @@
+<script lang="ts">
+  /**
+   * Google-Maps-shaped directions: a ranked option list with a headline ETA,
+   * rendered inside the existing mobile sheet / desktop drawer (#966).
+   *
+   * The map stays live behind this panel — see BottomSheet, which no longer
+   * lays a dismiss scrim over the map strip.
+   */
+  import { untrack } from "svelte";
+  import Footprints from "@lucide/svelte/icons/footprints";
+  import Bus from "@lucide/svelte/icons/bus";
+  import X from "@lucide/svelte/icons/x";
+  import Crosshair from "@lucide/svelte/icons/crosshair";
+  import Navigation from "@lucide/svelte/icons/navigation";
+  import MapPin from "@lucide/svelte/icons/map-pin";
+  import { directionsStore, locationStore, mapStore } from "@lib/store.svelte";
+  import { formatDistance, formatDuration } from "@lib/campus-route";
+  import {
+    describeJourney,
+    PLAN_STATUS_NOTES,
+    type Journey,
+    type RideLeg,
+  } from "@lib/travel-graph/journey";
+  import NavigationBar from "./NavigationBar.svelte";
+  import { JEEPNEY_FARE_NOTE } from "@constants/jeepney-routes";
+  import {
+    JEEPNEY_KPH,
+    JEEPNEY_WAIT_SECONDS,
+    WALK_KPH,
+  } from "@constants/travel-modes";
+
+  const journeys = $derived(directionsStore.journeys);
+  const selected = $derived(directionsStore.selected);
+
+  /** Clock time the rider actually arrives — the "how long till" answer. */
+  function arrivalLabel(seconds: number): string {
+    const at = new Date(Date.now() + seconds * 1000);
+    return at.toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+
+  function rideLeg(journey: Journey): RideLeg | undefined {
+    return journey.legs.find((leg): leg is RideLeg => leg.kind === "ride");
+  }
+
+  function fitSelected() {
+    const map = mapStore.mapInstance;
+    const journey = selected;
+    if (!map || !journey) return;
+    const coords = journey.legs.flatMap((leg) => leg.coordinates);
+    if (coords.length === 0) return;
+    let [minLng, minLat] = coords[0];
+    let [maxLng, maxLat] = coords[0];
+    for (const [lng, lat] of coords) {
+      minLng = Math.min(minLng, lng);
+      maxLng = Math.max(maxLng, lng);
+      minLat = Math.min(minLat, lat);
+      maxLat = Math.max(maxLat, lat);
+    }
+    map.fitBounds(
+      [
+        [minLng, minLat],
+        [maxLng, maxLat],
+      ],
+      { padding: { top: 72, bottom: 72, left: 48, right: 48 }, maxZoom: 18 },
+    );
+  }
+
+  const statusNote = $derived(
+    directionsStore.status ? PLAN_STATUS_NOTES[directionsStore.status] : null,
+  );
+
+  /**
+   * The chip fires before the GPS watch has a fix, so the first plan often has
+   * no origin. Replan when coordinates land, and again when they move far
+   * enough to matter — a drifting fix must not re-run Dijkstra every tick.
+   */
+  const REPLAN_THRESHOLD_METERS = 25;
+  /**
+   * Plain `let`, not `$state`: this is bookkeeping the effect both reads and
+   * writes, and as reactive state it would retrigger the very effect that set
+   * it.
+   */
+  let plannedFrom: [number, number] | null = null;
+
+  $effect(() => {
+    // Only the GPS fix is a tracked dependency. Everything below is read and
+    // written inside untrack, because replan() writes back to
+    // directionsStore.origin/destination/phase — tracking those here would
+    // make the effect retrigger itself (effect_update_depth_exceeded).
+    const coords = locationStore.coords;
+    if (!coords) return;
+
+    untrack(() => {
+      const destination = directionsStore.destination;
+      if (!destination) return;
+
+      if (plannedFrom) {
+        const movedMeters = Math.hypot(
+          (coords[0] - plannedFrom[0]) *
+            111_320 *
+            Math.cos((coords[1] * Math.PI) / 180),
+          (coords[1] - plannedFrom[1]) * 111_320,
+        );
+        if (movedMeters < REPLAN_THRESHOLD_METERS) return;
+      }
+
+      plannedFrom = [coords[0], coords[1]];
+      void directionsStore.replan(
+        { lat: coords[1], lng: coords[0], label: "Your location" },
+        destination,
+      );
+    });
+  });
+</script>
+
+<section class="directions" aria-label="Directions">
+  {#if directionsStore.navigating}
+    <NavigationBar />
+  {:else}
+  <header class="directions__head">
+    <div class="directions__ends">
+      <p class="directions__end">
+        <Crosshair size={14} aria-hidden="true" />
+        <span>{directionsStore.origin?.label ?? "Your location"}</span>
+      </p>
+      <p class="directions__end directions__end--to">
+        <MapPin size={14} aria-hidden="true" />
+        <span>{directionsStore.destination?.label ?? "Destination"}</span>
+      </p>
+    </div>
+    <button
+      type="button"
+      class="directions__close"
+      aria-label="Close directions"
+      onclick={() => directionsStore.close()}
+    >
+      <X size={18} aria-hidden="true" />
+    </button>
+  </header>
+
+  {#if directionsStore.phase === "planning"}
+    <p class="directions__note" role="status">
+      {locationStore.coords
+        ? "Finding the best ways there…"
+        : "Waiting for your location…"}
+    </p>
+  {:else if directionsStore.phase === "error"}
+    <p class="directions__note directions__note--warn" role="status">
+      Could not load the campus path map. Check your connection and try again.
+    </p>
+  {:else if journeys.length === 0}
+    <p class="directions__note directions__note--warn" role="status">
+      {statusNote ?? "No route found."}
+    </p>
+  {:else}
+    <ul class="directions__options">
+      {#each journeys as journey (journey.id)}
+        {@const ride = rideLeg(journey)}
+        {@const isSelected = selected?.id === journey.id}
+        <li>
+          <button
+            type="button"
+            class="option"
+            class:option--selected={isSelected}
+            aria-pressed={isSelected}
+            onclick={() => directionsStore.select(journey.id)}
+          >
+            <span
+              class="option__icon"
+              style:color={ride ? ride.color : "var(--color-brand, #8d1437)"}
+              aria-hidden="true"
+            >
+              {#if ride}
+                <Bus size={20} />
+              {:else}
+                <Footprints size={20} />
+              {/if}
+            </span>
+
+            <span class="option__body">
+              <span class="option__time">{formatDuration(journey.seconds)}</span>
+              <span class="option__meta">
+                {formatDistance(journey.meters)} · arrives {arrivalLabel(
+                  journey.seconds,
+                )}
+              </span>
+              <span class="option__desc">{describeJourney(journey)}</span>
+              {#if ride}
+                <span class="option__desc">
+                  Board at {ride.boardStopName} · alight at {ride.alightStopName}
+                </span>
+                <span class="option__fare">
+                  ₱{ride.fare.regular} · ₱{ride.fare.discounted} student/senior/PWD
+                </span>
+              {/if}
+            </span>
+          </button>
+        </li>
+      {/each}
+    </ul>
+
+    <div class="directions__actions">
+      <button type="button" class="directions__ghost" onclick={fitSelected}>
+        Show on map
+      </button>
+      <button
+        type="button"
+        class="directions__show"
+        onclick={() => directionsStore.startNavigation()}
+      >
+        <Navigation size={16} aria-hidden="true" />
+        Start
+      </button>
+    </div>
+
+    <p class="directions__caveat">
+      Estimated from campus path data at {WALK_KPH} km/h walking. Jeep times
+      assume a {Math.round(JEEPNEY_WAIT_SECONDS / 60)} min wait and a {JEEPNEY_KPH}
+      km/h average — there is no live tracking.
+      {#if selected && rideLeg(selected)}
+        {JEEPNEY_FARE_NOTE}
+      {/if}
+    </p>
+  {/if}
+  {/if}
+</section>
+
+<style>
+  .directions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
+  .directions__head {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .directions__ends {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+  }
+
+  .directions__end {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0;
+    color: #52525b;
+    font-size: 0.8125rem;
+    line-height: 1.3;
+  }
+
+  .directions__end span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .directions__end--to {
+    color: #18181b;
+    font-weight: 600;
+  }
+
+  .directions__close {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: none;
+    border-radius: 999px;
+    background: #f4f4f5;
+    color: #3f3f46;
+    cursor: pointer;
+  }
+
+  .directions__close:hover,
+  .directions__close:focus-visible {
+    background: #e4e4e7;
+  }
+
+  .directions__note {
+    margin: 0;
+    color: #52525b;
+    font-size: 0.875rem;
+  }
+
+  .directions__note--warn {
+    color: #92400e;
+  }
+
+  .directions__options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .option {
+    display: flex;
+    gap: 0.625rem;
+    width: 100%;
+    /* 44px minimum target, matching the browse chips (#942). */
+    min-height: 2.75rem;
+    padding: 0.625rem;
+    border: 1px solid transparent;
+    border-radius: 0.75rem;
+    background: #fafafa;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .option:hover {
+    background: #f4f4f5;
+  }
+
+  .option--selected {
+    border-color: var(--color-brand, #8d1437);
+    background: #fff;
+    box-shadow: var(--shadow-results, 0 2px 6px rgb(36 37 46 / 0.2));
+  }
+
+  .option__icon {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: flex-start;
+    padding-top: 0.125rem;
+  }
+
+  .option__body {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .option__time {
+    color: #18181b;
+    font-size: 1.125rem;
+    font-weight: 700;
+    line-height: 1.2;
+  }
+
+  .option__meta {
+    color: #3f3f46;
+    font-size: 0.8125rem;
+  }
+
+  .option__desc,
+  .option__fare {
+    color: #52525b;
+    font-size: 0.75rem;
+    line-height: 1.35;
+  }
+
+  .option__fare {
+    color: #3f3f46;
+    font-weight: 600;
+  }
+
+  .directions__actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .directions__ghost {
+    flex: 0 1 auto;
+    min-height: 2.75rem;
+    padding: 0.625rem 1rem;
+    border: 1px solid #e4e4e7;
+    border-radius: 999px;
+    background: #fff;
+    color: #3f3f46;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .directions__ghost:hover,
+  .directions__ghost:focus-visible {
+    background: #f4f4f5;
+  }
+
+  .directions__show {
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    min-height: 2.75rem;
+    padding: 0.625rem 1rem;
+    border: none;
+    border-radius: 999px;
+    background: var(--color-brand, #8d1437);
+    color: #fff;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .directions__show:hover,
+  .directions__show:focus-visible {
+    filter: brightness(1.08);
+  }
+
+  .directions__caveat {
+    margin: 0;
+    color: #71717a;
+    font-size: 0.6875rem;
+    line-height: 1.4;
+  }
+</style>

--- a/src/components/svelte/directions/DirectionsPanel.svelte
+++ b/src/components/svelte/directions/DirectionsPanel.svelte
@@ -9,11 +9,12 @@
   import { untrack } from "svelte";
   import Footprints from "@lucide/svelte/icons/footprints";
   import Bus from "@lucide/svelte/icons/bus";
-  import X from "@lucide/svelte/icons/x";
-  import Crosshair from "@lucide/svelte/icons/crosshair";
   import Navigation from "@lucide/svelte/icons/navigation";
-  import MapPin from "@lucide/svelte/icons/map-pin";
-  import { directionsStore, locationStore, mapStore } from "@lib/store.svelte";
+  import {
+    directionsStore,
+    locationStore,
+    mapStore,
+  } from "@lib/store.svelte";
   import { formatDistance, formatDuration } from "@lib/campus-route";
   import {
     describeJourney,
@@ -21,6 +22,13 @@
     type Journey,
     type RideLeg,
   } from "@lib/travel-graph/journey";
+  import { journeyOptionLabel } from "@lib/travel-graph/plan-multi-leg";
+  import {
+    computeDirectionsFitExtents,
+    directionsEdgeCamera,
+    directionsFitPaddingFromRects,
+    estimateDestinationLabelHalfWidthPx,
+  } from "@lib/travel-graph/directions-fit";
   import NavigationBar from "./NavigationBar.svelte";
   import { JEEPNEY_FARE_NOTE } from "@constants/jeepney-routes";
   import {
@@ -45,28 +53,108 @@
     return journey.legs.find((leg): leg is RideLeg => leg.kind === "ride");
   }
 
+  function measureDirectionsFitPadding(
+    map: { getContainer: () => HTMLElement },
+    destinationLabel: string,
+    destOnRight: boolean,
+  ) {
+    const mapRect = map.getContainer().getBoundingClientRect();
+    const mobile = window.matchMedia("(max-width: 48rem)").matches;
+
+    const topEl =
+      document.querySelector(".directions-route-chips") ??
+      document.querySelector(".map-search-chrome") ??
+      document.querySelector(".search-shell-main");
+    const topBottom =
+      topEl?.getBoundingClientRect().bottom ??
+      mapRect.top + (mobile ? 140 : 88);
+
+    const sheetEl = document.querySelector(".bottom-sheet");
+    const sheetTop =
+      sheetEl?.getBoundingClientRect().top ??
+      mapRect.bottom - (mobile ? mapRect.height * 0.44 : 64);
+
+    const statusEl = document.querySelector(".bottom-chrome");
+    const statusTop =
+      statusEl?.getBoundingClientRect().top ?? mapRect.bottom;
+    const coverBottom = mobile ? Math.min(sheetTop, statusTop) : statusTop;
+
+    const drawerEl = document.querySelector(".drawer:not(.is-collapsed)");
+    const drawerRight = drawerEl?.getBoundingClientRect().right ?? mapRect.left;
+
+    return directionsFitPaddingFromRects(mapRect, {
+      topBottom,
+      coverBottom,
+      leftCover: !mobile ? Math.max(0, drawerRight - mapRect.left) : 0,
+      mobile,
+      destinationLabelHalfWidthPx:
+        estimateDestinationLabelHalfWidthPx(destinationLabel),
+      destOnRight,
+      edgeGutterPx: 2,
+    });
+  }
+
   function fitSelected() {
     const map = mapStore.mapInstance;
-    const journey = selected;
-    if (!map || !journey) return;
-    const coords = journey.legs.flatMap((leg) => leg.coordinates);
-    if (coords.length === 0) return;
-    let [minLng, minLat] = coords[0];
-    let [maxLng, maxLat] = coords[0];
-    for (const [lng, lat] of coords) {
-      minLng = Math.min(minLng, lng);
-      maxLng = Math.max(maxLng, lng);
-      minLat = Math.min(minLat, lat);
-      maxLat = Math.max(maxLat, lat);
-    }
-    map.fitBounds(
-      [
-        [minLng, minLat],
-        [maxLng, maxLat],
-      ],
-      { padding: { top: 72, bottom: 72, left: 48, right: 48 }, maxZoom: 18 },
-    );
+    const destination = directionsStore.destination;
+    if (!map || !destination) return;
+
+    // Frame GPS puck ↔ destination pin only. Full polyline bbox is taller than
+    // wide on diagonal walks, so fitBounds zoomed out for height and left gaps.
+    const gps = locationStore.coords;
+    const origin = gps
+      ? { lng: gps[0], lat: gps[1] }
+      : directionsStore.origin;
+    if (!origin) return;
+
+    const extents = computeDirectionsFitExtents({
+      origin,
+      destination,
+      waypoints: directionsStore.waypoints,
+      accuracyMeters: locationStore.accuracyMeters ?? 25,
+    });
+    const destLabel = destination.label || "Destination";
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const padding = measureDirectionsFitPadding(
+          map,
+          destLabel,
+          extents.destOnRight,
+        );
+        const camera = directionsEdgeCamera(map, extents, padding);
+        map.easeTo({
+          center: camera.center,
+          zoom: camera.zoom,
+          bearing: 0,
+          pitch: 0,
+          duration: 900,
+          padding,
+        });
+      });
+    });
   }
+
+  /** Fit once per plan shape so open/replan/add-stop reframes both ends. */
+  let lastFittedKey: string | null = null;
+  let fitTimer: ReturnType<typeof setTimeout> | null = null;
+  $effect(() => {
+    const journey = selected;
+    const phase = directionsStore.phase;
+    const navigating = directionsStore.navigating;
+    const stopCount = directionsStore.waypoints.length;
+    const dest = directionsStore.destination;
+    if (phase !== "ready" || !journey || navigating) return;
+    const fitKey = `${journey.id}:${journey.meters}:${stopCount}:${dest?.lat}:${dest?.lng}`;
+    if (lastFittedKey === fitKey) return;
+    lastFittedKey = fitKey;
+    // Sheet peek animates in; measure after it settles or padding is stale.
+    if (fitTimer) clearTimeout(fitTimer);
+    fitTimer = setTimeout(() => {
+      fitTimer = null;
+      untrack(() => fitSelected());
+    }, 180);
+  });
 
   const statusNote = $derived(
     directionsStore.status ? PLAN_STATUS_NOTES[directionsStore.status] : null,
@@ -119,29 +207,7 @@
 <section class="directions" aria-label="Directions">
   {#if directionsStore.navigating}
     <NavigationBar />
-  {:else}
-  <header class="directions__head">
-    <div class="directions__ends">
-      <p class="directions__end">
-        <Crosshair size={14} aria-hidden="true" />
-        <span>{directionsStore.origin?.label ?? "Your location"}</span>
-      </p>
-      <p class="directions__end directions__end--to">
-        <MapPin size={14} aria-hidden="true" />
-        <span>{directionsStore.destination?.label ?? "Destination"}</span>
-      </p>
-    </div>
-    <button
-      type="button"
-      class="directions__close"
-      aria-label="Close directions"
-      onclick={() => directionsStore.close()}
-    >
-      <X size={18} aria-hidden="true" />
-    </button>
-  </header>
-
-  {#if directionsStore.phase === "planning"}
+  {:else if directionsStore.phase === "planning"}
     <p class="directions__note" role="status">
       {locationStore.coords
         ? "Finding the best ways there…"
@@ -160,6 +226,7 @@
       {#each journeys as journey (journey.id)}
         {@const ride = rideLeg(journey)}
         {@const isSelected = selected?.id === journey.id}
+        {@const modeLabel = journeyOptionLabel(journey)}
         <li>
           <button
             type="button"
@@ -181,7 +248,10 @@
             </span>
 
             <span class="option__body">
-              <span class="option__time">{formatDuration(journey.seconds)}</span>
+              <span class="option__mode">{modeLabel}</span>
+              <span class="option__time"
+                >{formatDuration(journey.seconds)}</span
+              >
               <span class="option__meta">
                 {formatDistance(journey.meters)} · arrives {arrivalLabel(
                   journey.seconds,
@@ -225,70 +295,17 @@
       {/if}
     </p>
   {/if}
-  {/if}
 </section>
 
 <style>
   .directions {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
-    width: 100%;
-  }
-
-  .directions__head {
-    display: flex;
-    align-items: flex-start;
     gap: 0.5rem;
-  }
-
-  .directions__ends {
-    display: flex;
-    flex: 1 1 auto;
-    flex-direction: column;
-    gap: 0.25rem;
+    width: 100%;
+    max-width: 100%;
     min-width: 0;
-  }
-
-  .directions__end {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    margin: 0;
-    color: #52525b;
-    font-size: 0.8125rem;
-    line-height: 1.3;
-  }
-
-  .directions__end span {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .directions__end--to {
-    color: #18181b;
-    font-weight: 600;
-  }
-
-  .directions__close {
-    display: flex;
-    flex: 0 0 auto;
-    align-items: center;
-    justify-content: center;
-    width: 2.25rem;
-    height: 2.25rem;
-    padding: 0;
-    border: none;
-    border-radius: 999px;
-    background: #f4f4f5;
-    color: #3f3f46;
-    cursor: pointer;
-  }
-
-  .directions__close:hover,
-  .directions__close:focus-visible {
-    background: #e4e4e7;
+    box-sizing: border-box;
   }
 
   .directions__note {
@@ -308,12 +325,22 @@
     margin: 0;
     padding: 0;
     list-style: none;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .directions__options > li {
+    min-width: 0;
+    max-width: 100%;
   }
 
   .option {
     display: flex;
     gap: 0.625rem;
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
     /* 44px minimum target, matching the browse chips (#942). */
     min-height: 2.75rem;
     padding: 0.625rem;
@@ -349,6 +376,14 @@
     min-width: 0;
   }
 
+  .option__mode {
+    color: #52525b;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+
   .option__time {
     color: #18181b;
     font-size: 1.125rem;
@@ -375,11 +410,14 @@
 
   .directions__actions {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
+    min-width: 0;
   }
 
   .directions__ghost {
     flex: 0 1 auto;
+    min-width: 0;
     min-height: 2.75rem;
     padding: 0.625rem 1rem;
     border: 1px solid #e4e4e7;
@@ -402,6 +440,7 @@
     align-items: center;
     justify-content: center;
     gap: 0.375rem;
+    min-width: 0;
     min-height: 2.75rem;
     padding: 0.625rem 1rem;
     border: none;

--- a/src/components/svelte/directions/DirectionsRouteChips.component.test.ts
+++ b/src/components/svelte/directions/DirectionsRouteChips.component.test.ts
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, test } from "vitest";
+import { directionsStore } from "@lib/store.svelte";
+import {
+  expectNoHorizontalOverflow,
+  mountAtWidth,
+} from "@test/layout-assertions";
+import DirectionsRouteChips from "./DirectionsRouteChips.svelte";
+
+function seedDirections() {
+  directionsStore.close();
+  directionsStore.phase = "ready";
+  directionsStore.origin = {
+    lat: 14.16,
+    lng: 121.24,
+    label: "Your location",
+  };
+  directionsStore.destination = {
+    lat: 14.161,
+    lng: 121.241,
+    label: "CDC Building",
+  };
+  directionsStore.waypoints = [
+    { lat: 14.1605, lng: 121.2405, label: "Main Library" },
+  ];
+  directionsStore.navigating = false;
+}
+
+describe("DirectionsRouteChips", () => {
+  beforeEach(() => {
+    directionsStore.close();
+  });
+
+  test("hidden when directions are idle", () => {
+    const { container } = render(DirectionsRouteChips);
+    expect(
+      container.querySelector(".directions-route-chips"),
+    ).toBeNull();
+  });
+
+  test.each([320, 768])(
+    "lists origin, stop, destination with close under search at %ipx",
+    (width) => {
+      mountAtWidth(width);
+      seedDirections();
+      const { container } = render(DirectionsRouteChips);
+
+      expect(screen.getByText("Your location")).toBeVisible();
+      expect(screen.getByText("Main Library")).toBeVisible();
+      expect(screen.getByText("CDC Building")).toBeVisible();
+      expect(
+        screen.getByRole("button", { name: "Remove stop Main Library" }),
+      ).toBeVisible();
+      expect(
+        screen.getByRole("button", { name: "Close directions" }),
+      ).toBeVisible();
+
+      expectNoHorizontalOverflow(
+        container.querySelector(".directions-route-chips") as HTMLElement,
+      );
+    },
+  );
+});

--- a/src/components/svelte/directions/DirectionsRouteChips.svelte
+++ b/src/components/svelte/directions/DirectionsRouteChips.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  /**
+   * Origin → stops → destination under the search bar while Get Directions
+   * is open. Reorder/remove waypoints here; the bottom sheet only shows options.
+   */
+  import Crosshair from "@lucide/svelte/icons/crosshair";
+  import MapPin from "@lucide/svelte/icons/map-pin";
+  import ChevronUp from "@lucide/svelte/icons/chevron-up";
+  import ChevronDown from "@lucide/svelte/icons/chevron-down";
+  import X from "@lucide/svelte/icons/x";
+  import { directionsStore } from "@lib/store.svelte";
+
+  const waypoints = $derived(directionsStore.waypoints);
+</script>
+
+{#if directionsStore.active && !directionsStore.navigating}
+  <div class="directions-route-chips">
+    <div
+      class="directions-route-chips__list"
+      role="list"
+      aria-label="Directions stop sequence"
+    >
+      <p class="directions-route-chips__end" role="listitem">
+        <Crosshair size={14} aria-hidden="true" />
+        <span>{directionsStore.origin?.label ?? "Your location"}</span>
+      </p>
+
+      {#each waypoints as stop, index (stop.label + index)}
+        <div class="directions-route-chips__stop" role="listitem">
+          <span class="directions-route-chips__badge" aria-hidden="true"
+            >{index + 1}</span
+          >
+          <span class="directions-route-chips__label">{stop.label}</span>
+          <div class="directions-route-chips__actions">
+            <button
+              type="button"
+              class="directions-route-chips__icon"
+              aria-label={`Move ${stop.label} up`}
+              disabled={index === 0}
+              onmousedown={(event) => event.preventDefault()}
+              onclick={() => void directionsStore.moveWaypoint(index, index - 1)}
+            >
+              <ChevronUp size={14} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              class="directions-route-chips__icon"
+              aria-label={`Move ${stop.label} down`}
+              disabled={index === waypoints.length - 1}
+              onmousedown={(event) => event.preventDefault()}
+              onclick={() => void directionsStore.moveWaypoint(index, index + 1)}
+            >
+              <ChevronDown size={14} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              class="directions-route-chips__icon"
+              aria-label={`Remove stop ${stop.label}`}
+              onmousedown={(event) => event.preventDefault()}
+              onclick={() => void directionsStore.removeWaypoint(index)}
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+      {/each}
+
+      <p
+        class="directions-route-chips__end directions-route-chips__end--to"
+        role="listitem"
+      >
+        <MapPin size={14} aria-hidden="true" />
+        <span>{directionsStore.destination?.label ?? "Destination"}</span>
+      </p>
+    </div>
+
+    <button
+      type="button"
+      class="directions-route-chips__close"
+      aria-label="Close directions"
+      onmousedown={(event) => event.preventDefault()}
+      onclick={() => directionsStore.close()}
+    >
+      <X size={16} aria-hidden="true" />
+    </button>
+  </div>
+{/if}
+
+<style>
+  .directions-route-chips {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.375rem;
+    max-width: 100%;
+    min-width: 0;
+    margin-top: 0.375rem;
+    padding: 0.5rem 0.55rem;
+    border-radius: 0.875rem;
+    background: #fff;
+    border: 1px solid hsl(5 10% 86%);
+    box-shadow: var(--shadow-search, 0 1px 3.5px rgb(58 58 71 / 0.12));
+    pointer-events: auto;
+  }
+
+  .directions-route-chips__list {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 0.3rem;
+    min-width: 0;
+  }
+
+  .directions-route-chips__end {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0;
+    min-width: 0;
+    color: #52525b;
+    font-size: 0.8125rem;
+    line-height: 1.3;
+  }
+
+  .directions-route-chips__end span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .directions-route-chips__end--to {
+    color: #18181b;
+    font-weight: 600;
+  }
+
+  .directions-route-chips__stop {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  .directions-route-chips__badge {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    width: 1.15rem;
+    height: 1.15rem;
+    border-radius: 999px;
+    background: var(--color-brand, #8d1437);
+    color: #fff;
+    font-size: 0.625rem;
+    font-weight: 700;
+  }
+
+  .directions-route-chips__label {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: #18181b;
+    font-size: 0.8125rem;
+    font-weight: 500;
+  }
+
+  .directions-route-chips__actions {
+    display: flex;
+    flex: 0 0 auto;
+    gap: 0.1rem;
+  }
+
+  .directions-route-chips__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+    border: none;
+    border-radius: 0.35rem;
+    background: #f4f4f5;
+    color: #3f3f46;
+    cursor: pointer;
+  }
+
+  .directions-route-chips__icon:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  .directions-route-chips__icon:not(:disabled):hover,
+  .directions-route-chips__icon:not(:disabled):focus-visible {
+    background: #e4e4e7;
+  }
+
+  .directions-route-chips__close {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    border: none;
+    border-radius: 999px;
+    background: #f4f4f5;
+    color: #3f3f46;
+    cursor: pointer;
+  }
+
+  .directions-route-chips__close:hover,
+  .directions-route-chips__close:focus-visible {
+    background: #e4e4e7;
+  }
+
+  @media (max-width: 48rem) {
+    .directions-route-chips {
+      margin-top: 0.5rem;
+      padding: 0.55rem 0.6rem;
+    }
+  }
+</style>

--- a/src/components/svelte/directions/NavigationBar.svelte
+++ b/src/components/svelte/directions/NavigationBar.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  /**
+   * Follow-mode chrome (#966): the GMaps navigation bar — remaining time,
+   * distance and arrival clock, an exit button, and a recentre control that
+   * appears once a manual pan has released the camera.
+   *
+   * Renders above the map rather than over it, so the route and the puck stay
+   * visible; the map itself keeps every gesture.
+   */
+  import X from "@lucide/svelte/icons/x";
+  import LocateFixed from "@lucide/svelte/icons/locate-fixed";
+  import Footprints from "@lucide/svelte/icons/footprints";
+  import Bus from "@lucide/svelte/icons/bus";
+  import { directionsStore, locationStore } from "@lib/store.svelte";
+  import { formatDistance, formatDuration } from "@lib/campus-route";
+  import { routeProgress, type RideLeg } from "@lib/travel-graph/journey";
+
+  const journey = $derived(directionsStore.selected);
+
+  const progress = $derived.by(() => {
+    const coords = locationStore.coords;
+    if (!journey || !coords) return null;
+    return routeProgress(journey, { lat: coords[1], lng: coords[0] });
+  });
+
+  /** Falls back to the planned total until the first fix lands. */
+  const remainingSeconds = $derived(
+    progress?.remainingSeconds ?? journey?.seconds ?? 0,
+  );
+  const remainingMeters = $derived(progress?.remainingMeters ?? journey?.meters ?? 0);
+
+  const arrival = $derived(
+    new Date(Date.now() + remainingSeconds * 1000).toLocaleTimeString(
+      undefined,
+      { hour: "numeric", minute: "2-digit" },
+    ),
+  );
+
+  const isRide = $derived(
+    journey?.legs.some((leg): leg is RideLeg => leg.kind === "ride") ?? false,
+  );
+
+  /** Past this the rider is not on the drawn line any more. */
+  const OFF_ROUTE_METERS = 40;
+  const offRoute = $derived(
+    (progress?.offRouteMeters ?? 0) > OFF_ROUTE_METERS,
+  );
+
+  const arrived = $derived(remainingMeters < 15);
+</script>
+
+{#if directionsStore.navigating && journey}
+  <div class="nav">
+    {#if !directionsStore.cameraFollowing}
+      <div class="nav__recenter-row">
+        <button
+          type="button"
+          class="nav__recenter"
+          onclick={() => directionsStore.recenter()}
+        >
+          <LocateFixed size={16} aria-hidden="true" />
+          Re-centre
+        </button>
+      </div>
+    {/if}
+
+    <div class="nav__bar">
+      <button
+        type="button"
+        class="nav__exit"
+        aria-label="Exit navigation"
+        onclick={() => directionsStore.stopNavigation()}
+      >
+        <X size={20} aria-hidden="true" />
+      </button>
+
+      <div class="nav__summary" role="status" aria-live="polite">
+        {#if arrived}
+          <p class="nav__time">You have arrived</p>
+          <p class="nav__meta">{directionsStore.destination?.label ?? ""}</p>
+        {:else}
+          <p class="nav__time">
+            {formatDuration(remainingSeconds)}
+            <span class="nav__mode" aria-hidden="true">
+              {#if isRide}
+                <Bus size={18} />
+              {:else}
+                <Footprints size={18} />
+              {/if}
+            </span>
+          </p>
+          <p class="nav__meta">
+            {formatDistance(remainingMeters)} · {arrival}
+          </p>
+        {/if}
+      </div>
+
+      <button
+        type="button"
+        class="nav__options"
+        aria-label="Back to route options"
+        onclick={() => directionsStore.stopNavigation()}
+      >
+        <span aria-hidden="true">⇅</span>
+      </button>
+    </div>
+
+    {#if offRoute && !arrived}
+      <p class="nav__off" role="status">
+        You look about {formatDistance(progress?.offRouteMeters ?? 0)} off the
+        route.
+      </p>
+    {/if}
+
+    {#if !locationStore.coords}
+      <p class="nav__off" role="status">
+        Waiting for your location — showing the planned time until then.
+      </p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
+  .nav__recenter-row {
+    display: flex;
+    justify-content: center;
+  }
+
+  .nav__recenter {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-height: 2.25rem;
+    padding: 0.375rem 0.875rem;
+    border: none;
+    border-radius: 999px;
+    background: #fff;
+    color: var(--color-brand, #8d1437);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    box-shadow: var(--shadow-results, 0 2px 6px rgb(36 37 46 / 0.2));
+    cursor: pointer;
+  }
+
+  .nav__bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .nav__exit,
+  .nav__options {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    /* 44px target, matching the browse chips (#942). */
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
+    border: 1px solid #e4e4e7;
+    border-radius: 999px;
+    background: #fff;
+    color: #3f3f46;
+    font-size: 1.125rem;
+    cursor: pointer;
+  }
+
+  .nav__exit:hover,
+  .nav__options:hover {
+    background: #f4f4f5;
+  }
+
+  .nav__summary {
+    flex: 1 1 auto;
+    min-width: 0;
+    text-align: center;
+  }
+
+  .nav__time {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    margin: 0;
+    color: #18181b;
+    font-size: 1.375rem;
+    font-weight: 700;
+    line-height: 1.15;
+  }
+
+  .nav__mode {
+    display: inline-flex;
+    color: #3f3f46;
+  }
+
+  .nav__meta {
+    margin: 0;
+    color: #52525b;
+    font-size: 0.875rem;
+  }
+
+  .nav__off {
+    margin: 0;
+    color: #92400e;
+    font-size: 0.75rem;
+    text-align: center;
+  }
+</style>

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -7,14 +7,17 @@
   import { getMapChromeVisibility } from "@lib/map-chrome";
   import {
     adminAuthStore,
+    directionsStore,
     editorChromeStore,
     mapEditStore,
+    MAX_DIRECTIONS_WAYPOINTS,
     modalStore,
     proposalsStore,
     queryStore,
     sidePanelStore,
   } from "@lib/store.svelte";
   import Suggestions from "./Suggestions.svelte";
+  import DirectionsRouteChips from "@ui/directions/DirectionsRouteChips.svelte";
   import MapFilterChips from "@ui/map-chrome/MapFilterChips.svelte";
   import { observeBlockHeight } from "@lib/layout-css-vars";
   import { registerSearchFocus } from "@lib/search-focus";
@@ -23,6 +26,7 @@
   import { MediaQuery } from "svelte/reactivity";
   import SearchIcon from "@lucide/svelte/icons/search";
   import MapPinPlus from "@lucide/svelte/icons/map-pin-plus";
+  import Plus from "@lucide/svelte/icons/plus";
   import ArrowLeft from "@lucide/svelte/icons/arrow-left";
 
   let searchElement = $state<HTMLInputElement | null>(null);
@@ -128,8 +132,38 @@
     chrome.showSearchSuggestions && searchFocused,
   );
 
+  const directionsSearchActive = $derived(
+    directionsStore.active && !directionsStore.navigating,
+  );
+
+  const canAddDirectionsStop = $derived(
+    directionsSearchActive &&
+      directionsStore.waypoints.length < MAX_DIRECTIONS_WAYPOINTS,
+  );
+
+  const searchPlaceholder = $derived(
+    directionsStore.addingStop
+      ? "Search a place to add as a stop"
+      : directionsSearchActive
+        ? "Search to add a stop"
+        : "ex. Institute of Computer Science",
+  );
+
+  function toggleDirectionsAddStop() {
+    if (!canAddDirectionsStop) return;
+    if (directionsStore.addingStop) {
+      directionsStore.cancelAddStop();
+    } else {
+      directionsStore.beginAddStop();
+    }
+    searchFocused = true;
+    searchElement?.focus();
+  }
+
   $effect(() => {
     if (queryStore.category !== null && queryStore.type === "result") {
+      // Keep the search open while adding multiple directions stops.
+      if (directionsSearchActive) return;
       searchElement?.blur();
     }
   });
@@ -195,7 +229,7 @@
                 aria-controls="search-suggestions"
                 aria-autocomplete="list"
                 aria-haspopup="listbox"
-                placeholder="ex. Institute of Computer Science"
+                placeholder={searchPlaceholder}
               />
               {#if draftInput !== "" || queryStore.category !== null}
                 <button
@@ -227,7 +261,25 @@
                   >
                 </button>
               {/if}
-              {#if !mobile.current}
+              {#if canAddDirectionsStop}
+                <button
+                  type="button"
+                  class="map-search-chrome__add map-search-chrome__add-stop"
+                  class:map-search-chrome__add-stop--armed={directionsStore.addingStop}
+                  aria-pressed={directionsStore.addingStop}
+                  aria-label={directionsStore.addingStop
+                    ? "Cancel adding a stop"
+                    : "Add a stop from search or the map"}
+                  title={directionsStore.addingStop
+                    ? "Cancel add stop"
+                    : "Add stop"}
+                  onmousedown={(event) => event.preventDefault()}
+                  onclick={toggleDirectionsAddStop}
+                >
+                  <Plus size={14} aria-hidden="true" />
+                  <span class="map-search-chrome__add-stop-text">Add stop</span>
+                </button>
+              {:else if !mobile.current && !directionsSearchActive}
                 <button
                   type="button"
                   class="map-search-chrome__add"
@@ -241,7 +293,7 @@
             </div>
           </div>
 
-          {#if !mobile.current && !searchFocused}
+          {#if !mobile.current && !searchFocused && !directionsSearchActive}
             <MapFilterChips />
           {/if}
 
@@ -268,9 +320,12 @@
             </button>
           {/if}
         </div>
+        {#if directionsSearchActive}
+          <DirectionsRouteChips />
+        {/if}
       </div>
 
-      {#if mobile.current && !searchFocused}
+      {#if mobile.current && !searchFocused && !directionsSearchActive}
         <div class="map-search-chrome__mobile-chips">
           <MapFilterChips />
         </div>
@@ -1006,9 +1061,8 @@
   }
 
   /* Figma: Add lives inside the search pill (pink wash). */
-  .search-root:not(.mobile-shell)
-    .map-search-chrome--redesign
-    .map-search-chrome__add {
+  .map-search-chrome__add,
+  .map-search-chrome__add-stop {
     display: inline-flex;
     flex: 0 0 auto;
     align-items: center;
@@ -1029,10 +1083,41 @@
     cursor: pointer;
   }
 
-  .search-root:not(.mobile-shell)
-    .map-search-chrome--redesign
-    .map-search-chrome__add:hover {
+  .map-search-chrome__add:hover,
+  .map-search-chrome__add-stop:hover,
+  .map-search-chrome__add:focus-visible,
+  .map-search-chrome__add-stop:focus-visible {
     background: #fcdada;
+  }
+
+  .map-search-chrome__add-stop--armed {
+    background: var(--color-brand, #8d1437);
+    color: #fff;
+  }
+
+  .map-search-chrome__add-stop--armed:hover,
+  .map-search-chrome__add-stop--armed:focus-visible {
+    background: #7a1130;
+  }
+
+  .search-root.mobile-shell .map-search-chrome__add-stop {
+    width: 2rem;
+    height: 2rem;
+    margin-right: 0.15rem;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .search-root.mobile-shell .map-search-chrome__add-stop-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .search-root:not(.mobile-shell)

--- a/src/components/svelte/search/Suggestion.svelte
+++ b/src/components/svelte/search/Suggestion.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import type { BuildingData, EventData } from "@lib/types";
-  import { queryStore, type QueryStoreState } from "@lib/store.svelte";
+  import {
+    directionsStore,
+    MAX_DIRECTIONS_WAYPOINTS,
+    queryStore,
+    toastStore,
+    type QueryStoreState,
+  } from "@lib/store.svelte";
   import {
     entityHoverPreviewStore,
     buildingPreviewFromRow,
@@ -9,10 +15,12 @@
   import ArrowUpRight from "@lucide/svelte/icons/arrow-up-right";
   import BookText from "@lucide/svelte/icons/book-text";
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
+  import Check from "@lucide/svelte/icons/check";
   import DoorClosed from "@lucide/svelte/icons/door-closed";
   import GraduationCap from "@lucide/svelte/icons/graduation-cap";
   import Home from "@lucide/svelte/icons/home";
   import MapPin from "@lucide/svelte/icons/map-pin";
+  import Plus from "@lucide/svelte/icons/plus";
   import School from "@lucide/svelte/icons/school";
   import University from "@lucide/svelte/icons/university";
   import Users from "@lucide/svelte/icons/users";
@@ -26,6 +34,8 @@
     building,
     event: eventData,
     secondary,
+    lat = null,
+    lon = null,
   }: {
     value: string;
     category: Exclude<QueryStoreState["category"], null>;
@@ -35,7 +45,25 @@
     event?: EventData;
     /** Supporting line under the value, e.g. a room's unabbreviated name (#875). */
     secondary?: string | null;
+    lat?: number | null;
+    lon?: number | null;
   } = $props();
+
+  const stopLat = $derived(lat ?? building?.lat ?? null);
+  const stopLon = $derived(lon ?? building?.lon ?? null);
+
+  const canAddStop = $derived(
+    directionsStore.active &&
+      !directionsStore.navigating &&
+      directionsStore.waypoints.length < MAX_DIRECTIONS_WAYPOINTS &&
+      stopLat != null &&
+      stopLon != null &&
+      Number.isFinite(stopLat) &&
+      Number.isFinite(stopLon),
+  );
+
+  let justAdded = $state(false);
+  let addedTimer: ReturnType<typeof setTimeout> | null = null;
 
   function handleSuggestionClick() {
     entityHoverPreviewStore.hideNow();
@@ -46,6 +74,33 @@
       eventSlug,
     });
     queryStore.inputValue = value;
+  }
+
+  function handleAddStop(event: MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (stopLat == null || stopLon == null || !canAddStop) return;
+    entityHoverPreviewStore.hideNow();
+    const before = directionsStore.waypoints.length;
+    void directionsStore
+      .addWaypoint({
+        lat: stopLat,
+        lng: stopLon,
+        label: value,
+      })
+      .then(() => {
+        if (directionsStore.waypoints.length <= before) return;
+        toastStore.show(`Added ${value} as a stop`, "success");
+        justAdded = true;
+        if (addedTimer) clearTimeout(addedTimer);
+        addedTimer = setTimeout(() => {
+          justAdded = false;
+          addedTimer = null;
+        }, 900);
+      });
+    // Clear the query text but stay in search mode so another stop can be typed.
+    queryStore.exitResultMode();
+    queryStore.inputValue = "";
   }
 
   function handleRemoveRecent(event: MouseEvent) {
@@ -148,11 +203,30 @@
         <span class="text-secondary">{secondary}</span>
       {/if}
     </div>
-    {#if typeof id === "undefined"}
+    {#if typeof id === "undefined" && !canAddStop}
       <ArrowUpRight size={18} class="icon trailing" />
     {/if}
   </button>
-  {#if typeof id !== "undefined"}
+  {#if canAddStop || justAdded}
+    <button
+      type="button"
+      class="suggestion-add-stop"
+      class:suggestion-add-stop--added={justAdded}
+      aria-label={justAdded
+        ? `${value} added as a stop`
+        : `Add ${value} as a directions stop`}
+      disabled={justAdded}
+      onmousedown={handleAddStop}
+    >
+      {#if justAdded}
+        <Check size={16} aria-hidden="true" />
+        <span>Added</span>
+      {:else}
+        <Plus size={16} aria-hidden="true" />
+        <span>Add stop</span>
+      {/if}
+    </button>
+  {:else if typeof id !== "undefined"}
     <button
       type="button"
       class="suggestion-remove"
@@ -224,6 +298,45 @@
   .suggestion-remove:focus-visible {
     background-color: hsl(0, 0%, 90%);
     color: #18181b;
+  }
+
+  .suggestion-add-stop {
+    all: unset;
+    box-sizing: border-box;
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    min-height: 2rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    color: var(--color-brand, #8d1437);
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .suggestion-add-stop:hover,
+  .suggestion-add-stop:focus-visible {
+    background-color: #fff7f7;
+  }
+
+  .suggestion-add-stop--added,
+  .suggestion-add-stop--added:hover,
+  .suggestion-add-stop--added:focus-visible {
+    background-color: #ecfdf5;
+    color: #047857;
+    cursor: default;
+  }
+
+  @media (max-width: 48rem) {
+    .suggestion-add-stop {
+      min-height: 2.75rem;
+      padding: 0.375rem 0.625rem;
+      font-size: 0.8125rem;
+    }
   }
 
   :global(.icon) {

--- a/src/components/svelte/search/Suggestions.svelte
+++ b/src/components/svelte/search/Suggestions.svelte
@@ -173,11 +173,20 @@
   {#if queryStore.inputValue !== ""}
     {#each aliasResults as alias (alias.value)}
       {#if !suggestedResult.some((s) => s.category === "building" && s.value === alias.value)}
+        {@const aliasBuilding = filteredBuildings.find(
+          (b) => b.buildingName === alias.value,
+        )}
         <div class="alias-hint">
           Showing results for <strong>{alias.alias}</strong> &rarr;
           {alias.value}
         </div>
-        <Suggestion value={alias.value} category="building" />
+        <Suggestion
+          value={alias.value}
+          category="building"
+          building={aliasBuilding}
+          lat={aliasBuilding?.lat}
+          lon={aliasBuilding?.lon}
+        />
       {/if}
     {/each}
   {/if}

--- a/src/constants/travel-modes.ts
+++ b/src/constants/travel-modes.ts
@@ -25,6 +25,51 @@ export const CYCLE_EXCLUDED_CLASS = "steps";
 /** Isochrone color ramp caps here; farther edges keep the last color. */
 export const ISOCHRONE_CAP_MINUTES = 30;
 
+/**
+ * Campus jeepney knobs for multi-modal journey planning (#966).
+ *
+ * ponytail: flat averages, no timetable — the campus jeeps run on headway, not
+ * a published schedule, so a planned trip can only ever be indicative. Every
+ * number here is a stated assumption the UI surfaces rather than hides.
+ */
+
+/** Door-to-door average including stops, not the cruising speed. */
+export const JEEPNEY_KPH = 14;
+
+/**
+ * Average wait at a stop. Campus jeeps are frequency-based; half a ~10 min
+ * headway is the standard expected-wait approximation.
+ */
+export const JEEPNEY_WAIT_SECONDS = 5 * 60;
+
+/** Beyond this, walking to a stop costs more than the ride saves. */
+export const MAX_ACCESS_WALK_METERS = 900;
+
+/**
+ * How far a stop may sit from the nearest walk-graph node and still count as
+ * served by it. Snapping is unconditional, so without this a stop off the
+ * mapped network silently inherits its neighbour's walk time and looks
+ * reachable when there is no path to it at all.
+ */
+export const STOP_SNAP_TOLERANCE_METERS = 120;
+
+/**
+ * The same guard for trip endpoints, but looser: a GPS fix indoors or a pin
+ * dropped mid-building is legitimately off-path, whereas the town-side stops
+ * sit over a kilometre outside the mapped campus. Past this we cannot plan
+ * honestly, and saying so beats inventing a walk from the nearest node.
+ */
+export const ENDPOINT_SNAP_TOLERANCE_METERS = 250;
+
+/**
+ * Drop a ride that only beats walking by less than this — a jeep that saves
+ * two minutes is not worth the wait, and offering it reads as noise.
+ */
+export const MIN_RIDE_SAVING_SECONDS = 3 * 60;
+
+/** Walk plus at most three ride variants, matching the GMaps option list. */
+export const MAX_JOURNEY_OPTIONS = 4;
+
 /** Standard viridis ramp (8 stops, matplotlib): near = dark purple, far = yellow. */
 export const VIRIDIS_STOPS = [
   "#440154",

--- a/src/lib/search-suggestions.ts
+++ b/src/lib/search-suggestions.ts
@@ -13,6 +13,9 @@ type Suggestion = {
   eventSlug?: string;
   building?: BuildingData;
   event?: EventData;
+  /** Map pin for "Add stop" while Get Directions is open. */
+  lat?: number | null;
+  lon?: number | null;
 };
 
 const MAX_SUGGESTIONS = 8;
@@ -52,7 +55,13 @@ export function buildEntitySuggestions(
     ...takeMatches(
       data.filteredBuildings,
       ({ buildingName }) => buildingName.toLowerCase().includes(needle),
-      (b) => ({ value: b.buildingName, category: "building", building: b }),
+      (b) => ({
+        value: b.buildingName,
+        category: "building",
+        building: b,
+        lat: b.lat,
+        lon: b.lon,
+      }),
     ),
     ...takeMatches(
       data.colleges,
@@ -69,7 +78,12 @@ export function buildEntitySuggestions(
       ({ dormName, shortName }) =>
         dormName.toLowerCase().includes(needle) ||
         Boolean(shortName?.toLowerCase().includes(needle)),
-      ({ dormName }) => ({ value: dormName, category: "dorm" }),
+      (d) => ({
+        value: d.dormName,
+        category: "dorm",
+        lat: d.lat,
+        lon: d.lon,
+      }),
     ),
     ...takeMatches(
       data.events,
@@ -88,14 +102,24 @@ export function buildEntitySuggestions(
       ({ name, description }) =>
         name.toLowerCase().includes(needle) ||
         Boolean(description?.toLowerCase().includes(needle)),
-      ({ name }) => ({ value: name, category: "organization" }),
+      (o) => ({
+        value: o.name,
+        category: "organization",
+        lat: o.lat,
+        lon: o.lon,
+      }),
     ),
     ...takeMatches(
       data.places,
       ({ name, description }) =>
         name.toLowerCase().includes(needle) ||
         Boolean(description?.toLowerCase().includes(needle)),
-      ({ name }) => ({ value: name, category: "place" }),
+      (p) => ({
+        value: p.name,
+        category: "place",
+        lat: p.lat,
+        lon: p.lon,
+      }),
     ),
   ];
 

--- a/src/lib/stores/directions-store.svelte.ts
+++ b/src/lib/stores/directions-store.svelte.ts
@@ -2,9 +2,9 @@
  * Directions session state (#966): where the rider is going, the ranked ways
  * to get there, and which one is drawn on the map.
  *
- * The search itself is pure and lives in lib/travel-graph/journey.ts; this
- * only owns session state and the lazy graph fetch, so the planner stays
- * unit-testable without a store.
+ * The search itself is pure and lives in lib/travel-graph; this only owns
+ * session state and the lazy graph fetch, so the planner stays unit-testable
+ * without a store.
  */
 
 import { JEEPNEY_ROUTES } from "@constants/jeepney-routes";
@@ -12,18 +12,29 @@ import {
   type Journey,
   type LatLng,
   type PlanStatus,
-  planJourneys,
 } from "../travel-graph/journey";
+import { planMultiLegJourneys } from "../travel-graph/plan-multi-leg";
+import { journeyLineCoordinates } from "../travel-graph/route-proximity";
 import { loadTravelGraph } from "../travel-graph/load";
 
 export type DirectionsPhase = "idle" | "planning" | "ready" | "error";
 
 export type DirectionsEndpoint = LatLng & { label: string };
 
+/** Max intermediate stops between origin and destination. */
+export const MAX_DIRECTIONS_WAYPOINTS = 3;
+
 export class DirectionsStore {
   phase: DirectionsPhase = $state("idle");
   origin: DirectionsEndpoint | null = $state(null);
   destination: DirectionsEndpoint | null = $state(null);
+  /** Ordered intermediates between origin and destination. */
+  waypoints: DirectionsEndpoint[] = $state([]);
+  /**
+   * When true, the next entity pick (map tap / Directions chip) inserts a
+   * waypoint instead of replacing the destination.
+   */
+  addingStop: boolean = $state(false);
   journeys: Journey[] = $state([]);
   selectedId: string | null = $state(null);
   /** Why an empty result is empty; drives the rider-facing note. */
@@ -62,12 +73,30 @@ export class DirectionsStore {
     return this.selected?.seconds ?? null;
   }
 
+  /** Selected journey polyline for pin proximity / map draw. */
+  get selectedRouteCoords(): [number, number][] {
+    const journey = this.selected;
+    if (!journey) return [];
+    return journeyLineCoordinates(journey.legs);
+  }
+
+  /** Origin → waypoints → destination (for UI list and replan). */
+  get routePoints(): DirectionsEndpoint[] {
+    const points: DirectionsEndpoint[] = [];
+    if (this.origin) points.push(this.origin);
+    points.push(...this.waypoints);
+    if (this.destination) points.push(this.destination);
+    return points;
+  }
+
   open = async (
     destination: DirectionsEndpoint,
     origin: DirectionsEndpoint | null,
   ) => {
     this.destination = destination;
     this.origin = origin;
+    this.waypoints = [];
+    this.addingStop = false;
     this.selectedId = null;
     this.journeys = [];
     this.status = null;
@@ -94,10 +123,14 @@ export class DirectionsStore {
       const graph = await loadTravelGraph();
       if (token !== this.#planToken) return; // superseded
 
-      const plan = planJourneys({
-        graph,
+      const points: LatLng[] = [
         origin,
+        ...this.waypoints,
         destination,
+      ];
+      const plan = planMultiLegJourneys({
+        graph,
+        points,
         routes: JEEPNEY_ROUTES,
       });
 
@@ -113,6 +146,66 @@ export class DirectionsStore {
     }
   };
 
+  /** Replan using current origin/destination/waypoints. */
+  refresh = async () => {
+    if (!this.origin || !this.destination) return;
+    await this.replan(this.origin, this.destination);
+  };
+
+  beginAddStop = () => {
+    if (this.waypoints.length >= MAX_DIRECTIONS_WAYPOINTS) return;
+    this.addingStop = true;
+  };
+
+  cancelAddStop = () => {
+    this.addingStop = false;
+  };
+
+  addWaypoint = async (stop: DirectionsEndpoint) => {
+    if (this.waypoints.length >= MAX_DIRECTIONS_WAYPOINTS) {
+      this.addingStop = false;
+      return;
+    }
+    // Skip near-duplicates of an existing stop / destination.
+    const same = (a: DirectionsEndpoint, b: DirectionsEndpoint) =>
+      Math.abs(a.lat - b.lat) < 1e-5 && Math.abs(a.lng - b.lng) < 1e-5;
+    if (this.destination && same(stop, this.destination)) {
+      this.addingStop = false;
+      return;
+    }
+    if (this.waypoints.some((w) => same(w, stop))) {
+      this.addingStop = false;
+      return;
+    }
+
+    this.waypoints = [...this.waypoints, stop];
+    this.addingStop = false;
+    await this.refresh();
+  };
+
+  removeWaypoint = async (index: number) => {
+    if (index < 0 || index >= this.waypoints.length) return;
+    this.waypoints = this.waypoints.filter((_, i) => i !== index);
+    await this.refresh();
+  };
+
+  moveWaypoint = async (from: number, to: number) => {
+    if (
+      from < 0 ||
+      to < 0 ||
+      from >= this.waypoints.length ||
+      to >= this.waypoints.length ||
+      from === to
+    ) {
+      return;
+    }
+    const next = [...this.waypoints];
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item);
+    this.waypoints = next;
+    await this.refresh();
+  };
+
   select = (id: string) => {
     this.selectedId = id;
   };
@@ -121,6 +214,7 @@ export class DirectionsStore {
     if (!this.selected) return;
     this.navigating = true;
     this.cameraFollowing = true;
+    this.addingStop = false;
   };
 
   stopNavigation = () => {
@@ -150,6 +244,8 @@ export class DirectionsStore {
     this.cameraFollowing = true;
     this.origin = null;
     this.destination = null;
+    this.waypoints = [];
+    this.addingStop = false;
     this.journeys = [];
     this.selectedId = null;
     this.status = null;

--- a/src/lib/stores/directions-store.svelte.ts
+++ b/src/lib/stores/directions-store.svelte.ts
@@ -137,6 +137,12 @@ export class DirectionsStore {
     this.cameraFollowing = true;
   };
 
+  /**
+   * Tear down the session. `onClose` clears cross-store leftovers (legacy
+   * OSRM destination) without this module importing locationStore.
+   */
+  onClose: (() => void) | null = null;
+
   close = () => {
     this.#planToken++;
     this.phase = "idle";
@@ -147,5 +153,6 @@ export class DirectionsStore {
     this.journeys = [];
     this.selectedId = null;
     this.status = null;
+    this.onClose?.();
   };
 }

--- a/src/lib/stores/directions-store.svelte.ts
+++ b/src/lib/stores/directions-store.svelte.ts
@@ -1,0 +1,151 @@
+/**
+ * Directions session state (#966): where the rider is going, the ranked ways
+ * to get there, and which one is drawn on the map.
+ *
+ * The search itself is pure and lives in lib/travel-graph/journey.ts; this
+ * only owns session state and the lazy graph fetch, so the planner stays
+ * unit-testable without a store.
+ */
+
+import { JEEPNEY_ROUTES } from "@constants/jeepney-routes";
+import {
+  type Journey,
+  type LatLng,
+  type PlanStatus,
+  planJourneys,
+} from "../travel-graph/journey";
+import { loadTravelGraph } from "../travel-graph/load";
+
+export type DirectionsPhase = "idle" | "planning" | "ready" | "error";
+
+export type DirectionsEndpoint = LatLng & { label: string };
+
+export class DirectionsStore {
+  phase: DirectionsPhase = $state("idle");
+  origin: DirectionsEndpoint | null = $state(null);
+  destination: DirectionsEndpoint | null = $state(null);
+  journeys: Journey[] = $state([]);
+  selectedId: string | null = $state(null);
+  /** Why an empty result is empty; drives the rider-facing note. */
+  status: PlanStatus | null = $state(null);
+
+  /**
+   * Turn-by-turn-style follow mode: tilted camera locked to the rider's
+   * heading. Separate from `active` because the option list and the follow
+   * camera are different screens over the same plan.
+   */
+  navigating: boolean = $state(false);
+
+  /**
+   * Whether the camera is still locked to the rider. A manual pan releases it
+   * (as GMaps does) and the recentre button takes it back.
+   */
+  cameraFollowing: boolean = $state(true);
+
+  /** Guards against a slow plan landing after a newer one. */
+  #planToken = 0;
+
+  get active(): boolean {
+    return this.phase !== "idle";
+  }
+
+  get selected(): Journey | null {
+    if (this.journeys.length === 0) return null;
+    return (
+      this.journeys.find((journey) => journey.id === this.selectedId) ??
+      this.journeys[0]
+    );
+  }
+
+  /** Total seconds for the selected option — the "12 min" headline. */
+  get selectedSeconds(): number | null {
+    return this.selected?.seconds ?? null;
+  }
+
+  open = async (
+    destination: DirectionsEndpoint,
+    origin: DirectionsEndpoint | null,
+  ) => {
+    this.destination = destination;
+    this.origin = origin;
+    this.selectedId = null;
+    this.journeys = [];
+    this.status = null;
+
+    if (!origin) {
+      // Waiting on a GPS fix; replan() runs once coords arrive.
+      this.phase = "planning";
+      return;
+    }
+    await this.replan(origin, destination);
+  };
+
+  /** Re-run the search, e.g. when the GPS fix finally lands or improves. */
+  replan = async (
+    origin: DirectionsEndpoint,
+    destination: DirectionsEndpoint,
+  ) => {
+    const token = ++this.#planToken;
+    this.phase = "planning";
+    this.origin = origin;
+    this.destination = destination;
+
+    try {
+      const graph = await loadTravelGraph();
+      if (token !== this.#planToken) return; // superseded
+
+      const plan = planJourneys({
+        graph,
+        origin,
+        destination,
+        routes: JEEPNEY_ROUTES,
+      });
+
+      this.journeys = plan.journeys;
+      this.status = plan.status;
+      this.selectedId = plan.journeys[0]?.id ?? null;
+      this.phase = "ready";
+    } catch {
+      if (token !== this.#planToken) return;
+      this.journeys = [];
+      this.status = null;
+      this.phase = "error";
+    }
+  };
+
+  select = (id: string) => {
+    this.selectedId = id;
+  };
+
+  startNavigation = () => {
+    if (!this.selected) return;
+    this.navigating = true;
+    this.cameraFollowing = true;
+  };
+
+  stopNavigation = () => {
+    this.navigating = false;
+    this.cameraFollowing = true;
+  };
+
+  /** A manual pan drops the camera lock; the recentre button restores it. */
+  releaseCamera = () => {
+    this.cameraFollowing = false;
+  };
+
+  recenter = () => {
+    this.cameraFollowing = true;
+  };
+
+  close = () => {
+    this.#planToken++;
+    this.phase = "idle";
+    this.navigating = false;
+    this.cameraFollowing = true;
+    this.origin = null;
+    this.destination = null;
+    this.journeys = [];
+    this.selectedId = null;
+    this.status = null;
+  };
+}

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -178,6 +178,7 @@ import {
 import { PlannerStore } from "./planner-store.svelte";
 import { TransitStore } from "./transit-store.svelte";
 import { AnnouncementsStore } from "./announcements-store.svelte";
+import { DirectionsStore } from "./directions-store.svelte";
 
 export { plannerRoomCodes } from "./data-stores.svelte";
 
@@ -1023,6 +1024,7 @@ export const measureRouteStore = new MeasureRouteStore();
 export const jeepneyStore = new JeepneyStore();
 export const transitStore = new TransitStore();
 export const announcementsStore = new AnnouncementsStore();
+export const directionsStore = new DirectionsStore();
 export const appBootstrapStore = new AppBootstrapStore();
 export const syncToastStore = new SyncToastStore();
 export const building3DStore = new Building3DStore();

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -178,7 +178,11 @@ import {
 import { PlannerStore } from "./planner-store.svelte";
 import { TransitStore } from "./transit-store.svelte";
 import { AnnouncementsStore } from "./announcements-store.svelte";
-import { DirectionsStore } from "./directions-store.svelte";
+import {
+  DirectionsStore,
+  MAX_DIRECTIONS_WAYPOINTS,
+} from "./directions-store.svelte";
+export { MAX_DIRECTIONS_WAYPOINTS };
 
 export { plannerRoomCodes } from "./data-stores.svelte";
 

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -1025,6 +1025,11 @@ export const jeepneyStore = new JeepneyStore();
 export const transitStore = new TransitStore();
 export const announcementsStore = new AnnouncementsStore();
 export const directionsStore = new DirectionsStore();
+// Get directions used to also set locationStore.destination (OSRM). Clear it
+// on close so Map.svelte does not redraw the foot polyline after the modal goes.
+directionsStore.onClose = () => {
+  locationStore.clearDestination();
+};
 export const appBootstrapStore = new AppBootstrapStore();
 export const syncToastStore = new SyncToastStore();
 export const building3DStore = new Building3DStore();

--- a/src/lib/travel-graph/directions-fit.test.ts
+++ b/src/lib/travel-graph/directions-fit.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  computeDirectionsFitExtents,
+  directionsEdgeCamera,
+  directionsFitPaddingFromRects,
+  estimateDestinationLabelHalfWidthPx,
+} from "./directions-fit";
+
+describe("computeDirectionsFitExtents", () => {
+  test("expands west by GPS accuracy when destination is east", () => {
+    const e = computeDirectionsFitExtents({
+      origin: { lng: 121.24, lat: 14.16 },
+      destination: { lng: 121.245, lat: 14.165 },
+      accuracyMeters: 40,
+    });
+    expect(e.destOnRight).toBe(true);
+    expect(e.west).toBeLessThan(121.24 - 0.0002);
+    expect(e.east).toBeCloseTo(121.245, 5);
+  });
+
+  test("marks destOnRight false when destination is west of origin", () => {
+    const e = computeDirectionsFitExtents({
+      origin: { lng: 121.25, lat: 14.16 },
+      destination: { lng: 121.24, lat: 14.161 },
+      accuracyMeters: 20,
+    });
+    expect(e.destOnRight).toBe(false);
+    expect(e.east).toBeGreaterThan(121.25);
+  });
+
+  test("ignores a winding polyline by not taking extra points", () => {
+    const e = computeDirectionsFitExtents({
+      origin: { lng: 121.24, lat: 14.16 },
+      destination: { lng: 121.241, lat: 14.161 },
+      accuracyMeters: 0,
+    });
+    // Lat span stays near the two endpoints, not a long detour.
+    expect(e.north - e.south).toBeLessThan(0.002);
+  });
+});
+
+describe("estimateDestinationLabelHalfWidthPx", () => {
+  test("scales with label length", () => {
+    expect(
+      estimateDestinationLabelHalfWidthPx("Old Math/Old Rural Building"),
+    ).toBeGreaterThan(estimateDestinationLabelHalfWidthPx("Pool"));
+  });
+});
+
+describe("directionsFitPaddingFromRects", () => {
+  test("pads the destination side for the name tag", () => {
+    const rightDest = directionsFitPaddingFromRects(
+      { top: 0, bottom: 800, left: 0, right: 360, width: 360, height: 800 },
+      {
+        topBottom: 160,
+        coverBottom: 480,
+        destinationLabelHalfWidthPx: 70,
+        destOnRight: true,
+        edgeGutterPx: 2,
+      },
+    );
+    expect(rightDest.left).toBe(2);
+    expect(rightDest.right).toBe(72);
+
+    const leftDest = directionsFitPaddingFromRects(
+      { top: 0, bottom: 800, left: 0, right: 360, width: 360, height: 800 },
+      {
+        topBottom: 160,
+        coverBottom: 480,
+        destinationLabelHalfWidthPx: 70,
+        destOnRight: false,
+        edgeGutterPx: 2,
+      },
+    );
+    expect(leftDest.left).toBe(72);
+    expect(leftDest.right).toBe(2);
+  });
+});
+
+describe("directionsEdgeCamera", () => {
+  test("uses width-only cameraForBounds zoom and trip midpoint", () => {
+    const map = {
+      cameraForBounds: () => ({
+        center: { lng: 121.242, lat: 14.162 },
+        zoom: 16.4,
+      }),
+    };
+    const cam = directionsEdgeCamera(
+      map,
+      {
+        west: 121.24,
+        east: 121.245,
+        south: 14.16,
+        north: 14.165,
+        destOnRight: true,
+      },
+      { top: 100, bottom: 200, left: 2, right: 60 },
+    );
+    expect(cam.zoom).toBe(16.4);
+    expect(cam.center[0]).toBeCloseTo(121.2425, 5);
+    expect(cam.center[1]).toBeCloseTo(14.1625, 5);
+  });
+});

--- a/src/lib/travel-graph/directions-fit.ts
+++ b/src/lib/travel-graph/directions-fit.ts
@@ -1,0 +1,230 @@
+/**
+ * Get Directions "Show on map" framing.
+ *
+ * Horizontal priority: GPS accuracy ring kisses one side of the free map
+ * strip; destination name tag kisses the other — for any destination bearing.
+ * Zoom is driven by width (not the tall route bbox), so diagonal walks do not
+ * leave empty side gutters.
+ */
+
+export type FitPadding = {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+};
+
+export type RectLike = {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  width: number;
+  height: number;
+};
+
+export type FitLngLat = { lng: number; lat: number };
+
+export type DirectionsFitExtents = {
+  west: number;
+  east: number;
+  south: number;
+  north: number;
+  /** Destination lies east of origin (label pads the right edge). */
+  destOnRight: boolean;
+};
+
+const METERS_PER_DEG_LAT = 111_320;
+
+function lngPadForMeters(meters: number, lat: number): number {
+  return (
+    meters / (METERS_PER_DEG_LAT * Math.max(0.2, Math.cos((lat * Math.PI) / 180)))
+  );
+}
+
+/** Rough half-width of a MapEntityPin label (centered on the pin). */
+export function estimateDestinationLabelHalfWidthPx(label: string): number {
+  const textPx = Math.min(
+    11 * 16,
+    Math.max(48, label.trim().length * 7.2 + 24),
+  );
+  return Math.ceil(textPx / 2);
+}
+
+/**
+ * Geographic box for origin (GPS + accuracy) ↔ destination (+ waypoints).
+ * Does not include the full walk polyline — that tall bbox was zooming out
+ * for height and leaving empty horizontal space.
+ */
+export function computeDirectionsFitExtents(opts: {
+  origin: FitLngLat;
+  destination: FitLngLat;
+  waypoints?: FitLngLat[];
+  accuracyMeters?: number | null;
+}): DirectionsFitExtents {
+  const { origin, destination, waypoints = [] } = opts;
+  const destOnRight = destination.lng >= origin.lng;
+
+  let west = Math.min(origin.lng, destination.lng);
+  let east = Math.max(origin.lng, destination.lng);
+  let south = Math.min(origin.lat, destination.lat);
+  let north = Math.max(origin.lat, destination.lat);
+
+  for (const stop of waypoints) {
+    west = Math.min(west, stop.lng);
+    east = Math.max(east, stop.lng);
+    south = Math.min(south, stop.lat);
+    north = Math.max(north, stop.lat);
+  }
+
+  const accuracy = opts.accuracyMeters;
+  if (accuracy != null && Number.isFinite(accuracy) && accuracy > 0) {
+    const latPad = accuracy / METERS_PER_DEG_LAT;
+    const lngPad = lngPadForMeters(accuracy, origin.lat);
+    west = Math.min(west, origin.lng - lngPad);
+    east = Math.max(east, origin.lng + lngPad);
+    south = Math.min(south, origin.lat - latPad);
+    north = Math.max(north, origin.lat + latPad);
+  }
+
+  const latSpan = Math.max(north - south, 1e-6);
+  const latMargin = latSpan * 0.04;
+  south -= latMargin;
+  north += latMargin;
+
+  const minLngSpan = 0.00015;
+  if (east - west < minLngSpan) {
+    const mid = (west + east) / 2;
+    west = mid - minLngSpan / 2;
+    east = mid + minLngSpan / 2;
+  }
+
+  return { west, east, south, north, destOnRight };
+}
+
+/** @deprecated Prefer computeDirectionsFitExtents — kept for older call sites. */
+export function expandRouteBounds(
+  minLng: number,
+  minLat: number,
+  maxLng: number,
+  maxLat: number,
+  opts?: {
+    accuracyMeters?: number | null;
+    gps?: [number, number] | null;
+    marginRatio?: number;
+  },
+): [[number, number], [number, number]] {
+  const gps = opts?.gps;
+  const origin = gps
+    ? { lng: gps[0], lat: gps[1] }
+    : { lng: minLng, lat: minLat };
+  const destination = { lng: maxLng, lat: maxLat };
+  const e = computeDirectionsFitExtents({
+    origin,
+    destination,
+    accuracyMeters: opts?.accuracyMeters,
+  });
+  return [
+    [e.west, e.south],
+    [e.east, e.north],
+  ];
+}
+
+/**
+ * Chrome covers + asymmetric label pad. Horizontal edge gutters stay tiny so
+ * the accuracy ring / name tag can sit on the screen edges.
+ */
+export function directionsFitPaddingFromRects(
+  mapRect: RectLike,
+  chrome: {
+    topBottom: number;
+    coverBottom: number;
+    leftCover?: number;
+    mobile?: boolean;
+    destinationLabelHalfWidthPx?: number;
+    destOnRight?: boolean;
+    edgeGutterPx?: number;
+  },
+): FitPadding {
+  const leftCover = chrome.leftCover ?? 0;
+  const edge = chrome.edgeGutterPx ?? 2;
+  const labelHalf = chrome.destinationLabelHalfWidthPx ?? 56;
+  const destOnRight = chrome.destOnRight ?? true;
+
+  let topCover = Math.max(0, chrome.topBottom - mapRect.top);
+  let bottomCover = Math.max(0, mapRect.bottom - chrome.coverBottom);
+  let left = Math.max(0, leftCover);
+
+  const minFreeH = 120;
+  const minFreeW = 160;
+  const maxTopBottom = Math.max(0, mapRect.height - minFreeH);
+  if (topCover + bottomCover > maxTopBottom) {
+    const scale = maxTopBottom / (topCover + bottomCover || 1);
+    topCover *= scale;
+    bottomCover *= scale;
+  }
+  if (left > mapRect.width - minFreeW) {
+    left = Math.max(0, mapRect.width - minFreeW);
+  }
+
+  const freeH = Math.max(0, mapRect.height - topCover - bottomCover);
+  const gutterY = Math.min(24, Math.max(10, Math.round(freeH * 0.06)));
+
+  return {
+    top: Math.round(topCover + gutterY),
+    bottom: Math.round(bottomCover + gutterY),
+    left: Math.round(left + edge + (destOnRight ? 0 : labelHalf)),
+    right: Math.round(edge + (destOnRight ? labelHalf : 0)),
+  };
+}
+
+type CameraForBoundsMap = {
+  cameraForBounds: (
+    bounds: [[number, number], [number, number]],
+    options?: {
+      padding?: FitPadding;
+      bearing?: number;
+      pitch?: number;
+      maxZoom?: number;
+    },
+  ) => { center: { lng: number; lat: number } | [number, number]; zoom: number };
+};
+
+/**
+ * Width-first camera: zoom so west↔east fills the padded strip. Center sits on
+ * the origin/destination midpoints (vertical chrome still applied via padding).
+ */
+export function directionsEdgeCamera(
+  map: CameraForBoundsMap,
+  extents: DirectionsFitExtents,
+  padding: FitPadding,
+): { center: [number, number]; zoom: number } {
+  const midLat = (extents.south + extents.north) / 2;
+  const midLng = (extents.west + extents.east) / 2;
+  const eps = 1e-7;
+
+  // Degenerate-height bounds → zoom is decided by width only.
+  const cam = map.cameraForBounds(
+    [
+      [extents.west, midLat - eps],
+      [extents.east, midLat + eps],
+    ],
+    {
+      padding,
+      bearing: 0,
+      pitch: 0,
+      maxZoom: 18,
+    },
+  );
+
+  const center = cam.center;
+  const lng = Array.isArray(center) ? center[0] : center.lng;
+  const lat = Array.isArray(center) ? center[1] : center.lat;
+
+  return {
+    // Prefer geographic midpoint of the trip, not whatever cameraForBounds
+    // picked for the flat band (keeps both pins in the vertical free strip).
+    center: [midLng || lng, midLat || lat],
+    zoom: cam.zoom,
+  };
+}

--- a/src/lib/travel-graph/engine.ts
+++ b/src/lib/travel-graph/engine.ts
@@ -226,6 +226,46 @@ export type TravelRoute = {
   coordinates: [number, number][];
 };
 
+/**
+ * Walk back up a settled Dijkstra result to the route from `from` to `to`.
+ *
+ * Split out from `shortestPath` so one full run can serve many targets — the
+ * journey planner reconstructs a path per candidate jeepney stop and must not
+ * pay for a fresh Dijkstra each time.
+ */
+export function reconstructPath(
+  graph: TravelGraph,
+  result: DijkstraResult,
+  from: number,
+  to: number,
+): TravelRoute | null {
+  if (from === to) {
+    return {
+      seconds: 0,
+      meters: 0,
+      coordinates: [[graph.lng[from], graph.lat[from]]],
+    };
+  }
+  const { seconds, prevEdge, prevNode } = result;
+  if (!Number.isFinite(seconds[to])) return null;
+  let meters = 0;
+  const segments: [number, number][][] = [];
+  for (let node = to; node !== from; node = prevNode[node]) {
+    const edgeIndex = prevEdge[node];
+    if (edgeIndex < 0) return null; // target settled in a run rooted elsewhere
+    const edge = graph.edges[edgeIndex];
+    meters += edge[2];
+    const coords = edgeCoordinates(graph, edgeIndex);
+    // Stored order is u -> v; flip when we traversed v -> u.
+    segments.push(edge[1] === node ? coords : [...coords].reverse());
+  }
+  segments.reverse();
+  const coordinates = segments.flatMap((coords, i) =>
+    i === 0 ? coords : coords.slice(1),
+  );
+  return { seconds: seconds[to], meters, coordinates };
+}
+
 /** Shortest path between two node indexes, or null when the mode has no route. */
 export function shortestPath(
   graph: TravelGraph,
@@ -240,23 +280,7 @@ export function shortestPath(
       coordinates: [[graph.lng[from], graph.lat[from]]],
     };
   }
-  const { seconds, prevEdge, prevNode } = dijkstra(graph, from, mode, to);
-  if (!Number.isFinite(seconds[to])) return null;
-  let meters = 0;
-  const segments: [number, number][][] = [];
-  for (let node = to; node !== from; node = prevNode[node]) {
-    const edgeIndex = prevEdge[node];
-    const edge = graph.edges[edgeIndex];
-    meters += edge[2];
-    const coords = edgeCoordinates(graph, edgeIndex);
-    // Stored order is u -> v; flip when we traversed v -> u.
-    segments.push(edge[1] === node ? coords : [...coords].reverse());
-  }
-  segments.reverse();
-  const coordinates = segments.flatMap((coords, i) =>
-    i === 0 ? coords : coords.slice(1),
-  );
-  return { seconds: seconds[to], meters, coordinates };
+  return reconstructPath(graph, dijkstra(graph, from, mode, to), from, to);
 }
 
 /**

--- a/src/lib/travel-graph/journey.test.ts
+++ b/src/lib/travel-graph/journey.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, test } from "bun:test";
+import type { JeepneyRoute } from "@constants/jeepney-routes";
+import {
+  JEEPNEY_WAIT_SECONDS,
+  MAX_ACCESS_WALK_METERS,
+} from "@constants/travel-modes";
+import { buildTravelGraph, type WalkGraphData } from "./engine";
+import {
+  describeJourney,
+  PLAN_STATUS_NOTES,
+  planJourneys,
+  routeProgress,
+  type RideLeg,
+} from "./journey";
+
+/**
+ * A straight 4 km corridor of five nodes, 1 km apart, all footway. Long
+ * enough that riding beats walking, so the ride branch is reachable without
+ * fighting the "not worth the wait" guard.
+ *
+ *   n0 --1km-- n1 --1km-- n2 --1km-- n3 --1km-- n4
+ */
+const LAT = 14.16;
+const KM_IN_DEGREES = 1000 / 111_320;
+
+function corridor(nodeCount: number): WalkGraphData {
+  const nodes: [number, number, number][] = [];
+  const edges: WalkGraphData["edges"] = [];
+  for (let i = 0; i < nodeCount; i++) {
+    nodes.push([i + 1, LAT + i * KM_IN_DEGREES, 121.24]);
+    if (i > 0) edges.push([i - 1, i, 1000, "footway", null, []]);
+  }
+  return {
+    meta: { coordScale: 1e6, nodeCount, edgeCount: edges.length },
+    nodes,
+    edges,
+  };
+}
+
+const graph = buildTravelGraph(corridor(5));
+
+const nodeAt = (index: number) => ({
+  lat: LAT + index * KM_IN_DEGREES,
+  lng: 121.24,
+});
+
+/** A jeep serving the corridor, stopping at n0, n2 and n4. */
+const corridorRoute: JeepneyRoute = {
+  id: "corridor",
+  name: "Corridor Line",
+  description: "test",
+  color: "#dc2626",
+  fare: { regular: 13, discounted: 11 },
+  stops: [0, 2, 4].map((index) => ({
+    name: `Stop ${index}`,
+    description: "test",
+    lat: nodeAt(index).lat,
+    lon: 121.24,
+  })),
+};
+
+describe("planJourneys", () => {
+  test("always offers the walk-only option first when it is fastest", () => {
+    const { journeys } = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(1),
+      routes: [corridorRoute],
+    });
+
+    expect(journeys[0].kind).toBe("walk");
+    expect(journeys[0].walkMeters).toBeCloseTo(1000, 0);
+    // 1 km at 4.5 km/h = 800s.
+    expect(journeys[0].seconds).toBeCloseTo(800, 0);
+  });
+
+  test("offers a ride when it beats walking, and counts the wait", () => {
+    const { journeys } = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(4),
+      routes: [corridorRoute],
+    });
+
+    const transit = journeys.find((j) => j.kind === "transit");
+    expect(transit).toBeDefined();
+
+    const ride = transit?.legs.find(
+      (leg): leg is RideLeg => leg.kind === "ride",
+    );
+    expect(ride?.boardStopName).toBe("Stop 0");
+    expect(ride?.alightStopName).toBe("Stop 4");
+    expect(ride?.waitSeconds).toBe(JEEPNEY_WAIT_SECONDS);
+    // Boarding at the origin and alighting at the destination: no walking.
+    expect(transit?.walkMeters).toBeCloseTo(0, 0);
+    // 4 km at 14 km/h = ~1029s, plus the 300s wait.
+    expect(transit?.seconds).toBeCloseTo(1029 + JEEPNEY_WAIT_SECONDS, -1);
+    expect(transit?.seconds).toBeLessThan(journeys[0].seconds + 1);
+  });
+
+  test("suppresses a ride that barely beats walking", () => {
+    // n0 -> n2 is 2 km: walking 1600s vs riding 514s + 300s wait saves ~13 min,
+    // but over a single 1 km hop the wait swallows the saving.
+    const { journeys } = planJourneys({
+      graph,
+      origin: nodeAt(1),
+      destination: nodeAt(2),
+      routes: [corridorRoute],
+    });
+
+    expect(journeys.every((j) => j.kind === "walk")).toBe(true);
+  });
+
+  test("ignores stops that are too far to walk to", () => {
+    const farRoute: JeepneyRoute = {
+      ...corridorRoute,
+      stops: corridorRoute.stops.map((stop) => ({
+        ...stop,
+        // Push the whole line a full degree east, far past the access cap.
+        lon: 122.24,
+      })),
+    };
+
+    const { journeys } = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(4),
+      routes: [farRoute],
+    });
+
+    expect(journeys.every((j) => j.kind === "walk")).toBe(true);
+    expect(MAX_ACCESS_WALK_METERS).toBeLessThan(111_320);
+  });
+
+  test("collapses the two directions of one loop into a single option", () => {
+    const { journeys } = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(4),
+      routes: [corridorRoute],
+    });
+
+    const rideRouteIds = journeys
+      .flatMap((j) => j.legs)
+      .filter((leg): leg is RideLeg => leg.kind === "ride")
+      .map((leg) => leg.routeId);
+
+    expect(rideRouteIds).toEqual(["corridor"]);
+  });
+
+  test("caps the option list", () => {
+    const { journeys } = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(4),
+      routes: [
+        corridorRoute,
+        { ...corridorRoute, id: "b", name: "B" },
+        { ...corridorRoute, id: "c", name: "C" },
+        { ...corridorRoute, id: "d", name: "D" },
+        { ...corridorRoute, id: "e", name: "E" },
+      ],
+      maxOptions: 3,
+    });
+
+    expect(journeys).toHaveLength(3);
+  });
+
+  test("reports no route when both ends are mapped but disconnected", () => {
+    const isolated = buildTravelGraph({
+      meta: { coordScale: 1e6, nodeCount: 2, edgeCount: 0 },
+      nodes: [
+        [1, 14.16, 121.24],
+        [2, 14.2, 121.3],
+      ],
+      edges: [],
+    });
+
+    const plan = planJourneys({
+      graph: isolated,
+      origin: { lat: 14.16, lng: 121.24 },
+      destination: { lat: 14.2, lng: 121.3 },
+      routes: [],
+    });
+
+    expect(plan.status).toBe("no-route");
+    expect(plan.journeys).toEqual([]);
+  });
+
+  /**
+   * Regression: the walk graph stops at the campus edge, and snapping is
+   * unconditional. Without the endpoint guard a town-side origin a kilometre
+   * off the network silently borrowed the nearest node and produced a
+   * confident, wholly invented walking time.
+   */
+  test("refuses to plan from a point off the mapped network", () => {
+    const plan = planJourneys({
+      graph,
+      origin: { lat: LAT, lng: 121.3 }, // ~6 km east of the corridor
+      destination: nodeAt(4),
+      routes: [corridorRoute],
+    });
+
+    expect(plan.status).toBe("origin-off-network");
+    expect(plan.journeys).toEqual([]);
+    expect(PLAN_STATUS_NOTES[plan.status]).toContain("outside the mapped");
+  });
+
+  test("refuses to plan to a point off the mapped network", () => {
+    const plan = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: { lat: LAT, lng: 121.3 },
+      routes: [corridorRoute],
+    });
+
+    expect(plan.status).toBe("destination-off-network");
+    expect(plan.journeys).toEqual([]);
+  });
+
+  test("still plans for a pin dropped just off a path", () => {
+    // A GPS fix inside a building is legitimately off-network; only the
+    // far-outside case should be refused.
+    const plan = planJourneys({
+      graph,
+      origin: { lat: LAT, lng: 121.2415 }, // ~160 m east of node 0
+      destination: nodeAt(2),
+      routes: [corridorRoute],
+    });
+
+    expect(plan.status).toBe("ok");
+    expect(plan.journeys.length).toBeGreaterThan(0);
+  });
+
+  test("legs join end to end, so the drawn line has no gaps", () => {
+    const { journeys } = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(4),
+      routes: [corridorRoute],
+    });
+    const transit = journeys.find((j) => j.kind === "transit");
+    const legs = transit?.legs ?? [];
+
+    for (let i = 1; i < legs.length; i++) {
+      const prevEnd = legs[i - 1].coordinates.at(-1);
+      const nextStart = legs[i].coordinates[0];
+      if (!prevEnd || !nextStart) continue;
+      expect(nextStart[0]).toBeCloseTo(prevEnd[0], 3);
+      expect(nextStart[1]).toBeCloseTo(prevEnd[1], 3);
+    }
+  });
+});
+
+describe("routeProgress", () => {
+  const plan = () =>
+    planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(4),
+      routes: [],
+    }).journeys[0];
+
+  test("counts the whole route as remaining at the start", () => {
+    const journey = plan();
+    const progress = routeProgress(journey, nodeAt(0));
+
+    expect(progress?.fraction).toBeCloseTo(0, 2);
+    expect(progress?.remainingMeters).toBeCloseTo(4000, -2);
+    expect(progress?.offRouteMeters).toBeLessThan(5);
+  });
+
+  test("shrinks the remainder as the rider advances", () => {
+    const journey = plan();
+    const start = routeProgress(journey, nodeAt(0));
+    const middle = routeProgress(journey, nodeAt(2));
+    const end = routeProgress(journey, nodeAt(4));
+
+    expect(middle!.remainingMeters).toBeLessThan(start!.remainingMeters);
+    expect(end!.remainingMeters).toBeLessThan(middle!.remainingMeters);
+    expect(middle?.fraction).toBeCloseTo(0.5, 1);
+    expect(end?.remainingMeters).toBeCloseTo(0, 0);
+    expect(end?.remainingSeconds).toBeCloseTo(0, 0);
+  });
+
+  /**
+   * Progress is the closest point on the line, not distance-to-destination.
+   * Stepping sideways off the path must not read as having made progress.
+   */
+  test("reports how far off the line the rider has strayed", () => {
+    const journey = plan();
+    const strayed = routeProgress(journey, {
+      lat: nodeAt(2).lat,
+      lng: 121.2427, // ~300 m east of the corridor
+    });
+
+    expect(strayed?.offRouteMeters).toBeGreaterThan(200);
+    // Still level with node 2, so the remainder is unchanged.
+    expect(strayed?.fraction).toBeCloseTo(0.5, 1);
+  });
+
+  test("returns null for a journey with no drawable line", () => {
+    expect(
+      routeProgress(
+        {
+          id: "x",
+          kind: "walk",
+          seconds: 1,
+          meters: 0,
+          walkMeters: 0,
+          legs: [],
+          fare: null,
+          geometrySource: "walk-graph",
+        },
+        nodeAt(0),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("describeJourney", () => {
+  test("names walking plainly", () => {
+    expect(
+      describeJourney({
+        id: "walk",
+        kind: "walk",
+        seconds: 600,
+        meters: 750,
+        walkMeters: 750,
+        legs: [],
+        fare: null,
+        geometrySource: "walk-graph",
+      }),
+    ).toBe("Walking the whole way");
+  });
+
+  test("counts hops, not stops, and singularises one", () => {
+    const { journeys } = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(4),
+      routes: [corridorRoute],
+    });
+    const transit = journeys.find((j) => j.kind === "transit");
+
+    expect(transit && describeJourney(transit)).toContain("2 stops on Corridor Line");
+  });
+});

--- a/src/lib/travel-graph/journey.ts
+++ b/src/lib/travel-graph/journey.ts
@@ -1,0 +1,449 @@
+/**
+ * Multi-modal journey search: walk-only and walk + campus jeepney (#966).
+ *
+ * Runs entirely client-side on the vendored walk graph, so directions work
+ * offline and cost no API calls. The whole search is two Dijkstra runs:
+ *
+ *   1. from the origin — walking seconds to every node, hence to every stop
+ *   2. from the destination — walking seconds from every stop to the end
+ *
+ * Walking is symmetric on this graph, so run 2 doubles as the egress table.
+ * Every board/alight pair is then a table lookup, which keeps the ride search
+ * at O(routes x stops^2) over ~20 stops — microseconds, no worker needed.
+ *
+ * ponytail: no timetable, no transfers between routes. Campus jeeps run on
+ * headway rather than a schedule, and the two routes meet only near the core
+ * where walking already wins, so a two-ride itinerary would be modelled noise.
+ */
+
+import {
+  ENDPOINT_SNAP_TOLERANCE_METERS,
+  JEEPNEY_KPH,
+  JEEPNEY_WAIT_SECONDS,
+  MAX_ACCESS_WALK_METERS,
+  MAX_JOURNEY_OPTIONS,
+  MIN_RIDE_SAVING_SECONDS,
+  STOP_SNAP_TOLERANCE_METERS,
+  WALK_KPH,
+} from "@constants/travel-modes";
+import type { JeepneyFare, JeepneyRoute } from "@constants/jeepney-routes";
+import { distanceMeters } from "../campus-route";
+import {
+  dijkstra,
+  nearestNodeIndex,
+  reconstructPath,
+  type TravelGraph,
+} from "./engine";
+
+export type LatLng = { lat: number; lng: number };
+
+export type WalkLeg = {
+  kind: "walk";
+  seconds: number;
+  meters: number;
+  /** [lng, lat] GeoJSON order. */
+  coordinates: [number, number][];
+};
+
+export type RideLeg = {
+  kind: "ride";
+  routeId: string;
+  routeName: string;
+  color: string;
+  fare: JeepneyFare;
+  boardStopName: string;
+  alightStopName: string;
+  /** Stops passed through, board and alight inclusive. */
+  stopCount: number;
+  /** Expected wait at the boarding stop, already counted in `seconds`. */
+  waitSeconds: number;
+  seconds: number;
+  meters: number;
+  coordinates: [number, number][];
+};
+
+export type JourneyLeg = WalkLeg | RideLeg;
+
+export type Journey = {
+  /** Stable across a search, so the UI can key a selection. */
+  id: string;
+  kind: "walk" | "transit";
+  /** Total door-to-door seconds, including the boarding wait. */
+  seconds: number;
+  /** Total distance travelled across every leg. */
+  meters: number;
+  /** Walking portion only — the number riders actually care about. */
+  walkMeters: number;
+  legs: JourneyLeg[];
+  /** Present on transit journeys; campus fares are per boarding. */
+  fare: JeepneyFare | null;
+  /**
+   * The ride leg is drawn through the stop list, not a road-traced line.
+   * Mirrors the "stops-only" provenance vocabulary in jeepney-routes.ts.
+   */
+  geometrySource: "walk-graph" | "stops-only";
+};
+
+const WALK_MPS = WALK_KPH / 3.6;
+const JEEPNEY_MPS = JEEPNEY_KPH / 3.6;
+
+/** A route walked in a given direction, as an ordered stop list. */
+type DirectedRoute = {
+  route: JeepneyRoute;
+  /** "" for the listed order, " (reverse)" for the mirrored run. */
+  suffix: string;
+  stops: JeepneyRoute["stops"];
+};
+
+/**
+ * Both ways round. Kaliwa and Kanan are the same loop driven in opposite
+ * directions, and the Forestry line is served up and down, so a rider can
+ * always board in whichever direction gets them there sooner.
+ */
+function directedRoutes(routes: JeepneyRoute[]): DirectedRoute[] {
+  const out: DirectedRoute[] = [];
+  for (const route of routes) {
+    if (route.stops.length < 2) continue;
+    out.push({ route, suffix: "", stops: route.stops });
+    out.push({
+      route,
+      suffix: " (reverse)",
+      stops: [...route.stops].reverse(),
+    });
+  }
+  return out;
+}
+
+/** Cumulative metres along a stop list, so any i..j span is one subtraction. */
+function cumulativeMeters(stops: JeepneyRoute["stops"]): number[] {
+  const cumulative = [0];
+  for (let i = 1; i < stops.length; i++) {
+    cumulative.push(
+      cumulative[i - 1] + distanceMeters(stops[i - 1], stops[i]),
+    );
+  }
+  return cumulative;
+}
+
+export type PlanJourneysInput = {
+  graph: TravelGraph;
+  origin: LatLng;
+  destination: LatLng;
+  routes: JeepneyRoute[];
+  /** Test seam; defaults to the campus-wide constant. */
+  maxOptions?: number;
+};
+
+/**
+ * Why a plan came back empty. The walk graph stops at the campus edge, so
+ * "we do not map that far" is a routine outcome, not a failure — and it reads
+ * very differently to the rider than "there is no way to get there".
+ */
+export type PlanStatus =
+  | "ok"
+  | "origin-off-network"
+  | "destination-off-network"
+  | "no-route";
+
+export type JourneyPlan = {
+  status: PlanStatus;
+  journeys: Journey[];
+};
+
+/** Nearest node, or null when the point is too far off the mapped network. */
+function snapEndpoint(graph: TravelGraph, point: LatLng): number | null {
+  const node = nearestNodeIndex(graph, point.lat, point.lng);
+  const snapMeters = distanceMeters(
+    { lat: point.lat, lon: point.lng },
+    { lat: graph.lat[node], lon: graph.lng[node] },
+  );
+  return snapMeters > ENDPOINT_SNAP_TOLERANCE_METERS ? null : node;
+}
+
+/**
+ * Rank the ways a rider could make this trip, best time first.
+ *
+ * Always leads with the walk-only option when one exists — on a 2 km campus
+ * that is usually the honest answer — then adds the ride options that save
+ * enough time to be worth the wait.
+ */
+export function planJourneys({
+  graph,
+  origin,
+  destination,
+  routes,
+  maxOptions = MAX_JOURNEY_OPTIONS,
+}: PlanJourneysInput): JourneyPlan {
+  const originNode = snapEndpoint(graph, origin);
+  if (originNode === null) {
+    return { status: "origin-off-network", journeys: [] };
+  }
+  const destNode = snapEndpoint(graph, destination);
+  if (destNode === null) {
+    return { status: "destination-off-network", journeys: [] };
+  }
+
+  const fromOrigin = dijkstra(graph, originNode, "walk");
+  const fromDestination = dijkstra(graph, destNode, "walk");
+
+  const journeys: Journey[] = [];
+
+  const walkPath = reconstructPath(graph, fromOrigin, originNode, destNode);
+  if (walkPath) {
+    journeys.push({
+      id: "walk",
+      kind: "walk",
+      seconds: walkPath.seconds,
+      meters: walkPath.meters,
+      walkMeters: walkPath.meters,
+      legs: [{ kind: "walk", ...walkPath }],
+      fare: null,
+      geometrySource: "walk-graph",
+    });
+  }
+
+  const walkOnlySeconds = walkPath?.seconds ?? Number.POSITIVE_INFINITY;
+
+  for (const { route, suffix, stops } of directedRoutes(routes)) {
+    // Snapping is unconditional, so a stop far off the mapped network would
+    // otherwise inherit a neighbouring node's walk time. Drop those instead.
+    const stopNodes = stops.map((stop) => {
+      const node = nearestNodeIndex(graph, stop.lat, stop.lon);
+      const snapMeters = distanceMeters(stop, {
+        lat: graph.lat[node],
+        lon: graph.lng[node],
+      });
+      return snapMeters > STOP_SNAP_TOLERANCE_METERS ? -1 : node;
+    });
+    const cumulative = cumulativeMeters(stops);
+
+    let best: { board: number; alight: number; seconds: number } | null = null;
+
+    for (let board = 0; board < stops.length - 1; board++) {
+      if (stopNodes[board] < 0) continue;
+      const accessSeconds = fromOrigin.seconds[stopNodes[board]];
+      if (!Number.isFinite(accessSeconds)) continue;
+      if (accessSeconds * WALK_MPS > MAX_ACCESS_WALK_METERS) continue;
+
+      for (let alight = board + 1; alight < stops.length; alight++) {
+        if (stopNodes[alight] < 0) continue;
+        const egressSeconds = fromDestination.seconds[stopNodes[alight]];
+        if (!Number.isFinite(egressSeconds)) continue;
+        if (egressSeconds * WALK_MPS > MAX_ACCESS_WALK_METERS) continue;
+
+        const rideMeters = cumulative[alight] - cumulative[board];
+        if (rideMeters <= 0) continue;
+
+        const total =
+          accessSeconds +
+          JEEPNEY_WAIT_SECONDS +
+          rideMeters / JEEPNEY_MPS +
+          egressSeconds;
+
+        if (!best || total < best.seconds) {
+          best = { board, alight, seconds: total };
+        }
+      }
+    }
+
+    if (!best) continue;
+    // A ride that barely beats walking is not worth standing at a stop for.
+    if (best.seconds > walkOnlySeconds - MIN_RIDE_SAVING_SECONDS) continue;
+
+    const access = reconstructPath(
+      graph,
+      fromOrigin,
+      originNode,
+      stopNodes[best.board],
+    );
+    const egressReversed = reconstructPath(
+      graph,
+      fromDestination,
+      destNode,
+      stopNodes[best.alight],
+    );
+    if (!access || !egressReversed) continue;
+
+    // Run 2 is rooted at the destination, so its path arrives backwards.
+    const egress: WalkLeg = {
+      kind: "walk",
+      seconds: egressReversed.seconds,
+      meters: egressReversed.meters,
+      coordinates: [...egressReversed.coordinates].reverse(),
+    };
+
+    const ridden = stops.slice(best.board, best.alight + 1);
+    const rideMeters = cumulative[best.alight] - cumulative[best.board];
+    const ride: RideLeg = {
+      kind: "ride",
+      routeId: route.id,
+      routeName: route.name,
+      color: route.color,
+      fare: route.fare,
+      boardStopName: stops[best.board].name,
+      alightStopName: stops[best.alight].name,
+      stopCount: ridden.length,
+      waitSeconds: JEEPNEY_WAIT_SECONDS,
+      seconds: JEEPNEY_WAIT_SECONDS + rideMeters / JEEPNEY_MPS,
+      meters: rideMeters,
+      coordinates: ridden.map((stop) => [stop.lon, stop.lat]),
+    };
+
+    journeys.push({
+      id: `${route.id}${suffix}`,
+      kind: "transit",
+      seconds: access.seconds + ride.seconds + egress.seconds,
+      meters: access.meters + ride.meters + egress.meters,
+      walkMeters: access.meters + egress.meters,
+      legs: [{ kind: "walk", ...access }, ride, egress],
+      fare: route.fare,
+      geometrySource: "stops-only",
+    });
+  }
+
+  journeys.sort((a, b) => a.seconds - b.seconds);
+
+  // One option per route: the reverse run is the same jeep, and offering both
+  // directions of one loop reads as two choices when it is really one.
+  const seenRoutes = new Set<string>();
+  const deduped = journeys.filter((journey) => {
+    if (journey.kind === "walk") return true;
+    const routeId = journey.legs.find(
+      (leg): leg is RideLeg => leg.kind === "ride",
+    )?.routeId;
+    if (!routeId || seenRoutes.has(routeId)) return false;
+    seenRoutes.add(routeId);
+    return true;
+  });
+
+  return {
+    status: deduped.length > 0 ? "ok" : "no-route",
+    journeys: deduped.slice(0, maxOptions),
+  };
+}
+
+/** Rider-facing copy per status; null when there is nothing to explain. */
+export const PLAN_STATUS_NOTES: Record<PlanStatus, string | null> = {
+  ok: null,
+  "origin-off-network":
+    "Your starting point is outside the mapped campus paths, so we cannot plan this trip yet.",
+  "destination-off-network":
+    "That destination is outside the mapped campus paths, so we cannot plan this trip yet.",
+  "no-route":
+    "No campus path connects these two points in our map. It may still be walkable.",
+};
+
+/**
+ * Where the rider is along a drawn journey, and what is left of it.
+ *
+ * Live navigation re-runs this on every GPS tick, so it is a linear scan over
+ * the polyline with no allocation per segment. Progress is measured by the
+ * closest point on the line rather than by distance to the destination, so
+ * stepping off the path sideways does not read as progress.
+ */
+export type RouteProgress = {
+  /** Metres still to travel along the line. */
+  remainingMeters: number;
+  /** Seconds left, scaled from the journey's own average pace. */
+  remainingSeconds: number;
+  /** How far off the line the rider is — large means they have strayed. */
+  offRouteMeters: number;
+  /** 0-1 along the journey. */
+  fraction: number;
+};
+
+/** Perpendicular distance from p to segment ab, plus how far along ab it lands. */
+function projectOnSegment(
+  p: LatLng,
+  a: [number, number],
+  b: [number, number],
+): { offMeters: number; alongMeters: number; segmentMeters: number } {
+  const toMeters = (lng: number, lat: number) => {
+    const meanLat = ((a[1] + p.lat) / 2) * (Math.PI / 180);
+    return {
+      x: lng * Math.cos(meanLat) * 111_320,
+      y: lat * 111_320,
+    };
+  };
+  const pa = toMeters(a[0], a[1]);
+  const pb = toMeters(b[0], b[1]);
+  const pp = toMeters(p.lng, p.lat);
+  const dx = pb.x - pa.x;
+  const dy = pb.y - pa.y;
+  const segmentMeters = Math.hypot(dx, dy);
+  if (segmentMeters === 0) {
+    return {
+      offMeters: Math.hypot(pp.x - pa.x, pp.y - pa.y),
+      alongMeters: 0,
+      segmentMeters: 0,
+    };
+  }
+  const t = Math.max(
+    0,
+    Math.min(1, ((pp.x - pa.x) * dx + (pp.y - pa.y) * dy) / (segmentMeters * segmentMeters)),
+  );
+  const projX = pa.x + t * dx;
+  const projY = pa.y + t * dy;
+  return {
+    offMeters: Math.hypot(pp.x - projX, pp.y - projY),
+    alongMeters: t * segmentMeters,
+    segmentMeters,
+  };
+}
+
+export function routeProgress(
+  journey: Journey,
+  position: LatLng,
+): RouteProgress | null {
+  const line = journey.legs.flatMap((leg) => leg.coordinates);
+  if (line.length < 2) return null;
+
+  // Cumulative length so the remainder is one subtraction once we know where
+  // on the line the rider is.
+  const cumulative = [0];
+  for (let i = 1; i < line.length; i++) {
+    cumulative.push(
+      cumulative[i - 1] +
+        distanceMeters(
+          { lat: line[i - 1][1], lon: line[i - 1][0] },
+          { lat: line[i][1], lon: line[i][0] },
+        ),
+    );
+  }
+  const total = cumulative[cumulative.length - 1];
+  if (total === 0) return null;
+
+  let bestOff = Number.POSITIVE_INFINITY;
+  let bestTravelled = 0;
+  for (let i = 1; i < line.length; i++) {
+    const { offMeters, alongMeters } = projectOnSegment(
+      position,
+      line[i - 1],
+      line[i],
+    );
+    if (offMeters < bestOff) {
+      bestOff = offMeters;
+      bestTravelled = cumulative[i - 1] + alongMeters;
+    }
+  }
+
+  const remainingMeters = Math.max(0, total - bestTravelled);
+  // Scale by the journey's own pace rather than a walking constant: a transit
+  // journey's average includes the ride and the boarding wait.
+  const pace = journey.seconds / total;
+  return {
+    remainingMeters,
+    remainingSeconds: remainingMeters * pace,
+    offRouteMeters: bestOff,
+    fraction: Math.max(0, Math.min(1, bestTravelled / total)),
+  };
+}
+
+/** "8 min walk · 2 stops on Kaliwa / Kanan" — the option-row subtitle. */
+export function describeJourney(journey: Journey): string {
+  const ride = journey.legs.find((leg): leg is RideLeg => leg.kind === "ride");
+  if (!ride) return "Walking the whole way";
+  const walkMinutes = Math.max(1, Math.round(journey.walkMeters / WALK_MPS / 60));
+  const stops = ride.stopCount - 1;
+  return `${walkMinutes} min walk · ${stops} stop${stops === 1 ? "" : "s"} on ${ride.routeName}`;
+}

--- a/src/lib/travel-graph/plan-multi-leg.test.ts
+++ b/src/lib/travel-graph/plan-multi-leg.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import type { JeepneyRoute } from "@constants/jeepney-routes";
+import { buildTravelGraph, type WalkGraphData } from "./engine";
+import { planJourneys } from "./journey";
+import {
+  journeyOptionLabel,
+  planMultiLegJourneys,
+} from "./plan-multi-leg";
+
+const LAT = 14.16;
+const KM_IN_DEGREES = 1000 / 111_320;
+
+function corridor(nodeCount: number): WalkGraphData {
+  const nodes: [number, number, number][] = [];
+  const edges: WalkGraphData["edges"] = [];
+  for (let i = 0; i < nodeCount; i++) {
+    nodes.push([i + 1, LAT + i * KM_IN_DEGREES, 121.24]);
+    if (i > 0) edges.push([i - 1, i, 1000, "footway", null, []]);
+  }
+  return {
+    meta: { coordScale: 1e6, nodeCount, edgeCount: edges.length },
+    nodes,
+    edges,
+  };
+}
+
+const graph = buildTravelGraph(corridor(5));
+
+const nodeAt = (index: number) => ({
+  lat: LAT + index * KM_IN_DEGREES,
+  lng: 121.24,
+});
+
+const corridorRoute: JeepneyRoute = {
+  id: "corridor",
+  name: "Corridor Line",
+  description: "test",
+  color: "#dc2626",
+  fare: { regular: 13, discounted: 11 },
+  stops: [0, 2, 4].map((index) => ({
+    name: `Stop ${index}`,
+    description: "test",
+    lat: nodeAt(index).lat,
+    lon: 121.24,
+  })),
+};
+
+describe("planMultiLegJourneys", () => {
+  test("two points delegates to planJourneys (walk first)", () => {
+    const multi = planMultiLegJourneys({
+      graph,
+      points: [nodeAt(0), nodeAt(1)],
+      routes: [corridorRoute],
+    });
+    const single = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(1),
+      routes: [corridorRoute],
+    });
+    expect(multi.journeys[0].kind).toBe("walk");
+    expect(multi.journeys[0].seconds).toBe(single.journeys[0].seconds);
+  });
+
+  test("stitches a walk option through a waypoint", () => {
+    const { journeys, status } = planMultiLegJourneys({
+      graph,
+      points: [nodeAt(0), nodeAt(2), nodeAt(4)],
+      routes: [corridorRoute],
+    });
+    expect(status).toBe("ok");
+    const walk = journeys.find((j) => j.kind === "walk");
+    expect(walk).toBeDefined();
+    expect(walk?.meters).toBeCloseTo(4000, 0);
+    expect(journeyOptionLabel(walk!)).toBe("Walk");
+  });
+
+  test("offers a commute option when a jeep serves the hops", () => {
+    const { journeys } = planMultiLegJourneys({
+      graph,
+      points: [nodeAt(0), nodeAt(4)],
+      routes: [corridorRoute],
+    });
+    const commute = journeys.find((j) => j.kind === "transit");
+    expect(commute).toBeDefined();
+    expect(journeyOptionLabel(commute!)).toContain("Commute");
+    expect(journeyOptionLabel(commute!)).toContain("Corridor Line");
+  });
+});
+
+describe("journeyOptionLabel", () => {
+  test("labels walk and named commute", () => {
+    const { journeys } = planJourneys({
+      graph,
+      origin: nodeAt(0),
+      destination: nodeAt(4),
+      routes: [corridorRoute],
+    });
+    const walk = journeys.find((j) => j.kind === "walk");
+    const transit = journeys.find((j) => j.kind === "transit");
+    expect(walk).toBeDefined();
+    expect(transit).toBeDefined();
+    expect(journeyOptionLabel(walk!)).toBe("Walk");
+    expect(journeyOptionLabel(transit!)).toBe("Commute · Corridor Line");
+  });
+});

--- a/src/lib/travel-graph/plan-multi-leg.ts
+++ b/src/lib/travel-graph/plan-multi-leg.ts
@@ -1,0 +1,254 @@
+/**
+ * Stitch origin → waypoints → destination into ranked Walk / Commute options
+ * by calling planJourneys per hop (#966 route UI).
+ */
+
+import { MAX_JOURNEY_OPTIONS } from "@constants/travel-modes";
+import type { JeepneyRoute } from "@constants/jeepney-routes";
+import type { TravelGraph } from "./engine";
+import {
+  type Journey,
+  type JourneyLeg,
+  type JourneyPlan,
+  type LatLng,
+  type PlanStatus,
+  type RideLeg,
+  planJourneys,
+} from "./journey";
+
+export type PlanMultiLegInput = {
+  graph: TravelGraph;
+  /** Ordered: origin, optional waypoints, destination (length ≥ 2). */
+  points: LatLng[];
+  routes: JeepneyRoute[];
+  maxOptions?: number;
+};
+
+function stitchLegs(segments: Journey[]): {
+  legs: JourneyLeg[];
+  seconds: number;
+  meters: number;
+  walkMeters: number;
+  fare: Journey["fare"];
+  rideCount: number;
+  routeNames: string[];
+} {
+  const legs: JourneyLeg[] = [];
+  let seconds = 0;
+  let meters = 0;
+  let walkMeters = 0;
+  let fare: Journey["fare"] = null;
+  const routeNames: string[] = [];
+  let rideCount = 0;
+
+  for (const segment of segments) {
+    for (const leg of segment.legs) {
+      legs.push(leg);
+      if (leg.kind === "ride") {
+        rideCount++;
+        if (!routeNames.includes(leg.routeName)) routeNames.push(leg.routeName);
+        if (!fare) fare = leg.fare;
+      }
+    }
+    seconds += segment.seconds;
+    meters += segment.meters;
+    walkMeters += segment.walkMeters;
+  }
+
+  return { legs, seconds, meters, walkMeters, fare, rideCount, routeNames };
+}
+
+function buildJourney(
+  id: string,
+  segments: Journey[],
+): Journey | null {
+  if (segments.length === 0 || segments.some((s) => !s)) return null;
+  const stitched = stitchLegs(segments);
+  if (stitched.legs.length === 0) return null;
+
+  const kind = stitched.rideCount > 0 ? "transit" : "walk";
+  const geometrySource =
+    stitched.rideCount > 0 &&
+    segments.every((s) => s.kind === "transit" || s.geometrySource === "stops-only")
+      ? "stops-only"
+      : "walk-graph";
+
+  return {
+    id,
+    kind,
+    seconds: stitched.seconds,
+    meters: stitched.meters,
+    walkMeters: stitched.walkMeters,
+    legs: stitched.legs,
+    fare: stitched.fare,
+    geometrySource,
+  };
+}
+
+/** Card title: Walk / Commute (Route) / Commute (partial). */
+export function journeyOptionLabel(journey: Journey): string {
+  if (journey.kind === "walk") return "Walk";
+  const rides = journey.legs.filter(
+    (leg): leg is RideLeg => leg.kind === "ride",
+  );
+  if (rides.length === 0) return "Walk";
+  const names = [...new Set(rides.map((r) => r.routeName))];
+  if (journey.id.includes("partial") || names.length > 1) {
+    return names.length === 1
+      ? `Commute (partial) · ${names[0]}`
+      : "Commute (partial)";
+  }
+  return names.length === 1 ? `Commute · ${names[0]}` : "Commute";
+}
+
+/**
+ * Plan a multi-stop trip. Walk stays first; commute variants follow by ETA.
+ * With no intermediate points this delegates to planJourneys.
+ */
+export function planMultiLegJourneys({
+  graph,
+  points,
+  routes,
+  maxOptions = MAX_JOURNEY_OPTIONS,
+}: PlanMultiLegInput): JourneyPlan {
+  if (points.length < 2) {
+    return { status: "no-route", journeys: [] };
+  }
+
+  if (points.length === 2) {
+    const plan = planJourneys({
+      graph,
+      origin: points[0],
+      destination: points[1],
+      routes,
+      maxOptions,
+    });
+    // Pin Walk as the baseline card even when a jeep is faster.
+    const walk = plan.journeys.filter((j) => j.kind === "walk");
+    const rest = plan.journeys
+      .filter((j) => j.kind !== "walk")
+      .sort((a, b) => a.seconds - b.seconds);
+    return {
+      ...plan,
+      journeys: [...walk, ...rest].slice(0, maxOptions),
+    };
+  }
+
+  const segmentPlans: JourneyPlan[] = [];
+  for (let i = 0; i < points.length - 1; i++) {
+    const plan = planJourneys({
+      graph,
+      origin: points[i],
+      destination: points[i + 1],
+      routes,
+      maxOptions,
+    });
+    if (plan.status === "origin-off-network" && i === 0) {
+      return { status: "origin-off-network", journeys: [] };
+    }
+    if (
+      plan.status === "destination-off-network" &&
+      i === points.length - 2
+    ) {
+      return { status: "destination-off-network", journeys: [] };
+    }
+    if (plan.journeys.length === 0) {
+      return { status: "no-route", journeys: [] };
+    }
+    segmentPlans.push(plan);
+  }
+
+  const journeys: Journey[] = [];
+
+  // 1. All-walk
+  const walkSegments = segmentPlans.map((p) =>
+    p.journeys.find((j) => j.kind === "walk"),
+  );
+  if (walkSegments.every((j): j is Journey => j != null)) {
+    const walk = buildJourney("walk", walkSegments);
+    if (walk) journeys.push(walk);
+  }
+
+  // 2. Prefer a single named route across hops when that route has a transit
+  //    option on every hop; otherwise fall back to walk for missing hops
+  //    (partial).
+  const routeIds = new Set<string>();
+  for (const plan of segmentPlans) {
+    for (const j of plan.journeys) {
+      if (j.kind !== "transit") continue;
+      const ride = j.legs.find((leg): leg is RideLeg => leg.kind === "ride");
+      if (ride) routeIds.add(ride.routeId);
+    }
+  }
+
+  for (const routeId of routeIds) {
+    const segments: Journey[] = [];
+    let usedWalkFallback = false;
+    let ok = true;
+    for (const plan of segmentPlans) {
+      const transit = plan.journeys.find((j) => {
+        if (j.kind !== "transit") return false;
+        return j.legs.some(
+          (leg) => leg.kind === "ride" && leg.routeId === routeId,
+        );
+      });
+      if (transit) {
+        segments.push(transit);
+      } else {
+        const walk = plan.journeys.find((j) => j.kind === "walk");
+        if (!walk) {
+          ok = false;
+          break;
+        }
+        usedWalkFallback = true;
+        segments.push(walk);
+      }
+    }
+    if (!ok) continue;
+    const id = usedWalkFallback
+      ? `commute-${routeId}-partial`
+      : `commute-${routeId}`;
+    const journey = buildJourney(id, segments);
+    if (journey) journeys.push(journey);
+  }
+
+  // 3. Fastest-per-hop mix (may blend routes) — only if it beats options above.
+  const fastestSegments = segmentPlans.map((p) => {
+    const sorted = [...p.journeys].sort((a, b) => a.seconds - b.seconds);
+    return sorted[0];
+  });
+  if (fastestSegments.every(Boolean)) {
+    const hasRide = fastestSegments.some((j) => j.kind === "transit");
+    const mixedRoutes = new Set(
+      fastestSegments.flatMap((j) =>
+        j.legs
+          .filter((leg): leg is RideLeg => leg.kind === "ride")
+          .map((leg) => leg.routeId),
+      ),
+    );
+    if (hasRide && (mixedRoutes.size > 1 || fastestSegments.some((j) => j.kind === "walk"))) {
+      const mixed = buildJourney("commute-mixed-partial", fastestSegments);
+      if (
+        mixed &&
+        !journeys.some(
+          (j) =>
+            j.seconds === mixed.seconds &&
+            j.meters === mixed.meters &&
+            j.kind === mixed.kind,
+        )
+      ) {
+        journeys.push(mixed);
+      }
+    }
+  }
+
+  // Walk first, then by ETA; cap.
+  const walk = journeys.filter((j) => j.kind === "walk");
+  const rest = journeys
+    .filter((j) => j.kind !== "walk")
+    .sort((a, b) => a.seconds - b.seconds);
+  const ranked = [...walk, ...rest].slice(0, maxOptions);
+
+  const status: PlanStatus = ranked.length > 0 ? "ok" : "no-route";
+  return { status, journeys: ranked };
+}

--- a/src/lib/travel-graph/route-proximity.test.ts
+++ b/src/lib/travel-graph/route-proximity.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DIRECTIONS_ROUTE_PIN_BUFFER_M,
+  distanceToPolylineMeters,
+  isNearRoute,
+  journeyLineCoordinates,
+} from "./route-proximity";
+
+describe("distanceToPolylineMeters", () => {
+  test("returns 0 for a vertex on the line", () => {
+    const line: [number, number][] = [
+      [121.24, 14.16],
+      [121.241, 14.16],
+      [121.241, 14.161],
+    ];
+    expect(
+      distanceToPolylineMeters({ lat: 14.16, lon: 121.24 }, line),
+    ).toBeLessThan(1);
+  });
+
+  test("is small for a point beside the middle of a segment", () => {
+    const line: [number, number][] = [
+      [121.24, 14.16],
+      [121.242, 14.16],
+    ];
+    // ~11 m north of the mid-point
+    const midLon = 121.241;
+    const near = { lat: 14.16 + 11 / 111_320, lon: midLon };
+    const d = distanceToPolylineMeters(near, line);
+    expect(d).toBeGreaterThan(8);
+    expect(d).toBeLessThan(15);
+  });
+
+  test("isNearRoute uses the 25 m buffer", () => {
+    const line: [number, number][] = [
+      [121.24, 14.16],
+      [121.242, 14.16],
+    ];
+    const close = {
+      lat: 14.16 + 10 / 111_320,
+      lon: 121.241,
+    };
+    const far = {
+      lat: 14.16 + 80 / 111_320,
+      lon: 121.241,
+    };
+    expect(isNearRoute(close, line)).toBe(true);
+    expect(isNearRoute(far, line)).toBe(false);
+    expect(DIRECTIONS_ROUTE_PIN_BUFFER_M).toBe(25);
+  });
+});
+
+describe("journeyLineCoordinates", () => {
+  test("joins legs without duplicating the shared vertex", () => {
+    const coords = journeyLineCoordinates([
+      {
+        coordinates: [
+          [121.24, 14.16],
+          [121.241, 14.16],
+        ],
+      },
+      {
+        coordinates: [
+          [121.241, 14.16],
+          [121.241, 14.161],
+        ],
+      },
+    ]);
+    expect(coords).toEqual([
+      [121.24, 14.16],
+      [121.241, 14.16],
+      [121.241, 14.161],
+    ]);
+  });
+});

--- a/src/lib/travel-graph/route-proximity.ts
+++ b/src/lib/travel-graph/route-proximity.ts
@@ -1,0 +1,86 @@
+/**
+ * Distance from a point to a drawn journey polyline — used to keep landmark
+ * pins near the active directions route readable while de-emphasizing the rest.
+ */
+
+import { distanceMeters } from "../campus-route";
+
+/** Pins within this buffer stay undimmed while Get Directions is open. */
+export const DIRECTIONS_ROUTE_PIN_BUFFER_M = 25;
+
+type LngLat = [number, number];
+type LatLon = { lat: number; lon: number };
+
+function lngLatToLatLon([lng, lat]: LngLat): LatLon {
+  return { lat, lon: lng };
+}
+
+/**
+ * Shortest distance from `point` to any segment of `lineCoords` ([lng, lat]).
+ * Equirectangular, matching `distanceMeters` campus precision.
+ */
+export function distanceToPolylineMeters(
+  point: { lat: number; lon: number },
+  lineCoords: LngLat[],
+): number {
+  if (lineCoords.length === 0) return Number.POSITIVE_INFINITY;
+  if (lineCoords.length === 1) {
+    return distanceMeters(point, lngLatToLatLon(lineCoords[0]));
+  }
+
+  let best = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < lineCoords.length - 1; i++) {
+    const a = lngLatToLatLon(lineCoords[i]);
+    const b = lngLatToLatLon(lineCoords[i + 1]);
+    best = Math.min(best, distanceToSegmentMeters(point, a, b));
+  }
+  return best;
+}
+
+/** Project `p` onto segment ab in local metres, then distance to the clamp. */
+function distanceToSegmentMeters(p: LatLon, a: LatLon, b: LatLon): number {
+  const metersPerDegree = 111_320;
+  const meanLat = ((a.lat + b.lat + p.lat) / 3) * (Math.PI / 180);
+  const cos = Math.cos(meanLat);
+
+  const ax = a.lon * cos * metersPerDegree;
+  const ay = a.lat * metersPerDegree;
+  const bx = b.lon * cos * metersPerDegree;
+  const by = b.lat * metersPerDegree;
+  const px = p.lon * cos * metersPerDegree;
+  const py = p.lat * metersPerDegree;
+
+  const abx = bx - ax;
+  const aby = by - ay;
+  const apx = px - ax;
+  const apy = py - ay;
+  const abLen2 = abx * abx + aby * aby;
+  if (abLen2 === 0) return Math.hypot(apx, apy);
+
+  const t = Math.max(0, Math.min(1, (apx * abx + apy * aby) / abLen2));
+  const qx = ax + t * abx;
+  const qy = ay + t * aby;
+  return Math.hypot(px - qx, py - qy);
+}
+
+export function isNearRoute(
+  point: { lat: number; lon: number },
+  lineCoords: LngLat[],
+  bufferM = DIRECTIONS_ROUTE_PIN_BUFFER_M,
+): boolean {
+  return distanceToPolylineMeters(point, lineCoords) <= bufferM;
+}
+
+/** Flatten journey legs into one [lng, lat] polyline for proximity checks. */
+export function journeyLineCoordinates(
+  legs: { coordinates: LngLat[] }[],
+): LngLat[] {
+  const out: LngLat[] = [];
+  for (const leg of legs) {
+    for (let i = 0; i < leg.coordinates.length; i++) {
+      if (out.length > 0 && i === 0) continue; // shared vertex
+      out.push(leg.coordinates[i]);
+    }
+  }
+  return out;
+}

--- a/src/test/components/BottomSheetHost.svelte
+++ b/src/test/components/BottomSheetHost.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import BottomSheet from "@ui/BottomSheet.svelte";
+
+  let {
+    open = true,
+    onDismiss,
+  }: { open?: boolean; onDismiss?: () => void } = $props();
+</script>
+
+<BottomSheet {open} {onDismiss}>
+  <p>Sheet content</p>
+</BottomSheet>


### PR DESCRIPTION
Plan walk-only and walk+jeepney journeys client-side over the vendored walk graph. Two Dijkstra runs (from origin, from destination) give walking times to every node, so each board/alight pair is a table lookup; ranks the best options and drops rides that do not beat walking by enough to be worth the wait.

Guards unconditional snapping at both stops and trip endpoints. The graph stops at the campus edge, so a town-side origin previously borrowed the nearest node and reported a confident, invented walking time; that now returns an explicit off-network status instead.

Adds follow mode: tilted heading-up camera, heading puck, and a live remaining time/distance/ETA bar driven by closest-point-on-line progress.

Fixes the map being inert behind open chrome. BottomSheet laid a full-bleed dismiss button across the whole root, so every tap and pan on the map strip hit that button instead of the map; the Add to map dialog covered the map with a modal backdrop while asking the user to place a pin. Both now leave the map live. The click-outside dismiss from #836 is kept for chrome but exempted over the map surface.

## Who are you?

- [ ] **Campus / data / QA only:** no code in this PR? Comment on the issue and skip the rest.
- [ ] **Developer:** code PR to `staging` ([CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Maintainer / agent:** full QA below plus issue hygiene for linked specs.

## Summary

<!, What changed and why (1–3 sentences)., >

**Linked issues:** Closes # / Refs #

## Developer checklist

- [ ] `bun test src`
- [ ] `bun run lint` (or Biome format on touched files)
- [ ] If a feature/page was removed, its automated test was removed or repurposed and `bun run generate:test-inventory` was run.
- [ ] Linked issue commented with this PR URL
- [ ] **Heavy CI:** PR marked ready for review (or `run/e2e` label) before merge: integration + E2E are gated ([testing.md § Heavy CI gating](docs/testing.md#heavy-ci-gating-prs))

## QA Summary (code changes)

Automated:

- [ ] Biome format passed: `bunx biome format.` (PR CI)
- [ ] Unit tests passed: `bun test src` (PR CI)
- [ ] E2E + integration passed: mark PR ready or add `run/e2e` label ([testing.md](docs/testing.md#heavy-ci-gating-prs))
- [ ] Full lint passed (local): `bun run lint`
- [ ] Build passed (local): `bun run build` (needs `DATABASE_URL`; not run in PR CI)

If auth, routing, or schema changed:

- [ ] Admin redirects verified: `/admin`, `/admin/login`
- [ ] Migration applied on Supabase (if `drizzle/` changed)

If map chrome, editor, or side panel changed:

- [ ] Verified at 320px and/or 768px per [map-ui-mode-matrix.md](docs/map-ui-mode-matrix.md)
- [ ] Editor/login/drag-save flows (see [editor-foundation-test-plan.md](docs/editor-foundation-test-plan.md))

Known gaps:

- <!, Anything not tested and why, >

Follow-up:

- <!, Issues or PRs to file next, >

## Issues updated (maintainers / detailed specs)

- [ ] Linked issue(s) commented with this PR
- [ ] Acceptance criteria / paths updated on issue body ([issue-hygiene.md](docs/issue-hygiene.md))
- [ ] `Last verified against staging:` date set on linked issues

## Test plan

<!, Optional: steps a reviewer can run locally., >
