### PR TITLE
fix(maps): prefer named place links

### DIFF
--- a/src/components/svelte/controls/BuildingResult.svelte
+++ b/src/components/svelte/controls/BuildingResult.svelte
@@ -621,6 +621,7 @@
           <EntityGoogleMapsLink
             lat={building.lat ?? 0}
             lon={building.lon ?? 0}
+            name={building.buildingName}
             ariaLabel={`Open ${building.buildingName} in Google Maps`}
           />
         {/if}

--- a/src/components/svelte/controls/DormResult.svelte
+++ b/src/components/svelte/controls/DormResult.svelte
@@ -713,6 +713,7 @@
           <EntityGoogleMapsLink
             lat={dorm.lat}
             lon={dorm.lon}
+            name={dorm.dormName}
             ariaLabel={`Open ${dorm.dormName} in Google Maps`}
           />
         {/if}

--- a/src/components/svelte/controls/EntityGoogleMapsLink.svelte
+++ b/src/components/svelte/controls/EntityGoogleMapsLink.svelte
@@ -6,6 +6,7 @@
   type Props = {
     lat: number;
     lon: number;
+    name?: string;
     ariaLabel?: string;
     label?: string;
     toolbar?: boolean;
@@ -14,12 +15,13 @@
   let {
     lat,
     lon,
+    name,
     ariaLabel = "Open in Google Maps",
     label = "Google Maps",
     toolbar = true,
   }: Props = $props();
 
-  const href = $derived(getGoogleMapsPinUrl(lat, lon));
+  const href = $derived(getGoogleMapsPinUrl(lat, lon, name));
 </script>
 
 <MapChromeActionLink {href} {ariaLabel} {toolbar}>

--- a/src/components/svelte/controls/JeepneyStopPanel.svelte
+++ b/src/components/svelte/controls/JeepneyStopPanel.svelte
@@ -107,6 +107,7 @@
         <EntityGoogleMapsLink
           lat={mapsUrl.lat}
           lon={mapsUrl.lon}
+          name={stop.name}
           ariaLabel={`Open ${stop.name} in Google Maps`}
         />
       {/if}

--- a/src/components/svelte/controls/OrgResult.svelte
+++ b/src/components/svelte/controls/OrgResult.svelte
@@ -274,6 +274,7 @@
           <EntityGoogleMapsLink
             lat={resolvedLat}
             lon={resolvedLon}
+            name={org.name}
             ariaLabel={`Open ${org.name} in Google Maps`}
           />
         {/if}

--- a/src/components/svelte/controls/PlaceResult.svelte
+++ b/src/components/svelte/controls/PlaceResult.svelte
@@ -163,6 +163,7 @@
           <EntityGoogleMapsLink
             lat={place.lat}
             lon={place.lon}
+            name={place.name}
             ariaLabel={`Open ${place.name} in Google Maps`}
           />
         {/if}

--- a/src/components/svelte/room/RoomResult.svelte
+++ b/src/components/svelte/room/RoomResult.svelte
@@ -546,6 +546,7 @@
           <EntityGoogleMapsLink
             lat={parentBuilding.lat}
             lon={parentBuilding.lon}
+            name={parentBuilding.name}
             ariaLabel={`Open ${parentBuilding.name} in Google Maps`}
           />
         {/if}

--- a/src/lib/google-maps-links.test.ts
+++ b/src/lib/google-maps-links.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, test } from "bun:test";
 import { getGoogleMapsPinUrl } from "./google-maps-links";
 
 describe("getGoogleMapsPinUrl", () => {
+  test("uses a verified Google Maps place URL when one is curated", () => {
+    expect(
+      getGoogleMapsPinUrl(
+        14.1615806166946,
+        121.247839677519,
+        "Electrical Engineering Building",
+      ),
+    ).toBe(
+      "https://www.google.com/maps/place/UPLB+Dante+B.+De+Padua+Hall+(CEAT+Administration+Building)/@14.1614261,121.2479207,19.07z/data=!4m6!3m5!1s0x33bd619058953c0d:0xbc3af31f3d3de971!8m2!3d14.1615904!4d121.2478685!16s%2Fg%2F11s5jspcv0",
+    );
+  });
+
+  test("searches for a named entity instead of opening raw coordinates", () => {
+    expect(getGoogleMapsPinUrl(14.6532, 121.0689, "Test Hall")).toBe(
+      "https://www.google.com/maps/search/?api=1&query=Test%20Hall%2C%20UPLB%2C%20Los%20Ba%C3%B1os",
+    );
+  });
+
   test("builds a Google Maps query URL from coordinates", () => {
     expect(getGoogleMapsPinUrl(14.6532, 121.0689)).toBe(
       "https://www.google.com/maps?q=14.6532,121.0689",

--- a/src/lib/google-maps-links.ts
+++ b/src/lib/google-maps-links.ts
@@ -1,4 +1,17 @@
-/** Open a lat/lon pin in Google Maps (same URL shape used across entity panels). */
-export function getGoogleMapsPinUrl(lat: number, lon: number): string {
+const curatedPlaceUrls: Record<string, string> = {
+  "Electrical Engineering Building":
+    "https://www.google.com/maps/place/UPLB+Dante+B.+De+Padua+Hall+(CEAT+Administration+Building)/@14.1614261,121.2479207,19.07z/data=!4m6!3m5!1s0x33bd619058953c0d:0xbc3af31f3d3de971!8m2!3d14.1615904!4d121.2478685!16s%2Fg%2F11s5jspcv0",
+};
+
+/** Open a verified place when available, otherwise search for the named entity. */
+export function getGoogleMapsPinUrl(
+  lat: number,
+  lon: number,
+  name?: string,
+): string {
+  if (name && curatedPlaceUrls[name]) return curatedPlaceUrls[name];
+  if (name) {
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${name}, UPLB, Los Baños`)}`;
+  }
   return `https://www.google.com/maps?q=${lat},${lon}`;
 }


### PR DESCRIPTION
Refs #891

## Summary
- search Google Maps by the named campus entity instead of raw coordinates
- use the verified Dante B. De Padua Hall place link for Electrical Engineering
- retain raw coordinates only for unnamed callers

## QA
- [x] `bun test src/lib/google-maps-links.test.ts`
- [x] targeted Biome check
- [x] `bun run build`