### PR TITLE
data: add UPOU and IRRI campus buildings to the directory

### DIFF
--- a/data/uplb-directory.json
+++ b/data/uplb-directory.json
@@ -1105,5 +1105,167 @@
     "lat": 14.164643,
     "lng": 121.241124,
     "source": "https://www.openstreetmap.org/node/7785052612"
+  },
+  {
+    "name": "UPOU Main Building",
+    "type": "academic",
+    "building_or_area": "UPOU headquarters campus, Brgy. Maahas, Los Baños",
+    "description": "Main administration and academic building of the UP Open University.",
+    "lat": 14.173872,
+    "lng": 121.262554,
+    "source": "https://www.openstreetmap.org/way/135956497"
+  },
+  {
+    "name": "UPOU Teaching and Learning Hub",
+    "type": "academic",
+    "building_or_area": "UPOU headquarters campus, Brgy. Maahas, Los Baños",
+    "description": "Teaching, learning, and conference facility of the UP Open University.",
+    "lat": 14.173736,
+    "lng": 121.261975,
+    "source": "https://www.openstreetmap.org/way/1153990240"
+  },
+  {
+    "name": "UPOU Community Hub",
+    "type": "unit",
+    "building_or_area": "UPOU headquarters campus, Brgy. Maahas, Los Baños",
+    "description": "Events and co-working hub on the UP Open University grounds.",
+    "lat": 14.175692,
+    "lng": 121.262017,
+    "source": "https://www.openstreetmap.org/way/459953051"
+  },
+  {
+    "name": "Harrar Hall (IRRI)",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Main headquarters building of the International Rice Research Institute.",
+    "lat": 14.16932,
+    "lng": 121.25483,
+    "source": "https://www.openstreetmap.org/way/85789142"
+  },
+  {
+    "name": "Chandler Hall (IRRI)",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Training and conference building at IRRI headquarters.",
+    "lat": 14.16847,
+    "lng": 121.25457,
+    "source": "https://www.openstreetmap.org/way/85789155"
+  },
+  {
+    "name": "F.F. Hill Hall (IRRI)",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Office and research building at IRRI headquarters.",
+    "lat": 14.1694,
+    "lng": 121.25556,
+    "source": "https://www.openstreetmap.org/way/85789153"
+  },
+  {
+    "name": "Bradfield Hall (IRRI)",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Laboratory and office building at IRRI headquarters.",
+    "lat": 14.17078,
+    "lng": 121.25622,
+    "source": "https://www.openstreetmap.org/way/259493092"
+  },
+  {
+    "name": "Drilon Hall (IRRI)",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Campus building at IRRI headquarters.",
+    "lat": 14.17017,
+    "lng": 121.25608,
+    "source": "https://www.openstreetmap.org/way/113355839"
+  },
+  {
+    "name": "R.P. Cantrell Building (IRRI)",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Office building at IRRI headquarters.",
+    "lat": 14.16991,
+    "lng": 121.25542,
+    "source": "https://www.openstreetmap.org/way/113355856"
+  },
+  {
+    "name": "N.C. Brady Laboratory (IRRI)",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Research laboratory at IRRI headquarters.",
+    "lat": 14.16918,
+    "lng": 121.2584,
+    "source": "https://www.openstreetmap.org/way/226495748"
+  },
+  {
+    "name": "K.J. Lampe Laboratory (IRRI)",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Research laboratory at IRRI headquarters.",
+    "lat": 14.16937,
+    "lng": 121.25898,
+    "source": "https://www.openstreetmap.org/way/226495721"
+  },
+  {
+    "name": "Kenzo Hemmi Laboratory (IRRI)",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Research laboratory at IRRI headquarters.",
+    "lat": 14.16989,
+    "lng": 121.25951,
+    "source": "https://www.openstreetmap.org/way/143938191"
+  },
+  {
+    "name": "IRRI Library",
+    "type": "unit",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Library of the International Rice Research Institute, one of the world's largest rice science collections.",
+    "lat": 14.16834,
+    "lng": 121.25432,
+    "source": "https://www.openstreetmap.org/node/3328100830"
+  },
+  {
+    "name": "IRRI Events and Visitors Office",
+    "type": "office",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Visitor reception and events office at IRRI headquarters.",
+    "lat": 14.16867,
+    "lng": 121.25498,
+    "source": "https://www.openstreetmap.org/node/3327934302"
+  },
+  {
+    "name": "IRRI Emergency Brigade",
+    "type": "service",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Fire and emergency response station on the IRRI campus.",
+    "lat": 14.1712,
+    "lng": 121.25798,
+    "source": "https://www.openstreetmap.org/node/3084468900"
+  },
+  {
+    "name": "IRRI Safety and Security Services",
+    "type": "service",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Campus safety and security office at IRRI.",
+    "lat": 14.17111,
+    "lng": 121.25785,
+    "source": "https://www.openstreetmap.org/node/4049772510"
+  },
+  {
+    "name": "IRRI Transport Services",
+    "type": "service",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "Transport services and motorpool at IRRI headquarters.",
+    "lat": 14.17136,
+    "lng": 121.2577,
+    "source": "https://www.openstreetmap.org/way/226495720"
+  },
+  {
+    "name": "Zeigler Experiment Station (IRRI)",
+    "type": "landmark",
+    "building_or_area": "IRRI headquarters campus",
+    "description": "IRRI's experimental rice fields, visible along Pili Drive.",
+    "lat": 14.16857,
+    "lng": 121.25551,
+    "source": "https://www.openstreetmap.org/node/7682420243"
   }
 ]


### PR DESCRIPTION
Adds 18 OSM-sourced entries to `data/uplb-directory.json`: 3 UPOU buildings and 15 IRRI headquarters buildings/offices (see commit message for the curation list and skips).

**Already seeded to prod** 2026-08-13 via `bun run scripts/seed-uplb-directory.ts` (20 inserted, incl. two older unseeded entries; verified via prod DB query and `/api/organizations` now serving Harrar Hall). This PR just lands the source-of-truth file so future reseeds keep the entries.

Data-only, no code paths touched. No release PR needed on its own; batch into the next staging → main release (Vercel deploy cap).