### PR TITLE
feat(safety): add offline hotlines and curfew guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ No account needed to browse. Editors and contributors fix data in the same app (
 | Common questions | [Student FAQ](https://room-tba.uplb.tools/faq) (3D models, data sources, offline) |
 | Tell us something is wrong | Settings → Feedback; free text, optional contact, or reach the team on Messenger / Discord |
 | Understand section names | Wiki guide to the A–H / S–Z class time blocks |
+| Find emergency contacts | Menu → Emergency hotlines; bundled for offline use |
+| Check dorm curfew rules | UP-managed dorm details → Curfew & permits |
 
 <details>
 <summary><strong>Editor / contributor mode</strong> (password from the team)</summary>

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -48,6 +48,8 @@ export default defineConfig({
           "changelog/index.html",
           "sponsors/index.html",
           "donate/index.html",
+          "wiki/emergency-hotlines/index.html",
+          "wiki/campus-curfew/index.html",
         ],
         // #716: desktop-only.css is never fetched by mobile viewports at
         // runtime — don't undo that by precaching it into every install

--- a/src/components/svelte/controls/DormResult.component.test.ts
+++ b/src/components/svelte/controls/DormResult.component.test.ts
@@ -115,3 +115,33 @@ describe("DormResult Kubo link", () => {
     expect(screen.queryByText("View on Kubo")).not.toBeInTheDocument();
   });
 });
+
+describe("DormResult curfew information", () => {
+  beforeEach(() => {
+    kuboDormDirectory.set(new Map());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 503 })),
+    );
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  test("shows curfew guidance only for UP-managed dorms", () => {
+    renderDormResult(dorm({ isUpManaged: true }));
+    expect(
+      screen.getByRole("heading", { name: "Curfew & permits" }),
+    ).toBeVisible();
+    expect(screen.getByRole("link", { name: /full policy/i })).toHaveAttribute(
+      "href",
+      "/wiki/campus-curfew",
+    );
+  });
+
+  test("hides curfew guidance for private dorms", () => {
+    renderDormResult(dorm({ isUpManaged: false }));
+    expect(
+      screen.queryByRole("heading", { name: "Curfew & permits" }),
+    ).toBeNull();
+  });
+});

--- a/src/components/svelte/controls/DormResult.svelte
+++ b/src/components/svelte/controls/DormResult.svelte
@@ -18,6 +18,7 @@
   import KeyRound from "@lucide/svelte/icons/key-round";
   import CircleDollarSign from "@lucide/svelte/icons/circle-dollar-sign";
   import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
+  import { CAMPUS_CURFEW } from "@constants/campus-curfew";
   import type { DormData } from "@lib/types";
   import {
     getStoredProposalForEntity,
@@ -874,6 +875,18 @@
           </div>
         {/if}
 
+        {#if dorm.isUpManaged}
+          <section class="entity-curfew" aria-labelledby="dorm-curfew-heading">
+            <h3 id="dorm-curfew-heading" class="entity-section-heading">
+              Curfew &amp; permits
+            </h3>
+            <p>
+              Curfew is {CAMPUS_CURFEW.hours}. {CAMPUS_CURFEW.latePermit}
+              <a href="/wiki/campus-curfew">Read the full policy.</a>
+            </p>
+          </section>
+        {/if}
+
         {#if dorm.isUpManaged || dorm.facebookLink || (!dorm.isUpManaged && dorm.priceRange)}
           <div class="entity-dorm-details__links">
             {#if dorm.isUpManaged}
@@ -937,6 +950,22 @@
     font-size: 0.6875rem;
     color: hsl(35, 80%, 45%);
     font-weight: 500;
+  }
+
+  .entity-curfew {
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .entity-curfew p {
+    margin: 0;
+    font-size: 0.8125rem;
+    line-height: 1.45;
+  }
+
+  .entity-curfew a {
+    color: hsl(5, 53%, 32%);
+    font-weight: 600;
   }
 
   .no-results {

--- a/src/components/svelte/modal/HotlinesModal.component.test.ts
+++ b/src/components/svelte/modal/HotlinesModal.component.test.ts
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+import HotlinesModal from "./HotlinesModal.svelte";
+import { mountAtWidth } from "@test/layout-assertions";
+
+describe("HotlinesModal", () => {
+  test("renders every category and callable number at 320px", () => {
+    mountAtWidth(320);
+    render(HotlinesModal);
+
+    for (const category of ["Student-led", "University", "Local", "Medical"]) {
+      expect(screen.getByRole("heading", { name: category })).toBeVisible();
+    }
+
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBeGreaterThan(10);
+    for (const link of links)
+      expect(link.getAttribute("href")).toMatch(/^tel:\+63/);
+  });
+});

--- a/src/components/svelte/modal/HotlinesModal.svelte
+++ b/src/components/svelte/modal/HotlinesModal.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import {
+    EMERGENCY_HOTLINE_CATEGORIES,
+    emergencyHotlineTel,
+  } from "@constants/emergency-hotlines";
+</script>
+
+<section class="hotlines-modal">
+  <header>
+    <p class="hotlines-modal__eyebrow">Emergency</p>
+    <h2>Emergency hotlines</h2>
+    <p>Tap a number to call. Save these contacts before you need them.</p>
+  </header>
+
+  <div class="hotlines-modal__scroll map-chrome-scroll">
+    {#each EMERGENCY_HOTLINE_CATEGORIES as category}
+      <section aria-labelledby="hotlines-{category.name}">
+        <h3 id="hotlines-{category.name}">{category.name}</h3>
+        {#each category.entries as entry}
+          <div class="hotlines-modal__entry">
+            <strong>{entry.name}</strong>
+            <div class="hotlines-modal__numbers">
+              {#each entry.numbers as number}
+                <a href={emergencyHotlineTel(number)}>{number}</a>
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </section>
+    {/each}
+  </div>
+</section>
+
+<style>
+  .hotlines-modal {
+    display: flex;
+    flex: 1 1 auto;
+    min-height: 0;
+    flex-direction: column;
+    gap: 0.625rem;
+    padding: 0.5rem 0.5rem 0.25rem;
+  }
+
+  header {
+    padding-right: 2.25rem;
+  }
+
+  h2,
+  h3,
+  p {
+    margin: 0;
+  }
+
+  h2 {
+    color: hsl(0 0% 15%);
+    font-size: 1rem;
+  }
+
+  h3 {
+    color: hsl(5 53% 28%);
+    font-size: 0.875rem;
+  }
+
+  header > p:last-child,
+  .hotlines-modal__eyebrow {
+    color: hsl(0 0% 42%);
+    font-size: 0.75rem;
+  }
+
+  .hotlines-modal__eyebrow {
+    margin-bottom: 0.125rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .hotlines-modal__scroll {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+    gap: 1rem;
+    overflow-y: auto;
+    padding-right: 0.375rem;
+  }
+
+  .hotlines-modal__scroll > section {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .hotlines-modal__entry {
+    display: grid;
+    gap: 0.25rem;
+    color: hsl(0 0% 22%);
+    font-size: 0.875rem;
+    line-height: 1.4;
+  }
+
+  .hotlines-modal__numbers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.75rem;
+  }
+
+  a {
+    color: hsl(5 53% 32%);
+    font-weight: 600;
+  }
+</style>

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -21,6 +21,7 @@
   import EditorToolsModal from "./EditorToolsModal.svelte";
   import PrivacyModal from "./PrivacyModal.svelte";
   import OfflineMapsModal from "./OfflineMapsModal.svelte";
+  import HotlinesModal from "./HotlinesModal.svelte";
   import IconButton from "@ui/IconButton.svelte";
   import X from "@lucide/svelte/icons/x";
 
@@ -55,6 +56,7 @@
     if (modalStore.type === "editor-tools") return "Editor tools";
     if (modalStore.type === "privacy") return "Privacy policy";
     if (modalStore.type === "offline-maps") return "Offline maps";
+    if (modalStore.type === "hotlines") return "Emergency hotlines";
     return "Dialog";
   });
 
@@ -98,7 +100,8 @@
                 modalStore.type === 'jeepney-route' ||
                 modalStore.type === 'editor-tools' ||
                 modalStore.type === 'privacy' ||
-                modalStore.type === 'offline-maps'
+                modalStore.type === 'offline-maps' ||
+                modalStore.type === 'hotlines'
               ? 'modal-content--reading'
               : ''}"
       id="modal-content"
@@ -227,6 +230,15 @@
           <X size={20} aria-hidden="true" />
         </IconButton>
         <OfflineMapsModal />
+      {:else if modalStore.type === "hotlines"}
+        <IconButton
+          class="modal-content__close-icon"
+          label="Close emergency hotlines"
+          onclick={closeDialog}
+        >
+          <X size={20} aria-hidden="true" />
+        </IconButton>
+        <HotlinesModal />
       {/if}
     </div>
   </div>

--- a/src/components/svelte/status-bar/AppMenu.component.test.ts
+++ b/src/components/svelte/status-bar/AppMenu.component.test.ts
@@ -69,6 +69,15 @@ describe("AppMenu help entry", () => {
     expect(modalStore.type).toBe("landing");
     expect(modalStore.landingTab).toBe("welcome");
   });
+
+  test("opens emergency hotlines", async () => {
+    render(AppMenu, { props: { onSignOut: () => {} } });
+    await fireEvent.click(screen.getByRole("button", { name: /app menu/i }));
+    await fireEvent.click(
+      screen.getByRole("button", { name: /emergency hotlines/i }),
+    );
+    expect(modalStore.type).toBe("hotlines");
+  });
 });
 
 describe("AppMenu navigation", () => {

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -14,6 +14,7 @@
   import Map from "@lucide/svelte/icons/map";
   import Megaphone from "@lucide/svelte/icons/megaphone";
   import UserRound from "@lucide/svelte/icons/user-round";
+  import Phone from "@lucide/svelte/icons/phone";
   import { onMount } from "svelte";
   import { APP_VERSION_LABEL } from "@constants/version";
   import { statusBarNavGroups } from "@constants/status-bar-links";
@@ -338,6 +339,17 @@
         aria-labelledby="app-menu-tools-heading"
       >
         <h3 id="app-menu-tools-heading" class="app-menu__heading">Tools</h3>
+        <button
+          type="button"
+          class="app-menu__nav-action"
+          onclick={() => {
+            closePanel();
+            modalStore.openModal("hotlines");
+          }}
+        >
+          <Phone size={18} aria-hidden="true" />
+          <span>Emergency hotlines</span>
+        </button>
         <button
           type="button"
           class="app-menu__nav-action"

--- a/src/constants/campus-curfew.ts
+++ b/src/constants/campus-curfew.ts
@@ -1,0 +1,9 @@
+export const CAMPUS_CURFEW = {
+  hours: "10 PM–5 AM",
+  noLoitering: "No loitering is allowed during curfew hours.",
+  residentRule:
+    "UP-managed dorm residents may not leave without an authorized guardian.",
+  latePermit: "A late permit is required to return from 10 PM–12 midnight.",
+  overnightPermit:
+    "An overnight permit is required to return from 12 midnight–5 AM.",
+} as const;

--- a/src/constants/emergency-hotlines.test.ts
+++ b/src/constants/emergency-hotlines.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import {
+  EMERGENCY_HOTLINE_CATEGORIES,
+  emergencyHotlineTel,
+} from "./emergency-hotlines.ts";
+
+describe("emergency hotlines", () => {
+  test("keeps every category and contact callable", () => {
+    expect(EMERGENCY_HOTLINE_CATEGORIES.map(({ name }) => name)).toEqual([
+      "Student-led",
+      "University",
+      "Local",
+      "Medical",
+    ]);
+
+    for (const { entries } of EMERGENCY_HOTLINE_CATEGORIES) {
+      expect(entries.length).toBeGreaterThan(0);
+      for (const entry of entries) {
+        expect(entry.name).not.toBe("");
+        expect(entry.numbers.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("normalizes Philippine mobile and landline numbers for tel links", () => {
+    expect(emergencyHotlineTel("0961 396 3441")).toBe("tel:+639613963441");
+    expect(emergencyHotlineTel("(049) 536 7965")).toBe("tel:+63495367965");
+  });
+});

--- a/src/constants/emergency-hotlines.ts
+++ b/src/constants/emergency-hotlines.ts
@@ -1,0 +1,77 @@
+export type EmergencyHotline = {
+  name: string;
+  numbers: readonly string[];
+};
+
+export const EMERGENCY_HOTLINE_CATEGORIES = [
+  {
+    name: "Student-led",
+    entries: [{ name: "Serve the People Brigade", numbers: ["0961 396 3441"] }],
+  },
+  {
+    name: "University",
+    entries: [
+      {
+        name: "UPLB Security and Safety Office",
+        numbers: ["0906 043 3288", "0921 890 1259"],
+      },
+      {
+        name: "University Planning and Maintenance Office",
+        numbers: ["0917 882 2479"],
+      },
+    ],
+  },
+  {
+    name: "Local",
+    entries: [
+      {
+        name: "Barangay Batong Malake",
+        numbers: ["0919 254 4257", "0995 107 9907"],
+      },
+      {
+        name: "Los Baños Police Station",
+        numbers: ["0927 509 1198", "0998 598 5649"],
+      },
+      {
+        name: "Los Baños Fire Station",
+        numbers: ["0939 432 5837", "(049) 536 7965"],
+      },
+      { name: "Municipal DRRMO", numbers: ["0977 204 9641"] },
+      {
+        name: "Provincial DRRMO",
+        numbers: ["(049) 501 4672", "(049) 501 2628"],
+      },
+    ],
+  },
+  {
+    name: "Medical",
+    entries: [
+      {
+        name: "University Health Service",
+        numbers: [
+          "(049) 536-3247",
+          "(049) 536-6238",
+          "(049) 536-2470",
+          "0915 802 2211",
+          "0998 346 6070",
+        ],
+      },
+      {
+        name: "Los Baños Doctors Hospital",
+        numbers: ["0906 399 2757", "(049) 536 0100"],
+      },
+      {
+        name: "Healthserv Los Baños Medical Center",
+        numbers: ["0917 301 6646"],
+      },
+    ],
+  },
+] as const satisfies readonly {
+  name: string;
+  entries: readonly EmergencyHotline[];
+}[];
+
+export function emergencyHotlineTel(number: string) {
+  const digits = number.replace(/\D/g, "");
+  return `tel:${digits.startsWith("0") ? `+63${digits.slice(1)}` : `+${digits}`}`;
+}

--- a/src/constants/modal-states.ts
+++ b/src/constants/modal-states.ts
@@ -14,4 +14,5 @@ export const modalOptions = [
   "editor-tools",
   "privacy",
   "offline-maps",
+  "hotlines",
 ] as const;

--- a/src/layouts/WikiLayout.astro
+++ b/src/layouts/WikiLayout.astro
@@ -22,6 +22,8 @@ const {
 // Sibling pages, for the "see also" list every article closes with. Titles
 // only, so copy edits to the index blurbs do not have to land here too.
 const siblings = [
+  { href: "/wiki/emergency-hotlines", label: "Emergency hotlines around UPLB" },
+  { href: "/wiki/campus-curfew", label: "Campus curfew and dorm permits" },
   { href: "/wiki/section-times", label: "What times do section names correspond to?" },
   { href: "/wiki/upcat-at-uplb", label: "Taking the UPCAT at UP Los Baños" },
   { href: "/wiki/fork-for-your-campus", label: "Fork this for your campus" },

--- a/src/pages/wiki/campus-curfew.astro
+++ b/src/pages/wiki/campus-curfew.astro
@@ -1,0 +1,55 @@
+---
+export const prerender = true;
+
+import WikiLayout from "@layouts/WikiLayout.astro";
+import WikiProvenance from "../../components/wiki/WikiProvenance.astro";
+import { CAMPUS_CURFEW } from "@constants/campus-curfew";
+import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";
+
+const title = "Campus curfew and dorm permits | Room TBA Wiki";
+const description =
+  "UPLB campus curfew hours and return-permit information for UP-managed dorm residents.";
+const structuredData = jsonLd(
+  webpageSchema({ title, description, path: "/wiki/campus-curfew" }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Wiki", path: "/wiki" },
+    { name: "Campus curfew", path: "/wiki/campus-curfew" },
+  ]),
+);
+---
+
+<WikiLayout
+  {title}
+  {description}
+  canonicalPath="/wiki/campus-curfew"
+  {structuredData}
+  crumb="Campus curfew"
+>
+  <article class="wiki-article">
+    <header class="article-hero">
+      <p class="wiki-eyebrow">Dorm guide</p>
+      <h1 class="wiki-title">Campus curfew and dorm permits</h1>
+      <p class="wiki-lede">
+        A short reference for the curfew and return permits that apply to
+        residents of UP-managed dormitories.
+      </p>
+      <WikiProvenance sourcePath="src/pages/wiki/campus-curfew.astro" />
+    </header>
+
+    <section aria-labelledby="curfew-hours">
+      <h2 id="curfew-hours">Curfew hours</h2>
+      <p>The campus curfew runs from <strong>{CAMPUS_CURFEW.hours}</strong>.</p>
+      <p>{CAMPUS_CURFEW.noLoitering}</p>
+    </section>
+
+    <section aria-labelledby="dorm-permits">
+      <h2 id="dorm-permits">UP-managed dorm residents</h2>
+      <ul>
+        <li>{CAMPUS_CURFEW.residentRule}</li>
+        <li>{CAMPUS_CURFEW.latePermit}</li>
+        <li>{CAMPUS_CURFEW.overnightPermit}</li>
+      </ul>
+    </section>
+  </article>
+</WikiLayout>

--- a/src/pages/wiki/emergency-hotlines.astro
+++ b/src/pages/wiki/emergency-hotlines.astro
@@ -1,0 +1,81 @@
+---
+export const prerender = true;
+
+import WikiLayout from "@layouts/WikiLayout.astro";
+import WikiProvenance from "../../components/wiki/WikiProvenance.astro";
+import {
+  EMERGENCY_HOTLINE_CATEGORIES,
+  emergencyHotlineTel,
+} from "@constants/emergency-hotlines";
+import { breadcrumbSchema, jsonLd, webpageSchema } from "@lib/site";
+
+const title = "Emergency hotlines | Room TBA Wiki";
+const description =
+  "Emergency hotline numbers for UPLB, Los Baños, and nearby medical services.";
+const structuredData = jsonLd(
+  webpageSchema({ title, description, path: "/wiki/emergency-hotlines" }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Wiki", path: "/wiki" },
+    { name: "Emergency hotlines", path: "/wiki/emergency-hotlines" },
+  ]),
+);
+---
+
+<WikiLayout
+  {title}
+  {description}
+  canonicalPath="/wiki/emergency-hotlines"
+  {structuredData}
+  crumb="Emergency hotlines"
+>
+  <article class="wiki-article">
+    <header class="article-hero">
+      <p class="wiki-eyebrow">Emergency contacts</p>
+      <h1 class="wiki-title">Emergency hotlines around UPLB</h1>
+      <p class="wiki-lede">
+        Call the service that can help. This directory is bundled in Room TBA’s
+        app menu too, so it remains available without a network connection.
+      </p>
+      <WikiProvenance sourcePath="src/pages/wiki/emergency-hotlines.astro" />
+    </header>
+
+    {
+      EMERGENCY_HOTLINE_CATEGORIES.map((category) => (
+        <section aria-labelledby={`hotlines-${category.name}`}>
+          <h2 id={`hotlines-${category.name}`}>{category.name}</h2>
+          <dl>
+            {category.entries.map((entry) => (
+              <>
+                <dt>{entry.name}</dt>
+                <dd>
+                  {entry.numbers.map((number, index) => (
+                    <>
+                      {index > 0 && " · "}
+                      <a href={emergencyHotlineTel(number)}>{number}</a>
+                    </>
+                  ))}
+                </dd>
+              </>
+            ))}
+          </dl>
+        </section>
+      ))
+    }
+  </article>
+</WikiLayout>
+
+<style>
+  dl {
+    margin: 0;
+  }
+
+  dt {
+    margin-top: 0.875rem;
+    font-weight: 700;
+  }
+
+  dd {
+    margin: 0.25rem 0 0;
+  }
+</style>

--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -7,6 +7,22 @@ import { wikiProvenance } from "@lib/wiki-provenance";
 
 const articles = [
   {
+    href: "/wiki/emergency-hotlines",
+    kicker: "Emergency contacts · 2 min read",
+    title: "Emergency hotlines around UPLB",
+    blurb:
+      "Offline-ready contacts for campus security, local responders, and nearby medical services.",
+    sourcePath: "src/pages/wiki/emergency-hotlines.astro",
+  },
+  {
+    href: "/wiki/campus-curfew",
+    kicker: "Dorm guide · 2 min read",
+    title: "Campus curfew and dorm permits",
+    blurb:
+      "Curfew hours and return-permit guidance for residents of UP-managed dormitories.",
+    sourcePath: "src/pages/wiki/campus-curfew.astro",
+  },
+  {
     href: "/faq",
     kicker: "Student FAQ · 3 min read",
     title: "Frequently asked questions",


### PR DESCRIPTION
## Summary

- add an offline-capable emergency hotline directory in the app menu and wiki
- add the campus curfew guide and UP-managed dorm notice
- precache both wiki pages and cover the static data and UI paths

Closes #995
Closes #996

## QA Summary

Automated:

- [x] `bun run lint` (existing warnings only)
- [x] `bun run check:readme`
- [x] emergency hotline unit test
- [x] focused modal, menu, and dorm component tests (11 passed)
- [x] `bun run build`

Manual browser:

- [ ] Offline airplane-mode smoke
- [ ] Visual review at 320px and desktop widths

Known gaps:

- The broad `bun test src` invocation currently reports unrelated component-suite failures despite exiting successfully; focused tests for this change pass.