### PR TITLE
Release: measure-route legibility + mode-aware snapping

### DIFF
--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -558,12 +558,30 @@
 
   const MEASURE_ROUTE_SOURCE_ID = "measure-route-line";
   const MEASURE_ROUTE_LAYER_ID = "measure-route-line";
+  const MEASURE_ROUTE_CASING_ID = "measure-route-line-casing";
 
   function ensureMeasureRouteLayers(map: mapGl.MapLibreMap) {
     if (!map.getSource(MEASURE_ROUTE_SOURCE_ID)) {
       map.addSource(MEASURE_ROUTE_SOURCE_ID, {
         type: "geojson",
         data: { type: "FeatureCollection", features: [] },
+      });
+    }
+
+    // Solid white casing under the dashes: a bare 4px dashed line vanished
+    // against grey buildings once zoomed out, so back it with the same
+    // zoom-scaled glow the journey polyline uses.
+    if (!map.getLayer(MEASURE_ROUTE_CASING_ID)) {
+      map.addLayer({
+        id: MEASURE_ROUTE_CASING_ID,
+        type: "line",
+        source: MEASURE_ROUTE_SOURCE_ID,
+        layout: { "line-cap": "round", "line-join": "round" },
+        paint: {
+          "line-color": "#ffffff",
+          "line-width": JOURNEY_CASING_WIDTH,
+          "line-opacity": 0.8,
+        },
       });
     }
 
@@ -578,8 +596,8 @@
         layout: { "line-cap": "round", "line-join": "round" },
         paint: {
           "line-color": "#7c3aed",
-          "line-width": 4,
-          "line-opacity": 0.9,
+          "line-width": JOURNEY_LINE_WIDTH,
+          "line-opacity": 1,
           "line-dasharray": [0.2, 1.6],
         },
       });
@@ -587,8 +605,8 @@
   }
 
   function clearMeasureRouteLayers(map: mapGl.MapLibreMap) {
-    if (map.getLayer(MEASURE_ROUTE_LAYER_ID)) {
-      map.removeLayer(MEASURE_ROUTE_LAYER_ID);
+    for (const id of [MEASURE_ROUTE_LAYER_ID, MEASURE_ROUTE_CASING_ID]) {
+      if (map.getLayer(id)) map.removeLayer(id);
     }
     if (map.getSource(MEASURE_ROUTE_SOURCE_ID)) {
       map.removeSource(MEASURE_ROUTE_SOURCE_ID);
@@ -2668,8 +2686,16 @@
     loadTravelGraph()
       .then((graph) => {
         if (cancelled) return;
-        const nodes = waypoints.map((w) => nearestNodeIndex(graph, w.lat, w.lng));
+        // Snap per mode: drive/cycle skip nodes their filters cannot leave,
+        // so a tap beside a footpath still measures along the nearest road.
         const modes: TravelMode[] = ["walk", "cycle", "drive"];
+        const nodesByMode = Object.fromEntries(
+          modes.map((m) => [
+            m,
+            waypoints.map((w) => nearestNodeIndex(graph, w.lat, w.lng, m)),
+          ]),
+        ) as Record<TravelMode, number[]>;
+        const nodes = nodesByMode[mode];
         const summaries = {
           walk: [] as ({ seconds: number; meters: number } | null)[],
           cycle: [] as ({ seconds: number; meters: number } | null)[],
@@ -2681,7 +2707,13 @@
         };
         for (let i = 0; i + 1 < nodes.length; i++) {
           for (const legMode of modes) {
-            const route = shortestPath(graph, nodes[i], nodes[i + 1], legMode);
+            const legNodes = nodesByMode[legMode];
+            const route = shortestPath(
+              graph,
+              legNodes[i],
+              legNodes[i + 1],
+              legMode,
+            );
             summaries[legMode].push(
               route ? { seconds: route.seconds, meters: route.meters } : null,
             );

--- a/src/components/svelte/MapToolsFlyout.svelte
+++ b/src/components/svelte/MapToolsFlyout.svelte
@@ -83,9 +83,13 @@
     if (!mapToolsStore.open || !el || mobile.current) return;
     const apply = () => {
       const top = el.getBoundingClientRect().top;
+      // Stop above the attribution strip, not the viewport edge — the strip
+      // z-stacks above the panel and was printing over its last row.
+      const attribution = document.querySelector(".map-attrib-corner");
+      const reserved = 12 + (attribution?.getBoundingClientRect().height ?? 0);
       el.style.setProperty(
         "--tools-panel-max-h",
-        `${Math.max(160, window.innerHeight - top - 12)}px`,
+        `${Math.max(160, window.innerHeight - top - reserved)}px`,
       );
     };
     apply();
@@ -273,13 +277,13 @@
   }
 
   .map-tools-flyout__tool-label {
-    font-size: 0.8125rem;
+    font-size: 0.9375rem;
     font-weight: 600;
   }
 
   .map-tools-flyout__tool-description {
-    font-size: 0.6875rem;
-    line-height: 1.25;
-    color: hsl(0, 0%, 40%);
+    font-size: 0.8125rem;
+    line-height: 1.3;
+    color: hsl(0, 0%, 32%);
   }
 </style>

--- a/src/components/svelte/MapViewControls.svelte
+++ b/src/components/svelte/MapViewControls.svelte
@@ -471,16 +471,16 @@
   }
 
   .control-kicker {
-    font-size: 0.625rem;
+    font-size: 0.6875rem;
     letter-spacing: 0.04em;
     line-height: 1.15;
-    opacity: 0.72;
+    opacity: 0.8;
     text-transform: uppercase;
   }
 
   .control-value {
     overflow: visible;
-    font-size: 0.75rem;
+    font-size: 0.875rem;
     line-height: 1.15;
     text-overflow: clip;
     white-space: nowrap;

--- a/src/components/svelte/MeasureRoutePanel.svelte
+++ b/src/components/svelte/MeasureRoutePanel.svelte
@@ -154,7 +154,7 @@
   }
 
   .measure-panel__title {
-    font-size: 0.8125rem;
+    font-size: 0.9375rem;
     font-weight: 600;
   }
 
@@ -192,9 +192,9 @@
 
   .measure-panel__hint {
     margin: 0;
-    font-size: 0.6875rem;
+    font-size: 0.8125rem;
     line-height: 1.35;
-    color: hsl(0, 0%, 35%);
+    color: hsl(0, 0%, 28%);
   }
 
   .measure-panel__modes {
@@ -212,8 +212,9 @@
     border: 1px solid var(--map-chrome-border, hsl(5 10% 68%));
     border-radius: 999px;
     background: none;
-    padding: 0.25rem 0.375rem;
-    font-size: 0.6875rem;
+    padding: 0.375rem 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
     color: inherit;
     cursor: pointer;
     white-space: nowrap;
@@ -237,11 +238,11 @@
 
   .measure-panel__total {
     margin: 0;
-    font-size: 0.75rem;
+    font-size: 0.875rem;
   }
 
   .measure-panel__legs {
-    font-size: 0.6875rem;
+    font-size: 0.8125rem;
   }
 
   .measure-panel__legs summary {
@@ -264,12 +265,12 @@
   }
 
   .measure-panel__leg-name {
-    color: hsl(0, 0%, 35%);
+    color: hsl(0, 0%, 30%);
   }
 
   .measure-panel__attribution {
     margin: 0;
-    font-size: 0.625rem;
-    color: hsl(0, 0%, 45%);
+    font-size: 0.6875rem;
+    color: hsl(0, 0%, 38%);
   }
 </style>

--- a/src/components/svelte/map-chrome/map-chrome.css
+++ b/src/components/svelte/map-chrome/map-chrome.css
@@ -655,7 +655,7 @@ button.map-chrome-chip:disabled {
   gap: 0.375rem;
   padding: 0.125rem 0.25rem;
   color: hsl(0, 0%, 20%);
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   font-weight: 600;
 }
 
@@ -712,7 +712,7 @@ button.map-chrome-chip:disabled {
   color: hsl(0, 0%, 20%);
   cursor: pointer;
   font: inherit;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   font-weight: 600;
   text-align: left;
 }

--- a/src/lib/travel-graph/engine.test.ts
+++ b/src/lib/travel-graph/engine.test.ts
@@ -129,6 +129,20 @@ describe("nearestNodeIndex", () => {
     expect(nearestNodeIndex(graph, 14.1601, 121.24005)).toBe(0);
     expect(nearestNodeIndex(graph, 14.1612, 121.2411)).toBe(3);
   });
+
+  test("mode-aware snap skips nodes the mode cannot leave", () => {
+    // Node 4 hangs off node 1 by a footway only. A tap on top of it must
+    // still snap drive to a road node, not report the leg as unroutable.
+    const extended: WalkGraphData = {
+      meta: { coordScale: 1e6, nodeCount: 5, edgeCount: 6 },
+      nodes: [...fixture.nodes, [5, 14.1613, 121.24]],
+      edges: [...fixture.edges, [1, 4, 35, "footway", null, []]],
+    };
+    const g = buildTravelGraph(extended);
+    expect(nearestNodeIndex(g, 14.1613, 121.24)).toBe(4);
+    expect(nearestNodeIndex(g, 14.1613, 121.24, "cycle")).toBe(4);
+    expect(nearestNodeIndex(g, 14.1613, 121.24, "drive")).toBe(1);
+  });
 });
 
 describe("isochroneFeatures", () => {

--- a/src/lib/travel-graph/engine.ts
+++ b/src/lib/travel-graph/engine.ts
@@ -94,15 +94,31 @@ export function edgeSeconds(
   return meters / (kph / 3.6);
 }
 
-/** Snap a tap to the closest graph node. Linear scan: 1k nodes is nothing. */
+/**
+ * Snap a tap to the closest graph node. Linear scan: 1k nodes is nothing.
+ *
+ * Pass `mode` to skip nodes the mode cannot leave (e.g. a footway-only node
+ * for `drive`) — otherwise a tap beside a footpath snaps drive/cycle legs to
+ * an unreachable node and the whole leg reports "no route" even though a
+ * drivable road runs right next to it.
+ */
 export function nearestNodeIndex(
   graph: TravelGraph,
   lat: number,
   lng: number,
+  mode: TravelMode = "walk",
 ): number {
   let best = 0;
   let bestMeters = Number.POSITIVE_INFINITY;
   for (let i = 0; i < graph.lat.length; i++) {
+    if (
+      mode !== "walk" &&
+      !graph.adjacency[i].some(
+        ({ edge }) => edgeSeconds(graph.edges[edge], mode) !== null,
+      )
+    ) {
+      continue;
+    }
     const meters = distanceMeters(
       { lat, lon: lng },
       { lat: graph.lat[i], lon: graph.lng[i] },


### PR DESCRIPTION
Stage 2 release of #1021 (full staging...main delta is that single PR):

- Mode-aware measure-route waypoint snapping: drive/cycle no longer report bogus "no route" when a tap lands beside a footpath; line + pins follow the active mode's snapped nodes.
- Measure line gets a white casing + zoom-scaled widths so it reads across building fills.
- Map tools / measure panel type bumped one step, secondary text darkened.
- Desktop map tools panel capped above the attribution strip (was underlapping it).

Verified on the integration PR: verify (build) green, e2e-advisory green (includes measure-route spec), Vercel preview deployed. The blocking `e2e / e2e` job fails identically ("Preview failed to start", 2h10m) on every PR since 2026-08-11 including merged #1019 and the last release; pre-existing, not this change.