### PR TITLE
feat(map): surface satellite controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ No account needed to browse. Editors and contributors fix data in the same app (
 | Walking time from a point | Map tools → Travel time; tap the map, paths color by minutes |
 | Measure a route | Map tools → Measure route; drop waypoints, get walk / cycle / car times |
 | 3D view | Buildings + Makiling terrain (online) |
+| Satellite imagery | Satellite button in the map controls (when available) |
 | Common questions | [Student FAQ](https://room-tba.uplb.tools/faq) (3D models, data sources, offline) |
 | Tell us something is wrong | Settings → Feedback; free text, optional contact, or reach the team on Messenger / Discord |
 | Understand section names | Wiki guide to the A–H / S–Z class time blocks |

--- a/docs/map-ui-mode-matrix.md
+++ b/docs/map-ui-mode-matrix.md
@@ -53,7 +53,7 @@ Portaled popovers use `use:portal` so they are not trapped in the bottom-chrome 
 ## Layout zones (Entry.svelte)
 
 - **Top band:** search column (editor icon button when signed in), term selector, and event banner. The sidebar directories are Buildings, Dorms, Colleges, Divisions, Student orgs, Units & offices, Landmarks, Services & establishments, Classes, Events, and Jeepney routes. Each directory opens its own `CampusBrowseList.svelte` view in the side drawer and an entry then opens the regular entity detail view; they are not centered modals. The search suggestions dropdown is for recent searches and typed results only. **Keyboard shortcuts** are opened from the Help & settings group or the `?` key. Editor tools open in a modal.
-- **Map face:** map canvas, desktop unified camera column (`camera-controls-card`: vertical 2D/3D + rotate/tilt/north)
+- **Map face:** map canvas and the persistent control stack (location, 2D/3D, satellite when available, and zoom). Satellite also remains in Settings → View.
 - **Bottom band:** unified bottom chrome tray (`.bottom-chrome` in `Entry.svelte`); attribution leading, status center, compact Map tools + Legend chips plus location/propose actions trailing; one shared surface. The Map tools chip opens `MapToolsFlyout` (`mapToolsStore`) with the travel tools; while Travel time is active its minutes legend stacks above the tray as the bottom band's first child.
 - **Ephemeral:** toast and modals
 

--- a/docs/map-ui-mode-matrix.md
+++ b/docs/map-ui-mode-matrix.md
@@ -53,7 +53,7 @@ Portaled popovers use `use:portal` so they are not trapped in the bottom-chrome 
 ## Layout zones (Entry.svelte)
 
 - **Top band:** search column (editor icon button when signed in), term selector, and event banner. The sidebar directories are Buildings, Dorms, Colleges, Divisions, Student orgs, Units & offices, Landmarks, Services & establishments, Classes, Events, and Jeepney routes. Each directory opens its own `CampusBrowseList.svelte` view in the side drawer and an entry then opens the regular entity detail view; they are not centered modals. The search suggestions dropdown is for recent searches and typed results only. **Keyboard shortcuts** are opened from the Help & settings group or the `?` key. Editor tools open in a modal.
-- **Map face:** map canvas and the persistent control stack (location, 2D/3D, satellite when available, and zoom). Satellite also remains in Settings → View.
+- **Map face:** map canvas and the persistent control stack (location, 2D/3D, satellite when available, and zoom). Satellite also remains in Map tools → View.
 - **Bottom band:** unified bottom chrome tray (`.bottom-chrome` in `Entry.svelte`); attribution leading, status center, compact Map tools + Legend chips plus location/propose actions trailing; one shared surface. The Map tools chip opens `MapToolsFlyout` (`mapToolsStore`) with the travel tools; while Travel time is active its minutes legend stacks above the tray as the bottom band's first child.
 - **Ephemeral:** toast and modals
 

--- a/e2e/advisory/clear-cached-data.spec.ts
+++ b/e2e/advisory/clear-cached-data.spec.ts
@@ -39,13 +39,11 @@ test.describe("Settings → Storage: clear cached data", () => {
     const settings = page.getByRole("dialog", { name: "Settings" });
     await expect(settings).toBeVisible();
 
-    await settings
-      .getByRole("button", { name: "Clear cached data and reload" })
-      .click();
+    await settings.getByRole("button", { name: "Reset offline data" }).click();
     await expect(
-      settings.getByText(/Downloaded offline maps go too/),
+      settings.getByText(/Downloaded offline maps will be removed/),
     ).toBeVisible();
-    await settings.getByRole("button", { name: "Clear and reload" }).click();
+    await settings.getByRole("button", { name: "Reset and reload" }).click();
 
     // The reload is the success signal — wait for the marker to disappear.
     await expect

--- a/e2e/browse/satellite-toggle.spec.ts
+++ b/e2e/browse/satellite-toggle.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
 import { waitForAppBoot } from "../helpers/app";
-import { openSettingsModal } from "../helpers/map-tools";
 
 /**
  * The Basemap toggle only renders while MapTiler is the live provider, so the
@@ -12,7 +11,9 @@ import { openSettingsModal } from "../helpers/map-tools";
  * before the first goto, which that file's beforeEach already performs.
  */
 test.describe("satellite basemap toggle", () => {
-  test("switches to satellite imagery from Settings", async ({ page }) => {
+  test("switches to satellite imagery from the map controls", async ({
+    page,
+  }) => {
     test.skip(
       !process.env.PUBLIC_MAPTILER_KEY,
       "no PUBLIC_MAPTILER_KEY configured",
@@ -53,9 +54,7 @@ test.describe("satellite basemap toggle", () => {
     await page.goto("/");
     await waitForAppBoot(page);
 
-    const settings = await openSettingsModal(page);
-
-    const toggle = settings.getByRole("button", {
+    const toggle = page.getByRole("button", {
       name: /switch to satellite imagery/i,
     });
     await expect(toggle).toBeVisible();
@@ -64,7 +63,7 @@ test.describe("satellite basemap toggle", () => {
 
     // The accessible name flips with the state (WCAG 2.5.3), so re-query.
     await expect(
-      settings.getByRole("button", { name: /switch to the standard map/i }),
+      page.getByRole("button", { name: /switch to the standard map/i }),
     ).toHaveAttribute("aria-pressed", "true");
 
     // The imagery source is added lazily on first toggle; its TileJSON fetch

--- a/src/components/svelte/map-chrome/MapControlsStack.svelte
+++ b/src/components/svelte/map-chrome/MapControlsStack.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import Locate from "@lucide/svelte/icons/locate";
   import LocateFixed from "@lucide/svelte/icons/locate-fixed";
+  import Satellite from "@lucide/svelte/icons/satellite";
   import {
     enterFlatMapDimension,
     enterTiltedMapDimension,
@@ -9,9 +11,14 @@
   import {
     locationStore,
     mapStore,
+    mapViewStore,
     terrainStore,
     toastStore,
   } from "@lib/store.svelte";
+  import {
+    getBasemapProvider,
+    onBasemapProviderChange,
+  } from "@lib/basemap-provider";
   import compassIcon from "../../../assets/icons/compass.svg?url";
 
   type Props = {
@@ -26,8 +33,17 @@
   let centered = $state(false);
 
   const is2D = $derived(isMap2DPitch(pitch));
+  let basemapProvider = $state(getBasemapProvider());
+  const satelliteAvailable = $derived(basemapProvider === "maptiler");
+  const satelliteTitle = $derived(
+    mapViewStore.satellite
+      ? "Switch to the standard map"
+      : "Switch to satellite imagery",
+  );
   /** compass.svg has N + red tip upright at 0°; counter-rotate with map bearing. */
   const northRotation = $derived(-bearing);
+
+  onMount(() => onBasemapProviderChange((next) => (basemapProvider = next)));
 
   function syncCamera() {
     const map = mapStore.mapInstance;
@@ -153,6 +169,20 @@
   >
     {is2D ? "2D" : "3D"}
   </button>
+
+  {#if satelliteAvailable}
+    <button
+      type="button"
+      class="map-ctrl"
+      class:map-ctrl--active={mapViewStore.satellite}
+      aria-label={satelliteTitle}
+      title={satelliteTitle}
+      aria-pressed={mapViewStore.satellite}
+      onclick={mapViewStore.toggleSatellite}
+    >
+      <Satellite size={18} aria-hidden="true" />
+    </button>
+  {/if}
 
   <div class="map-ctrl-zoom" role="group" aria-label="Zoom">
     <button

--- a/src/components/svelte/modal/SettingsModal.component.test.ts
+++ b/src/components/svelte/modal/SettingsModal.component.test.ts
@@ -24,7 +24,7 @@ vi.mock("@lib/local/data/invalidate-sync-key", () => ({
 const reload = vi.fn();
 
 const clearButton = () =>
-  screen.getByRole("button", { name: "Clear cached data and reload" });
+  screen.getByRole("button", { name: "Reset offline data" });
 
 // The row label carries "campus data" now, so the button is just the verb.
 const resyncButton = () => screen.getByRole("button", { name: "Resync" });
@@ -74,10 +74,10 @@ describe("SettingsModal storage section (#865)", () => {
 
     expect(clearCachedData).not.toHaveBeenCalled();
     expect(
-      screen.getByText(/Downloaded offline maps go too/),
+      screen.getByText(/Downloaded offline maps will be removed/),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Clear and reload" }),
+      screen.getByRole("button", { name: "Reset and reload" }),
     ).toBeInTheDocument();
   });
 
@@ -86,7 +86,7 @@ describe("SettingsModal storage section (#865)", () => {
 
     clearButton().click();
     const confirm = await screen.findByRole("button", {
-      name: "Clear and reload",
+      name: "Reset and reload",
     });
     await vi.waitFor(() => expect(document.activeElement).toBe(confirm));
     expect(confirm.getAttribute("aria-describedby")).toBe(
@@ -111,7 +111,7 @@ describe("SettingsModal storage section (#865)", () => {
 
     clearButton().click();
     await Promise.resolve();
-    screen.getByRole("button", { name: "Clear and reload" }).click();
+    screen.getByRole("button", { name: "Reset and reload" }).click();
 
     await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
     expect(clearCachedData).toHaveBeenCalledTimes(1);
@@ -129,9 +129,9 @@ describe("SettingsModal storage section (#865)", () => {
 
     clearButton().click();
     await Promise.resolve();
-    screen.getByRole("button", { name: "Clear and reload" }).click();
+    screen.getByRole("button", { name: "Reset and reload" }).click();
 
-    const busy = await screen.findByRole("button", { name: "Clearing…" });
+    const busy = await screen.findByRole("button", { name: "Resetting…" });
     expect((busy as HTMLButtonElement).disabled).toBe(true);
     expect(
       (screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement)

--- a/src/components/svelte/modal/SettingsModal.svelte
+++ b/src/components/svelte/modal/SettingsModal.svelte
@@ -111,7 +111,7 @@
       </div>
 
       <div class="map-chrome-row">
-        <span class="map-chrome-row__label">Cached app data</span>
+        <span class="map-chrome-row__label">Offline data</span>
         {#if !confirming}
           <div class="map-chrome-row__control">
             <button
@@ -120,22 +120,22 @@
               aria-describedby="settings-storage-hint"
               onclick={() => (confirming = true)}
             >
-              Clear cached data and reload
+              Reset offline data
             </button>
           </div>
         {/if}
       </div>
       <p id="settings-storage-hint" class="map-chrome-row-hint">
-        Clears the cached app, saved campus data, and downloaded offline maps,
-        then reloads. Your saved class plans stay.
+        Removes saved campus data, offline maps, and cached app files. Your
+        saved class plans stay.
       </p>
       {#if confirming}
         <p
           id="settings-storage-warning"
           class="map-chrome-row-hint map-chrome-row-hint--warn"
         >
-          Downloaded offline maps go too. You will need a connection to
-          download them again.
+          Downloaded offline maps will be removed. You will need a connection
+          to download them again.
         </p>
         <div class="map-chrome-row-actions">
           <button
@@ -146,7 +146,7 @@
             bind:this={confirmButton}
             onclick={clearAndReload}
           >
-            {clearing ? "Clearing…" : "Clear and reload"}
+            {clearing ? "Resetting…" : "Reset and reload"}
           </button>
           <button
             type="button"


### PR DESCRIPTION
## Summary

- Add a persistent satellite toggle to the desktop and mobile map control stack when MapTiler is available.
- Clarify the offline-data reset action and its confirmation without changing what is preserved.

## QA Summary

Automated:

- [x] Targeted Biome check passed.
- [x] Settings component tests passed (14 tests).
- [x] Production build passed.
- [x] README drift check passed.
- [ ] E2E + integration: requested through the `run/e2e` label.

Known gaps:

- `bun run lint` is red on pre-existing files from `staging`, outside this diff.
- Local Playwright bootstrap is blocked by local database schema drift: `buildings.street_view_pano_id` is absent. CI E2E uses its current schema.

## Test plan

1. Open the map with MapTiler available and use the satellite button in the map controls.
2. Verify it toggles back to the standard map.
3. Settings → Storage → Reset offline data → Reset and reload preserves class plans.