### PR TITLE
fix(dorms): show full photos

### DIFF
--- a/src/components/svelte/controls/DormResult.component.test.ts
+++ b/src/components/svelte/controls/DormResult.component.test.ts
@@ -114,4 +114,26 @@ describe("DormResult Kubo link", () => {
 
     expect(screen.queryByText("View on Kubo")).not.toBeInTheDocument();
   });
+
+  test("uses Kubo's full image and opens it in a viewer", async () => {
+    const { container } = renderDormResult(
+      dorm({
+        dormName: "Tuiza Bldg",
+        imageUrl:
+          "https://media.kubo.community/dorms/tuiza/gallery/photo.thumb.webp",
+      }),
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "View full photo of Tuiza Bldg",
+    });
+    const image = trigger.querySelector("img");
+    expect(image).toHaveAttribute(
+      "src",
+      "https://media.kubo.community/dorms/tuiza/gallery/photo.webp",
+    );
+
+    await trigger.click();
+    expect(container.querySelector("dialog")?.open).toBe(true);
+  });
 });

--- a/src/components/svelte/controls/DormResult.svelte
+++ b/src/components/svelte/controls/DormResult.svelte
@@ -17,6 +17,8 @@
   import BadgeCheck from "@lucide/svelte/icons/badge-check";
   import KeyRound from "@lucide/svelte/icons/key-round";
   import CircleDollarSign from "@lucide/svelte/icons/circle-dollar-sign";
+  import Maximize2 from "@lucide/svelte/icons/maximize-2";
+  import X from "@lucide/svelte/icons/x";
   import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
   import type { DormData } from "@lib/types";
   import {
@@ -108,6 +110,22 @@
   const kuboDormCta = $derived(
     dorm ? getKuboDormCta($kuboDormDirectory, dorm.id, dorm.dormName) : null,
   );
+  const dormImageUrl = $derived(
+    dorm?.imageUrl ? getDormImageUrl(dorm.imageUrl) : null,
+  );
+  let imageViewer = $state<HTMLDialogElement>();
+
+  function getDormImageUrl(imageUrl: string) {
+    try {
+      const url = new URL(imageUrl);
+      if (url.hostname === "media.kubo.community") {
+        url.pathname = url.pathname.replace(/\.thumb(?=\.webp$)/i, "");
+      }
+      return url.toString();
+    } catch {
+      return imageUrl;
+    }
+  }
 
   $effect(() => {
     if (dorm) void loadKuboDormDirectory();
@@ -753,16 +771,38 @@
       </div>
     {/if}
 
-    {#if !editing && dorm.imageUrl}
-      <img
-        class="entity-image"
-        src={dorm.imageUrl}
-        alt={dorm.dormName}
-        width="800"
-        height="450"
-        loading="lazy"
-        decoding="async"
-      />
+    {#if !editing && dormImageUrl}
+      <button
+        type="button"
+        class="entity-image-viewer-trigger"
+        aria-label="View full photo of {dorm.dormName}"
+        onclick={() => imageViewer?.showModal()}
+      >
+        <img
+          class="entity-image"
+          src={dormImageUrl}
+          alt={dorm.dormName}
+          width="800"
+          height="450"
+          loading="lazy"
+          decoding="async"
+        />
+        <span class="entity-image-viewer-trigger__label">
+          <Maximize2 size={16} /> View full photo
+        </span>
+      </button>
+
+      <dialog bind:this={imageViewer} class="entity-image-dialog">
+        <button
+          type="button"
+          class="entity-image-dialog__close"
+          aria-label="Close full photo"
+          onclick={() => imageViewer?.close()}
+        >
+          <X size={20} />
+        </button>
+        <img src={dormImageUrl} alt={dorm.dormName} />
+      </dialog>
     {/if}
 
     {#if editing}

--- a/src/components/svelte/controls/entity-detail.css
+++ b/src/components/svelte/controls/entity-detail.css
@@ -365,6 +365,19 @@
   padding-top: 0.125rem;
 }
 
+.entity-dorm-details .entity-section-heading {
+  font-size: 0.875rem;
+}
+
+.entity-dorm-details .entity-detail-row__label {
+  font-size: 0.75rem;
+}
+
+.entity-dorm-details .entity-tag-chip {
+  padding: 0.3125rem 0.6875rem;
+  font-size: 0.8125rem;
+}
+
 .entity-tag-block {
   display: flex;
   flex-direction: column;
@@ -867,4 +880,83 @@
   border-radius: 0.5rem;
   border: 1px solid hsl(5, 53%, 90%);
   background: white;
+}
+
+.entity-image-viewer-trigger {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  border-radius: 0.5rem;
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.entity-image-viewer-trigger .entity-image {
+  display: block;
+}
+
+.entity-image-viewer-trigger__label {
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3125rem 0.5rem;
+  border-radius: 999px;
+  background: rgb(24 24 27 / 84%);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.entity-image-viewer-trigger:focus-visible {
+  outline: 3px solid #7b1113;
+  outline-offset: 2px;
+}
+
+.entity-image-dialog {
+  width: min(100vw - 1.5rem, 64rem);
+  max-width: none;
+  max-height: calc(100vh - 1.5rem);
+  padding: 0;
+  overflow: visible;
+  border: 0;
+  border-radius: 0.75rem;
+  background: #18181b;
+}
+
+.entity-image-dialog::backdrop {
+  background: rgb(0 0 0 / 76%);
+}
+
+.entity-image-dialog img {
+  display: block;
+  width: 100%;
+  max-height: calc(100vh - 1.5rem);
+  object-fit: contain;
+  border-radius: inherit;
+}
+
+.entity-image-dialog__close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  place-items: center;
+  border: 0;
+  border-radius: 999px;
+  background: rgb(24 24 27 / 84%);
+  color: white;
+  cursor: pointer;
+}
+
+.entity-image-dialog__close:focus-visible {
+  outline: 3px solid white;
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- use Kubo full-size image variants instead of 128px thumbnails
- open dorm photos in an accessible native image viewer
- enlarge dorm detail headings and amenity chips

## QA Summary

Automated:
- [x] `bunx biome check src/components/svelte/controls/DormResult.svelte src/components/svelte/controls/DormResult.component.test.ts src/components/svelte/controls/entity-detail.css`
- [x] `bun run test:components -- src/components/svelte/controls/DormResult.component.test.ts`
- [x] `bun run build`

Manual browser:
- [ ] Mobile visual check pending PR preview