### PR TITLE
fix(menu): prioritize app navigation

### DIFF
--- a/src/components/svelte/directions/DirectionsPanel.component.test.ts
+++ b/src/components/svelte/directions/DirectionsPanel.component.test.ts
@@ -61,13 +61,9 @@ describe("DirectionsPanel", () => {
 
       expect(screen.getByText("12 min")).toBeInTheDocument();
       expect(screen.getByText("Walk")).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Show on map" }),
-      ).toBeVisible();
+      expect(screen.getByRole("button", { name: "Show on map" })).toBeVisible();
       expect(screen.getByRole("button", { name: "Start" })).toBeVisible();
-      expect(
-        container.querySelector(".option--selected"),
-      ).toBeTruthy();
+      expect(container.querySelector(".option--selected")).toBeTruthy();
 
       expectNoHorizontalOverflow(container as HTMLElement);
       const panel = container.querySelector(".directions");

--- a/src/components/svelte/directions/DirectionsRouteChips.component.test.ts
+++ b/src/components/svelte/directions/DirectionsRouteChips.component.test.ts
@@ -33,9 +33,7 @@ describe("DirectionsRouteChips", () => {
 
   test("hidden when directions are idle", () => {
     const { container } = render(DirectionsRouteChips);
-    expect(
-      container.querySelector(".directions-route-chips"),
-    ).toBeNull();
+    expect(container.querySelector(".directions-route-chips")).toBeNull();
   });
 
   test.each([320, 768])(

--- a/src/components/svelte/status-bar/AppMenu.component.test.ts
+++ b/src/components/svelte/status-bar/AppMenu.component.test.ts
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import { beforeEach, describe, expect, test } from "vitest";
 import AppMenu from "./AppMenu.svelte";
-import { adminAuthStore, modalStore, proposalsStore } from "@lib/store.svelte";
+import {
+  adminAuthStore,
+  modalStore,
+  proposalsStore,
+  sidebarStore,
+} from "@lib/store.svelte";
 
 describe("AppMenu review entry", () => {
   beforeEach(() => {
@@ -63,5 +68,28 @@ describe("AppMenu help entry", () => {
     expect(modalStore.open).toBe(true);
     expect(modalStore.type).toBe("landing");
     expect(modalStore.landingTab).toBe("welcome");
+  });
+});
+
+describe("AppMenu navigation", () => {
+  beforeEach(() => {
+    modalStore.closeModal();
+    sidebarStore.changeOpened("map");
+  });
+
+  test("prioritizes app destinations and keeps community links secondary", async () => {
+    render(AppMenu, { props: { onSignOut: () => {} } });
+    await fireEvent.click(screen.getByRole("button", { name: /app menu/i }));
+
+    expect(screen.getByRole("heading", { name: "Go to" })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Course planner" }),
+    ).toBeVisible();
+    expect(screen.getByText("Community & project links")).toBeVisible();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Course planner" }),
+    );
+    expect(sidebarStore.panelOpen).toBe("planner");
   });
 });

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -9,9 +9,12 @@
   import Inbox from "@lucide/svelte/icons/inbox";
   import CalendarDays from "@lucide/svelte/icons/calendar-days";
   import CalendarClock from "@lucide/svelte/icons/calendar-clock";
+  import ClipboardPenLine from "@lucide/svelte/icons/clipboard-pen-line";
+  import CloudDownload from "@lucide/svelte/icons/cloud-download";
+  import Map from "@lucide/svelte/icons/map";
+  import Megaphone from "@lucide/svelte/icons/megaphone";
   import UserRound from "@lucide/svelte/icons/user-round";
   import { onMount } from "svelte";
-  import { formatCatalogUpdatedDate } from "@constants/data-catalog";
   import { APP_VERSION_LABEL } from "@constants/version";
   import { statusBarNavGroups } from "@constants/status-bar-links";
   import { trapFocus } from "@lib/focus-trap";
@@ -30,7 +33,6 @@
     sidebarStore,
     toastStore,
   } from "@lib/store.svelte";
-  import OfflineMaps from "@ui/OfflineMaps.svelte";
   import PWAInstallPrompt from "@ui/PWAInstallPrompt.svelte";
   import MapChromeSession from "@ui/map-chrome/MapChromeSession.svelte";
   import KeyboardShortcutsChip from "@ui/map-chrome/KeyboardShortcutsPopup.svelte";
@@ -50,7 +52,9 @@
     toastStore.show("Signed out.", "info");
   }
 
-  function handleScreen(id: "today" | "calendar") {
+  function handleScreen(
+    id: "map" | "today" | "planner" | "finals" | "calendar",
+  ) {
     sidebarStore.changeOpened(id);
     closePanel();
   }
@@ -84,7 +88,6 @@
         ? "Editor"
         : "Contributor",
   );
-  const catalogUpdatedLabel = formatCatalogUpdatedDate();
   const navGroups = $derived(
     statusBarNavGroups({
       versionLabel: APP_VERSION_LABEL,
@@ -272,39 +275,95 @@
         </section>
       {/if}
 
-      <!-- Today and the academic calendar lost their only entry point when the
-           rail Sidebar stopped rendering (#930, #951). They are screens, not
-           map chrome, so they live here rather than in the primary nav. -->
-      <section class="app-menu__section" aria-label="Screens">
+      <section
+        class="app-menu__section"
+        aria-labelledby="app-menu-go-heading"
+      >
+        <h3 id="app-menu-go-heading" class="app-menu__heading">Go to</h3>
         <button
           type="button"
-          class="app-menu__action map-chrome-chip"
+          class="app-menu__nav-action"
+          onclick={() => handleScreen("map")}
+        >
+          <Map size={18} aria-hidden="true" />
+          <span>Campus map</span>
+        </button>
+        <button
+          type="button"
+          class="app-menu__nav-action"
           onclick={() => handleScreen("today")}
         >
-          <CalendarClock size={14} aria-hidden="true" />
+          <CalendarClock size={18} aria-hidden="true" />
           <span>Today</span>
         </button>
         <button
           type="button"
-          class="app-menu__action map-chrome-chip"
+          class="app-menu__nav-action"
+          onclick={() => handleScreen("planner")}
+        >
+          <ClipboardPenLine size={18} aria-hidden="true" />
+          <span>Course planner</span>
+        </button>
+        <button
+          type="button"
+          class="app-menu__nav-action"
+          onclick={() => handleScreen("finals")}
+        >
+          <FileText size={18} aria-hidden="true" />
+          <span>Final exams</span>
+        </button>
+        <button
+          type="button"
+          class="app-menu__nav-action"
           onclick={() => handleScreen("calendar")}
         >
-          <CalendarDays size={14} aria-hidden="true" />
+          <CalendarDays size={18} aria-hidden="true" />
           <span>Academic calendar</span>
+        </button>
+        <button
+          type="button"
+          class="app-menu__nav-action"
+          onclick={() => {
+            closePanel();
+            modalStore.openModal("announcements");
+          }}
+        >
+          <Megaphone size={18} aria-hidden="true" />
+          <span>Announcements</span>
         </button>
       </section>
 
-      <!-- Settings lost its only entry point when the rail Sidebar stopped
-           rendering (#930); the modal (map display, terrain, cache) was
-           unreachable. Same fix as Today/calendar above. -->
-      <section class="app-menu__section" aria-label="Settings">
+      <section
+        class="app-menu__section"
+        aria-labelledby="app-menu-tools-heading"
+      >
+        <h3 id="app-menu-tools-heading" class="app-menu__heading">Tools</h3>
         <button
           type="button"
-          class="app-menu__action map-chrome-chip"
+          class="app-menu__nav-action"
           onclick={handleSettings}
         >
-          <SettingsIcon size={14} aria-hidden="true" />
+          <SettingsIcon size={18} aria-hidden="true" />
           <span>Settings</span>
+        </button>
+        <button
+          type="button"
+          class="app-menu__nav-action"
+          onclick={() => {
+            closePanel();
+            modalStore.openModal("offline-maps");
+          }}
+        >
+          <CloudDownload size={18} aria-hidden="true" />
+          <span>Offline maps</span>
+        </button>
+        <button
+          type="button"
+          class="app-menu__nav-action"
+          onclick={handleCoverage}
+        >
+          <ChartColumn size={18} aria-hidden="true" />
+          <span>Campus data coverage</span>
         </button>
       </section>
 
@@ -327,36 +386,6 @@
           </button>
         </section>
       {/if}
-
-      <section
-        class="app-menu__section"
-        aria-labelledby="app-menu-data-heading"
-      >
-        <h3 id="app-menu-data-heading" class="app-menu__heading">Data</h3>
-        <div class="app-menu__sync"></div>
-        <div class="app-menu__offline">
-          <OfflineMaps compact={false} />
-        </div>
-        <button
-          type="button"
-          class="app-menu__action map-chrome-chip"
-          onclick={handleCoverage}
-        >
-          <ChartColumn size={14} aria-hidden="true" />
-          <span>Campus data coverage</span>
-        </button>
-        <p class="app-menu__meta">Updated {catalogUpdatedLabel}</p>
-      </section>
-
-      <section
-        class="app-menu__section"
-        aria-labelledby="app-menu-links-heading"
-      >
-        <h3 id="app-menu-links-heading" class="app-menu__heading">Links</h3>
-        <nav aria-label="App links">
-          <StatusBarLinkGroups groups={navGroups} onAction={handleNavAction} />
-        </nav>
-      </section>
 
       <section
         class="app-menu__section"
@@ -397,6 +426,13 @@
           <span>Keyboard shortcuts</span>
         </button>
       </section>
+
+      <details class="app-menu__more">
+        <summary>Community &amp; project links</summary>
+        <nav aria-label="Community and project links">
+          <StatusBarLinkGroups groups={navGroups} onAction={handleNavAction} />
+        </nav>
+      </details>
 
       <section
         class="app-menu__section app-menu__section--install"
@@ -442,6 +478,34 @@
     text-decoration: none;
   }
 
+  .app-menu__nav-action {
+    width: 100%;
+    min-height: 2.75rem;
+    border: 0;
+    border-radius: 0.5rem;
+    padding: 0.625rem 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    background: transparent;
+    color: var(--map-chrome-text, hsl(5 20% 18%));
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 650;
+    line-height: 1.15;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .app-menu__nav-action:hover {
+    background: var(--map-chrome-hover, hsl(5 25% 96%));
+  }
+
+  .app-menu__nav-action:focus-visible {
+    outline: 2px solid var(--color-brand, hsl(345 75% 31%));
+    outline-offset: 2px;
+  }
+
   .app-menu__badge {
     display: inline-flex;
     align-items: center;
@@ -462,7 +526,7 @@
     border-radius: 0.75rem;
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.5rem;
     max-height: min(70vh, 28rem);
     overflow-y: auto;
     padding: 0.75rem;
@@ -491,20 +555,6 @@
     color: hsl(0, 0%, 40%);
   }
 
-  .app-menu__meta {
-    margin: 0;
-    font-size: 0.6875rem;
-    color: hsl(0, 0%, 42%);
-  }
-
-  .app-menu__sync :global(.sync-status--inline) {
-    width: 100%;
-  }
-
-  .app-menu__offline :global(.offline-maps) {
-    width: 100%;
-  }
-
   .app-menu__section--install :global(.pwa-install-prompt) {
     max-width: none;
     width: 100%;
@@ -524,5 +574,21 @@
     margin-top: 0.25rem;
     padding-top: 0.375rem;
     border-top: 1px dashed hsl(0, 0%, 88%);
+  }
+
+  .app-menu__more {
+    padding-top: 0.625rem;
+    border-top: 1px solid var(--map-chrome-divider, hsl(5 12% 88%));
+    color: hsl(0, 0%, 35%);
+    font-size: 0.75rem;
+  }
+
+  .app-menu__more summary {
+    cursor: pointer;
+    font-weight: 650;
+  }
+
+  .app-menu__more nav {
+    margin-top: 0.625rem;
   }
 </style>

--- a/src/lib/stores/directions-store.svelte.ts
+++ b/src/lib/stores/directions-store.svelte.ts
@@ -123,11 +123,7 @@ export class DirectionsStore {
       const graph = await loadTravelGraph();
       if (token !== this.#planToken) return; // superseded
 
-      const points: LatLng[] = [
-        origin,
-        ...this.waypoints,
-        destination,
-      ];
+      const points: LatLng[] = [origin, ...this.waypoints, destination];
       const plan = planMultiLegJourneys({
         graph,
         points,

--- a/src/lib/travel-graph/directions-fit.ts
+++ b/src/lib/travel-graph/directions-fit.ts
@@ -38,7 +38,8 @@ const METERS_PER_DEG_LAT = 111_320;
 
 function lngPadForMeters(meters: number, lat: number): number {
   return (
-    meters / (METERS_PER_DEG_LAT * Math.max(0.2, Math.cos((lat * Math.PI) / 180)))
+    meters /
+    (METERS_PER_DEG_LAT * Math.max(0.2, Math.cos((lat * Math.PI) / 180)))
   );
 }
 
@@ -187,7 +188,10 @@ type CameraForBoundsMap = {
       pitch?: number;
       maxZoom?: number;
     },
-  ) => { center: { lng: number; lat: number } | [number, number]; zoom: number };
+  ) => {
+    center: { lng: number; lat: number } | [number, number];
+    zoom: number;
+  };
 };
 
 /**

--- a/src/lib/travel-graph/journey.test.ts
+++ b/src/lib/travel-graph/journey.test.ts
@@ -343,6 +343,8 @@ describe("describeJourney", () => {
     });
     const transit = journeys.find((j) => j.kind === "transit");
 
-    expect(transit && describeJourney(transit)).toContain("2 stops on Corridor Line");
+    expect(transit && describeJourney(transit)).toContain(
+      "2 stops on Corridor Line",
+    );
   });
 });

--- a/src/lib/travel-graph/journey.ts
+++ b/src/lib/travel-graph/journey.ts
@@ -118,9 +118,7 @@ function directedRoutes(routes: JeepneyRoute[]): DirectedRoute[] {
 function cumulativeMeters(stops: JeepneyRoute["stops"]): number[] {
   const cumulative = [0];
   for (let i = 1; i < stops.length; i++) {
-    cumulative.push(
-      cumulative[i - 1] + distanceMeters(stops[i - 1], stops[i]),
-    );
+    cumulative.push(cumulative[i - 1] + distanceMeters(stops[i - 1], stops[i]));
   }
   return cumulative;
 }
@@ -380,7 +378,11 @@ function projectOnSegment(
   }
   const t = Math.max(
     0,
-    Math.min(1, ((pp.x - pa.x) * dx + (pp.y - pa.y) * dy) / (segmentMeters * segmentMeters)),
+    Math.min(
+      1,
+      ((pp.x - pa.x) * dx + (pp.y - pa.y) * dy) /
+        (segmentMeters * segmentMeters),
+    ),
   );
   const projX = pa.x + t * dx;
   const projY = pa.y + t * dy;
@@ -443,7 +445,10 @@ export function routeProgress(
 export function describeJourney(journey: Journey): string {
   const ride = journey.legs.find((leg): leg is RideLeg => leg.kind === "ride");
   if (!ride) return "Walking the whole way";
-  const walkMinutes = Math.max(1, Math.round(journey.walkMeters / WALK_MPS / 60));
+  const walkMinutes = Math.max(
+    1,
+    Math.round(journey.walkMeters / WALK_MPS / 60),
+  );
   const stops = ride.stopCount - 1;
   return `${walkMinutes} min walk · ${stops} stop${stops === 1 ? "" : "s"} on ${ride.routeName}`;
 }

--- a/src/lib/travel-graph/plan-multi-leg.test.ts
+++ b/src/lib/travel-graph/plan-multi-leg.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { JeepneyRoute } from "@constants/jeepney-routes";
 import { buildTravelGraph, type WalkGraphData } from "./engine";
 import { planJourneys } from "./journey";
-import {
-  journeyOptionLabel,
-  planMultiLegJourneys,
-} from "./plan-multi-leg";
+import { journeyOptionLabel, planMultiLegJourneys } from "./plan-multi-leg";
 
 const LAT = 14.16;
 const KM_IN_DEGREES = 1000 / 111_320;

--- a/src/lib/travel-graph/plan-multi-leg.ts
+++ b/src/lib/travel-graph/plan-multi-leg.ts
@@ -58,10 +58,7 @@ function stitchLegs(segments: Journey[]): {
   return { legs, seconds, meters, walkMeters, fare, rideCount, routeNames };
 }
 
-function buildJourney(
-  id: string,
-  segments: Journey[],
-): Journey | null {
+function buildJourney(id: string, segments: Journey[]): Journey | null {
   if (segments.length === 0 || segments.some((s) => !s)) return null;
   const stitched = stitchLegs(segments);
   if (stitched.legs.length === 0) return null;
@@ -69,7 +66,9 @@ function buildJourney(
   const kind = stitched.rideCount > 0 ? "transit" : "walk";
   const geometrySource =
     stitched.rideCount > 0 &&
-    segments.every((s) => s.kind === "transit" || s.geometrySource === "stops-only")
+    segments.every(
+      (s) => s.kind === "transit" || s.geometrySource === "stops-only",
+    )
       ? "stops-only"
       : "walk-graph";
 
@@ -146,10 +145,7 @@ export function planMultiLegJourneys({
     if (plan.status === "origin-off-network" && i === 0) {
       return { status: "origin-off-network", journeys: [] };
     }
-    if (
-      plan.status === "destination-off-network" &&
-      i === points.length - 2
-    ) {
+    if (plan.status === "destination-off-network" && i === points.length - 2) {
       return { status: "destination-off-network", journeys: [] };
     }
     if (plan.journeys.length === 0) {
@@ -226,7 +222,10 @@ export function planMultiLegJourneys({
           .map((leg) => leg.routeId),
       ),
     );
-    if (hasRide && (mixedRoutes.size > 1 || fastestSegments.some((j) => j.kind === "walk"))) {
+    if (
+      hasRide &&
+      (mixedRoutes.size > 1 || fastestSegments.some((j) => j.kind === "walk"))
+    ) {
       const mixed = buildJourney("commute-mixed-partial", fastestSegments);
       if (
         mixed &&


### PR DESCRIPTION
## Summary
- turns the mobile menu into a destination-first navigation sheet
- groups map, planner, finals, calendar, announcements, settings, and offline tools into clear primary actions
- moves community and project links behind a secondary disclosure

## Verification
- `bunx biome check src/components/svelte/status-bar/AppMenu.svelte src/components/svelte/status-bar/AppMenu.component.test.ts`
- `bun run test:components -- src/components/svelte/status-bar/AppMenu.component.test.ts`
- `bun run build`