### PR TITLE
perf(api): edge-cache public campus read routes

### DIFF
--- a/src/lib/api/json.test.ts
+++ b/src/lib/api/json.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { PUBLIC_READ_CACHE_CONTROL, cachedJson, json } from "./json";
+
+describe("cachedJson", () => {
+  test("sets public edge Cache-Control on success bodies", async () => {
+    const res = cachedJson({ ok: true });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    expect(res.headers.get("Cache-Control")).toBe(PUBLIC_READ_CACHE_CONTROL);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test("merges extra headers without dropping cache", () => {
+    const res = cachedJson([], 200, { "Access-Control-Allow-Origin": "*" });
+    expect(res.headers.get("Cache-Control")).toBe(PUBLIC_READ_CACHE_CONTROL);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  test("plain json stays uncached", () => {
+    const res = json({ error: "nope" }, 400);
+    expect(res.headers.get("Cache-Control")).toBeNull();
+  });
+});

--- a/src/lib/api/json.test.ts
+++ b/src/lib/api/json.test.ts
@@ -16,6 +16,11 @@ describe("cachedJson", () => {
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
   });
 
+  test("does not cache non-2xx statuses", () => {
+    const res = cachedJson({ error: "nope" }, 500);
+    expect(res.headers.get("Cache-Control")).toBeNull();
+  });
+
   test("plain json stays uncached", () => {
     const res = json({ error: "nope" }, 400);
     expect(res.headers.get("Cache-Control")).toBeNull();

--- a/src/lib/api/json.ts
+++ b/src/lib/api/json.ts
@@ -5,11 +5,35 @@
  * `new Response(JSON.stringify(...), { status, headers })`.
  */
 
+/**
+ * Vercel CDN cache for anonymous campus reads.
+ * One hour fresh at the edge; serve stale up to a day while revalidating.
+ * Do not use on auth, account, admin, proposals, or presence.
+ */
+export const PUBLIC_READ_CACHE_CONTROL =
+  "public, s-maxage=3600, stale-while-revalidate=86400";
+
 /** Standard JSON response. */
 export function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** JSON response with {@link PUBLIC_READ_CACHE_CONTROL}. */
+export function cachedJson(
+  body: unknown,
+  status = 200,
+  extraHeaders?: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": PUBLIC_READ_CACHE_CONTROL,
+      ...extraHeaders,
+    },
   });
 }
 

--- a/src/lib/api/json.ts
+++ b/src/lib/api/json.ts
@@ -8,7 +8,9 @@
 /**
  * Vercel CDN cache for anonymous campus reads.
  * One hour fresh at the edge; serve stale up to a day while revalidating.
- * Do not use on auth, account, admin, proposals, or presence.
+ * Do not use on auth, account, admin, proposals, presence, or alias export
+ * dumps (those poison PGlite sync). Entity sync fetches pass `?v=<syncKey>`
+ * so a key bump misses the prior edge entry.
  */
 export const PUBLIC_READ_CACHE_CONTROL =
   "public, s-maxage=3600, stale-while-revalidate=86400";
@@ -21,20 +23,20 @@ export function json(body: unknown, status = 200): Response {
   });
 }
 
-/** JSON response with {@link PUBLIC_READ_CACHE_CONTROL}. */
+/** JSON response with {@link PUBLIC_READ_CACHE_CONTROL} on 2xx only. */
 export function cachedJson(
   body: unknown,
   status = 200,
   extraHeaders?: Record<string, string>,
 ): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": PUBLIC_READ_CACHE_CONTROL,
-      ...extraHeaders,
-    },
-  });
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...extraHeaders,
+  };
+  if (status >= 200 && status < 300) {
+    headers["Cache-Control"] = PUBLIC_READ_CACHE_CONTROL;
+  }
+  return new Response(JSON.stringify(body), { status, headers });
 }
 
 /** Standard error response — `{ error: message }` with the given status. */

--- a/src/lib/local/data/get-entity.store.test.ts
+++ b/src/lib/local/data/get-entity.store.test.ts
@@ -36,10 +36,27 @@ describe("getEntity", () => {
   });
 
   test("fetches remote when cache is empty despite valid sync key", async () => {
-    mockFetch([{ id: 3 }]);
+    const urls: string[] = [];
+    globalThis.fetch = (async (input) => {
+      urls.push(String(input));
+      return new Response(JSON.stringify([{ id: 3 }]), { status: 200 });
+    }) as typeof fetch;
     const load = getEntity<Row>("things", async () => []);
     const result = await load({ valid: true, newKey: "k" });
     expect(result).toEqual({ rows: [{ id: 3 }], source: "remote" });
+    expect(urls).toEqual(["/api/things?v=k"]);
+  });
+
+  test("busts the CDN with the sync key when refetching after a bump", async () => {
+    const urls: string[] = [];
+    globalThis.fetch = (async (input) => {
+      urls.push(String(input));
+      return new Response(JSON.stringify([{ id: 5 }]), { status: 200 });
+    }) as typeof fetch;
+    const load = getEntity<Row>("things", async () => [{ id: 1 }]);
+    const result = await load({ valid: false, newKey: "buildings-v2" });
+    expect(result).toEqual({ rows: [{ id: 5 }], source: "remote" });
+    expect(urls).toEqual(["/api/things?v=buildings-v2"]);
   });
 
   test("falls back to cache when remote returns a non-array", async () => {

--- a/src/lib/local/data/utils.ts
+++ b/src/lib/local/data/utils.ts
@@ -577,8 +577,12 @@ export function getEntity<T>(
       }
     }
     try {
+      // Include the sync key in the URL so a Vercel edge cache of a prior
+      // version cannot be written into PGlite after /api/check reports a bump
+      // (perf/api-cache-control). Same key → CDN hit; new key → miss.
+      const remoteUrl = `/api/${tableName}?v=${encodeURIComponent(checker.newKey)}`;
       const fetchedData = await fetchJsonWithRetry<T[]>(
-        `/api/${tableName}`,
+        remoteUrl,
         ENTITY_FETCH_OPTIONS,
       );
       if (Array.isArray(fetchedData)) {

--- a/src/pages/api/aliases.ts
+++ b/src/pages/api/aliases.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { cachedJson } from "@lib/api/json";
 import {
   listAliasesForCache,
   searchAliases,
@@ -9,19 +10,13 @@ export const prerender = false;
 export const GET = (async ({ url }) => {
   if (url.searchParams.get("export") === "all") {
     const data = await listAliasesForCache();
-    return new Response(JSON.stringify({ data, success: true }), {
-      headers: { "content-type": "application/json" },
-    });
+    return cachedJson({ data, success: true });
   }
 
   const q = url.searchParams.get("q") ?? "";
   if (q.trim() === "") {
-    return new Response(JSON.stringify({ data: [], success: true }), {
-      headers: { "content-type": "application/json" },
-    });
+    return cachedJson({ data: [], success: true });
   }
   const data = await searchAliases(q);
-  return new Response(JSON.stringify({ data, success: true }), {
-    headers: { "content-type": "application/json" },
-  });
+  return cachedJson({ data, success: true });
 }) satisfies APIRoute;

--- a/src/pages/api/aliases.ts
+++ b/src/pages/api/aliases.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { cachedJson } from "@lib/api/json";
+import { cachedJson, json } from "@lib/api/json";
 import {
   listAliasesForCache,
   searchAliases,
@@ -8,9 +8,10 @@ import {
 export const prerender = false;
 
 export const GET = (async ({ url }) => {
+  // Full dump feeds PGlite DELETE+INSERT with no sync-key bust. Never edge-cache it.
   if (url.searchParams.get("export") === "all") {
     const data = await listAliasesForCache();
-    return cachedJson({ data, success: true });
+    return json({ data, success: true });
   }
 
   const q = url.searchParams.get("q") ?? "";

--- a/src/pages/api/buildings.ts
+++ b/src/pages/api/buildings.ts
@@ -1,9 +1,10 @@
 import type { APIRoute } from "astro";
+import { cachedJson } from "@lib/api/json";
 import { getAllBuildings } from "@lib/services/map-data-service";
 
 export const prerender = false;
 
 export const GET = (async (_) => {
   const data = await getAllBuildings();
-  return new Response(JSON.stringify(data));
+  return cachedJson(data);
 }) satisfies APIRoute;

--- a/src/pages/api/classes.ts
+++ b/src/pages/api/classes.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 import { decodeClassCursor } from "@lib/api/class-cursor";
+import { cachedJson } from "@lib/api/json";
 import { clampLimitParam, paginationErrorResponse } from "@lib/api/pagination";
 import {
   checkRateLimit,
@@ -32,7 +33,7 @@ export const GET = (async ({ request, url }) => {
       roomCode,
       Number.isFinite(termId) ? termId : undefined,
     );
-    return new Response(JSON.stringify(data));
+    return cachedJson(data);
   }
 
   if (url.searchParams.has("offset")) {
@@ -59,5 +60,5 @@ export const GET = (async ({ request, url }) => {
     limit: limit.value,
     cursor: cursor ?? undefined,
   });
-  return new Response(JSON.stringify(data));
+  return cachedJson(data);
 }) satisfies APIRoute;

--- a/src/pages/api/final-exams.ts
+++ b/src/pages/api/final-exams.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { cachedJson } from "@lib/api/json";
 import { queryFinalExams } from "@lib/services/map-data-service";
 
 export const prerender = false;
@@ -17,5 +18,5 @@ export const GET = (async ({ url }) => {
     date,
     termId: Number.isFinite(termId) ? termId : undefined,
   });
-  return new Response(JSON.stringify(data));
+  return cachedJson(data);
 }) satisfies APIRoute;

--- a/src/pages/api/rooms.ts
+++ b/src/pages/api/rooms.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { PUBLIC_READ_CACHE_CONTROL } from "@lib/api/json";
 import {
   getBuildingRooms,
   getCollegeRooms,
@@ -7,7 +8,16 @@ import {
   searchRooms,
 } from "@lib/services/map-data-service";
 import type { RoomData } from "@lib/types";
-// import { getAllRooms } from "@lib/services/map-data-service";
+
+function cachedPretty(body: unknown, extraHeaders?: Record<string, string>) {
+  return new Response(JSON.stringify(body, null, 2), {
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": PUBLIC_READ_CACHE_CONTROL,
+      ...extraHeaders,
+    },
+  });
+}
 
 export const GET = (async ({ url }) => {
   const searchKeys = Array.from(url.searchParams.keys());
@@ -34,33 +44,20 @@ export const GET = (async ({ url }) => {
   if (searchField === "code") {
     const code = url.searchParams.get(searchField) as string;
     const room = await getRoomByCode(code);
-    return new Response(
-      JSON.stringify(
-        {
-          data: room,
-          success: true,
-        },
-        null,
-        2,
-      ),
-    );
+    return cachedPretty({
+      data: room,
+      success: true,
+    });
   }
 
   if (searchField === "search_code") {
     const searchString = url.searchParams.get(searchField) as string;
-    if (searchString === "")
-      return new Response(JSON.stringify({ data: [], success: true }, null, 2));
+    if (searchString === "") return cachedPretty({ data: [], success: true });
     const rooms = await searchRooms(searchString);
-    return new Response(
-      JSON.stringify(
-        {
-          data: rooms,
-          success: true,
-        },
-        null,
-        2,
-      ),
-    );
+    return cachedPretty({
+      data: rooms,
+      success: true,
+    });
   }
 
   const id = parseInt(url.searchParams.get(searchField) as string, 10);
@@ -88,18 +85,12 @@ export const GET = (async ({ url }) => {
       status: 404,
       statusText: "query not found",
     });
-  return new Response(
-    JSON.stringify(
-      {
-        data,
-        success: true,
-      },
-      null,
-      2,
-    ),
+  return cachedPretty(
     {
-      headers: [["Access-Control-Allow-Origin", "*"]],
+      data,
+      success: true,
     },
+    { "Access-Control-Allow-Origin": "*" },
   );
 }) satisfies APIRoute;
 

--- a/src/pages/api/rooms/class-counts.ts
+++ b/src/pages/api/rooms/class-counts.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { cachedJson, json } from "@lib/api/json";
 import { getRoomClassCounts } from "@lib/services/map-data-service";
 
 export const prerender = false;
@@ -23,17 +24,11 @@ export const GET = (async ({ url }) => {
     entityName = "division";
     id = Number(divisionId);
   } else {
-    return new Response(
-      JSON.stringify({ error: "Missing entity filter", success: false }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
+    return json({ error: "Missing entity filter", success: false }, 400);
   }
 
   if (!Number.isFinite(id)) {
-    return new Response(
-      JSON.stringify({ error: "Invalid entity id", success: false }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
+    return json({ error: "Invalid entity id", success: false }, 400);
   }
 
   try {
@@ -46,16 +41,10 @@ export const GET = (async ({ url }) => {
       roomId,
       count,
     }));
-    return new Response(JSON.stringify({ data, success: true }, null, 2), {
-      headers: [
-        ["Access-Control-Allow-Origin", "*"],
-        ["Content-Type", "application/json"],
-      ],
+    return cachedJson({ data, success: true }, 200, {
+      "Access-Control-Allow-Origin": "*",
     });
   } catch {
-    return new Response(
-      JSON.stringify({ error: "Failed to fetch class counts", success: false }),
-      { status: 500, headers: { "Content-Type": "application/json" } },
-    );
+    return json({ error: "Failed to fetch class counts", success: false }, 500);
   }
 }) satisfies APIRoute;

--- a/src/pages/api/terms.ts
+++ b/src/pages/api/terms.ts
@@ -1,9 +1,10 @@
 import type { APIRoute } from "astro";
+import { cachedJson } from "@lib/api/json";
 import { getAllTerms } from "@lib/services/term-service";
 
 export const prerender = false;
 
 export const GET = (async () => {
   const data = await getAllTerms();
-  return new Response(JSON.stringify(data));
+  return cachedJson(data);
 }) satisfies APIRoute;


### PR DESCRIPTION
## Summary
- Add `cachedJson` / `PUBLIC_READ_CACHE_CONTROL` (`public, s-maxage=3600, stale-while-revalidate=86400`) for anonymous campus reads.
- Wire it on `/api/classes`, `/api/buildings`, `/api/rooms`, `/api/rooms/class-counts`, `/api/final-exams`, `/api/terms`, and alias **search** (`?q=`).
- **Sync safety:** `getEntity` fetches `/api/<table>?v=<syncKey>` so a key bump misses the prior CDN entry and cannot poison PGlite.
- **`/api/aliases?export=all` stays uncached** (feeds DELETE+INSERT with no sync key).
- `cachedJson` only sets Cache-Control on 2xx.
- Auth, account, admin, proposals, and presence stay uncached.

## Test plan
- [x] `bun test src/lib/api/json.test.ts`
- [x] `bun run test:components -- src/lib/local/data/get-entity.store.test.ts src/lib/local/data/entity-cache-gate.store.test.ts`
- [ ] Preview: `/api/buildings` has Cache-Control; `/api/aliases?export=all` does not
- [ ] After an editor building edit + sync key bump, a client refetch with the new `?v=` returns fresh coords
- [ ] Confirm `/api/admin/*` and `/api/presence` still send no public cache header