### PR TITLE
feat(map): camera debug mode via right-click menu (#964)

### DIFF
--- a/e2e/advisory/map-camera-debug.spec.ts
+++ b/e2e/advisory/map-camera-debug.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppBoot } from "../helpers/app";
+
+// #964: camera debug mode — right-click the map for the options menu, toggle
+// the live camera HUD, and confirm Escape/close behavior. First right-click
+// spec in the suite; MapLibre fires `contextmenu` for Playwright's right click.
+test.describe("map camera debug @advisory", () => {
+  test("right-click toggles the camera HUD; Escape and close work", async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+
+    await page.goto("/");
+    await waitForAppBoot(page);
+
+    const canvas = page.locator(".maplibregl-canvas");
+    await expect(canvas).toBeVisible({ timeout: 20_000 });
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error("map canvas has no bounding box");
+
+    // Off-center to dodge entity pins layered over the canvas middle.
+    const position = { x: box.width * 0.35, y: box.height * 0.35 };
+    await canvas.click({ button: "right", position });
+
+    const menu = page.getByRole("dialog", { name: "Map options" });
+    await expect(menu).toBeVisible();
+    // Footnote shows the clicked coordinates (lat, lng to 5 decimals).
+    await expect(menu.getByText(/^1?\d\.\d{5}, 1\d{2}\.\d{5}$/)).toBeVisible();
+
+    await menu.getByRole("checkbox", { name: /show camera details/i }).check();
+
+    const hud = page.getByRole("region", { name: "Camera details" });
+    await expect(hud).toBeVisible();
+    await expect(hud.getByText(/^\d+\.\d{2}$/)).toBeVisible(); // zoom
+
+    // Escape closes the menu, HUD stays.
+    await page.keyboard.press("Escape");
+    await expect(menu).toBeHidden();
+    await expect(hud).toBeVisible();
+
+    // HUD close button turns the readout off.
+    await hud.getByRole("button", { name: /hide camera details/i }).click();
+    await expect(hud).toBeHidden();
+
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/src/components/svelte/CameraDebugHud.component.test.ts
+++ b/src/components/svelte/CameraDebugHud.component.test.ts
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { mapStore, mapViewStore } from "@lib/store.svelte";
+import {
+  expectNoHorizontalOverflow,
+  mountAtWidth,
+} from "@test/layout-assertions";
+import CameraDebugHud from "./CameraDebugHud.svelte";
+
+type Handler = () => void;
+
+function fakeMap(values: {
+  zoom: number;
+  pitch: number;
+  bearing: number;
+  lat: number;
+  lng: number;
+}) {
+  const handlers = new Map<string, Handler>();
+  const off = vi.fn((event: string) => handlers.delete(event));
+  return {
+    values,
+    handlers,
+    off,
+    instance: {
+      getZoom: () => values.zoom,
+      getPitch: () => values.pitch,
+      getBearing: () => values.bearing,
+      getCenter: () => ({ lat: values.lat, lng: values.lng }),
+      on: (event: string, handler: Handler) => handlers.set(event, handler),
+      off,
+    } as never,
+  };
+}
+
+describe("CameraDebugHud", () => {
+  beforeEach(() => {
+    mapViewStore.cameraDebug = true;
+  });
+
+  afterEach(() => {
+    mapStore.mapInstance = undefined;
+    mapViewStore.cameraDebug = false;
+  });
+
+  test.each([320, 768])("fits without horizontal overflow at %ipx", (width) => {
+    mapStore.mapInstance = fakeMap({
+      zoom: 16.2,
+      pitch: 48,
+      bearing: 322.5,
+      lat: 14.16512,
+      lng: 121.24138,
+    }).instance;
+    mountAtWidth(width);
+    const { container } = render(CameraDebugHud);
+    expectNoHorizontalOverflow(container as HTMLElement);
+  });
+
+  test("renders the camera values and updates on map events", async () => {
+    const map = fakeMap({
+      zoom: 16.204,
+      pitch: 48.04,
+      bearing: 322.51,
+      lat: 14.16512,
+      lng: 121.24138,
+    });
+    mapStore.mapInstance = map.instance;
+    render(CameraDebugHud);
+
+    expect(screen.getByText("16.20")).toBeInTheDocument();
+    expect(screen.getByText("48.0°")).toBeInTheDocument();
+    expect(screen.getByText("322.5°")).toBeInTheDocument();
+    expect(screen.getByText("14.16512, 121.24138")).toBeInTheDocument();
+
+    map.values.zoom = 17.5;
+    map.handlers.get("move")?.();
+    expect(await screen.findByText("17.50")).toBeInTheDocument();
+  });
+
+  test("close button turns the readout off; unmount unsubscribes", () => {
+    const map = fakeMap({
+      zoom: 16,
+      pitch: 0,
+      bearing: 0,
+      lat: 14.165,
+      lng: 121.243,
+    });
+    mapStore.mapInstance = map.instance;
+    const { unmount } = render(CameraDebugHud);
+
+    screen.getByRole("button", { name: /hide camera details/i }).click();
+    expect(mapViewStore.cameraDebug).toBe(false);
+
+    unmount();
+    const offEvents = map.off.mock.calls.map((call) => call[0]).sort();
+    expect(offEvents).toEqual(["move", "pitch", "rotate", "zoom"]);
+  });
+});

--- a/src/components/svelte/CameraDebugHud.svelte
+++ b/src/components/svelte/CameraDebugHud.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import X from "@lucide/svelte/icons/x";
+  import { mapStore, mapViewStore } from "@lib/store.svelte";
+
+  let zoom = $state(0);
+  let pitch = $state(0);
+  let bearing = $state(0);
+  let lat = $state(0);
+  let lng = $state(0);
+
+  // Pure reads on camera events (MapControlsStack pattern) — no rAF wrap
+  // needed, that constraint covers camera writes from effects.
+  function syncCamera() {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    zoom = map.getZoom();
+    pitch = map.getPitch();
+    bearing = map.getBearing();
+    const center = map.getCenter();
+    lat = center.lat;
+    lng = center.lng;
+  }
+
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    syncCamera();
+    const onChange = () => syncCamera();
+    map.on("move", onChange);
+    map.on("zoom", onChange);
+    map.on("rotate", onChange);
+    map.on("pitch", onChange);
+    return () => {
+      map.off("move", onChange);
+      map.off("zoom", onChange);
+      map.off("rotate", onChange);
+      map.off("pitch", onChange);
+    };
+  });
+</script>
+
+<section class="camera-hud" aria-label="Camera details">
+  <div class="camera-hud__header">
+    <span class="camera-hud__title">Camera</span>
+    <button
+      type="button"
+      class="camera-hud__close"
+      aria-label="Hide camera details"
+      onclick={mapViewStore.toggleCameraDebug}
+    >
+      <X size={14} aria-hidden="true" />
+    </button>
+  </div>
+  <dl class="camera-hud__grid">
+    <dt>Zoom</dt>
+    <dd>{zoom.toFixed(2)}</dd>
+    <dt>Pitch</dt>
+    <dd>{pitch.toFixed(1)}°</dd>
+    <dt>Bearing</dt>
+    <dd>{bearing.toFixed(1)}°</dd>
+    <dt>Center</dt>
+    <dd>{lat.toFixed(5)}, {lng.toFixed(5)}</dd>
+  </dl>
+</section>
+
+<style>
+  .camera-hud {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    width: min(15rem, calc(100vw - 1rem));
+    align-self: flex-start;
+    box-sizing: border-box;
+    border: 1px solid var(--map-chrome-border, hsl(5 10% 68%));
+    border-radius: var(--map-chrome-radius, 1rem);
+    background-color: var(--map-chrome-surface, hsl(5 20% 97%));
+    backdrop-filter: blur(10px);
+    padding: 0.5rem 0.625rem;
+    box-shadow: var(
+      --map-chrome-panel-shadow,
+      0 0 0 1px hsla(15, 8%, 20%, 0.16),
+      0 2px 8px hsla(0, 0%, 0%, 0.14),
+      0 8px 20px hsla(0, 0%, 0%, 0.18)
+    );
+    pointer-events: auto;
+  }
+
+  .camera-hud__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .camera-hud__title {
+    font-size: 0.9375rem;
+    font-weight: 600;
+  }
+
+  .camera-hud__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border: none;
+    border-radius: 50%;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .camera-hud__close:hover {
+    background-color: hsl(5, 20%, 90%);
+  }
+
+  .camera-hud__close:focus-visible {
+    outline: 2px solid hsl(5, 53%, 32%);
+    outline-offset: 1px;
+  }
+
+  .camera-hud__grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.125rem 0.875rem;
+    margin: 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .camera-hud__grid dt {
+    color: hsl(0, 0%, 38%);
+  }
+
+  .camera-hud__grid dd {
+    margin: 0;
+    color: hsl(0, 0%, 12%);
+  }
+</style>

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -32,6 +32,8 @@
   import Map from "@ui/Map.svelte";
   import MapAttribution from "@ui/MapAttribution.svelte";
   import MeasureRoutePanel from "@ui/MeasureRoutePanel.svelte";
+  import CameraDebugHud from "@ui/CameraDebugHud.svelte";
+  import MapContextMenu from "@ui/map-chrome/MapContextMenu.svelte";
   import TravelTimeLegend from "@ui/TravelTimeLegend.svelte";
   import Toast from "@ui/Toast.svelte";
   import Building3DViewer from "@ui/Building3DViewer.svelte";
@@ -450,6 +452,7 @@
           <MapAttribution />
         </div>
       {/if}
+      <MapContextMenu />
       <div class="inner-layer">
         <MainControls />
         <div class="bottom-band">
@@ -458,6 +461,9 @@
           {/if}
           {#if measureRouteStore.active}
             <MeasureRoutePanel />
+          {/if}
+          {#if mapViewStore.cameraDebug}
+            <CameraDebugHud />
           {/if}
         </div>
       </div>

--- a/src/components/svelte/MapViewControls.component.test.ts
+++ b/src/components/svelte/MapViewControls.component.test.ts
@@ -52,3 +52,21 @@ describe("MapViewControls My classes toggle", () => {
     expect(mapViewStore.highlightMyBuildings).toBe(true);
   });
 });
+
+describe("MapViewControls camera details toggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mapViewStore.cameraDebug = false;
+  });
+
+  test("row toggles the camera debug flag and tracks aria-pressed", async () => {
+    render(MapViewControls, { props: { embedded: true, variant: "modes" } });
+
+    const toggle = screen.getByRole("button", {
+      name: /show a live camera readout/i,
+    });
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    toggle.click();
+    expect(mapViewStore.cameraDebug).toBe(true);
+  });
+});

--- a/src/components/svelte/MapViewControls.svelte
+++ b/src/components/svelte/MapViewControls.svelte
@@ -9,6 +9,7 @@
   import GraduationCap from "@lucide/svelte/icons/graduation-cap";
   import MapIcon from "@lucide/svelte/icons/map";
   import Satellite from "@lucide/svelte/icons/satellite";
+  import Gauge from "@lucide/svelte/icons/gauge";
   import {
     mapStore,
     mapViewStore,
@@ -84,6 +85,11 @@
     mapViewStore.satellite
       ? "Showing satellite imagery. Switch to the standard map."
       : "Showing the standard map. Switch to satellite imagery.",
+  );
+  const cameraDebugTitle = $derived(
+    mapViewStore.cameraDebug
+      ? "Hide the live camera readout."
+      : "Show a live camera readout (zoom, pitch, bearing, center).",
   );
   function syncCamera() {
     const map = mapStore.mapInstance;
@@ -248,6 +254,25 @@
         </span>
       </button>
     {/if}
+
+    <div class="divider"></div>
+
+    <button
+      class="control mode-toggle camera-debug-toggle"
+      class:active={mapViewStore.cameraDebug}
+      onclick={mapViewStore.toggleCameraDebug}
+      title={cameraDebugTitle}
+      aria-label={cameraDebugTitle}
+      aria-pressed={mapViewStore.cameraDebug}
+    >
+      <Gauge size={18} aria-hidden="true" />
+      <span class="control-copy">
+        <span class="control-kicker">Camera details</span>
+        <span class="control-value">
+          {mapViewStore.cameraDebug ? "On" : "Off"}
+        </span>
+      </span>
+    </button>
   {/if}
 
   {#if showCameraNav}
@@ -520,13 +545,15 @@
   }
 
   .camera-toggle,
-  .satellite-toggle {
+  .satellite-toggle,
+  .camera-debug-toggle {
     border-color: hsl(5, 34%, 78%);
     background-color: hsl(0, 100%, 99%);
   }
 
   .camera-toggle:hover,
-  .satellite-toggle:hover {
+  .satellite-toggle:hover,
+  .camera-debug-toggle:hover {
     border-color: hsl(5, 34%, 68%);
     background-color: hsl(0, 78%, 97%);
   }

--- a/src/components/svelte/map-chrome/MapContextMenu.component.test.ts
+++ b/src/components/svelte/map-chrome/MapContextMenu.component.test.ts
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { mapStore, mapViewStore } from "@lib/store.svelte";
+import MapContextMenu from "./MapContextMenu.svelte";
+
+type ContextHandler = (event: {
+  lngLat: { lat: number; lng: number };
+  originalEvent: {
+    clientX: number;
+    clientY: number;
+    preventDefault: () => void;
+  };
+}) => void;
+
+function fakeMap() {
+  let contextHandler: ContextHandler | undefined;
+  const off = vi.fn();
+  return {
+    fire: (lat: number, lng: number, x = 200, y = 150) =>
+      contextHandler?.({
+        lngLat: { lat, lng },
+        originalEvent: { clientX: x, clientY: y, preventDefault: vi.fn() },
+      }),
+    off,
+    instance: {
+      on: (event: string, handler: ContextHandler) => {
+        if (event === "contextmenu") contextHandler = handler;
+      },
+      off,
+    } as never,
+  };
+}
+
+describe("MapContextMenu", () => {
+  beforeEach(() => {
+    localStorage.removeItem("camera-debug");
+    mapViewStore.cameraDebug = false;
+  });
+
+  afterEach(() => {
+    mapStore.mapInstance = undefined;
+    mapViewStore.cameraDebug = false;
+    localStorage.removeItem("camera-debug");
+  });
+
+  test("right-click opens the dialog with the clicked coordinates", async () => {
+    const map = fakeMap();
+    mapStore.mapInstance = map.instance;
+    render(MapContextMenu);
+
+    expect(screen.queryByRole("dialog", { name: "Map options" })).toBeNull();
+    map.fire(14.16512, 121.24138);
+    expect(
+      await screen.findByRole("dialog", { name: "Map options" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("14.16512, 121.24138")).toBeInTheDocument();
+  });
+
+  test("checkbox reflects and toggles the camera debug flag", async () => {
+    const map = fakeMap();
+    mapStore.mapInstance = map.instance;
+    render(MapContextMenu);
+    map.fire(14.165, 121.243);
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: /show camera details/i,
+    });
+    expect((checkbox as HTMLInputElement).checked).toBe(false);
+    await fireEvent.click(checkbox);
+    expect(mapViewStore.cameraDebug).toBe(true);
+  });
+
+  test("Escape closes the menu; unmount unsubscribes", async () => {
+    const map = fakeMap();
+    mapStore.mapInstance = map.instance;
+    const { unmount } = render(MapContextMenu);
+    map.fire(14.165, 121.243);
+
+    const dialog = await screen.findByRole("dialog", { name: "Map options" });
+    await fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Map options" })).toBeNull();
+
+    unmount();
+    expect(map.off).toHaveBeenCalledWith("contextmenu", expect.any(Function));
+  });
+
+  test("outside pointerdown closes the menu", async () => {
+    const map = fakeMap();
+    mapStore.mapInstance = map.instance;
+    render(MapContextMenu);
+    map.fire(14.165, 121.243);
+    await screen.findByRole("dialog", { name: "Map options" });
+
+    await fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole("dialog", { name: "Map options" })).toBeNull();
+  });
+});

--- a/src/components/svelte/map-chrome/MapContextMenu.svelte
+++ b/src/components/svelte/map-chrome/MapContextMenu.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import type * as mapGl from "maplibre-gl";
+  import { onMount } from "svelte";
+  import { trapFocus } from "@lib/focus-trap";
+  import { portal } from "@lib/portal";
+  import {
+    registerEphemeralOverlayDismisser,
+    openEphemeralOverlay,
+  } from "@lib/overlay-stack";
+  import { mapStore, mapViewStore } from "@lib/store.svelte";
+  import "./map-chrome.css";
+
+  type MenuState = { x: number; y: number; lat: number; lng: number };
+
+  let menu = $state<MenuState | null>(null);
+  let panelEl = $state<HTMLDivElement | null>(null);
+
+  onMount(() => registerEphemeralOverlayDismisser(() => (menu = null)));
+
+  // #964: right-click opens map options. Registered here rather than in
+  // Map.svelte so the whole feature stays in one component (the same shape
+  // MapControlsStack uses to subscribe to camera events).
+  $effect(() => {
+    const map = mapStore.mapInstance;
+    if (!map) return;
+    const handleContextMenu = (event: mapGl.MapMouseEvent) => {
+      // MapLibre suppresses the native menu once a listener exists; keep the
+      // explicit call so a future listener reshuffle cannot regress it.
+      event.originalEvent.preventDefault();
+      openEphemeralOverlay(() => {
+        menu = {
+          x: event.originalEvent.clientX,
+          y: event.originalEvent.clientY,
+          lat: event.lngLat.lat,
+          lng: event.lngLat.lng,
+        };
+      });
+    };
+    map.on("contextmenu", handleContextMenu);
+    return () => {
+      map.off("contextmenu", handleContextMenu);
+    };
+  });
+
+  // Clamp to the viewport once the panel has a size; right-clicks near the
+  // bottom/right edge would otherwise push the menu off-screen.
+  const clamped = $derived.by(() => {
+    const state = menu;
+    if (!state) return null;
+    const width = panelEl?.offsetWidth ?? 0;
+    const height = panelEl?.offsetHeight ?? 0;
+    if (typeof window === "undefined") return { left: state.x, top: state.y };
+    return {
+      left: Math.max(8, Math.min(state.x, window.innerWidth - width - 8)),
+      top: Math.max(8, Math.min(state.y, window.innerHeight - height - 8)),
+    };
+  });
+
+  function close() {
+    menu = null;
+  }
+
+  $effect(() => {
+    if (!menu || !panelEl) return;
+    return trapFocus(panelEl, { onEscape: close });
+  });
+
+  function handleDocumentPointerDown(event: PointerEvent) {
+    if (!menu) return;
+    const target = event.target;
+    if (!(target instanceof Node)) return;
+    if (panelEl?.contains(target)) return;
+    close();
+  }
+</script>
+
+<svelte:window onpointerdown={handleDocumentPointerDown} />
+
+{#if menu && clamped}
+  <div
+    bind:this={panelEl}
+    class="map-context-menu map-chrome-popover"
+    style={`left: ${clamped.left}px; top: ${clamped.top}px;`}
+    role="dialog"
+    aria-label="Map options"
+    use:portal
+  >
+    <label class="map-context-menu__toggle">
+      <input
+        type="checkbox"
+        checked={mapViewStore.cameraDebug}
+        onchange={mapViewStore.toggleCameraDebug}
+      />
+      Show camera details
+    </label>
+    <p class="map-chrome-popover-footnote">
+      {menu.lat.toFixed(5)}, {menu.lng.toFixed(5)}
+    </p>
+  </div>
+{/if}
+
+<style>
+  .map-context-menu {
+    position: fixed;
+    z-index: var(--z-chrome-popover, 17);
+    width: min(13rem, calc(100vw - 1rem));
+    padding: 0.375rem;
+  }
+
+  .map-context-menu__toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.375rem;
+    border-radius: 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: hsl(0, 0%, 13%);
+    cursor: pointer;
+  }
+
+  .map-context-menu__toggle:hover {
+    background-color: hsl(5, 20%, 95%);
+  }
+
+  .map-context-menu__toggle input {
+    accent-color: hsl(5, 53%, 32%);
+    width: 0.9375rem;
+    height: 0.9375rem;
+  }
+</style>

--- a/src/lib/stores/map-stores.store.test.ts
+++ b/src/lib/stores/map-stores.store.test.ts
@@ -57,6 +57,29 @@ describe("TerrainStore", () => {
 });
 
 describe("MapViewStore", () => {
+  test("cameraDebug persists to localStorage and hydrates in a new instance", () => {
+    localStorage.removeItem("camera-debug");
+    const store = new MapViewStore();
+    expect(store.cameraDebug).toBe(false);
+    store.toggleCameraDebug();
+    expect(localStorage.getItem("camera-debug")).toBe("true");
+
+    const rehydrated = new MapViewStore();
+    expect(rehydrated.cameraDebug).toBe(true);
+    rehydrated.toggleCameraDebug();
+    expect(localStorage.getItem("camera-debug")).toBe("false");
+    localStorage.removeItem("camera-debug");
+  });
+
+  test("showAll leaves cameraDebug alone (it resets pin layers, not chrome)", () => {
+    localStorage.removeItem("camera-debug");
+    const store = new MapViewStore();
+    store.toggleCameraDebug();
+    store.showAll();
+    expect(store.cameraDebug).toBe(true);
+    localStorage.removeItem("camera-debug");
+  });
+
   test("toggleEventsOnly flips eventsOnly", () => {
     const store = new MapViewStore();
     store.toggleEventsOnly();

--- a/src/lib/stores/map-stores.svelte.ts
+++ b/src/lib/stores/map-stores.svelte.ts
@@ -27,9 +27,23 @@ export class MapViewStore {
   satellite: boolean = $state(false);
   /** A locally changed Esri World Imagery Wayback release, when selected. */
   waybackSnapshot: WaybackSnapshot | null = $state(null);
+  /** Live camera readout HUD (#964). Persisted: map debugging spans reloads. */
+  cameraDebug: boolean = $state(
+    typeof localStorage !== "undefined" &&
+      localStorage.getItem("camera-debug") === "true",
+  );
 
   toggleEventsOnly = () => {
     this.eventsOnly = !this.eventsOnly;
+  };
+
+  toggleCameraDebug = () => {
+    this.cameraDebug = !this.cameraDebug;
+    try {
+      localStorage.setItem("camera-debug", String(this.cameraDebug));
+    } catch {
+      // Private mode: the toggle still works for this session.
+    }
   };
 
   toggleSatellite = () => {


### PR DESCRIPTION
Implements #964 per the mocks posted on the issue (https://github.com/uplbtools/room-tba/issues/964#issuecomment-5280880096).

- Right-click the map: "Map options" dialog with a **Show camera details** checkbox + the clicked coordinates as a footnote. Portal, focus trap, Escape, outside-pointerdown, ephemeral-overlay registration, viewport-clamped at the cursor.
- Toggled on: **camera HUD** docks in the bottom band (zoom 2dp, pitch/bearing 1dp, center 5dp, monospace/tabular), live via move/zoom/rotate/pitch subscriptions, close button turns it off.
- Persists in localStorage (`camera-debug`), SSR-guarded, deliberately not part of `showAll()` and not in the cache-clear preserve list.
- Touch/keyboard path: **Camera details** row in Map tools → View (satellite-toggle clone).
- Zero changes to Map.svelte: the contextmenu listener lives in `MapContextMenu` via the MapControlsStack subscribe pattern.

Tests: store persistence (2), MapContextMenu (4), CameraDebugHud (3 incl. live-update + unsubscribe + 320/768 overflow), MapViewControls row (1) — 24 pass; plus `e2e/advisory/map-camera-debug.spec.ts`, the suite's first right-click spec. `bun run test` 871 pass, lint clean, build completes.

Batch into the next release with #1024/#1025/#1026.