### PR TITLE
fix: prod UX audit batch (modal paint stall, planner scroll, menu sizing, onboarding, search rank, fast bootstrap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: bunx biome ci .
 
       - name: Unit tests
-        run: bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts' --reporter=junit --reporter-outfile=junit-unit.xml
+        run: bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts' --path-ignore-patterns='**/*.component.test.ts' --reporter=junit --reporter-outfile=junit-unit.xml
 
       - name: Retire feature coverage with retired pages
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ data/transit-geometry-cache/
 !data/final-exams-sample.json
 .vercel
 .env*.local
+
+# graphify knowledge-graph output (local tool artifacts)
+graphify-out/

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write --unsafe .",
     "format": "biome format --write .",
-    "test": "bun test src/lib src/constants scripts/lib --path-ignore-patterns='**/*.store.test.ts'",
+    "test": "bun test src/lib src/constants scripts/lib --path-ignore-patterns='**/*.store.test.ts' --path-ignore-patterns='**/*.component.test.ts'",
     "test:components": "vitest run",
     "test:integration": "bun test ./integration --preload ./integration/preload.ts --concurrency 1 --timeout 20000",
     "test:integration:live": "bash scripts/run-integration-preview.sh",

--- a/src/components/svelte/AppRoot.svelte
+++ b/src/components/svelte/AppRoot.svelte
@@ -28,6 +28,10 @@
   import { onMount } from "svelte";
   import { jitteredBackoffDelay, sleep } from "@lib/local/data/fetch-json";
   import {
+    loadAppDataSnapshot,
+    saveAppDataSnapshot,
+  } from "@lib/local/data/app-data-snapshot";
+  import {
     fetchRemoteEvents,
     getBuildings,
     getColleges,
@@ -249,6 +253,7 @@
 
       const hasData = hasUsableCampusData(nextData);
       if (hasData) {
+        saveAppDataSnapshot(nextData);
         appBootstrapStore.setHasCachedData(true);
       } else if (!hasCachedDataAtStart) {
         appBootstrapStore.setHasCachedData(false);
@@ -395,12 +400,27 @@
           getSyncKeysFromLs() ?? {},
         ).some(Boolean);
 
+        // Fast path: last visit's data as flat JSON. Applies in milliseconds
+        // while PGlite (5 MB wasm) and the network are still warming up, so a
+        // returning visitor (or a wiki round-trip) skips the splash screen.
+        let pgliteCacheApplied = false;
+        void loadAppDataSnapshot().then((snapshot) => {
+          if (!snapshot || !hasUsableCampusData(snapshot)) return;
+          if (networkDataApplied || pgliteCacheApplied) return;
+          applyData(snapshot);
+          appBootstrapStore.setHasCachedData(true);
+          appBootstrapStore.complete();
+          dismissStaticLoadingShell();
+        }, console.error);
+
         void loadCachedAppData().then((cached) => {
           if (!hasUsableCampusData(cached)) return;
           appBootstrapStore.setHasCachedData(true);
           // The network may have painted fresher rows while the cache was
           // still hydrating; never regress the UI back to the cached copy.
           if (networkDataApplied) return;
+          pgliteCacheApplied = true;
+          saveAppDataSnapshot(cached);
           applyData(cached);
           appBootstrapStore.complete();
           dismissStaticLoadingShell();

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -296,6 +296,9 @@
       return;
     }
     landingModalAutoOpenConsumed = true;
+    // Auto-open counts as seen: the welcome tour shows once per browser, not
+    // on every visit. Reopen stays available from the app menu.
+    localStorage.setItem("hideLandingModal", "true");
     modalStore.openModal("landing");
   });
   $effect(() => {

--- a/src/components/svelte/final-exams/FinalExamsScreen.svelte
+++ b/src/components/svelte/final-exams/FinalExamsScreen.svelte
@@ -116,8 +116,8 @@
       <p class="finals-status" role="status">Loading final exams…</p>
     {:else if exams.length === 0}
       <p class="finals-status">
-        No final exam schedule published for this term yet.{#if finalsWindow}
-          The academic calendar sets final exams for {finalsWindow}.{/if}
+        No final exam schedule published for this term yet.{#if finalsWindow}{" "}The
+          academic calendar sets final exams for {finalsWindow}.{/if}
       </p>
     {:else if filtered.length === 0}
       <p class="finals-status">No exams match “{filter}”.</p>

--- a/src/components/svelte/modal/LandingModal.component.test.ts
+++ b/src/components/svelte/modal/LandingModal.component.test.ts
@@ -107,16 +107,10 @@ describe("landing modal controls", () => {
     expect(localStorage.getItem("hideLandingModal")).toBeNull();
   });
 
-  test("Get Started persists the don't-show-again choice", async () => {
+  test("has no don't-show-again checkbox (auto-open persists as seen)", () => {
     modalStore.openModal("landing");
     render(LandingModal);
 
-    await fireEvent.click(
-      screen.getByRole("checkbox", { name: /Don't show again/i }),
-    );
-    await fireEvent.click(screen.getByRole("button", { name: "Get Started" }));
-
-    expect(localStorage.getItem("hideLandingModal")).toBe("true");
-    expect(modalStore.open).toBe(false);
+    expect(screen.queryByRole("checkbox")).toBeNull();
   });
 });

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -25,7 +25,6 @@
   type LandingTab = "welcome" | "campus";
 
   let activeTab = $state<LandingTab>("welcome");
-  let dontShowAgain = $state(false);
   let installPrompt = $state<
     | (Event & {
         prompt: () => Promise<void>;
@@ -119,9 +118,6 @@
   }
 
   function handleGetStarted() {
-    if (dontShowAgain) {
-      localStorage.setItem("hideLandingModal", "true");
-    }
     if (installPrompt) {
       void installPrompt.prompt();
       installPrompt.userChoice.then(({ outcome }) => {
@@ -369,10 +365,6 @@
       <button class="primary-btn" onclick={handleGetStarted}>Get Started</button
       >
     {/if}
-    <label class="checkbox-label">
-      <input type="checkbox" bind:checked={dontShowAgain} />
-      Don't show again
-    </label>
   </footer>
 </div>
 
@@ -712,23 +704,6 @@
     align-items: center;
     gap: 0.5rem;
     background-color: hsl(5, 75%, 28%);
-  }
-
-  .checkbox-label {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.8125rem;
-    color: hsl(0, 0%, 22%);
-    cursor: pointer;
-    user-select: none;
-  }
-
-  .checkbox-label input[type="checkbox"] {
-    cursor: pointer;
-    width: 1rem;
-    height: 1rem;
-    accent-color: hsl(5, 75%, 28%);
   }
 
   @media screen and (max-width: 48rem) {

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -333,9 +333,11 @@
     height: 100%;
     inset: 0;
     position: absolute;
-    background-color: hsla(0, 0%, 8%, 0.42);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    /* No backdrop-filter here: blurring the full-viewport WebGL map stalls
+       the compositor for seconds (30s+ seen in prod) — the dialog mounts,
+       blocks all input, and never paints. Verified: with blur the Settings
+       modal takes 5-8s to appear locally, without it ~1 frame. Dim only. */
+    background-color: hsla(0, 0%, 8%, 0.48);
     cursor: pointer;
   }
 

--- a/src/components/svelte/planner/PlannerScreen.svelte
+++ b/src/components/svelte/planner/PlannerScreen.svelte
@@ -600,6 +600,12 @@
        (tabs, week grid) own their horizontal scrolling; the root never does. */
     flex: 1 1 auto;
     min-width: 0;
+    /* min-height too: overflow-y stays visible here (unlike the sibling
+       screens' overflow: hidden), so without this the automatic min-size is
+       content height, the screen outgrows the fixed .ui-layer, and
+       .planner-body's overflow-y: auto never engages — the course list
+       becomes unscrollable and everything below the fold is unreachable. */
+    min-height: 0;
     max-width: 100%;
     overflow-x: clip;
     display: flex;

--- a/src/components/svelte/status-bar/AppMenu.svelte
+++ b/src/components/svelte/status-bar/AppMenu.svelte
@@ -537,6 +537,10 @@
   }
 
   .app-menu__nav-action {
+    /* No global border-box reset in this app: without this, min-height +
+       padding stack to 64px-tall rows and width: 100% + padding overflows
+       the panel sideways (stray horizontal scrollbar). */
+    box-sizing: border-box;
     width: 100%;
     min-height: 2.75rem;
     border: 0;

--- a/src/lib/final-exams.ts
+++ b/src/lib/final-exams.ts
@@ -1,7 +1,7 @@
 import type { FinalExamRow } from "@lib/types";
 
 export const FINALS_SCOPE_NOTE =
-  "Final exam times come from OUR/registrar releases, not AMIS class schedules. Regular lecture and lab timetables stay on the room panel above. If nothing appears here, OUR may not have published finals for this term yet.";
+  "Final exam times come from OUR/registrar releases, not AMIS class schedules. Regular lecture and lab timetables stay on each room's schedule panel. If nothing appears here, OUR may not have published finals for this term yet.";
 
 const COURSE_CODE_PATTERN = /^[A-Za-z]{2,8}\s*\d{1,4}[A-Za-z]?$/;
 

--- a/src/lib/focus-trap.component.test.ts
+++ b/src/lib/focus-trap.component.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { trapFocus } from "./focus-trap";
+
+function dialogWithButtons(): HTMLElement {
+  const container = document.createElement("div");
+  const first = document.createElement("button");
+  first.textContent = "first";
+  const last = document.createElement("button");
+  last.textContent = "last";
+  container.append(first, last);
+  document.body.append(container);
+  return container;
+}
+
+function pressEscape(target: EventTarget = document.body) {
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+  );
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("trapFocus", () => {
+  it("fires onEscape even when focus sits outside the container", () => {
+    // The app menu restores focus to its trigger after opening a modal, so
+    // Escape must be caught at the document level, not on the container.
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const container = dialogWithButtons();
+    let escaped = 0;
+    const release = trapFocus(container, { onEscape: () => escaped++ });
+
+    outside.focus();
+    pressEscape(outside);
+
+    expect(escaped).toBe(1);
+    release();
+  });
+
+  it("routes Escape to the innermost trap only, and back after release", () => {
+    const outerEl = dialogWithButtons();
+    const innerEl = dialogWithButtons();
+    const hits: string[] = [];
+    const releaseOuter = trapFocus(outerEl, {
+      onEscape: () => hits.push("outer"),
+    });
+    const releaseInner = trapFocus(innerEl, {
+      onEscape: () => hits.push("inner"),
+    });
+
+    pressEscape();
+    expect(hits).toEqual(["inner"]);
+
+    releaseInner();
+    pressEscape();
+    expect(hits).toEqual(["inner", "outer"]);
+    releaseOuter();
+  });
+
+  it("stops handling after release and restores previous focus", async () => {
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    outside.focus();
+
+    const container = dialogWithButtons();
+    let escaped = 0;
+    const release = trapFocus(container, { onEscape: () => escaped++ });
+    await Promise.resolve(); // initial-focus microtask
+    expect(container.contains(document.activeElement)).toBe(true);
+
+    release();
+    pressEscape();
+    expect(escaped).toBe(0);
+    expect(document.activeElement).toBe(outside);
+  });
+});

--- a/src/lib/focus-trap.ts
+++ b/src/lib/focus-trap.ts
@@ -7,13 +7,28 @@ function focusableElements(container: HTMLElement): HTMLElement[] {
   );
 }
 
-/** Trap Tab within a dialog and restore focus on teardown. */
+/** Innermost trap wins when several are open (menu under a modal, etc.). */
+const activeTraps: symbol[] = [];
+
+/**
+ * Trap Tab within a dialog and restore focus on teardown.
+ *
+ * Listens on `document`, not the container: openers like the app menu
+ * restore focus to their trigger when they close, so the first Escape after
+ * "menu → Settings" used to land outside the dialog and never reach a
+ * container-scoped listener — the modal looked un-closable.
+ */
 export function trapFocus(
   container: HTMLElement,
   options?: { onEscape?: () => void; initialFocus?: HTMLElement | null },
 ): () => void {
   const previous = document.activeElement;
+  const trapId = Symbol("focus-trap");
+  activeTraps.push(trapId);
+  const isInnermost = () => activeTraps[activeTraps.length - 1] === trapId;
+
   const handleKeydown = (event: KeyboardEvent) => {
+    if (!isInnermost()) return;
     if (event.key === "Escape") {
       options?.onEscape?.();
       event.stopPropagation();
@@ -28,8 +43,15 @@ export function trapFocus(
     const last = items[items.length - 1]!;
     const active = document.activeElement;
 
+    if (!container.contains(active)) {
+      // Focus escaped (or never arrived): pull the next Tab into the dialog.
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+      return;
+    }
+
     if (event.shiftKey) {
-      if (active === first || !container.contains(active)) {
+      if (active === first) {
         event.preventDefault();
         last.focus();
       }
@@ -42,13 +64,15 @@ export function trapFocus(
     }
   };
 
-  container.addEventListener("keydown", handleKeydown);
+  document.addEventListener("keydown", handleKeydown, true);
   queueMicrotask(() => {
     (options?.initialFocus ?? focusableElements(container)[0])?.focus();
   });
 
   return () => {
-    container.removeEventListener("keydown", handleKeydown);
+    const index = activeTraps.indexOf(trapId);
+    if (index !== -1) activeTraps.splice(index, 1);
+    document.removeEventListener("keydown", handleKeydown, true);
     if (previous instanceof HTMLElement && document.contains(previous)) {
       previous.focus();
     }

--- a/src/lib/landing-modal-auto-open.test.ts
+++ b/src/lib/landing-modal-auto-open.test.ts
@@ -14,6 +14,19 @@ describe("shouldAutoOpenLandingModal", () => {
     expect(shouldAutoOpenLandingModal(ready)).toBe(true);
   });
 
+  it("opens while data is still loading (no waiting for phase ready)", () => {
+    expect(shouldAutoOpenLandingModal({ ...ready, phase: "remote" })).toBe(
+      true,
+    );
+    expect(shouldAutoOpenLandingModal({ ...ready, phase: "sync" })).toBe(true);
+  });
+
+  it("stays closed on the bootstrap error overlay", () => {
+    expect(shouldAutoOpenLandingModal({ ...ready, phase: "error" })).toBe(
+      false,
+    );
+  });
+
   it("does not reopen after the auto-open slot was consumed", () => {
     expect(shouldAutoOpenLandingModal({ ...ready, consumed: true })).toBe(
       false,

--- a/src/lib/landing-modal-auto-open.ts
+++ b/src/lib/landing-modal-auto-open.ts
@@ -7,12 +7,19 @@ export type LandingModalAutoOpenInput = {
   modalOpen: boolean;
 };
 
-/** Whether the welcome modal should auto-open once after bootstrap (#302). */
+/**
+ * Whether the welcome modal should auto-open once per browser (#302).
+ *
+ * Opens as soon as the app is interactive rather than waiting for phase
+ * "ready": on slow networks "ready" lands 5-10s after first paint, so the
+ * modal used to pop up mid-interaction and swallow clicks. Only the error
+ * phase blocks it (the error overlay owns the screen then).
+ */
 export function shouldAutoOpenLandingModal(
   input: LandingModalAutoOpenInput,
 ): boolean {
   if (input.consumed) return false;
-  if (input.phase !== "ready") return false;
+  if (input.phase === "error") return false;
   if (input.suppressLandingModal) return false;
   if (input.hideLandingModal) return false;
   if (input.modalOpen) return false;

--- a/src/lib/local/data/app-data-snapshot.test.ts
+++ b/src/lib/local/data/app-data-snapshot.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { DBData } from "@lib/context";
+import { loadAppDataSnapshot, saveAppDataSnapshot } from "./app-data-snapshot";
+
+const sample = { buildings: [{ buildingName: "ICS" }], totalRooms: 3 };
+
+function stubCaches() {
+  const store = new Map<string, Response>();
+  const cache = {
+    match: (url: string) => Promise.resolve(store.get(url) ?? undefined),
+    put: (url: string, res: Response) => {
+      store.set(url, res);
+      return Promise.resolve();
+    },
+  };
+  (globalThis as { caches?: unknown }).caches = {
+    open: () => Promise.resolve(cache),
+  };
+}
+
+afterEach(() => {
+  delete (globalThis as { caches?: unknown }).caches;
+});
+
+describe("app data snapshot", () => {
+  it("round-trips the saved data", async () => {
+    stubCaches();
+    saveAppDataSnapshot(sample as unknown as DBData);
+    // save is fire-and-forget; let the cache.put microtask settle
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(await loadAppDataSnapshot()).toEqual(sample);
+  });
+
+  it("returns null with no snapshot and without Cache Storage", async () => {
+    stubCaches();
+    expect(await loadAppDataSnapshot()).toBeNull();
+    delete (globalThis as { caches?: unknown }).caches;
+    expect(await loadAppDataSnapshot()).toBeNull();
+    // save must not throw either
+    saveAppDataSnapshot(sample as unknown as DBData);
+  });
+});

--- a/src/lib/local/data/app-data-snapshot.ts
+++ b/src/lib/local/data/app-data-snapshot.ts
@@ -14,7 +14,13 @@ import type { DBData } from "@lib/context";
  * origin, so "Clear cached data" covers the snapshot for free.
  */
 const SNAPSHOT_CACHE = "app-data-snapshot";
-const SNAPSHOT_URL = "/__app-data-snapshot__";
+/**
+ * Bump when the DBData shape changes: a snapshot written by an older deploy
+ * is then ignored instead of feeding stale field names to new code. Old
+ * entries linger until the next write or a cache clear; that is fine.
+ */
+const SNAPSHOT_VERSION = 1;
+const SNAPSHOT_URL = `/__app-data-snapshot__?v=${SNAPSHOT_VERSION}`;
 
 export async function loadAppDataSnapshot(): Promise<DBData | null> {
   try {

--- a/src/lib/local/data/app-data-snapshot.ts
+++ b/src/lib/local/data/app-data-snapshot.ts
@@ -1,0 +1,49 @@
+import type { DBData } from "@lib/context";
+
+/**
+ * Plain-JSON snapshot of the last applied campus data, read in milliseconds.
+ *
+ * The offline source of truth stays PGlite, but hydrating ~5 MB of wasm sits
+ * between a returning visitor and first paint — the splash screen ran for
+ * 10s+ on every visit, including a wiki round-trip (map → wiki → map is a
+ * full navigation). Bootstrap applies this snapshot immediately, then lets
+ * the PGlite read and the network refresh race behind it as before.
+ *
+ * Cache Storage, not localStorage: campus data outgrows the 5 MB string
+ * quota, and `clear-cached-data.ts` already sweeps every cache on this
+ * origin, so "Clear cached data" covers the snapshot for free.
+ */
+const SNAPSHOT_CACHE = "app-data-snapshot";
+const SNAPSHOT_URL = "/__app-data-snapshot__";
+
+export async function loadAppDataSnapshot(): Promise<DBData | null> {
+  try {
+    if (!("caches" in globalThis)) return null;
+    const cache = await caches.open(SNAPSHOT_CACHE);
+    const hit = await cache.match(SNAPSHOT_URL);
+    if (!hit) return null;
+    return (await hit.json()) as DBData;
+  } catch {
+    return null;
+  }
+}
+
+/** Fire-and-forget; quota or private-mode failures only cost the fast path. */
+export function saveAppDataSnapshot(data: DBData): void {
+  try {
+    if (!("caches" in globalThis)) return;
+    void caches
+      .open(SNAPSHOT_CACHE)
+      .then((cache) =>
+        cache.put(
+          SNAPSHOT_URL,
+          new Response(JSON.stringify(data), {
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      )
+      .catch(() => {});
+  } catch {
+    // ignore: PGlite and network paths still populate the app
+  }
+}

--- a/src/lib/search-suggestions.test.ts
+++ b/src/lib/search-suggestions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { buildEntitySuggestions, nameMatchScore } from "./search-suggestions";
+import type { BuildingData } from "./types";
+
+function building(name: string): BuildingData {
+  return { buildingName: name, lat: 14.16, lon: 121.24 } as BuildingData;
+}
+
+const emptyData = {
+  loaded: true,
+  filteredBuildings: [] as BuildingData[],
+  filteredDorms: [],
+  colleges: [],
+  divisions: [],
+  events: [],
+  organizations: [],
+  places: [],
+};
+
+describe("nameMatchScore", () => {
+  it("scores exact and parenthesized-acronym matches best", () => {
+    expect(nameMatchScore("ICS", "ics")).toBe(0);
+    expect(nameMatchScore("Institute of Computer Science (ICS)", "ics")).toBe(
+      0,
+    );
+  });
+
+  it("scores word-start above mid-word substring", () => {
+    expect(nameMatchScore("Computer Science", "comp")).toBe(1);
+    expect(nameMatchScore("College of Economics", "ics")).toBe(2);
+  });
+
+  it("misses cleanly", () => {
+    expect(nameMatchScore("Baker Hall", "ics")).toBeNull();
+    expect(nameMatchScore(undefined, "ics")).toBeNull();
+  });
+});
+
+describe("buildEntitySuggestions", () => {
+  it("ranks the ICS building above mid-word -ics- matches (prod bug)", () => {
+    const suggestions = buildEntitySuggestions("ics", {
+      ...emptyData,
+      // Alphabetical data order used to fill the per-category cap with
+      // mid-word matches before the ICS building was ever considered.
+      filteredBuildings: [
+        building("CEM Building"),
+        building("Department of Human Kinetics"),
+        building("Hydraulics Laboratory"),
+        building("Institute of Statistics"),
+        building("Institute of Computer Science (ICS)"),
+      ],
+      colleges: [{ collegeName: "College of Economics and Management" }],
+    });
+
+    expect(suggestions[0]?.value).toBe("Institute of Computer Science (ICS)");
+  });
+
+  it("still caps per category and overall", () => {
+    const many = Array.from({ length: 10 }, (_, i) =>
+      building(`Physics Building ${i}`),
+    );
+    const suggestions = buildEntitySuggestions("physics", {
+      ...emptyData,
+      filteredBuildings: many,
+    });
+    expect(suggestions.length).toBe(4);
+  });
+});

--- a/src/lib/search-suggestions.ts
+++ b/src/lib/search-suggestions.ts
@@ -21,18 +21,64 @@ type Suggestion = {
 const MAX_SUGGESTIONS = 8;
 const MAX_PER_CATEGORY = 4;
 
+/**
+ * Relevance of `needle` inside a display name; lower is better, null = miss.
+ * 0 exact name or exact parenthesized acronym ("Institute of Computer
+ *   Science (ICS)" for "ics"), 1 word-start ("Comp" in "Computer"), 2 mid-word
+ *   substring ("ics" in "Economics").
+ *
+ * Mid-word matches used to win on alphabetical order alone: searching "ICS"
+ * surfaced Econom-ics- and Kinet-ics- while the ICS building never made the
+ * top 8.
+ */
+export function nameMatchScore(
+  name: string | null | undefined,
+  needle: string,
+): number | null {
+  if (!name) return null;
+  const haystack = name.toLowerCase();
+  const index = haystack.indexOf(needle);
+  if (index === -1) return null;
+  if (haystack === needle || haystack.includes(`(${needle})`)) return 0;
+  const before = index === 0 ? "" : haystack[index - 1];
+  return before === "" || !/[a-z0-9]/.test(before) ? 1 : 2;
+}
+
+/** Description hits rank behind any name hit. */
+function descriptionMatchScore(
+  description: string | null | undefined,
+  needle: string,
+): number | null {
+  return description?.toLowerCase().includes(needle) ? 3 : null;
+}
+
+function bestScore(...scores: (number | null)[]): number | null {
+  const hits = scores.filter((s): s is number => s !== null);
+  return hits.length ? Math.min(...hits) : null;
+}
+
+type Scored = { score: number; suggestion: Suggestion };
+
 function takeMatches<T>(
   items: T[],
-  predicate: (item: T) => boolean,
+  score: (item: T) => number | null,
   map: (item: T) => Suggestion,
-): Suggestion[] {
-  const out: Suggestion[] = [];
+): Scored[] {
+  const out: Scored[] = [];
   for (const item of items) {
-    if (!predicate(item)) continue;
-    out.push(map(item));
-    if (out.length >= MAX_PER_CATEGORY) break;
+    const s = score(item);
+    if (s === null) continue;
+    out.push({ score: s, suggestion: map(item) });
   }
-  return out;
+  return out
+    .sort(
+      (a, b) =>
+        a.score - b.score ||
+        a.suggestion.value
+          .toLowerCase()
+          .localeCompare(b.suggestion.value.toLowerCase()),
+    )
+    .slice(0, MAX_PER_CATEGORY);
 }
 
 export function buildEntitySuggestions(
@@ -54,7 +100,7 @@ export function buildEntitySuggestions(
   const suggestions = [
     ...takeMatches(
       data.filteredBuildings,
-      ({ buildingName }) => buildingName.toLowerCase().includes(needle),
+      ({ buildingName }) => nameMatchScore(buildingName, needle),
       (b) => ({
         value: b.buildingName,
         category: "building",
@@ -65,19 +111,21 @@ export function buildEntitySuggestions(
     ),
     ...takeMatches(
       data.colleges,
-      ({ collegeName }) => collegeName.toLowerCase().includes(needle),
+      ({ collegeName }) => nameMatchScore(collegeName, needle),
       ({ collegeName }) => ({ value: collegeName, category: "college" }),
     ),
     ...takeMatches(
       data.divisions,
-      ({ divisionName }) => divisionName.toLowerCase().includes(needle),
+      ({ divisionName }) => nameMatchScore(divisionName, needle),
       ({ divisionName }) => ({ value: divisionName, category: "division" }),
     ),
     ...takeMatches(
       data.filteredDorms,
       ({ dormName, shortName }) =>
-        dormName.toLowerCase().includes(needle) ||
-        Boolean(shortName?.toLowerCase().includes(needle)),
+        bestScore(
+          nameMatchScore(dormName, needle),
+          nameMatchScore(shortName, needle),
+        ),
       (d) => ({
         value: d.dormName,
         category: "dorm",
@@ -88,8 +136,10 @@ export function buildEntitySuggestions(
     ...takeMatches(
       data.events,
       ({ title, description }) =>
-        title.toLowerCase().includes(needle) ||
-        Boolean(description?.toLowerCase().includes(needle)),
+        bestScore(
+          nameMatchScore(title, needle),
+          descriptionMatchScore(description, needle),
+        ),
       (e) => ({
         value: e.title,
         category: "event",
@@ -100,8 +150,10 @@ export function buildEntitySuggestions(
     ...takeMatches(
       data.organizations,
       ({ name, description }) =>
-        name.toLowerCase().includes(needle) ||
-        Boolean(description?.toLowerCase().includes(needle)),
+        bestScore(
+          nameMatchScore(name, needle),
+          descriptionMatchScore(description, needle),
+        ),
       (o) => ({
         value: o.name,
         category: "organization",
@@ -112,8 +164,10 @@ export function buildEntitySuggestions(
     ...takeMatches(
       data.places,
       ({ name, description }) =>
-        name.toLowerCase().includes(needle) ||
-        Boolean(description?.toLowerCase().includes(needle)),
+        bestScore(
+          nameMatchScore(name, needle),
+          descriptionMatchScore(description, needle),
+        ),
       (p) => ({
         value: p.name,
         category: "place",
@@ -124,8 +178,13 @@ export function buildEntitySuggestions(
   ];
 
   return suggestions
-    .sort(({ value: a }, { value: b }) =>
-      a.toLowerCase().localeCompare(b.toLowerCase()),
+    .sort(
+      (a, b) =>
+        a.score - b.score ||
+        a.suggestion.value
+          .toLowerCase()
+          .localeCompare(b.suggestion.value.toLowerCase()),
     )
-    .slice(0, MAX_SUGGESTIONS);
+    .slice(0, MAX_SUGGESTIONS)
+    .map(({ suggestion }) => suggestion);
 }


### PR DESCRIPTION
Batch of fixes from the 2026-08-13 prod UX audit (full report in session; basemap/MapLibre-6 outage tracked separately and NOT addressed here).

## Fixes
- **Modal paint stall + input lockout**: `backdrop-filter: blur(8px)` over the full-viewport WebGL map stalled the compositor; the Settings dialog mounted invisibly for 5-30s while its wrapper ate every click and wheel event (the reported "can't scroll"). Overlay is dim-only now (0.48). Verified locally: paint went from 5-8s to ~1 frame.
- **Escape couldn't close modals opened from the app menu**: menu restores focus to its trigger, so the container-scoped focus-trap never saw the key. Trap now listens on document (capture) with an innermost-trap-wins stack. New tests cover nesting, out-of-container Escape, focus restore.
- **Planner course list unscrollable**: `.planner-screen` kept flex min-height:auto (its overflow-y is visible, unlike sibling screens), outgrew the fixed `.ui-layer`, and `.planner-body`'s `overflow-y: auto` never engaged. Sections below the fold were unreachable. One-line `min-height: 0`.
- **App menu 64px rows + stray horizontal scrollbar**: content-box artifacts; `box-sizing: border-box` on nav actions.
- **Welcome modal**: opened 5-10s after first paint (waited for bootstrap "ready") and re-opened every visit. Now opens while data loads, once per browser; auto-open persists as seen; checkbox removed ("How it works" in the menu reopens it).
- **Search ranking**: "ICS" surfaced Econom**ics**/Kinet**ics**/Hydraul**ics**; exact + parenthesized-acronym + word-start matches now outrank mid-word substrings (unit-tested with the prod repro).
- **Cold load / wiki round-trip splash**: campus data snapshot (flat JSON in Cache Storage, schema-versioned) applies in milliseconds at bootstrap; PGlite and network race behind as before. Returning visits skip the 10s+ splash.
- **Finals empty-state copy**: missing space ("yet.The"), and scope note no longer references a "room panel above" on screens that have none.

## Verification
- `bun run test` 870 pass, `bun run test:components` 312 pass, `bun run build` green, biome clean on changed files (repo-wide lint is red on origin/staging already, preexisting).
- Browser-verified on the node build: Settings paints instantly, Escape closes, menu compact with no stray scrollbars, snapshot reload paints in <4s with no welcome modal, planner `min-height` applied.
- Reviewed by a second-pass agent; follow-ups (focus-trap tests, snapshot schema version) included.