### PR TITLE
fix(map): prevent production render failure

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -14,6 +14,7 @@
     adminAuthStore,
     mapEditStore,
     mapToolsStore,
+    mapViewStore,
     travelTimeStore,
     measureRouteStore,
     editorChromeStore,


### PR DESCRIPTION
## Summary

- Import `mapViewStore` in `Entry.svelte`.
- Prevent the production `ReferenceError` introduced by camera debug mode.

## Verification

- Unit suite passed with exit 0.
- Component suite passed: 71 files, 323 tests.
- `bun run build` passed.

Staging contains one commit and one changed file relative to `main`.