### PR TITLE
fix(security): drop unpaired angle brackets from scraped text

### DIFF
--- a/scripts/lib/landmark-images-core.test.ts
+++ b/scripts/lib/landmark-images-core.test.ts
@@ -41,4 +41,10 @@ describe("stripHtml", () => {
       stripHtml('<a href="//commons.wikimedia.org/wiki/User:X">Juan\nD</a>'),
     ).toBe("Juan D");
   });
+
+  test("drops angle brackets the tag pattern cannot pair off", () => {
+    expect(stripHtml("Juan <b")).toBe("Juan b");
+    expect(stripHtml('<a href="<script>">Juan</a>')).toBe('"Juan');
+    expect(stripHtml("<<a>script>alert(1)")).toBe("scriptalert(1)");
+  });
 });

--- a/scripts/lib/landmark-images-core.ts
+++ b/scripts/lib/landmark-images-core.ts
@@ -56,10 +56,17 @@ export function isLikelyPhotoTitle(title: string): boolean {
   return PHOTO_EXTENSIONS.test(title);
 }
 
-/** Strip the HTML Commons wraps around artist names ("<a ...>Juan</a>"). */
+/**
+ * Strip the HTML Commons wraps around artist names ("<a ...>Juan</a>").
+ *
+ * The Artist field is whatever a Commons editor typed, so the second replace
+ * drops any angle bracket the tag pattern could not pair off ("Juan <b" keeps
+ * a live "<" otherwise). Result is plain text: it can never open a tag.
+ */
 export function stripHtml(value: string): string {
   return value
     .replace(/<[^>]*>/g, "")
+    .replace(/[<>]/g, "")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/src/lib/osa-organization-directory.test.ts
+++ b/src/lib/osa-organization-directory.test.ts
@@ -16,4 +16,12 @@ describe("parseOsaOrganizations", () => {
       },
     ]);
   });
+
+  test("drops angle brackets the tag pattern cannot pair off", () => {
+    const organizations = parseOsaOrganizations(
+      '<a class="orgText" href="orgs/example">UP <Example</a>',
+    );
+
+    expect(organizations[0]?.name).toBe("UP Example");
+  });
 });

--- a/src/lib/osa-organization-directory.ts
+++ b/src/lib/osa-organization-directory.ts
@@ -5,9 +5,15 @@ export type OsaOrganization = {
   officialUrl: string;
 };
 
+/**
+ * Plain text of a scraped fragment. The `[<>]` pass drops any angle bracket the
+ * tag pattern could not pair off, so a name like "UP <Example" cannot carry a
+ * live "<" out of here.
+ */
 function textContent(html: string) {
   return html
     .replace(/<[^>]*>/g, " ")
+    .replace(/[<>]/g, " ")
     .replace(/&(amp|nbsp|quot|#39|#x27);/gi, (_, entity: string) => {
       switch (entity.toLowerCase()) {
         case "amp":


### PR DESCRIPTION
Clears the CodeQL `js/incomplete-multi-character-sanitization` alert (#10) blocking the release PR #972.

## What the scanner found

`stripHtml` in `scripts/lib/landmark-images-core.ts` strips tags with a single `replace(/<[^>]*>/g, "")`. CodeQL's stock finding for that shape is the nesting bypass: `<<a>script>` collapses back into a live `<script>`.

## That specific bypass does not apply here

`[^>]*` is greedy and crosses `<`, so the first pass already consumes the outer bracket. Probed every nesting case against both a single pass and a loop-until-stable variant, and no input differs. Looping would have been dead code that only silences the scanner.

## The real gap

An **unpaired** `<`, one with no `>` anywhere after it, never matches the tag pattern and survives untouched. `"Juan <b"` comes out as `"Juan <b"`.

Both call sites read remotely authored text:

- `landmark-images-core.ts` gets Commons `Artist` / `LicenseShortName`, editable by any Commons user
- `src/lib/osa-organization-directory.ts` has the identical pattern over scraped OSA organization names

Fixed both. Not exploitable today (Svelte escapes on render), so this is depth, not an active hole.

## Change

One `.replace(/[<>]/g, ...)` pass per call site, so the output is plain text that cannot open a tag. Plus a regression test each.

## Verification

- `bun run test`: 819 pass, 0 fail
- `bun run lint`: no new findings