### PR TITLE
hotfix: restore vector basemap (MapLibre 6 worker) + keep map tools panel on-screen

### DIFF
--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
   import { MapLibre, Marker } from "svelte-maplibre";
   import * as maplibregl from "maplibre-gl";
-  import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?url";
+  // `?worker&url`, NOT `?url`. MapLibre 6 is ESM-only and its worker is a
+  // module that imports a sibling chunk (maplibre-gl-shared). `?url` copies the
+  // worker file verbatim without that sibling, so in production the module
+  // worker fails on its first import and NO vector tile ever loads (blank
+  // basemap under working pins, #1003). `?worker&url` routes it through Vite's
+  // worker pipeline, emitting a self-contained worker with its imports bundled.
+  // Ref: MapLibre v5->v6 migration guide (setWorkerUrl + Vite).
+  import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
 
-  // In production Vite inlines maplibre into the app chunk and boots its
-  // worker by importScripts-ing that same chunk; vector tiles survive but the
-  // GeoJSON source path dies inside the worker ("f is not defined"), so no
-  // geojson line layer (jeepney/event routes) ever rendered on prod. Point
-  // maplibre at its self-contained CSP worker bundle instead.
   maplibregl.setWorkerUrl(maplibreWorkerUrl);
   import { getAppActions, getAppData } from "@lib/context";
   import {

--- a/src/components/svelte/MapToolsFlyout.svelte
+++ b/src/components/svelte/MapToolsFlyout.svelte
@@ -29,6 +29,7 @@
   import { MediaQuery } from "svelte/reactivity";
 
   let panelEl = $state<HTMLDivElement | null>(null);
+  let shellEl = $state<HTMLDivElement | null>(null);
   const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
   const mobile = new MediaQuery("max-width:48rem");
   // Transit moved to the sidebar's Jeepney routes browse panel; Map tools now
@@ -72,6 +73,25 @@
     if (!mapToolsStore.open || !panelEl) return;
     return trapFocus(panelEl, { onEscape: () => mapToolsStore.close() });
   });
+
+  // The desktop panel opens absolutely below the trigger, which can sit well
+  // down the screen. A plain `max-height: 75vh` is measured from the viewport
+  // top, so the panel ran off the bottom edge with no way to scroll to it.
+  // Cap it to the space that actually remains below its own top edge instead.
+  $effect(() => {
+    const el = shellEl;
+    if (!mapToolsStore.open || !el || mobile.current) return;
+    const apply = () => {
+      const top = el.getBoundingClientRect().top;
+      el.style.setProperty(
+        "--tools-panel-max-h",
+        `${Math.max(160, window.innerHeight - top - 12)}px`,
+      );
+    };
+    apply();
+    window.addEventListener("resize", apply);
+    return () => window.removeEventListener("resize", apply);
+  });
 </script>
 
 <div class="map-tools-flyout">
@@ -87,6 +107,7 @@
   {#if mapToolsStore.open}
     <div
       class="map-tools-panel-shell"
+      bind:this={shellEl}
       in:fade={panelFadeIn(reducedMotion.current)}
       out:fade={panelFadeOut(reducedMotion.current)}
     >

--- a/src/components/svelte/fork/ForkWizard.svelte
+++ b/src/components/svelte/fork/ForkWizard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import * as maplibregl from "maplibre-gl";
-  import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?url";
+  import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
   import "maplibre-gl/dist/maplibre-gl.css";
   import { campusMap } from "../../../campus.config";
   import {
@@ -12,9 +12,8 @@
   } from "@lib/fork/campus-config-template";
   import { copyTextToClipboard } from "@lib/clipboard";
 
-  // Same prod trap as Map.svelte: Vite inlines maplibre into the app chunk and
-  // the GeoJSON path dies inside the worker ("f is not defined") on production
-  // builds. Point maplibre at its self-contained CSP worker bundle.
+  // See Map.svelte: `?worker&url` (not `?url`) so Vite bundles the v6 module
+  // worker with its sibling chunk; `?url` leaves it unable to load, no tiles.
   maplibregl.setWorkerUrl(maplibreWorkerUrl);
 
   /** Plain OSM raster style — works on any deployment, no MapTiler key. */

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -629,6 +629,10 @@ button.map-chrome-chip:disabled {
 /* Map tools flyout — shared width; mobile sizing in Entry.svelte */
 .map-tools-panel {
   width: min(24rem, calc(100vw - 1rem));
+  /* --tools-panel-max-h is set by MapToolsFlyout to the space below the
+     trigger, so the panel never runs off the bottom of a short viewport; the
+     body scrolls within it. Falls back to the plain viewport cap. */
+  max-height: min(28rem, var(--tools-panel-max-h, 75vh));
 }
 
 .map-tools-panel


### PR DESCRIPTION
Prod hotfix for two map bugs.

## 1. Blank basemap (the big one)
The v6 rebase (#1003) kept `setWorkerUrl(... .mjs?url)`. MapLibre 6 is ESM-only and its worker imports a sibling chunk; `?url` copies the worker file verbatim without that sibling, so the module worker fails on its first import and **no vector tile ever loads**, blank basemap under working pins. Switched to `?worker&url` (the documented MapLibre v6 + Vite fix) so Vite bundles the worker with its imports.

**Verified in a clean headless context** (fresh, no service worker): `.pbf` tiles stream at 200 and streets/water/buildings/3D render. The MapTiler key was never the cause (both old and new keys serve tiles); it is rotated separately.

## 2. Map tools panel runs off the bottom
The desktop tools flyout capped at `max-height: min(75vh, 28rem)` measured from the viewport top, but it opens partway down the screen, so on shorter viewports it overflowed the bottom with content unreachable. Now measured to the space below the panel's own top edge; body scrolls. Verified at 513px tall: panel bottom 598 (off-screen) → 501, body scrollable.

## Verify
- Clean-room Playwright: basemap tiles render, tools panel fits + scrolls.
- `bun run test:components` green (MapToolsFlyout), biome clean on changed files, build green.