### PR TITLE
feat(map): browse historical imagery (#967)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ No account needed to browse. Editors and contributors fix data in the same app (
 | Walking time from a point | Map tools → Travel time; tap the map, paths color by minutes |
 | Measure a route | Map tools → Measure route; drop waypoints, get walk / cycle / car times |
 | 3D view | Buildings + Makiling terrain (online) |
-| Satellite imagery | Satellite button in the map controls (when available) |
+| Satellite imagery | Map tools → View → Satellite; choose locally changed historical imagery back to 2015 when online |
 | Common questions | [Student FAQ](https://room-tba.uplb.tools/faq) (3D models, data sources, offline) |
 | Tell us something is wrong | Settings → Feedback; free text, optional contact, or reach the team on Messenger / Discord |
 | Understand section names | Wiki guide to the A–H / S–Z class time blocks |

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@aws-sdk/client-s3": "^3.1105.0",
         "@datadog/browser-rum": "^7.8.0",
         "@electric-sql/pglite": "^0.5.4",
+        "@esri/wayback-core": "^1.1.0",
         "@lucide/svelte": "^1.29.0",
         "@maplibre/maplibre-gl-directions": "^0.9.1",
         "@supabase/ssr": "^0.12.3",
@@ -508,6 +509,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@esri/wayback-core": ["@esri/wayback-core@1.1.0", "", {}, "sha512-+VtsL7n/tqa8aYpdmOdvL7r1/R45r4YVXxE5bmDeXcENIfrZIg2cK0pH9bo8MIcQng7p6jhByQotMX7NVPxIcA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@aws-sdk/client-s3": "^3.1105.0",
     "@datadog/browser-rum": "^7.8.0",
     "@electric-sql/pglite": "^0.5.4",
+    "@esri/wayback-core": "^1.1.0",
     "@lucide/svelte": "^1.29.0",
     "@maplibre/maplibre-gl-directions": "^0.9.1",
     "@supabase/ssr": "^0.12.3",

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -2101,11 +2101,12 @@
   $effect(() => {
     const map = mapStore.mapInstance;
     const satellite = mapViewStore.satellite;
+    const historicalTileUrl = mapViewStore.waybackSnapshot?.tileUrl;
     if (!map) return;
 
     let cancelled = false;
     const applySatellite = () => {
-      if (!cancelled) syncSatelliteLayer(map, satellite);
+      if (!cancelled) syncSatelliteLayer(map, satellite, historicalTileUrl);
     };
     if (map.isStyleLoaded()) {
       applySatellite();

--- a/src/components/svelte/MapAttribution.svelte
+++ b/src/components/svelte/MapAttribution.svelte
@@ -5,7 +5,8 @@
     MAPTILER_COPYRIGHT_URL,
     OSM_COPYRIGHT_URL,
   } from "@constants/data-license";
-  import { terrainStore } from "@lib/store.svelte";
+  import { mapViewStore, terrainStore } from "@lib/store.svelte";
+  import { WAYBACK_ATTRIBUTION_URL } from "@lib/wayback-imagery";
   import { onMount } from "svelte";
   import {
     getBasemapProvider,
@@ -59,6 +60,16 @@
         © OpenFreeMap
       </a>
     {/if}
+    {#if mapViewStore.waybackSnapshot}
+      <span aria-hidden="true">·</span>
+      <a
+        href={WAYBACK_ATTRIBUTION_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        © Esri Wayback
+      </a>
+    {/if}
   </p>
   <button
     type="button"
@@ -98,6 +109,15 @@
           rel="noopener noreferrer"
         >
           © OpenFreeMap
+        </a>
+      {/if}
+      {#if mapViewStore.waybackSnapshot}
+        <a
+          href={WAYBACK_ATTRIBUTION_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          © Esri World Imagery Wayback — release {mapViewStore.waybackSnapshot.releaseDate}{#if mapViewStore.waybackSnapshot.acquisitionDate}, imagery acquired {mapViewStore.waybackSnapshot.acquisitionDate}{/if}
         </a>
       {/if}
       <a href={DATA_LICENSE_FAQ_PATH}>Campus data license</a>

--- a/src/components/svelte/MapToolsFlyout.svelte
+++ b/src/components/svelte/MapToolsFlyout.svelte
@@ -15,6 +15,7 @@
   } from "@lib/store.svelte";
   import { panelFadeIn, panelFadeOut } from "@lib/motion";
   import MapViewControls from "@ui/MapViewControls.svelte";
+  import WaybackImageryControl from "@ui/WaybackImageryControl.svelte";
   import MapLegend from "@ui/MapLegend.svelte";
   import TerrainControl from "@ui/TerrainControl.svelte";
   import { TERRAIN_ENABLED } from "@constants/map-terrain";
@@ -154,6 +155,7 @@
               >
                 {#if section.id === "view"}
                   <MapViewControls embedded variant="modes" />
+                  <WaybackImageryControl />
                 {:else if section.id === "legend"}
                   <MapLegend embedded />
                 {:else if section.id === "terrain"}

--- a/src/components/svelte/WaybackImageryControl.component.test.ts
+++ b/src/components/svelte/WaybackImageryControl.component.test.ts
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { mapStore, mapViewStore } from "@lib/store.svelte";
+import { mountAtWidth } from "@test/layout-assertions";
+import WaybackImageryControl from "./WaybackImageryControl.svelte";
+
+vi.mock("@lib/wayback-imagery", () => ({
+  loadWaybackSnapshots: vi.fn().mockResolvedValue([
+    {
+      releaseNum: 123,
+      releaseDate: "2018-03-14",
+      acquisitionDate: "2017-12-02",
+      tileUrl: "https://wayback.example/{z}/{y}/{x}",
+    },
+  ]),
+}));
+
+describe("WaybackImageryControl", () => {
+  beforeEach(() => {
+    mapStore.mapInstance = {
+      getCenter: () => ({ lat: 14.165, lng: 121.242 }),
+      getZoom: () => 16,
+    } as never;
+    mapViewStore.satellite = true;
+    mapViewStore.waybackSnapshot = null;
+  });
+
+  afterEach(() => {
+    mapStore.mapInstance = undefined;
+    mapViewStore.satellite = false;
+    mapViewStore.waybackSnapshot = null;
+  });
+
+  test("offers locally changed years and applies the chosen release", async () => {
+    mountAtWidth(320);
+    render(WaybackImageryControl);
+    const select = await screen.findByRole("combobox", {
+      name: "Historical imagery year",
+    });
+    expect(screen.getByRole("option", { name: "2018-03-14" })).toBeTruthy();
+
+    await fireEvent.change(select, { target: { value: "123" } });
+    expect(mapViewStore.waybackSnapshot?.releaseNum).toBe(123);
+    expect(screen.getByText(/captured 2017-12-02/)).toBeTruthy();
+  });
+});

--- a/src/components/svelte/WaybackImageryControl.svelte
+++ b/src/components/svelte/WaybackImageryControl.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { mapStore, mapViewStore } from "@lib/store.svelte";
+  import {
+    loadWaybackSnapshots,
+    type WaybackSnapshot,
+  } from "@lib/wayback-imagery";
+
+  let online = $state(false);
+  let snapshots = $state<WaybackSnapshot[]>([]);
+  const selected = $derived(mapViewStore.waybackSnapshot);
+
+  onMount(() => {
+    const updateOnline = () => (online = navigator.onLine);
+    updateOnline();
+    window.addEventListener("online", updateOnline);
+    window.addEventListener("offline", updateOnline);
+    return () => {
+      window.removeEventListener("online", updateOnline);
+      window.removeEventListener("offline", updateOnline);
+    };
+  });
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    if (!online || !mapViewStore.satellite || !map) {
+      snapshots = [];
+      return;
+    }
+
+    const controller = new AbortController();
+    const center = map.getCenter();
+    void loadWaybackSnapshots(
+      { latitude: center.lat, longitude: center.lng },
+      map.getZoom(),
+      controller.signal,
+    )
+      .then((available) => {
+        if (!controller.signal.aborted) snapshots = available;
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) snapshots = [];
+      });
+    return () => controller.abort();
+  });
+
+  function selectSnapshot(event: Event) {
+    const releaseNum = Number((event.currentTarget as HTMLSelectElement).value);
+    mapViewStore.setWaybackSnapshot(
+      snapshots.find((snapshot) => snapshot.releaseNum === releaseNum) ?? null,
+    );
+  }
+</script>
+
+{#if snapshots.length > 0}
+  <div class="wayback-imagery-control">
+    <label for="wayback-imagery-year">Historical imagery</label>
+    <select
+      id="wayback-imagery-year"
+      aria-label="Historical imagery year"
+      value={selected?.releaseNum ?? ""}
+      onchange={selectSnapshot}
+    >
+      <option value="">Current imagery</option>
+      {#each snapshots as snapshot (snapshot.releaseNum)}
+        <option value={snapshot.releaseNum}>{snapshot.releaseDate}</option>
+      {/each}
+    </select>
+    {#if selected}
+      <p>
+        Wayback release {selected.releaseDate}
+        {#if selected.acquisitionDate}
+          · captured {selected.acquisitionDate}
+        {/if}
+      </p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .wayback-imagery-control {
+    display: grid;
+    gap: 0.25rem;
+    padding: 0.5rem 0;
+    color: var(--color-text, #25232a);
+    font-size: 0.8125rem;
+  }
+
+  select {
+    width: 100%;
+    min-height: 2.25rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--color-border, #d4d0d5);
+    border-radius: 0.375rem;
+    background: #fff;
+    color: inherit;
+    font: inherit;
+  }
+
+  p {
+    margin: 0;
+    color: var(--color-text-muted, #6a6670);
+    font-size: 0.75rem;
+  }
+</style>

--- a/src/lib/map-satellite.test.ts
+++ b/src/lib/map-satellite.test.ts
@@ -19,11 +19,16 @@ function fakeMap(layers: FakeLayer[]) {
     getLayer: (id: string) => layers.find((layer) => layer.id === id),
     getSource: (id: string) => sources.get(id),
     addSource: (id: string, source: unknown) => sources.set(id, source),
+    removeSource: (id: string) => sources.delete(id),
     addLayer: (layer: FakeLayer, beforeId?: string) => {
       const at = beforeId
         ? layers.findIndex((existing) => existing.id === beforeId)
         : layers.length;
       layers.splice(at === -1 ? layers.length : at, 0, layer);
+    },
+    removeLayer: (id: string) => {
+      const index = layers.findIndex((layer) => layer.id === id);
+      if (index !== -1) layers.splice(index, 1);
     },
     getStyle: () => ({ layers }),
     setLayoutProperty: (id: string, _prop: string, value: string) => {
@@ -91,5 +96,22 @@ describe("syncSatelliteLayer", () => {
     );
     expect(satelliteLayers).toHaveLength(1);
     expect(satelliteLayers[0]?.visibility).toBe("visible");
+  });
+
+  test("replaces MapTiler tiles with a selected Wayback release", () => {
+    const map = fakeMap(baseLayers());
+    const waybackTileUrl =
+      "https://wayback.maptiles.arcgis.com/tile/123/{z}/{y}/{x}";
+    syncSatelliteLayer(asMap(map), true);
+    syncSatelliteLayer(asMap(map), true, waybackTileUrl);
+
+    expect(
+      map.layers.filter((layer) => layer.id === SATELLITE_LAYER_ID),
+    ).toHaveLength(1);
+    expect(map.sources.get(SATELLITE_SOURCE_ID)).toEqual({
+      type: "raster",
+      tiles: [waybackTileUrl],
+      tileSize: 256,
+    });
   });
 });

--- a/src/lib/map-satellite.ts
+++ b/src/lib/map-satellite.ts
@@ -12,6 +12,8 @@ export const SATELLITE_LAYER_ID = "satellite-basemap";
 const SATELLITE_TILEJSON_URL =
   "https://api.maptiler.com/tiles/satellite-v2/tiles.json?key=__MAPTILER_KEY__";
 
+const currentSourceUrls = new WeakMap<maplibregl.Map, string>();
+
 /**
  * Show or hide satellite imagery under the app's own layers.
  *
@@ -24,13 +26,26 @@ const SATELLITE_TILEJSON_URL =
 export function syncSatelliteLayer(
   map: maplibregl.Map,
   visible: boolean,
+  historicalTileUrl?: string | null,
 ): void {
+  const sourceUrl =
+    historicalTileUrl ?? withMaptilerKey(SATELLITE_TILEJSON_URL);
+  if (
+    map.getLayer(SATELLITE_LAYER_ID) &&
+    currentSourceUrls.get(map) !== sourceUrl
+  ) {
+    map.removeLayer(SATELLITE_LAYER_ID);
+    if (map.getSource(SATELLITE_SOURCE_ID))
+      map.removeSource(SATELLITE_SOURCE_ID);
+  }
   if (!map.getLayer(SATELLITE_LAYER_ID)) {
     if (!visible) return;
     if (!map.getSource(SATELLITE_SOURCE_ID)) {
       map.addSource(SATELLITE_SOURCE_ID, {
         type: "raster",
-        url: withMaptilerKey(SATELLITE_TILEJSON_URL),
+        ...(historicalTileUrl
+          ? { tiles: [historicalTileUrl], tileSize: 256 }
+          : { url: sourceUrl }),
       });
     }
     const firstSymbolId = map
@@ -40,6 +55,7 @@ export function syncSatelliteLayer(
       { id: SATELLITE_LAYER_ID, type: "raster", source: SATELLITE_SOURCE_ID },
       firstSymbolId,
     );
+    currentSourceUrls.set(map, sourceUrl);
   }
   map.setLayoutProperty(
     SATELLITE_LAYER_ID,

--- a/src/lib/stores/map-stores.svelte.ts
+++ b/src/lib/stores/map-stores.svelte.ts
@@ -6,6 +6,7 @@ import {
 import { dismissEphemeralOverlays } from "../overlay-stack.js";
 import { deactivateMapModesExcept } from "./map-modes.js";
 import type { MapToolsSection, TerrainStatus } from "./store-types.js";
+import type { WaybackSnapshot } from "../wayback-imagery.js";
 
 export class MapStore {
   mapInstance: maplibre.MapLibreMap | undefined = $state.raw();
@@ -24,6 +25,8 @@ export class MapViewStore {
   poiPinsZoomVisible: boolean = $state(true);
   /** Satellite imagery under the basemap labels (MapTiler raster). */
   satellite: boolean = $state(false);
+  /** A locally changed Esri World Imagery Wayback release, when selected. */
+  waybackSnapshot: WaybackSnapshot | null = $state(null);
 
   toggleEventsOnly = () => {
     this.eventsOnly = !this.eventsOnly;
@@ -31,6 +34,12 @@ export class MapViewStore {
 
   toggleSatellite = () => {
     this.satellite = !this.satellite;
+    if (!this.satellite) this.waybackSnapshot = null;
+  };
+
+  setWaybackSnapshot = (snapshot: WaybackSnapshot | null) => {
+    this.waybackSnapshot = snapshot;
+    this.satellite = true;
   };
 
   toggleOrgs = () => {

--- a/src/lib/wayback-imagery.test.ts
+++ b/src/lib/wayback-imagery.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import type { WaybackItem } from "@esri/wayback-core";
+import { selectWaybackYears, toWaybackTileUrl } from "@lib/wayback-imagery";
+
+const item = (releaseDateLabel: string): WaybackItem => ({
+  itemID: releaseDateLabel,
+  itemTitle: releaseDateLabel,
+  itemURL: "https://wayback.example/tile/{level}/{row}/{col}",
+  metadataLayerItemID: "metadata",
+  metadataLayerUrl: "https://wayback.example/metadata",
+  releaseNum: Number(releaseDateLabel.replaceAll("-", "")),
+  releaseDateLabel,
+  releaseDatetime: Date.parse(`${releaseDateLabel}T00:00:00Z`),
+});
+
+describe("Wayback imagery", () => {
+  test("uses MapLibre tile tokens", () => {
+    expect(toWaybackTileUrl(item("2024-01-01").itemURL)).toBe(
+      "https://wayback.example/tile/{z}/{y}/{x}",
+    );
+  });
+
+  test("keeps the newest locally changed release for every year since 2015", () => {
+    expect(
+      selectWaybackYears([
+        item("2024-10-01"),
+        item("2024-02-01"),
+        item("2015-07-01"),
+        item("2014-12-01"),
+      ]).map(({ releaseDateLabel }) => releaseDateLabel),
+    ).toEqual(["2024-10-01", "2015-07-01"]);
+  });
+});

--- a/src/lib/wayback-imagery.ts
+++ b/src/lib/wayback-imagery.ts
@@ -1,0 +1,68 @@
+import type { WaybackItem, WaybackMetadata } from "@esri/wayback-core";
+
+export const WAYBACK_MIN_YEAR = 2015;
+export const WAYBACK_ATTRIBUTION_URL =
+  "https://livingatlas.arcgis.com/wayback/";
+
+export type WaybackSnapshot = {
+  releaseNum: number;
+  releaseDate: string;
+  acquisitionDate: string | null;
+  tileUrl: string;
+};
+
+type Point = { latitude: number; longitude: number };
+
+export function toWaybackTileUrl(itemUrl: string): string {
+  return itemUrl
+    .replace("{level}", "{z}")
+    .replace("{row}", "{y}")
+    .replace("{col}", "{x}");
+}
+
+/** Keep the latest locally changed release for each available year. */
+export function selectWaybackYears(items: WaybackItem[]): WaybackItem[] {
+  const years = new Map<number, WaybackItem>();
+  for (const item of items) {
+    const year = new Date(item.releaseDatetime).getUTCFullYear();
+    if (year >= WAYBACK_MIN_YEAR && !years.has(year)) years.set(year, item);
+  }
+  return [...years.values()].sort(
+    (a, b) => b.releaseDatetime - a.releaseDatetime,
+  );
+}
+
+function dateLabel(timestamp: number | undefined): string | null {
+  return timestamp ? new Date(timestamp).toISOString().slice(0, 10) : null;
+}
+
+export async function loadWaybackSnapshots(
+  point: Point,
+  zoom: number,
+  signal?: AbortSignal,
+): Promise<WaybackSnapshot[]> {
+  const { getMetadata, getWaybackItemsWithLocalChanges } = await import(
+    "@esri/wayback-core"
+  );
+  const items = selectWaybackYears(
+    await getWaybackItemsWithLocalChanges(point, Math.round(zoom), { signal }),
+  );
+  const metadata = await Promise.all(
+    items.map(async (item) => {
+      try {
+        return await getMetadata(point, Math.round(zoom), item.releaseNum);
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return items.map((item, index) => ({
+    releaseNum: item.releaseNum,
+    releaseDate: item.releaseDateLabel,
+    acquisitionDate: dateLabel(
+      (metadata[index] as WaybackMetadata | null)?.date,
+    ),
+    tileUrl: toWaybackTileUrl(item.itemURL),
+  }));
+}


### PR DESCRIPTION
## Summary

Adds an online-only Esri World Imagery Wayback selector to Map tools → View. It lists only locally changed releases for the map center, swaps the existing satellite raster source, and displays release/acquisition dates with attribution.

**Linked issues:** Closes #967

## QA Summary

Automated:

- [x] Unit tests passed: `bun run test`
- [x] Component tests passed: `bun run test:components` (309 tests, including 320px Wayback picker)
- [x] Full lint passed locally: `bun run lint` (existing repository warnings only)
- [x] README drift check passed: `bun run check:readme`
- [x] Build passed locally: `bun run build`
- [x] Live Esri Wayback query at UPLB returned distinct 2015–2025 releases and acquisition dates
- [ ] E2E / integration: intentionally bypassed per maintainer direction

Manual browser:

- [ ] 768px browser pass not run

Known gaps:

- E2E was explicitly bypassed for this release train. The selector hides offline or when the Wayback lookup fails.

## Issues updated

- [x] #967 acceptance criteria, implementation notes, and test evidence updated

## Test plan

1. Open Map tools → View and enable Satellite.
2. Choose an available historical date; confirm the raster changes and the capture date/Esri credit appear.
3. Toggle Satellite off/on or go offline; confirm the historical selector is hidden when it cannot be used.