### PR TITLE
fix(planner): auto-load more sections on scroll; friendlier count

### DIFF
--- a/src/components/svelte/planner/PlannerCourseSearch.svelte
+++ b/src/components/svelte/planner/PlannerCourseSearch.svelte
@@ -20,6 +20,7 @@
   let rows = $state<ClassMapValue[]>([]);
   let nextCursor = $state<string | null>(null);
   let hasMore = $state(false);
+  let sentinelEl = $state<HTMLDivElement | null>(null);
   const expanded = new SvelteSet<string>();
 
   // Browse mode (no query) pages through the term 100 at a time (#planner).
@@ -41,6 +42,25 @@
       loadingMore = false;
     }
   }
+
+  // Auto-load the next page when the end of the list scrolls into view, so
+  // browsing does not stall on a "Show more" click every 100 sections. The
+  // button stays as the visible affordance and keyboard path. Reading
+  // rows.length re-arms the observer after each page: if the sentinel is
+  // still on screen (short viewport), a fresh observer fires again.
+  $effect(() => {
+    const el = sentinelEl;
+    void rows.length;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) loadMore();
+      },
+      { rootMargin: "300px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  });
 
   $effect(() => {
     const q = query.trim();
@@ -245,12 +265,20 @@
             {/if}
           </div>
         {/each}
+        {#if hasMore && !query.trim()}
+          <div
+            class="course-search__sentinel"
+            bind:this={sentinelEl}
+            aria-hidden="true"
+          ></div>
+        {/if}
       </div>
     </div>
     {#if hasMore}
       <p class="course-search__note">
-        Showing the first {rows.length} sections.
         {#if !query.trim()}
+          Showing {courses.length} courses so far ({courses.at(-1)?.courseCode}
+          and earlier).
           <button
             type="button"
             class="course-search__more"
@@ -260,7 +288,8 @@
             {loadingMore ? "Loading…" : "Show more"}
           </button>
         {:else}
-          Search a course code to find the rest.
+          Showing the first {rows.length} sections. Search a fuller course code
+          to find the rest.
         {/if}
       </p>
     {/if}
@@ -346,6 +375,11 @@
     display: flex;
     flex-direction: column;
     gap: 0.375rem;
+  }
+
+  .course-search__sentinel {
+    height: 1px;
+    flex-shrink: 0;
   }
 
   .course-item {


### PR DESCRIPTION
Browse mode required a "Show more" click every 100 sections, and the note counted sections while the list shows grouped courses ("first 100 sections" above 11 course cards).

- IntersectionObserver sentinel at the list end auto-fetches the next page (300px prefetch margin); re-arms per page so short viewports keep loading. Button retained as visible affordance / keyboard path; guarded for environments without IO (jsdom).
- Note now reads "Showing N courses so far (CODE and earlier)"; search-mode truncation copy unchanged in spirit.

Component test + lint green. Batch into the next release; no solo release.